### PR TITLE
Fix FAB button positioning

### DIFF
--- a/frontend/src/components/common/FAB.tsx
+++ b/frontend/src/components/common/FAB.tsx
@@ -54,7 +54,7 @@ export function FAB() {
         direction="up"
         sx={{
           position: "fixed",
-          bottom: 80,
+          bottom: 16,
           right: 16,
           zIndex: 100,
           "@media (min-width: 900px)": {


### PR DESCRIPTION
## Summary
- Changed FAB bottom margin from 80px to 16px to match the right margin, giving consistent spacing from the screen edges

## Test plan
- [ ] Verify FAB has equal spacing from bottom and right edges on mobile