### PR TITLE
fix: show sidebar for logged-out users beyond landing page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useState } from "react";
-import { BrowserRouter, Routes, Route } from "react-router-dom";
+import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { Provider } from "react-redux";
 import { ThemeProvider, CssBaseline, Box, Alert } from "@mui/material";
 import { getTheme } from "./theme";
@@ -46,10 +46,11 @@ function AppContent() {
     return () => mediaQuery.removeEventListener("change", handleChange);
   }, [dispatch]);
 
-  const showLanding = !user && !isAuthLoading;
+  const location = useLocation();
+  const showLanding = !user && !isAuthLoading && location.pathname === "/";
 
   return (
-    <BrowserRouter>
+    <>
       {!showLanding && (
         <Alert
           severity="warning"
@@ -98,7 +99,7 @@ function AppContent() {
       <UploadModal />
       <DeleteConfirmDialog />
       <ToastContainer />
-    </BrowserRouter>
+    </>
   );
 }
 
@@ -109,7 +110,9 @@ function ThemedApp() {
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />
-      <AppContent />
+      <BrowserRouter>
+        <AppContent />
+      </BrowserRouter>
     </ThemeProvider>
   );
 }


### PR DESCRIPTION
## Summary
- Show the sidebar when logged-out users navigate past the landing page (e.g. clicking "Explore")
- Previously the sidebar was hidden for all unauthenticated pages; now it only hides on the root `/` landing page
- Lifted `BrowserRouter` to `ThemedApp` so `useLocation` can be used to check the current route

## Test plan
- [x] Visit `/` while logged out — landing page renders full-width, no sidebar
- [x] Click "Explore" from landing page — sidebar appears with nav links, theme toggle, and login button
- [x] Visit `/observation/:did/:rkey` while logged out — sidebar visible
- [x] Log in — sidebar and all routes work as before