### PR TITLE
Remove frontend: prefix from npm scripts

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -39,7 +39,7 @@ export PORT=3000
 npm install
 
 # Build frontend
-npm run frontend:build
+npm run build
 
 # Typecheck frontend
 npx tsc
@@ -102,14 +102,14 @@ cargo run -p observing-media-proxy
 cargo run -p observing-taxonomy
 
 # Frontend dev server
-npm run frontend:dev
+npm run dev
 ```
 
 ### After Frontend Changes
 
 Rebuild and restart:
 ```bash
-npm run frontend:build && process-compose process restart appview
+npm run build && process-compose process restart appview
 ```
 
 The app runs at `http://localhost:3000` (not 5173). Port 3000 serves built files from `dist/public`.

--- a/package.json
+++ b/package.json
@@ -8,8 +8,7 @@
   "scripts": {
     "build": "vite build -c frontend/vite.config.ts",
     "generate-rust-types": "./scripts/generate-rust-types.sh",
-    "frontend:dev": "vite -c frontend/vite.config.ts",
-    "frontend:build": "npm run build",
+    "dev": "vite -c frontend/vite.config.ts",
     "lint": "oxlint frontend/src",
     "test:e2e": "playwright test --config=e2e/playwright.config.ts"
   },

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -24,7 +24,7 @@ processes:
         condition: process_healthy
 
   frontend:
-    command: npm run frontend:dev
+    command: npm run dev
     depends_on:
       appview:
         condition: process_healthy


### PR DESCRIPTION
## Summary
- Renamed `frontend:dev` to `dev` in package.json
- Removed redundant `frontend:build` script (was just an alias for `build`)
- Updated references in process-compose.yaml and docs/development.md

## Test plan
- [x] Verify `npm run dev` starts the Vite dev server
- [x] Verify `npm run build` builds the frontend
- [x] Verify `process-compose up` starts the frontend process correctly