### PR TITLE
fix: use _json_key for Artifact Registry docker login

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,14 +214,16 @@ jobs:
       - uses: docker/setup-buildx-action@v3
 
       - uses: google-github-actions/auth@v2
+        id: gcp-auth
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
+          token_format: access_token
 
       - uses: docker/login-action@v3
         with:
           registry: us-central1-docker.pkg.dev
-          username: _json_key
-          password: ${{ secrets.GCP_SA_KEY }}
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
 
       - name: Build and push ${{ matrix.service }}
         uses: docker/build-push-action@v6


### PR DESCRIPTION
## Summary
- Fixes the `build-images` CI failure: the service account lacks `iam.serviceAccountTokenCreator` role needed for `token_format: access_token`
- Uses `_json_key` + `GCP_SA_KEY` secret directly for docker login instead, which doesn't require extra IAM permissions

## Test plan
- [ ] CI `build-images` job passes after merge