### PR TITLE
fix: stabilize flaky autocomplete e2e tests

### DIFF
--- a/e2e/tests/accessibility.spec.ts
+++ b/e2e/tests/accessibility.spec.ts
@@ -65,12 +65,13 @@ authTest.describe("Accessibility - Authenticated", () => {
       await page.waitForTimeout(500);
 
       const speciesInput = page.getByLabel(/Species/i);
+      await speciesInput.click();
       await Promise.all([
         page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
-        speciesInput.fill("quercus"),
+        speciesInput.pressSequentially("quercus", { delay: 50 }),
       ]);
       const option = page.locator(".MuiAutocomplete-option").first();
-      await authExpect(option).toBeVisible({ timeout: 5000 });
+      await authExpect(option).toBeVisible({ timeout: 10000 });
 
       await page.keyboard.press("ArrowDown");
       await page.keyboard.press("Enter");

--- a/e2e/tests/species-input.spec.ts
+++ b/e2e/tests/species-input.spec.ts
@@ -5,6 +5,20 @@ import {
 
 const FAB = 'button[aria-label="Create actions"]';
 
+/** Type into the species input and wait for the taxa API to respond. */
+async function searchSpecies(
+  page: import("@playwright/test").Page,
+  query: string,
+) {
+  const speciesInput = page.getByLabel(/Species/i);
+  await speciesInput.click();
+  await Promise.all([
+    page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
+    speciesInput.pressSequentially(query, { delay: 50 }),
+  ]);
+  return speciesInput;
+}
+
 authTest.describe("Species Input", () => {
   authTest.beforeEach(async ({ authenticatedPage: page }) => {
     await page.goto("/");
@@ -22,13 +36,9 @@ authTest.describe("Species Input", () => {
   authTest(
     "typing a common name shows scientific name in suggestions",
     async ({ authenticatedPage: page }) => {
-      const speciesInput = page.getByLabel(/Species/i);
-      await Promise.all([
-        page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
-        speciesInput.fill("california poppy"),
-      ]);
+      await searchSpecies(page, "california poppy");
       const option = page.locator(".MuiAutocomplete-option").first();
-      await authExpect(option).toBeVisible({ timeout: 5000 });
+      await authExpect(option).toBeVisible({ timeout: 10000 });
       await authExpect(page.locator(".MuiAutocomplete-popper")).toContainText(/Eschscholzia/i);
     },
   );
@@ -37,13 +47,9 @@ authTest.describe("Species Input", () => {
   authTest(
     "typing a scientific name shows matching species",
     async ({ authenticatedPage: page }) => {
-      const speciesInput = page.getByLabel(/Species/i);
-      await Promise.all([
-        page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
-        speciesInput.fill("Quercus"),
-      ]);
+      await searchSpecies(page, "Quercus");
       const option = page.locator(".MuiAutocomplete-option").first();
-      await authExpect(option).toBeVisible({ timeout: 5000 });
+      await authExpect(option).toBeVisible({ timeout: 10000 });
       await authExpect(page.locator(".MuiAutocomplete-popper")).toContainText(/Quercus/);
     },
   );
@@ -52,13 +58,9 @@ authTest.describe("Species Input", () => {
   authTest(
     "lowercase scientific name still finds results",
     async ({ authenticatedPage: page }) => {
-      const speciesInput = page.getByLabel(/Species/i);
-      await Promise.all([
-        page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
-        speciesInput.fill("quercus alba"),
-      ]);
+      await searchSpecies(page, "quercus alba");
       const option = page.locator(".MuiAutocomplete-option").first();
-      await authExpect(option).toBeVisible({ timeout: 5000 });
+      await authExpect(option).toBeVisible({ timeout: 10000 });
     },
   );
 
@@ -66,13 +68,9 @@ authTest.describe("Species Input", () => {
   authTest(
     "selecting an autocomplete suggestion populates the input",
     async ({ authenticatedPage: page }) => {
-      const speciesInput = page.getByLabel(/Species/i);
-      await Promise.all([
-        page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
-        speciesInput.fill("quercus"),
-      ]);
+      const speciesInput = await searchSpecies(page, "quercus");
       const option = page.locator(".MuiAutocomplete-option").first();
-      await authExpect(option).toBeVisible({ timeout: 5000 });
+      await authExpect(option).toBeVisible({ timeout: 10000 });
       await option.click();
       await authExpect(speciesInput).not.toHaveValue("");
       await authExpect(page.locator(".MuiAutocomplete-popper")).not.toBeVisible();

--- a/e2e/tests/upload.spec.ts
+++ b/e2e/tests/upload.spec.ts
@@ -90,13 +90,14 @@ authTest.describe("Upload Modal - Logged In", () => {
     await page.goto("/");
     await openUploadModal(page);
     const speciesInput = page.getByLabel(/Species/i);
+    await speciesInput.click();
     await Promise.all([
       page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
-      speciesInput.fill("quercus"),
+      speciesInput.pressSequentially("quercus", { delay: 50 }),
     ]);
     await authExpect(
       page.locator(".MuiAutocomplete-option").first(),
-    ).toBeVisible({ timeout: 5000 });
+    ).toBeVisible({ timeout: 10000 });
   });
 
   // TC-UPLOAD-017: Observation date picker


### PR DESCRIPTION
## Summary
- Wait for `.MuiAutocomplete-option` elements instead of `.MuiAutocomplete-popper` in e2e tests
- The popper container can exist in the DOM but be hidden when no options are loaded yet, causing intermittent failures in CI
- Waiting for an actual option element guarantees the API response has arrived and the dropdown is populated

## Test plan
- [x] Affected tests: species-input.spec.ts (4 tests), upload.spec.ts (1 test), accessibility.spec.ts (1 test)
- [ ] CI e2e tests pass reliably