### PR TITLE
Hide test account from production feeds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -228,7 +228,7 @@ jobs:
             --region=$REGION \
             --allow-unauthenticated \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,MEDIA_PROXY_URL=$MEDIA_PROXY_URL,TAXONOMY_SERVICE_URL=$TAXONOMY_URL \
+            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,MEDIA_PROXY_URL=$MEDIA_PROXY_URL,TAXONOMY_SERVICE_URL=$TAXONOMY_URL,HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b \
             --set-secrets=DB_PASSWORD=observing-db-password:latest \
             --format='value(status.url)')
           echo "url=$URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Add `HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b` to the appview Cloud Run deploy env vars
- Requires the `fix/hide-test-account-from-feeds` branch to be merged first (adds `HIDDEN_DIDS` support to the appview)

## Test plan
- [x] Merge `fix/hide-test-account-from-feeds` first
- [x] Verify test account observations no longer appear in production feeds