### PR TITLE
Ban explicit `any` and replace all occurrences with proper types

### DIFF
--- a/e2e/helpers/mock-observation.ts
+++ b/e2e/helpers/mock-observation.ts
@@ -1,10 +1,11 @@
+import { type Page, type Route } from "@playwright/test";
 import { getTestUser } from "../fixtures/auth";
 
 /**
  * Builds a mock observation object for API responses.
  * Matches the Occurrence type from the Rust-generated bindings.
  */
-export function buildMockObservation(overrides: Record<string, any> = {}) {
+export function buildMockObservation(overrides: Record<string, unknown> = {}) {
   const user = getTestUser();
   return {
     uri: `at://${user.did}/org.observ.ing.occurrence/test123`,
@@ -46,7 +47,7 @@ export function buildMockObservation(overrides: Record<string, any> = {}) {
 /**
  * Builds a full observation detail API response including identifications and comments.
  */
-function buildMockObservationResponse(overrides: Record<string, any> = {}) {
+function buildMockObservationResponse(overrides: Record<string, unknown> = {}) {
   const {
     identifications = [],
     comments = [],
@@ -65,11 +66,11 @@ function buildMockObservationResponse(overrides: Record<string, any> = {}) {
  * Intercepts GET /api/occurrences/* and returns the mocked response.
  */
 export async function mockObservationDetailRoute(
-  page: any,
-  overrides: Record<string, any> = {},
+  page: Page,
+  overrides: Record<string, unknown> = {},
 ) {
   const response = buildMockObservationResponse(overrides);
-  await page.route("**/api/occurrences/*", (route: any) => {
+  await page.route("**/api/occurrences/*", (route: Route) => {
     if (route.request().method() === "GET") {
       return route.fulfill({
         status: 200,
@@ -86,10 +87,10 @@ export async function mockObservationDetailRoute(
  * Sets up page.route() mock for the interactions API endpoint.
  */
 export async function mockInteractionsRoute(
-  page: any,
-  interactions: any[] = [],
+  page: Page,
+  interactions: unknown[] = [],
 ) {
-  await page.route("**/api/interactions/occurrence/*", (route: any) => {
+  await page.route("**/api/interactions/occurrence/*", (route: Route) => {
     return route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -102,14 +103,14 @@ export async function mockInteractionsRoute(
  * Sets up route mocks for all feed endpoints with a single owned observation.
  */
 export async function mockOwnObservationFeed(
-  page: any,
-  overrides: Record<string, any> = {},
+  page: Page,
+  overrides: Record<string, unknown> = {},
 ) {
   const body = JSON.stringify({
     occurrences: [buildMockObservation(overrides)],
     cursor: null,
   });
-  const handler = (route: any) =>
+  const handler = (route: Route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",

--- a/e2e/tests/comments.spec.ts
+++ b/e2e/tests/comments.spec.ts
@@ -1,11 +1,12 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page, type Request } from "@playwright/test";
+import type { Expect } from "@playwright/test";
 import {
   test as authTest,
   expect as authExpect,
 } from "../fixtures/auth";
 
 /** Navigate from the feed to the first observation's detail page. */
-async function navigateToDetail(page: any, expectFn: any) {
+async function navigateToDetail(page: Page, expectFn: Expect) {
   await page.goto("/");
   const card = page
     .locator(".MuiCard-root .MuiCardActionArea-root")
@@ -84,7 +85,7 @@ authTest.describe("Comments - Logged In", () => {
         .fill("This is a test comment");
 
       const postRequest = page.waitForRequest(
-        (req: any) =>
+        (req: Request) =>
           req.method() === "POST" && req.url().includes("/api/comments"),
       );
       await page.getByRole("button", { name: "Post" }).click();

--- a/e2e/tests/identification.spec.ts
+++ b/e2e/tests/identification.spec.ts
@@ -1,4 +1,4 @@
-import { type Page } from "@playwright/test";
+import { type Page, type Request } from "@playwright/test";
 import {
   test as authTest,
   expect as authExpect,
@@ -17,7 +17,7 @@ function muiSelect(page: Page, label: string) {
 }
 
 /** Navigate from the feed to the first observation's detail page. */
-async function navigateToDetail(page: any) {
+async function navigateToDetail(page: Page) {
   await page.goto("/");
   const card = page
     .locator(".MuiCard-root .MuiCardActionArea-root")
@@ -38,7 +38,7 @@ authTest.describe("Identification - Logged In", () => {
       await authExpect(agreeBtn).toBeVisible({ timeout: 10000 });
 
       const postRequest = page.waitForRequest(
-        (req: any) =>
+        (req: Request) =>
           req.method() === "POST" &&
           req.url().includes("/api/identifications"),
       );
@@ -83,7 +83,7 @@ authTest.describe("Identification - Logged In", () => {
       await speciesInput.fill("Quercus rubra");
 
       const postRequest = page.waitForRequest(
-        (req: any) =>
+        (req: Request) =>
           req.method() === "POST" &&
           req.url().includes("/api/identifications"),
       );

--- a/e2e/tests/interactions.spec.ts
+++ b/e2e/tests/interactions.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type Request } from "@playwright/test";
+import type { Expect } from "@playwright/test";
 import {
   test as authTest,
   expect as authExpect,
@@ -17,7 +18,7 @@ function muiSelect(page: Page, label: string) {
 }
 
 /** Navigate from the feed to the first observation's detail page. */
-async function navigateToDetail(page: any, expectFn: any) {
+async function navigateToDetail(page: Page, expectFn: Expect) {
   await page.goto("/");
   const card = page
     .locator(".MuiCard-root .MuiCardActionArea-root")
@@ -89,7 +90,7 @@ authTest.describe("Interactions - Logged In", () => {
         .fill("Apis mellifera");
 
       const postRequest = page.waitForRequest(
-        (req: any) =>
+        (req: Request) =>
           req.method() === "POST" &&
           req.url().includes("/api/interactions"),
       );

--- a/e2e/tests/observation-detail.spec.ts
+++ b/e2e/tests/observation-detail.spec.ts
@@ -1,7 +1,7 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 
 /** Navigate from the feed to the first observation's detail page. */
-async function navigateToDetail(page: any) {
+async function navigateToDetail(page: Page) {
   await page.goto("/");
   const card = page
     .locator(".MuiCard-root .MuiCardActionArea-root")

--- a/e2e/tests/observation-edit.spec.ts
+++ b/e2e/tests/observation-edit.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Route, type Request } from "@playwright/test";
 import {
   test as authTest,
   expect as authExpect,
@@ -71,7 +71,7 @@ authTest.describe("Observation Edit - Logged In", () => {
         occurrences: [otherUserObs],
         cursor: null,
       });
-      const handler = (route: any) =>
+      const handler = (route: Route) =>
         route.fulfill({
           status: 200,
           contentType: "application/json",
@@ -189,7 +189,7 @@ authTest.describe("Observation Edit - Logged In", () => {
       ).toBeVisible({ timeout: 5000 });
 
       const putRequest = page.waitForRequest(
-        (req: any) =>
+        (req: Request) =>
           req.method() === "PUT" &&
           req.url().includes("/api/occurrences"),
       );

--- a/e2e/tests/upload.spec.ts
+++ b/e2e/tests/upload.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import {
   test as authTest,
   expect as authExpect,
@@ -17,7 +17,7 @@ test.describe("Upload Modal - Logged Out", () => {
 });
 
 authTest.describe("Upload Modal - Logged In", () => {
-  async function openUploadModal(page: any) {
+  async function openUploadModal(page: Page) {
     const fab = page.locator(FAB);
     await authExpect(fab).toBeVisible({ timeout: 5000 });
     await fab.click();

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "generate-rust-types": "./scripts/generate-rust-types.sh",
     "frontend:dev": "vite -c frontend/vite.config.ts",
     "frontend:build": "npm run build",
-    "test:e2e": "playwright test --config=e2e/playwright.config.ts"
+    "test:e2e": "playwright test --config=e2e/playwright.config.ts",
+    "lint:no-any": "! grep -rn --include='*.ts' --include='*.tsx' -E ':\\s*any\\b|as any\\b|<any>|any\\[\\]' frontend/src/ scripts/ e2e/"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/scripts/delete-non-inat.ts
+++ b/scripts/delete-non-inat.ts
@@ -39,18 +39,22 @@ async function main() {
     });
 
     for (const rec of resp.data.records) {
-      const val = rec.value as any;
+      const val = rec.value as Record<string, unknown>;
       const rkey = rec.uri.split("/").pop()!;
 
-      if (val.taxonId && val.taxonId.startsWith("inat:")) {
+      const taxonId = val["taxonId"] as string | undefined;
+      const scientificName = val["scientificName"] as string | undefined;
+      const verbatimLocality = val["verbatimLocality"] as string | undefined;
+
+      if (taxonId && taxonId.startsWith("inat:")) {
         toKeep.push(
-          `  KEEP: ${val.scientificName || "Unknown"} (${val.taxonId})`,
+          `  KEEP: ${scientificName || "Unknown"} (${taxonId})`,
         );
       } else {
         toDelete.push({
           uri: rec.uri,
           rkey,
-          name: val.scientificName || val.verbatimLocality || "Unknown",
+          name: scientificName || verbatimLocality || "Unknown",
         });
       }
     }


### PR DESCRIPTION
## Summary
- Replaced all explicit `any` usage across 12 files with proper types
- Added `npm run lint:no-any` script to prevent regressions via grep check
- E2E tests now use Playwright's `Page`, `Route`, `Request`, and `Expect` types
- Frontend components use typed interfaces (`WikiMediaPage`, `WikiMediaImageInfo`)
- Test mocks use `stubOccurrence()` helper and typed `ExploreFeedResponse`/`HomeFeedResponse`
- Scripts use `InatObservation`, `InatIdentification`, `BlobRef` interfaces and `unknown` error handling

## Test plan
- [x] `npx tsc` — no new errors in changed files (pre-existing errors unrelated to this PR)
- [x] `npm run lint:no-any` — passes with zero matches
- [ ] `npm run frontend:build` — verify build succeeds
- [ ] E2E tests pass against running server