### PR TITLE
refactor: extract shared useAutocomplete hook

### DIFF
--- a/frontend/src/hooks/useAutocomplete.ts
+++ b/frontend/src/hooks/useAutocomplete.ts
@@ -1,0 +1,69 @@
+import { useState, useCallback, useRef, useEffect } from "react";
+
+const DEFAULT_DEBOUNCE_MS = 300;
+const DEFAULT_MIN_LENGTH = 2;
+
+interface UseAutocompleteOptions<T> {
+  /** The async function that fetches results for a query */
+  searchFn: (query: string) => Promise<T[]>;
+  /** Optional transform applied to results before setting state */
+  filterResults?: (results: T[]) => T[];
+  /** Minimum query length before searching (default: 2) */
+  minLength?: number;
+  /** Debounce delay in milliseconds (default: 300) */
+  debounceMs?: number;
+}
+
+interface UseAutocompleteReturn<T> {
+  options: T[];
+  loading: boolean;
+  handleSearch: (query: string) => void;
+  clearOptions: () => void;
+}
+
+export function useAutocomplete<T>({
+  searchFn,
+  filterResults,
+  minLength = DEFAULT_MIN_LENGTH,
+  debounceMs = DEFAULT_DEBOUNCE_MS,
+}: UseAutocompleteOptions<T>): UseAutocompleteReturn<T> {
+  const [options, setOptions] = useState<T[]>([]);
+  const [loading, setLoading] = useState(false);
+  const latestQuery = useRef("");
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
+
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current);
+  }, []);
+
+  const handleSearch = useCallback(
+    (query: string) => {
+      latestQuery.current = query;
+      clearTimeout(timerRef.current);
+
+      if (query.length < minLength) {
+        setOptions([]);
+        setLoading(false);
+        return;
+      }
+
+      setLoading(true);
+      timerRef.current = setTimeout(async () => {
+        const results = await searchFn(query);
+        if (latestQuery.current === query) {
+          setOptions(filterResults ? filterResults(results) : results);
+          setLoading(false);
+        }
+      }, debounceMs);
+    },
+    [searchFn, filterResults, minLength, debounceMs],
+  );
+
+  const clearOptions = useCallback(() => {
+    clearTimeout(timerRef.current);
+    setOptions([]);
+    setLoading(false);
+  }, []);
+
+  return { options, loading, handleSearch, clearOptions };
+}


### PR DESCRIPTION
## Summary
- Extract a generic `useAutocomplete<T>` hook that encapsulates debounced search, loading state, latest-query tracking via ref, and cleanup on unmount
- Refactor `TaxaAutocomplete`, `ActorAutocomplete`, and `useDebouncedTaxaSearch` to use the shared hook, eliminating ~70% duplicated logic across the three files
- The hook accepts a `searchFn`, optional `filterResults` transform, configurable `minLength`, and `debounceMs`

## Test plan
- [ ] Verify taxa autocomplete still searches, shows loading spinner, and selects results correctly
- [ ] Verify actor autocomplete still searches, filters excluded DIDs, and triggers onSelect
- [ ] Verify explore filter panel taxa search (which uses `useDebouncedTaxaSearch`) still works
- [ ] Confirm `npx tsc` and `npx oxlint` pass with no new warnings