### PR TITLE
refactor: use sqlx query macros for compile-time checked batch queries

### DIFF
--- a/.sqlx/query-2729f87b5433844cda3fa1817e2b5d9ed92026493680b28f6256c98ac6aadf0e.json
+++ b/.sqlx/query-2729f87b5433844cda3fa1817e2b5d9ed92026493680b28f6256c98ac6aadf0e.json
@@ -1,0 +1,28 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT DISTINCT ON (occurrence_uri)\n            occurrence_uri as \"occurrence_uri!\", scientific_name\n        FROM community_ids\n        WHERE occurrence_uri = ANY($1) AND subject_index = 0\n        ORDER BY occurrence_uri, id_count DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "occurrence_uri!",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "scientific_name",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      true,
+      true
+    ]
+  },
+  "hash": "2729f87b5433844cda3fa1817e2b5d9ed92026493680b28f6256c98ac6aadf0e"
+}

--- a/.sqlx/query-4f5cd4072645b4952114a149f203238d7e129cc022035538b0da2d9b3dd66a0b.json
+++ b/.sqlx/query-4f5cd4072645b4952114a149f203238d7e129cc022035538b0da2d9b3dd66a0b.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT occurrence_uri, observer_did as did, role, added_at\n        FROM occurrence_observers\n        WHERE occurrence_uri = ANY($1)\n        ORDER BY occurrence_uri, role ASC, added_at ASC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "occurrence_uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "did",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "role",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "added_at",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      true
+    ]
+  },
+  "hash": "4f5cd4072645b4952114a149f203238d7e129cc022035538b0da2d9b3dd66a0b"
+}

--- a/.sqlx/query-6179f130ea72eec15b3bf3569498430b8288a33a095b2429a7c540d31b153150.json
+++ b/.sqlx/query-6179f130ea72eec15b3bf3569498430b8288a33a095b2429a7c540d31b153150.json
@@ -1,0 +1,40 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            subject_uri,\n            subject_index,\n            COUNT(*) as \"identification_count!\",\n            MAX(date_identified) as latest_identification\n        FROM identifications\n        WHERE subject_uri = ANY($1)\n        GROUP BY subject_uri, subject_index\n        ORDER BY subject_uri, subject_index\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "subject_uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "subject_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 2,
+        "name": "identification_count!",
+        "type_info": "Int8"
+      },
+      {
+        "ordinal": 3,
+        "name": "latest_identification",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      null,
+      null
+    ]
+  },
+  "hash": "6179f130ea72eec15b3bf3569498430b8288a33a095b2429a7c540d31b153150"
+}

--- a/.sqlx/query-ebc74f72d0479a34eac1cd41bf2b3db918e4ae1a9f0e9a72e74a2d961542eefa.json
+++ b/.sqlx/query-ebc74f72d0479a34eac1cd41bf2b3db918e4ae1a9f0e9a72e74a2d961542eefa.json
@@ -1,0 +1,154 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            uri, cid, did, subject_uri, subject_cid, subject_index, scientific_name,\n            taxon_rank, identification_qualifier, taxon_id, identification_remarks,\n            identification_verification_status, type_status, is_agreement, date_identified,\n            vernacular_name, kingdom, phylum, class, \"order\" as order_, family, genus, confidence\n        FROM identifications\n        WHERE subject_uri = ANY($1) AND subject_index = 0\n        ORDER BY subject_uri, date_identified DESC\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "did",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "subject_uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "subject_cid",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "subject_index",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "scientific_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 7,
+        "name": "taxon_rank",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 8,
+        "name": "identification_qualifier",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 9,
+        "name": "taxon_id",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 10,
+        "name": "identification_remarks",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 11,
+        "name": "identification_verification_status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 12,
+        "name": "type_status",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 13,
+        "name": "is_agreement",
+        "type_info": "Bool"
+      },
+      {
+        "ordinal": 14,
+        "name": "date_identified",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 15,
+        "name": "vernacular_name",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 16,
+        "name": "kingdom",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 17,
+        "name": "phylum",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 18,
+        "name": "class",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 19,
+        "name": "order_",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 20,
+        "name": "family",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 21,
+        "name": "genus",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 22,
+        "name": "confidence",
+        "type_info": "Text"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "TextArray"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      false,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true,
+      true
+    ]
+  },
+  "hash": "ebc74f72d0479a34eac1cd41bf2b3db918e4ae1a9f0e9a72e74a2d961542eefa"
+}

--- a/crates/observing-db/src/observers.rs
+++ b/crates/observing-db/src/observers.rs
@@ -121,23 +121,15 @@ pub async fn get_for_occurrences(
         return Ok(HashMap::new());
     }
 
-    #[derive(sqlx::FromRow)]
-    struct Row {
-        occurrence_uri: String,
-        did: String,
-        role: String,
-        added_at: Option<chrono::DateTime<chrono::Utc>>,
-    }
-
-    let rows: Vec<Row> = sqlx::query_as(
+    let rows = sqlx::query!(
         r#"
         SELECT occurrence_uri, observer_did as did, role, added_at
         FROM occurrence_observers
         WHERE occurrence_uri = ANY($1)
         ORDER BY occurrence_uri, role ASC, added_at ASC
         "#,
+        uris,
     )
-    .bind(uris)
     .fetch_all(executor)
     .await?;
 


### PR DESCRIPTION
## Summary

- Switches the 4 batch query functions added in #62 from runtime `sqlx::query_as()` to compile-time `sqlx::query!`/`query_as!` macros
- Matches the pattern used throughout the rest of the codebase for compile-time SQL validation
- Removes intermediate `#[derive(sqlx::FromRow)]` structs that are no longer needed

## Test plan
- [x] `cargo build` — compiles clean (offline mode)
- [x] `cargo test` — all 190 tests pass
- [x] `cargo sqlx prepare` — offline cache updated