### PR TITLE
feat: add observation date picker to upload modal

### DIFF
--- a/e2e/tests/upload.spec.ts
+++ b/e2e/tests/upload.spec.ts
@@ -96,6 +96,21 @@ authTest.describe("Upload Modal - Logged In", () => {
     ).toBeVisible({ timeout: 5000 });
   });
 
+  // TC-UPLOAD-017: Observation date picker
+  authTest("upload modal shows observation date picker defaulting to today", async ({
+    authenticatedPage: page,
+  }) => {
+    await page.goto("/");
+    await openUploadModal(page);
+    const dateInput = page.getByLabel("Observation date");
+    await authExpect(dateInput).toBeVisible();
+    const value = await dateInput.inputValue();
+    // Date input uses local time, so compare with local date
+    const now = new Date();
+    const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(now.getDate()).padStart(2, "0")}`;
+    authExpect(value.startsWith(today)).toBeTruthy();
+  });
+
   // TC-UPLOAD-016: Invalid image file type
   authTest("file input only accepts image types", async ({
     authenticatedPage: page,


### PR DESCRIPTION
## Summary
- Replaces the conditional EXIF-only date checkbox with an always-visible `datetime-local` picker in the upload modal
- Defaults to current date/time; auto-fills from photo EXIF when available
- Pre-fills with existing event date when editing an observation
- Adds e2e test verifying the date picker is visible and defaults to today

## Motivation
Biodiversity data quality depends critically on accurate observation dates. Previously, users could only get a correct date if their photo had EXIF metadata — observations from field notes, old photos, or past sightings were silently recorded as "today." This brings the platform closer to scientific data standards (comparable platforms like iNaturalist always show a date picker).

## Test plan
- [x] All 55 e2e tests pass (54 existing + 1 new)
- [x] `npx tsc` passes with no errors
- [x] New test verifies date picker is visible and defaults to today's date
- [x] EXIF date extraction still works (sets picker value + shows toast)
- [x] Edit mode pre-fills with existing observation date