### PR TITLE
Exclude target/ and test artifacts from Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,7 +1,14 @@
+target
 node_modules
 dist
 .git
 .github
+.claude
+.playwright-mcp
+playwright
+playwright-report
+e2e
 *.md
 .env*
+.DS_Store
 cache


### PR DESCRIPTION
## Summary
- Add `target/` to `.dockerignore`
- Also exclude `e2e/`, `playwright/`, `playwright-report/`, `.claude/`, `.playwright-mcp/`, `.DS_Store`

## Test plan
- [x] Verify Docker builds still succeed (no excluded files are needed by Dockerfiles)