### PR TITLE
fix: resolve common names for taxa with untagged vernacular names

### DIFF
--- a/crates/observing-taxonomy/src/gbif.rs
+++ b/crates/observing-taxonomy/src/gbif.rs
@@ -764,9 +764,6 @@ mod tests {
             ],
         );
         let result = client.search_result_to_taxon(&item);
-        assert_eq!(
-            result.common_name.as_deref(),
-            Some("Powdery Mildew Fungi")
-        );
+        assert_eq!(result.common_name.as_deref(), Some("Powdery Mildew Fungi"));
     }
 }


### PR DESCRIPTION
## Summary
- GBIF sometimes omits the `language` field for English vernacular names (e.g., Erysiphaceae has `"Powdery Mildews"` with no language tag)
- The existing fallback chain only matched `language == "eng"`, so these entries were skipped
- Adds a fallback for `language == None` between the explicit English check and the preferred/first-available fallbacks

Fixes the issue where searching "powdery mildew" shows "Erysiphaceae" without its common name.

## Test plan
- [x] Search "powdery mildew" in the taxa autocomplete and verify "Powdery Mildews" appears alongside "Erysiphaceae"