### PR TITLE
Remove quick species presets from upload modal

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -39,13 +39,6 @@ interface ImagePreview {
   preview: string;
 }
 
-const QUICK_SPECIES = [
-  { name: "Eschscholzia californica", label: "California Poppy" },
-  { name: "Quercus agrifolia", label: "Coast Live Oak" },
-  { name: "Columba livia", label: "Rock Dove" },
-  { name: "Sciurus griseus", label: "Western Gray Squirrel" },
-];
-
 const LICENSE_OPTIONS = [
   { value: "CC0-1.0", label: "CC0 (Public Domain)" },
   { value: "CC-BY-4.0", label: "CC BY (Attribution)" },
@@ -281,11 +274,6 @@ export function UploadModal() {
       setSuggestions([]);
     }
   }, []);
-
-  const handleQuickSpecies = (name: string) => {
-    setSpecies(name);
-    setSuggestions([]);
-  };
 
   // Poll for observation to appear in database after AT Protocol submission
   const waitForObservation = async (uri: string, maxAttempts = 30): Promise<boolean> => {
@@ -529,25 +517,6 @@ export function UploadModal() {
             );
           }}
         />
-
-        <Stack direction="row" spacing={0.5} sx={{ mt: 1, flexWrap: "wrap", gap: 0.5 }}>
-          {QUICK_SPECIES.map((s) => (
-            <Chip
-              key={s.name}
-              label={s.label}
-              size="small"
-              onClick={() => handleQuickSpecies(s.name)}
-              sx={{
-                cursor: "pointer",
-                "&:hover": {
-                  borderColor: "primary.main",
-                  bgcolor: "background.paper",
-                },
-              }}
-              variant="outlined"
-            />
-          ))}
-        </Stack>
 
         <TextField
           fullWidth


### PR DESCRIPTION
## Summary
- Removes the hardcoded quick-select species chips (California Poppy, Coast Live Oak, Rock Dove, Western Gray Squirrel) from the observation upload modal
- Users should use the species autocomplete search instead of preset shortcuts

## Test plan
- [ ] Open the upload modal and verify the species chips are gone
- [ ] Verify species autocomplete search still works correctly