### PR TITLE
Add species interactions feature for documenting ecological relationships

### DIFF
--- a/crates/observing-ingester/src/types.rs
+++ b/crates/observing-ingester/src/types.rs
@@ -44,6 +44,19 @@ pub struct CommentEvent {
     pub record: Option<serde_json::Value>,
 }
 
+/// An interaction event (species interaction between organisms)
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InteractionEvent {
+    pub did: String,
+    pub uri: String,
+    pub cid: String,
+    pub action: String,
+    pub seq: i64,
+    pub time: DateTime<Utc>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub record: Option<serde_json::Value>,
+}
+
 /// Timing information for lag tracking
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CommitTimingInfo {
@@ -57,6 +70,7 @@ pub struct IngesterStats {
     pub occurrences: u64,
     pub identifications: u64,
     pub comments: u64,
+    pub interactions: u64,
     pub errors: u64,
 }
 
@@ -94,6 +108,7 @@ impl Default for IngesterConfig {
 pub const OCCURRENCE_COLLECTION: &str = "org.rwell.test.occurrence";
 pub const IDENTIFICATION_COLLECTION: &str = "org.rwell.test.identification";
 pub const COMMENT_COLLECTION: &str = "org.rwell.test.comment";
+pub const INTERACTION_COLLECTION: &str = "org.rwell.test.interaction";
 
 #[cfg(test)]
 mod tests {
@@ -213,5 +228,7 @@ mod tests {
     fn test_collection_constants() {
         assert_eq!(OCCURRENCE_COLLECTION, "org.rwell.test.occurrence");
         assert_eq!(IDENTIFICATION_COLLECTION, "org.rwell.test.identification");
+        assert_eq!(COMMENT_COLLECTION, "org.rwell.test.comment");
+        assert_eq!(INTERACTION_COLLECTION, "org.rwell.test.interaction");
     }
 }

--- a/lexicons/org/rwell/test/interaction.json
+++ b/lexicons/org/rwell/test/interaction.json
@@ -1,0 +1,95 @@
+{
+  "lexicon": 1,
+  "id": "org.rwell.test.interaction",
+  "defs": {
+    "main": {
+      "type": "record",
+      "description": "Species interaction documenting ecological relationship between organisms.",
+      "key": "tid",
+      "record": {
+        "type": "object",
+        "required": ["subjectA", "subjectB", "interactionType", "direction", "createdAt"],
+        "properties": {
+          "subjectA": {
+            "type": "ref",
+            "ref": "#interactionSubject",
+            "description": "The first subject (actor) in the interaction."
+          },
+          "subjectB": {
+            "type": "ref",
+            "ref": "#interactionSubject",
+            "description": "The second subject (recipient) in the interaction."
+          },
+          "interactionType": {
+            "type": "string",
+            "description": "Type of ecological interaction between the subjects.",
+            "knownValues": [
+              "predation",
+              "pollination",
+              "parasitism",
+              "herbivory",
+              "symbiosis",
+              "mutualism",
+              "competition",
+              "shelter",
+              "transportation",
+              "oviposition",
+              "seed_dispersal"
+            ],
+            "maxLength": 64
+          },
+          "direction": {
+            "type": "string",
+            "description": "Direction of the interaction: AtoB means A acts on B, BtoA means B acts on A, bidirectional means mutual.",
+            "enum": ["AtoB", "BtoA", "bidirectional"],
+            "default": "AtoB"
+          },
+          "confidence": {
+            "type": "string",
+            "description": "Confidence level in the interaction observation.",
+            "enum": ["low", "medium", "high"],
+            "default": "medium"
+          },
+          "comment": {
+            "type": "string",
+            "description": "Additional notes about the interaction.",
+            "maxLength": 3000
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "datetime",
+            "description": "Timestamp when this record was created."
+          }
+        }
+      }
+    },
+    "interactionSubject": {
+      "type": "object",
+      "description": "A subject in an interaction - can reference an existing occurrence or just specify a taxon name.",
+      "properties": {
+        "occurrence": {
+          "type": "ref",
+          "ref": "com.atproto.repo.strongRef",
+          "description": "Reference to an existing occurrence record."
+        },
+        "subjectIndex": {
+          "type": "integer",
+          "description": "Index of the subject within the occurrence (for multi-subject observations).",
+          "minimum": 0,
+          "maximum": 99,
+          "default": 0
+        },
+        "taxonName": {
+          "type": "string",
+          "description": "Scientific name of the organism (for unobserved subjects or to override occurrence ID).",
+          "maxLength": 256
+        },
+        "kingdom": {
+          "type": "string",
+          "description": "Taxonomic kingdom to disambiguate homonyms.",
+          "maxLength": 64
+        }
+      }
+    }
+  }
+}

--- a/packages/observing-frontend/src/components/interaction/InteractionPanel.tsx
+++ b/packages/observing-frontend/src/components/interaction/InteractionPanel.tsx
@@ -1,0 +1,454 @@
+import { useState, useEffect } from "react";
+import {
+  Box,
+  Typography,
+  Button,
+  Paper,
+  Stack,
+  Chip,
+  TextField,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
+  Avatar,
+  Divider,
+  Alert,
+  CircularProgress,
+} from "@mui/material";
+import AddIcon from "@mui/icons-material/Add";
+import LinkIcon from "@mui/icons-material/Link";
+import { useAppSelector } from "../../store";
+import {
+  submitInteraction,
+  fetchInteractionsForOccurrence,
+  searchTaxa,
+  type InteractionResponse,
+} from "../../services/api";
+import type { Subject, TaxaResult } from "../../services/types";
+import { formatDate } from "../../lib/utils";
+
+// Known interaction types with human-readable labels
+const INTERACTION_TYPES = [
+  { value: "predation", label: "Predation", description: "One organism eating another" },
+  { value: "pollination", label: "Pollination", description: "Transfer of pollen between plants" },
+  { value: "parasitism", label: "Parasitism", description: "One organism living on/in another" },
+  { value: "herbivory", label: "Herbivory", description: "Animal eating plant material" },
+  { value: "symbiosis", label: "Symbiosis", description: "Close physical association" },
+  { value: "mutualism", label: "Mutualism", description: "Both organisms benefit" },
+  { value: "competition", label: "Competition", description: "Competing for resources" },
+  { value: "shelter", label: "Shelter", description: "One provides shelter to another" },
+  { value: "transportation", label: "Transportation", description: "One transports another" },
+  { value: "oviposition", label: "Oviposition", description: "Laying eggs on/in another organism" },
+  { value: "seed_dispersal", label: "Seed Dispersal", description: "Dispersing seeds of another" },
+];
+
+const DIRECTION_OPTIONS = [
+  { value: "AtoB", label: "A affects B" },
+  { value: "BtoA", label: "B affects A" },
+  { value: "bidirectional", label: "Bidirectional" },
+];
+
+const CONFIDENCE_OPTIONS = [
+  { value: "high", label: "High" },
+  { value: "medium", label: "Medium" },
+  { value: "low", label: "Low" },
+];
+
+interface InteractionPanelProps {
+  observation: {
+    uri: string;
+    cid: string;
+    scientificName?: string;
+    communityId?: string;
+  };
+  subjects: Subject[];
+  onSuccess?: () => void;
+}
+
+export function InteractionPanel({
+  observation,
+  subjects,
+  onSuccess,
+}: InteractionPanelProps) {
+  const user = useAppSelector((state) => state.auth.user);
+  const [interactions, setInteractions] = useState<InteractionResponse[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [showForm, setShowForm] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Form state
+  const [subjectAIndex, setSubjectAIndex] = useState(0);
+  const [subjectBType, setSubjectBType] = useState<"occurrence" | "taxon">("taxon");
+  const [subjectBTaxon, setSubjectBTaxon] = useState("");
+  const [subjectBKingdom, setSubjectBKingdom] = useState("");
+  const [taxonSuggestions, setTaxonSuggestions] = useState<TaxaResult[]>([]);
+  const [interactionType, setInteractionType] = useState("predation");
+  const [direction, setDirection] = useState<"AtoB" | "BtoA" | "bidirectional">("AtoB");
+  const [confidence, setConfidence] = useState<"low" | "medium" | "high">("medium");
+  const [comment, setComment] = useState("");
+
+  useEffect(() => {
+    loadInteractions();
+  }, [observation.uri]);
+
+  const loadInteractions = async () => {
+    setLoading(true);
+    try {
+      const result = await fetchInteractionsForOccurrence(observation.uri);
+      setInteractions(result.interactions);
+    } catch {
+      // Ignore errors, just show empty list
+    }
+    setLoading(false);
+  };
+
+  const handleTaxonSearch = async (query: string) => {
+    setSubjectBTaxon(query);
+    if (query.length >= 2) {
+      const results = await searchTaxa(query);
+      setTaxonSuggestions(results.slice(0, 5));
+    } else {
+      setTaxonSuggestions([]);
+    }
+  };
+
+  const handleSelectTaxon = (taxon: TaxaResult) => {
+    setSubjectBTaxon(taxon.scientificName);
+    setSubjectBKingdom(taxon.rank === "kingdom" ? taxon.scientificName : "");
+    setTaxonSuggestions([]);
+  };
+
+  const handleSubmit = async () => {
+    if (!subjectBTaxon.trim()) {
+      setError("Please specify the other organism");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+
+    try {
+      const selectedSubject = subjects.find((s) => s.index === subjectAIndex) || subjects[0];
+
+      await submitInteraction({
+        subjectA: {
+          occurrenceUri: observation.uri,
+          occurrenceCid: observation.cid,
+          subjectIndex: subjectAIndex,
+          taxonName: selectedSubject?.communityId || observation.communityId || observation.scientificName,
+        },
+        subjectB: {
+          taxonName: subjectBTaxon.trim(),
+          kingdom: subjectBKingdom || undefined,
+        },
+        interactionType,
+        direction,
+        confidence,
+        comment: comment.trim() || undefined,
+      });
+
+      // Reset form
+      setShowForm(false);
+      setSubjectBTaxon("");
+      setSubjectBKingdom("");
+      setComment("");
+      setInteractionType("predation");
+      setDirection("AtoB");
+      setConfidence("medium");
+
+      // Reload interactions
+      await loadInteractions();
+      onSuccess?.();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to submit interaction");
+    }
+
+    setSubmitting(false);
+  };
+
+  const getInteractionLabel = (type: string) => {
+    return INTERACTION_TYPES.find((t) => t.value === type)?.label || type;
+  };
+
+  const getDirectionLabel = (dir: string, subjectA: string, subjectB: string) => {
+    switch (dir) {
+      case "AtoB":
+        return `${subjectA} \u2192 ${subjectB}`;
+      case "BtoA":
+        return `${subjectB} \u2192 ${subjectA}`;
+      case "bidirectional":
+        return `${subjectA} \u2194 ${subjectB}`;
+      default:
+        return "";
+    }
+  };
+
+  if (loading) {
+    return (
+      <Box sx={{ py: 2, textAlign: "center" }}>
+        <CircularProgress size={24} />
+      </Box>
+    );
+  }
+
+  return (
+    <Paper sx={{ mt: 3, p: 2, bgcolor: "background.paper" }}>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" sx={{ mb: 2 }}>
+        <Typography variant="subtitle1" fontWeight={600}>
+          <LinkIcon sx={{ fontSize: 18, mr: 0.5, verticalAlign: "middle" }} />
+          Species Interactions
+        </Typography>
+        {user && !showForm && (
+          <Button
+            size="small"
+            startIcon={<AddIcon />}
+            onClick={() => setShowForm(true)}
+          >
+            Add
+          </Button>
+        )}
+      </Stack>
+
+      {/* Existing interactions */}
+      {interactions.length > 0 ? (
+        <Stack spacing={1.5} sx={{ mb: showForm ? 2 : 0 }}>
+          {interactions.map((interaction) => (
+            <Box
+              key={interaction.uri}
+              sx={{
+                p: 1.5,
+                borderRadius: 1,
+                bgcolor: "action.hover",
+              }}
+            >
+              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                <Chip
+                  label={getInteractionLabel(interaction.interaction_type)}
+                  size="small"
+                  color="primary"
+                  variant="outlined"
+                />
+                <Typography variant="body2">
+                  {getDirectionLabel(
+                    interaction.direction,
+                    interaction.subject_a_taxon_name || "Subject A",
+                    interaction.subject_b_taxon_name || "Subject B"
+                  )}
+                </Typography>
+                {interaction.confidence && (
+                  <Chip
+                    label={interaction.confidence}
+                    size="small"
+                    variant="outlined"
+                    sx={{ textTransform: "capitalize" }}
+                  />
+                )}
+              </Stack>
+              {interaction.comment && (
+                <Typography variant="body2" color="text.secondary" sx={{ mt: 1 }}>
+                  {interaction.comment}
+                </Typography>
+              )}
+              <Stack direction="row" spacing={1} alignItems="center" sx={{ mt: 1 }}>
+                {interaction.creator && (
+                  <>
+                    <Avatar
+                      src={interaction.creator.avatar}
+                      alt={interaction.creator.displayName || interaction.creator.handle}
+                      sx={{ width: 20, height: 20 }}
+                    />
+                    <Typography variant="caption" color="text.secondary">
+                      {interaction.creator.displayName || interaction.creator.handle}
+                    </Typography>
+                  </>
+                )}
+                <Typography variant="caption" color="text.secondary">
+                  {formatDate(interaction.created_at)}
+                </Typography>
+              </Stack>
+            </Box>
+          ))}
+        </Stack>
+      ) : (
+        !showForm && (
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            No interactions documented yet.
+          </Typography>
+        )
+      )}
+
+      {/* Add interaction form */}
+      {showForm && user && (
+        <Box sx={{ mt: 2 }}>
+          <Divider sx={{ mb: 2 }} />
+
+          {error && (
+            <Alert severity="error" sx={{ mb: 2 }} onClose={() => setError(null)}>
+              {error}
+            </Alert>
+          )}
+
+          <Stack spacing={2}>
+            {/* Subject A - select from occurrence subjects */}
+            {subjects.length > 1 && (
+              <FormControl size="small" fullWidth>
+                <InputLabel>Subject A (this observation)</InputLabel>
+                <Select
+                  value={subjectAIndex}
+                  label="Subject A (this observation)"
+                  onChange={(e) => setSubjectAIndex(Number(e.target.value))}
+                >
+                  {subjects.map((subject) => (
+                    <MenuItem key={subject.index} value={subject.index}>
+                      Subject {subject.index + 1}
+                      {subject.communityId && ` - ${subject.communityId}`}
+                    </MenuItem>
+                  ))}
+                </Select>
+              </FormControl>
+            )}
+
+            {/* Subject B - taxon name input */}
+            <Box>
+              <TextField
+                size="small"
+                fullWidth
+                label="Other organism (Subject B)"
+                placeholder="Start typing to search..."
+                value={subjectBTaxon}
+                onChange={(e) => handleTaxonSearch(e.target.value)}
+              />
+              {taxonSuggestions.length > 0 && (
+                <Paper
+                  sx={{
+                    mt: 0.5,
+                    maxHeight: 200,
+                    overflow: "auto",
+                    position: "absolute",
+                    zIndex: 10,
+                    width: "calc(100% - 32px)",
+                  }}
+                >
+                  {taxonSuggestions.map((taxon) => (
+                    <Box
+                      key={taxon.id}
+                      sx={{
+                        p: 1,
+                        cursor: "pointer",
+                        "&:hover": { bgcolor: "action.hover" },
+                      }}
+                      onClick={() => handleSelectTaxon(taxon)}
+                    >
+                      <Typography variant="body2" sx={{ fontStyle: "italic" }}>
+                        {taxon.scientificName}
+                      </Typography>
+                      {taxon.commonName && (
+                        <Typography variant="caption" color="text.secondary">
+                          {taxon.commonName}
+                        </Typography>
+                      )}
+                    </Box>
+                  ))}
+                </Paper>
+              )}
+            </Box>
+
+            {/* Interaction type */}
+            <FormControl size="small" fullWidth>
+              <InputLabel>Interaction Type</InputLabel>
+              <Select
+                value={interactionType}
+                label="Interaction Type"
+                onChange={(e) => setInteractionType(e.target.value)}
+              >
+                {INTERACTION_TYPES.map((type) => (
+                  <MenuItem key={type.value} value={type.value}>
+                    <Stack>
+                      <Typography>{type.label}</Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {type.description}
+                      </Typography>
+                    </Stack>
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {/* Direction */}
+            <FormControl size="small" fullWidth>
+              <InputLabel>Direction</InputLabel>
+              <Select
+                value={direction}
+                label="Direction"
+                onChange={(e) => setDirection(e.target.value as typeof direction)}
+              >
+                {DIRECTION_OPTIONS.map((opt) => (
+                  <MenuItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {/* Confidence */}
+            <FormControl size="small" fullWidth>
+              <InputLabel>Confidence</InputLabel>
+              <Select
+                value={confidence}
+                label="Confidence"
+                onChange={(e) => setConfidence(e.target.value as typeof confidence)}
+              >
+                {CONFIDENCE_OPTIONS.map((opt) => (
+                  <MenuItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+
+            {/* Comment */}
+            <TextField
+              size="small"
+              fullWidth
+              multiline
+              rows={2}
+              label="Comment (optional)"
+              placeholder="Describe the interaction..."
+              value={comment}
+              onChange={(e) => setComment(e.target.value)}
+            />
+
+            {/* Actions */}
+            <Stack direction="row" spacing={1} justifyContent="flex-end">
+              <Button
+                size="small"
+                onClick={() => {
+                  setShowForm(false);
+                  setError(null);
+                }}
+              >
+                Cancel
+              </Button>
+              <Button
+                size="small"
+                variant="contained"
+                onClick={handleSubmit}
+                disabled={submitting || !subjectBTaxon.trim()}
+              >
+                {submitting ? <CircularProgress size={20} /> : "Add Interaction"}
+              </Button>
+            </Stack>
+          </Stack>
+        </Box>
+      )}
+
+      {!user && !showForm && (
+        <Typography variant="body2" color="text.secondary" sx={{ textAlign: "center" }}>
+          Log in to add interactions
+        </Typography>
+      )}
+    </Paper>
+  );
+}

--- a/packages/observing-frontend/src/components/observation/ObservationDetail.tsx
+++ b/packages/observing-frontend/src/components/observation/ObservationDetail.tsx
@@ -29,6 +29,7 @@ import type { Occurrence, Identification, Comment } from "../../services/types";
 import { IdentificationPanel } from "../identification/IdentificationPanel";
 import { IdentificationHistory } from "../identification/IdentificationHistory";
 import { CommentSection } from "../comment/CommentSection";
+import { InteractionPanel } from "../interaction/InteractionPanel";
 import { LocationMap } from "../map/LocationMap";
 import { TaxonLink } from "../common/TaxonLink";
 import { ObservationDetailSkeleton } from "../common/Skeletons";
@@ -519,6 +520,18 @@ export function ObservationDetail() {
               </Typography>
             </Paper>
           )}
+
+          {/* Interactions Panel */}
+          <InteractionPanel
+            observation={{
+              uri: observation.uri,
+              cid: observation.cid,
+              scientificName: observation.scientificName,
+              communityId: currentSubject?.communityId || observation.communityId,
+            }}
+            subjects={observation.subjects || [{ index: 0, identificationCount: 0 }]}
+            onSuccess={handleIdentificationSuccess}
+          />
         </Box>
 
         {/* Discussion / Comments */}

--- a/packages/observing-frontend/src/services/api.ts
+++ b/packages/observing-frontend/src/services/api.ts
@@ -374,3 +374,84 @@ export async function fetchTaxonObservations(
 
   return response.json();
 }
+
+// ============================================================================
+// Interaction API Functions
+// ============================================================================
+
+export interface InteractionResponse {
+  uri: string;
+  cid: string;
+  did: string;
+  subject_a_occurrence_uri: string | null;
+  subject_a_occurrence_cid: string | null;
+  subject_a_subject_index: number;
+  subject_a_taxon_name: string | null;
+  subject_a_kingdom: string | null;
+  subject_b_occurrence_uri: string | null;
+  subject_b_occurrence_cid: string | null;
+  subject_b_subject_index: number;
+  subject_b_taxon_name: string | null;
+  subject_b_kingdom: string | null;
+  interaction_type: string;
+  direction: string;
+  confidence: string | null;
+  comment: string | null;
+  created_at: string;
+  creator?: {
+    did: string;
+    handle?: string;
+    displayName?: string;
+    avatar?: string;
+  };
+}
+
+export async function submitInteraction(data: {
+  subjectA: {
+    occurrenceUri?: string;
+    occurrenceCid?: string;
+    subjectIndex?: number;
+    taxonName?: string;
+    kingdom?: string;
+  };
+  subjectB: {
+    occurrenceUri?: string;
+    occurrenceCid?: string;
+    subjectIndex?: number;
+    taxonName?: string;
+    kingdom?: string;
+  };
+  interactionType: string;
+  direction: "AtoB" | "BtoA" | "bidirectional";
+  confidence?: "low" | "medium" | "high";
+  comment?: string;
+}): Promise<{ uri: string; cid: string }> {
+  const response = await fetch(`${API_BASE}/api/interactions`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    credentials: "include",
+    body: JSON.stringify(data),
+  });
+
+  if (!response.ok) {
+    const error = await response.json();
+    throw new Error(error.error || "Failed to submit interaction");
+  }
+
+  return response.json();
+}
+
+export async function fetchInteractionsForOccurrence(
+  occurrenceUri: string
+): Promise<{ interactions: InteractionResponse[] }> {
+  const response = await fetch(
+    `${API_BASE}/api/interactions/occurrence/${encodeURIComponent(occurrenceUri)}`
+  );
+  if (!response.ok) {
+    throw new Error("Failed to fetch interactions");
+  }
+
+  return response.json();
+}

--- a/packages/observing-frontend/src/services/types.ts
+++ b/packages/observing-frontend/src/services/types.ts
@@ -16,6 +16,8 @@ export type {
   Occurrence,
   Identification,
   Comment,
+  Interaction,
+  InteractionSubject,
 
   // Request/Response types
   CreateOccurrenceRequest,
@@ -23,6 +25,7 @@ export type {
   OccurrenceDetailResponse,
   CreateIdentificationRequest,
   CreateCommentRequest,
+  CreateInteractionRequest,
 
   // Feed types
   FeedFilters,

--- a/packages/observing-shared/src/index.ts
+++ b/packages/observing-shared/src/index.ts
@@ -9,7 +9,7 @@ export * from "./types.js";
 export * from "./schemas/index.js";
 
 // Database
-export { Database, type OccurrenceRow, type IdentificationRow, type CommentRow, type ObservationRow } from "./database/index.js";
+export { Database, type OccurrenceRow, type IdentificationRow, type CommentRow, type InteractionRow, type ObservationRow } from "./database/index.js";
 
 // Services
 export { TaxonomyClient, type TaxonResult, type TaxonDetail as TaxonDetailService, type TaxonAncestor as TaxonAncestorService, type TaxonDescription, type TaxonReference, type TaxonMedia, type ValidationResult, type ConservationStatus as ConservationStatusService, type IUCNCategory as IUCNCategoryService } from "./services/taxonomy.js";

--- a/packages/observing-shared/src/schemas/index.ts
+++ b/packages/observing-shared/src/schemas/index.ts
@@ -213,6 +213,47 @@ export const CreateCommentRequestSchema = z
   .openapi("CreateCommentRequest");
 
 // ============================================================================
+// Interaction Schemas
+// ============================================================================
+
+export const InteractionSubjectSchema = z
+  .object({
+    occurrenceUri: z.string().optional().describe("URI of the related occurrence"),
+    occurrenceCid: z.string().optional().describe("CID of the related occurrence"),
+    subjectIndex: z.number().int().min(0).max(99).default(0).describe("Subject index within the occurrence"),
+    taxonName: z.string().max(256).optional().describe("Scientific name of the organism"),
+    kingdom: z.string().max(64).optional().describe("Taxonomic kingdom"),
+  })
+  .openapi("InteractionSubject");
+
+export const InteractionSchema = z
+  .object({
+    uri: z.string(),
+    cid: z.string(),
+    did: z.string(),
+    subjectA: InteractionSubjectSchema,
+    subjectB: InteractionSubjectSchema,
+    interactionType: z.string(),
+    direction: z.enum(["AtoB", "BtoA", "bidirectional"]),
+    confidence: z.enum(["low", "medium", "high"]).optional(),
+    comment: z.string().optional(),
+    createdAt: z.string().datetime(),
+    creator: ProfileSchema.optional(),
+  })
+  .openapi("Interaction");
+
+export const CreateInteractionRequestSchema = z
+  .object({
+    subjectA: InteractionSubjectSchema,
+    subjectB: InteractionSubjectSchema,
+    interactionType: z.string().max(64),
+    direction: z.enum(["AtoB", "BtoA", "bidirectional"]).default("AtoB"),
+    confidence: z.enum(["low", "medium", "high"]).default("medium"),
+    comment: z.string().max(3000).optional(),
+  })
+  .openapi("CreateInteractionRequest");
+
+// ============================================================================
 // Feed Schemas
 // ============================================================================
 
@@ -406,6 +447,9 @@ export type Identification = z.infer<typeof IdentificationSchema>;
 export type CreateIdentificationRequest = z.infer<typeof CreateIdentificationRequestSchema>;
 export type Comment = z.infer<typeof CommentSchema>;
 export type CreateCommentRequest = z.infer<typeof CreateCommentRequestSchema>;
+export type InteractionSubject = z.infer<typeof InteractionSubjectSchema>;
+export type Interaction = z.infer<typeof InteractionSchema>;
+export type CreateInteractionRequest = z.infer<typeof CreateInteractionRequestSchema>;
 export type FeedFilters = z.infer<typeof FeedFiltersSchema>;
 export type FeedResponse = z.infer<typeof FeedResponseSchema>;
 export type ExploreFeedResponse = z.infer<typeof ExploreFeedResponseSchema>;

--- a/packages/observing-shared/src/types.ts
+++ b/packages/observing-shared/src/types.ts
@@ -118,5 +118,40 @@ export interface CommentRow {
   created_at: Date;
 }
 
+export interface InteractionRow {
+  uri: string;
+  cid: string;
+  did: string;
+  // Subject A
+  subject_a_occurrence_uri: string | null;
+  subject_a_occurrence_cid: string | null;
+  subject_a_subject_index: number;
+  subject_a_taxon_name: string | null;
+  subject_a_kingdom: string | null;
+  // Subject B
+  subject_b_occurrence_uri: string | null;
+  subject_b_occurrence_cid: string | null;
+  subject_b_subject_index: number;
+  subject_b_taxon_name: string | null;
+  subject_b_kingdom: string | null;
+  // Interaction details
+  interaction_type: string;
+  direction: string;
+  confidence: string | null;
+  comment: string | null;
+  created_at: Date;
+  indexed_at: Date;
+}
+
+export interface InteractionEvent {
+  did: string;
+  uri: string;
+  cid: string;
+  action: "create" | "update" | "delete";
+  record?: unknown;
+  seq: number;
+  time: string;
+}
+
 // Legacy type aliases
 export type ObservationRow = OccurrenceRow;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -50,8 +50,10 @@ model Occurrence {
   createdAt                     DateTime @map("created_at")
   indexedAt                     DateTime @default(now()) @map("indexed_at")
 
-  identifications Identification[]
-  comments        Comment[]
+  identifications  Identification[]
+  comments         Comment[]
+  interactionsAsA  Interaction[]    @relation("InteractionSubjectA")
+  interactionsAsB  Interaction[]    @relation("InteractionSubjectB")
 
   @@index([location], name: "occurrences_location_idx", type: Gist)
   @@index([scientificName], name: "occurrences_scientific_name_idx")
@@ -103,4 +105,35 @@ model Comment {
   @@index([did], name: "comments_did_idx")
   @@index([replyToUri], name: "comments_reply_to_uri_idx")
   @@map("comments")
+}
+
+model Interaction {
+  uri                    String   @id
+  cid                    String
+  did                    String
+  subjectAOccurrenceUri  String?  @map("subject_a_occurrence_uri")
+  subjectAOccurrenceCid  String?  @map("subject_a_occurrence_cid")
+  subjectASubjectIndex   Int      @default(0) @map("subject_a_subject_index")
+  subjectATaxonName      String?  @map("subject_a_taxon_name")
+  subjectAKingdom        String?  @map("subject_a_kingdom")
+  subjectBOccurrenceUri  String?  @map("subject_b_occurrence_uri")
+  subjectBOccurrenceCid  String?  @map("subject_b_occurrence_cid")
+  subjectBSubjectIndex   Int      @default(0) @map("subject_b_subject_index")
+  subjectBTaxonName      String?  @map("subject_b_taxon_name")
+  subjectBKingdom        String?  @map("subject_b_kingdom")
+  interactionType        String   @map("interaction_type")
+  direction              String   @default("AtoB")
+  confidence             String?
+  comment                String?
+  createdAt              DateTime @map("created_at")
+  indexedAt              DateTime @default(now()) @map("indexed_at")
+
+  occurrenceA Occurrence? @relation("InteractionSubjectA", fields: [subjectAOccurrenceUri], references: [uri], onDelete: Cascade)
+  occurrenceB Occurrence? @relation("InteractionSubjectB", fields: [subjectBOccurrenceUri], references: [uri], onDelete: Cascade)
+
+  @@index([did], name: "interactions_did_idx")
+  @@index([subjectAOccurrenceUri], name: "interactions_subject_a_occurrence_idx")
+  @@index([subjectBOccurrenceUri], name: "interactions_subject_b_occurrence_idx")
+  @@index([interactionType], name: "interactions_type_idx")
+  @@map("interactions")
 }


### PR DESCRIPTION
## Summary

- Add lexicon schema for `org.rwell.test.interaction` record type defining species interactions
- Add interactions table schema and database methods in both Prisma and raw SQL
- Update Rust ingester to handle interaction events from the AT Protocol firehose
- Add API routes (`POST /api/interactions`, `GET /api/interactions/occurrence/:uri`)
- Add InteractionPanel component to observation detail page for viewing and creating interactions
- Support flexible subject references - interactions can reference an occurrence or just a taxon name

## Test plan

- [ ] Verify interactions table is created via Prisma migration
- [ ] Test creating an interaction via the UI on an observation detail page
- [ ] Verify interactions are displayed correctly after creation
- [ ] Test that ingester correctly processes interaction events from firehose