### PR TITLE
Fix HTML entity decoding in Wikimedia Commons attribution

### DIFF
--- a/frontend/src/components/common/WikiCommonsGallery.test.ts
+++ b/frontend/src/components/common/WikiCommonsGallery.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { decodeHtmlText } from "./WikiCommonsGallery.js";
+
+describe("decodeHtmlText", () => {
+  it("decodes &amp; entity", () => {
+    expect(decodeHtmlText("Andy Reago &amp; Chrissy McClarren")).toBe(
+      "Andy Reago & Chrissy McClarren",
+    );
+  });
+
+  it("decodes other common entities", () => {
+    expect(decodeHtmlText("&lt;script&gt;")).toBe("<script>");
+    expect(decodeHtmlText("O&#39;Brien")).toBe("O'Brien");
+    expect(decodeHtmlText("&quot;quoted&quot;")).toBe('"quoted"');
+  });
+
+  it("strips HTML tags and decodes entities", () => {
+    expect(
+      decodeHtmlText('<a href="https://example.com">John &amp; Jane</a>'),
+    ).toBe("John & Jane");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(decodeHtmlText("")).toBe("");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(decodeHtmlText("John Smith")).toBe("John Smith");
+  });
+});


### PR DESCRIPTION
## Summary
- Wikimedia Commons artist attribution showed raw HTML entities (e.g. `Andy Reago &amp; Chrissy McClarren` instead of `Andy Reago & Chrissy McClarren`)
- Extracted a `decodeHtmlText` helper that strips HTML tags and decodes entities (named, decimal, and hex)
- Added regression tests for the helper

## Test plan
- [x] `npx vitest run frontend/src/components/common/WikiCommonsGallery.test.ts` — 5 tests pass
- [x] `npx tsc` — no type errors