### PR TITLE
Simplify CI workflow deploy conditions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
   build-images:
     runs-on: ubuntu-latest
     needs: [npm-audit, check-ts-bindings, typecheck-scripts, build, rust-fmt, rust-audit, rust-clippy, rust-sqlx, rust-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: github.event_name == 'push'
     strategy:
       matrix:
         include:
@@ -143,7 +143,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     needs: [build-images]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     environment:
       name: production
       url: ${{ steps.deploy-appview.outputs.url }}


### PR DESCRIPTION
The `on.push.branches: [main]` filter already restricts pushes to main, so the `github.ref` check is redundant. The deploy job inherits the gate from build-images via `needs:`, so its own `if:` is also unnecessary.