### PR TITLE
chore: namespace CI job IDs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   # Node.js jobs
-  npm-audit:
+  frontend-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
       - run: npm ci
       - run: npm audit --audit-level=high
 
-  check-ts-bindings:
+  ts-bindings-check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,7 +36,7 @@ jobs:
           npx oxfmt frontend/src/bindings
           git diff --exit-code frontend/src/bindings/
 
-  fmt:
+  ts-fmt:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -47,7 +47,7 @@ jobs:
       - run: npm ci
       - run: npm run fmt:check
 
-  lint:
+  frontend-lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
       - run: npm ci
       - run: npm run lint
 
-  typecheck-scripts:
+  ts-typecheck:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -69,7 +69,7 @@ jobs:
       - run: npm ci
       - run: npx tsc --project tsconfig.json
 
-  build:
+  frontend-build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +189,7 @@ jobs:
   # Build Docker images in parallel with caching
   build-images:
     runs-on: ubuntu-latest
-    needs: [npm-audit, fmt, lint, check-ts-bindings, typecheck-scripts, build, rust-fmt, rust-deny, rust-clippy, rust-sqlx, rust-test, e2e]
+    needs: [frontend-audit, ts-fmt, frontend-lint, ts-bindings-check, ts-typecheck, frontend-build, rust-fmt, rust-deny, rust-clippy, rust-sqlx, rust-test, e2e]
     if: github.event_name == 'push'
     env:
       REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/observing


### PR DESCRIPTION
## Summary
- Prefix frontend/TS CI job IDs for clarity in GitHub checks UI
  - `npm-audit` → `frontend-audit`
  - `check-ts-bindings` → `ts-bindings-check`
  - `fmt` → `ts-fmt` (covers frontend, e2e, and scripts)
  - `lint` → `frontend-lint`
  - `typecheck-scripts` → `ts-typecheck`
  - `build` → `frontend-build`
- Rust jobs already had `rust-` prefix, left as-is
- Updated `build-images` `needs` list to match

## Test plan
- [ ] Verify all CI checks pass with new job names