### PR TITLE
chore: modernize CI with cargo-deny, e2e gating, and Artifact Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,14 +73,11 @@ jobs:
           components: rustfmt
       - run: cargo fmt --all -- --check
 
-  rust-audit:
+  rust-deny:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: taiki-e/cache-cargo-install-action@v3
-        with:
-          tool: cargo-audit
-      - run: cargo audit --file Cargo.lock --ignore RUSTSEC-2023-0071
+      - uses: EmbarkStudios/cargo-deny-action@v2
 
   rust-clippy:
     runs-on: ubuntu-latest
@@ -113,6 +110,7 @@ jobs:
 
   # End-to-end tests
   e2e:
+    needs: [lint, typecheck-scripts, build, rust-clippy, rust-test]
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -175,7 +173,7 @@ jobs:
   # Build Docker images in parallel with caching
   build-images:
     runs-on: ubuntu-latest
-    needs: [npm-audit, lint, check-ts-bindings, typecheck-scripts, build, rust-fmt, rust-audit, rust-clippy, rust-sqlx, rust-test, e2e]
+    needs: [npm-audit, lint, check-ts-bindings, typecheck-scripts, build, rust-fmt, rust-deny, rust-clippy, rust-sqlx, rust-test, e2e]
     if: github.event_name == 'push'
     strategy:
       matrix:
@@ -192,16 +190,20 @@ jobs:
           - service: taxonomy
             context: .
             dockerfile: crates/observing-taxonomy/Dockerfile
+    env:
+      REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/observing
     steps:
       - uses: actions/checkout@v4
 
       - uses: docker/setup-buildx-action@v3
 
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+
       - uses: docker/login-action@v3
         with:
-          registry: gcr.io
-          username: _json_key
-          password: ${{ secrets.GCP_SA_KEY }}
+          registry: us-central1-docker.pkg.dev
 
       - name: Build and push ${{ matrix.service }}
         uses: docker/build-push-action@v6
@@ -209,7 +211,7 @@ jobs:
           context: ${{ matrix.context }}
           file: ${{ matrix.dockerfile }}
           push: true
-          tags: gcr.io/${{ secrets.GCP_PROJECT_ID }}/observing-${{ matrix.service }}:latest
+          tags: ${{ env.REGISTRY }}/observing-${{ matrix.service }}:latest
           cache-from: type=gha,scope=${{ matrix.service }}
           cache-to: type=gha,mode=max,scope=${{ matrix.service }}
 
@@ -222,6 +224,7 @@ jobs:
     env:
       PROJECT_ID: ${{ secrets.GCP_PROJECT_ID }}
       REGION: us-central1
+      REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/observing
       PUBLIC_URL: https://observ.ing
       MEDIA_PROXY_URL: https://observing-media-proxy-378013734384.us-central1.run.app
       TAXONOMY_URL: https://observing-taxonomy-378013734384.us-central1.run.app
@@ -236,7 +239,7 @@ jobs:
         id: deploy-appview
         run: |
           URL=$(gcloud run deploy observing-appview \
-            --image=gcr.io/$PROJECT_ID/observing-appview:latest \
+            --image=$REGISTRY/observing-appview:latest \
             --region=$REGION \
             --allow-unauthenticated \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
@@ -248,7 +251,7 @@ jobs:
       - name: Deploy ingester
         run: |
           gcloud run deploy observing-ingester \
-            --image=gcr.io/$PROJECT_ID/observing-ingester:latest \
+            --image=$REGISTRY/observing-ingester:latest \
             --region=$REGION \
             --allow-unauthenticated \
             --cpu=1 \
@@ -263,7 +266,7 @@ jobs:
       - name: Deploy media-proxy
         run: |
           gcloud run deploy observing-media-proxy \
-            --image=gcr.io/$PROJECT_ID/observing-media-proxy:latest \
+            --image=$REGISTRY/observing-media-proxy:latest \
             --region=$REGION \
             --allow-unauthenticated \
             --set-env-vars=RUST_LOG=observing_media_proxy=info,LOG_FORMAT=json
@@ -271,7 +274,7 @@ jobs:
       - name: Deploy taxonomy
         run: |
           gcloud run deploy observing-taxonomy \
-            --image=gcr.io/$PROJECT_ID/observing-taxonomy:latest \
+            --image=$REGISTRY/observing-taxonomy:latest \
             --region=$REGION \
             --allow-unauthenticated \
             --set-env-vars=RUST_LOG=observing_taxonomy=info,LOG_FORMAT=json

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,42 @@
+[advisories]
+ignore = [
+    # rsa crate timing sidechannel (Marvin Attack). No patched version available.
+    # Transitive dependency — we don't use RSA decryption directly.
+    { id = "RUSTSEC-2023-0071", reason = "no fix available, transitive dep only" },
+]
+
+[licenses]
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "MPL-2.0",
+    "Unicode-3.0",
+    "Zlib",
+    "OpenSSL",
+    "Unlicense",
+    "0BSD",
+    "CC0-1.0",
+    "MIT-0",
+    "BSL-1.0",
+    "CDLA-Permissive-2.0",
+    "AGPL-3.0-only",
+]
+confidence-threshold = 0.8
+
+[[licenses.clarify]]
+crate = "ring"
+expression = "MIT AND ISC AND OpenSSL"
+license-files = [{ path = "LICENSE", hash = 0xbd0eed23 }]
+
+[bans]
+multiple-versions = "warn"
+wildcards = "allow"
+
+[sources]
+unknown-registry = "warn"
+unknown-git = "warn"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]


### PR DESCRIPTION
## Summary
- **cargo-deny**: Replace `cargo-audit` with `cargo-deny` (`EmbarkStudios/cargo-deny-action@v2`) for advisory, license, ban, and source checks in one tool. Adds `deny.toml` with an allowlist of 17 permissive licenses and the existing RUSTSEC-2023-0071 ignore (rsa Marvin Attack, no fix available).
- **E2E needs gate**: E2E job now depends on `[lint, typecheck-scripts, build, rust-clippy, rust-test]` so it won't burn CI minutes when basic checks are already failing.
- **Artifact Registry**: Migrate from deprecated `gcr.io` to `us-central1-docker.pkg.dev`. Auth switched to `google-github-actions/auth@v2` + `docker/login-action` (standard AR pattern). Added `REGISTRY` env var to DRY up image references across build and deploy jobs.

## Before merging
Create the Artifact Registry repository in GCP:
```bash
gcloud artifacts repositories create observing \
  --repository-format=docker \
  --location=us-central1 \
  --description="Observing Docker images"
```

## Test plan
- [ ] Verify `rust-deny` job passes (advisories, licenses, bans, sources)
- [ ] Verify e2e job correctly waits for dependent jobs
- [ ] Create AR repo and verify `build-images` pushes successfully
- [ ] Verify deploy job pulls from AR and deploys correctly