### PR TITLE
Add coordinate uncertainty circle feature

### DIFF
--- a/packages/observing-appview/src/api.ts
+++ b/packages/observing-appview/src/api.ts
@@ -288,6 +288,7 @@ export class AppViewServer {
           scientificName,
           latitude,
           longitude,
+          coordinateUncertaintyInMeters,
           notes,
           license,
           eventDate,
@@ -378,9 +379,9 @@ export class AppViewServer {
         const location: org.rwell.test.occurrence.Location = {
           decimalLatitude: String(latitude),
           decimalLongitude: String(longitude),
-          coordinateUncertaintyInMeters: 50,
           geodeticDatum: "WGS84",
           // Darwin Core administrative geography from geocoding
+          ...(coordinateUncertaintyInMeters && { coordinateUncertaintyInMeters }),
           ...(geocoded.continent && { continent: geocoded.continent }),
           ...(geocoded.country && { country: geocoded.country }),
           ...(geocoded.countryCode && { countryCode: geocoded.countryCode }),
@@ -462,6 +463,7 @@ export class AppViewServer {
           scientificName,
           latitude,
           longitude,
+          coordinateUncertaintyInMeters,
           notes,
           license,
           eventDate,
@@ -546,9 +548,9 @@ export class AppViewServer {
         const location: org.rwell.test.occurrence.Location = {
           decimalLatitude: String(latitude),
           decimalLongitude: String(longitude),
-          coordinateUncertaintyInMeters: 50,
           geodeticDatum: "WGS84",
           // Darwin Core administrative geography from geocoding
+          ...(coordinateUncertaintyInMeters && { coordinateUncertaintyInMeters }),
           ...(geocoded.continent && { continent: geocoded.continent }),
           ...(geocoded.country && { country: geocoded.country }),
           ...(geocoded.countryCode && { countryCode: geocoded.countryCode }),

--- a/packages/observing-frontend/src/components/modals/UploadModal.tsx
+++ b/packages/observing-frontend/src/components/modals/UploadModal.tsx
@@ -84,6 +84,7 @@ export function UploadModal() {
   const [coObserverInput, setCoObserverInput] = useState("");
   const [photoDate, setPhotoDate] = useState<Date | null>(null);
   const [usePhotoDate, setUsePhotoDate] = useState(false);
+  const [uncertaintyMeters, setUncertaintyMeters] = useState(50);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const MAX_IMAGES = 10;
@@ -98,6 +99,9 @@ export function UploadModal() {
         if (editingObservation.location) {
           setLat(editingObservation.location.latitude.toFixed(6));
           setLng(editingObservation.location.longitude.toFixed(6));
+          if (editingObservation.location.uncertaintyMeters) {
+            setUncertaintyMeters(editingObservation.location.uncertaintyMeters);
+          }
         }
       } else if (currentLocation) {
         setLat(currentLocation.lat.toFixed(6));
@@ -129,6 +133,7 @@ export function UploadModal() {
     setCoObserverInput("");
     setPhotoDate(null);
     setUsePhotoDate(false);
+    setUncertaintyMeters(50);
   };
 
   const handleAddCoObserver = () => {
@@ -309,6 +314,7 @@ export function UploadModal() {
           scientificName: species.trim() || undefined,
           latitude: parseFloat(lat),
           longitude: parseFloat(lng),
+          coordinateUncertaintyInMeters: uncertaintyMeters,
           notes: notes || undefined,
           license,
           eventDate: editingObservation.eventDate || new Date().toISOString(),
@@ -334,6 +340,7 @@ export function UploadModal() {
           scientificName: species.trim() || undefined,
           latitude: parseFloat(lat),
           longitude: parseFloat(lng),
+          coordinateUncertaintyInMeters: uncertaintyMeters,
           notes: notes || undefined,
           license,
           eventDate,
@@ -669,6 +676,8 @@ export function UploadModal() {
             latitude={parseFloat(lat)}
             longitude={parseFloat(lng)}
             onChange={handleLocationChange}
+            uncertaintyMeters={uncertaintyMeters}
+            onUncertaintyChange={setUncertaintyMeters}
           />
         )}
 

--- a/packages/observing-frontend/src/services/api.ts
+++ b/packages/observing-frontend/src/services/api.ts
@@ -176,9 +176,10 @@ export async function searchTaxa(query: string): Promise<TaxaResult[]> {
 }
 
 export async function submitObservation(data: {
-  scientificName: string;
+  scientificName?: string;
   latitude: number;
   longitude: number;
+  coordinateUncertaintyInMeters?: number;
   notes?: string;
   license?: string;
   eventDate: string;
@@ -215,9 +216,10 @@ export async function submitObservation(data: {
 
 export async function updateObservation(data: {
   uri: string;
-  scientificName: string;
+  scientificName?: string;
   latitude: number;
   longitude: number;
+  coordinateUncertaintyInMeters?: number;
   notes?: string;
   license?: string;
   eventDate: string;

--- a/packages/observing-shared/src/schemas/index.ts
+++ b/packages/observing-shared/src/schemas/index.ts
@@ -107,6 +107,7 @@ export const CreateOccurrenceRequestSchema = z
     scientificName: z.string().optional(),
     latitude: z.number().min(-90).max(90),
     longitude: z.number().min(-180).max(180),
+    coordinateUncertaintyInMeters: z.number().min(1).max(500000).optional().describe("Coordinate uncertainty in meters"),
     notes: z.string().optional(),
     license: z.string().optional(),
     eventDate: z.string().datetime().optional(),


### PR DESCRIPTION
## Summary
- Add interactive slider (1m-500km) to specify coordinate uncertainty when creating observations
- Visualize uncertainty as a green circle on the map that updates in real-time
- Store the value in the AT Protocol lexicon's `coordinateUncertaintyInMeters` field
- Pre-populate uncertainty when editing existing observations

## Test plan
- [ ] Open New Observation modal and verify uncertainty slider appears below the map
- [ ] Drag slider and verify circle on map updates in real-time
- [ ] Submit observation with non-default uncertainty (e.g., 10km)
- [ ] Verify AT Protocol record contains correct `coordinateUncertaintyInMeters` value
- [ ] Edit an existing observation and verify uncertainty is pre-populated