### PR TITLE
fix: pass OAuth2 access token to docker login for Artifact Registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,16 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - uses: google-github-actions/auth@v2
+        id: gcp-auth
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
+          token_format: access_token
 
       - uses: docker/login-action@v3
         with:
           registry: us-central1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: Build and push ${{ matrix.service }}
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Fixes the `build-images` CI job failing with "Username and password required" after the gcr.io to Artifact Registry migration (#48)
- Adds `id` and `token_format: access_token` to the `google-github-actions/auth` step
- Passes `oauth2accesstoken` username and the access token to `docker/login-action`

## Test plan
- [ ] CI `build-images` job passes on this PR's merge to main