### PR TITLE
refactor: extract string validation helper

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -7,6 +7,7 @@ mod resolver;
 mod routes;
 mod state;
 mod taxonomy_client;
+mod validation;
 
 use std::path::PathBuf;
 use std::sync::Arc;

--- a/crates/observing-appview/src/routes/comments.rs
+++ b/crates/observing-appview/src/routes/comments.rs
@@ -14,6 +14,7 @@ use ts_rs::TS;
 use crate::auth;
 use crate::error::AppError;
 use crate::state::AppState;
+use crate::validation::validate_string_length;
 
 #[derive(Deserialize, TS)]
 #[serde(rename_all = "camelCase")]
@@ -37,11 +38,7 @@ pub async fn create_comment(
         .await
         .map_err(|_| AppError::Unauthorized)?;
 
-    if body.body.is_empty() || body.body.len() > 3000 {
-        return Err(AppError::BadRequest(
-            "Comment body must be 1-3000 characters".into(),
-        ));
-    }
+    validate_string_length(&body.body, 1, 3000, "Comment body")?;
 
     let subject = StrongRef::new()
         .uri(

--- a/crates/observing-appview/src/routes/identifications.rs
+++ b/crates/observing-appview/src/routes/identifications.rs
@@ -15,6 +15,7 @@ use crate::auth;
 use crate::enrichment;
 use crate::error::AppError;
 use crate::state::AppState;
+use crate::validation::validate_string_length;
 use at_uri_parser::AtUri;
 
 pub async fn get_for_occurrence(
@@ -63,11 +64,7 @@ pub async fn create_identification(
         .await
         .map_err(|_| AppError::Unauthorized)?;
 
-    if body.scientific_name.is_empty() || body.scientific_name.len() > 256 {
-        return Err(AppError::BadRequest(
-            "Scientific name must be 1-256 characters".into(),
-        ));
-    }
+    validate_string_length(&body.scientific_name, 1, 256, "Scientific name")?;
 
     // Validate taxonomy via GBIF
     let mut taxon_id = None;

--- a/crates/observing-appview/src/routes/interactions.rs
+++ b/crates/observing-appview/src/routes/interactions.rs
@@ -17,6 +17,7 @@ use crate::auth;
 use crate::enrichment;
 use crate::error::AppError;
 use crate::state::AppState;
+use crate::validation::validate_string_length;
 
 pub async fn get_for_occurrence(
     State(state): State<AppState>,
@@ -102,11 +103,7 @@ pub async fn create_interaction(
         .await
         .map_err(|_| AppError::Unauthorized)?;
 
-    if body.interaction_type.is_empty() || body.interaction_type.len() > 64 {
-        return Err(AppError::BadRequest(
-            "Interaction type must be 1-64 characters".into(),
-        ));
-    }
+    validate_string_length(&body.interaction_type, 1, 64, "Interaction type")?;
 
     let direction = body.direction.as_deref().unwrap_or("AtoB");
 

--- a/crates/observing-appview/src/validation.rs
+++ b/crates/observing-appview/src/validation.rs
@@ -1,0 +1,16 @@
+use crate::error::AppError;
+
+/// Validate that a string's length falls within the given range (inclusive).
+pub fn validate_string_length(
+    value: &str,
+    min: usize,
+    max: usize,
+    field_name: &str,
+) -> Result<(), AppError> {
+    if value.len() < min || value.len() > max {
+        return Err(AppError::BadRequest(format!(
+            "{field_name} must be {min}-{max} characters"
+        )));
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary
- Extract repeated `is_empty() || len() > N` string validation into a shared `validate_string_length()` helper in a new `validation.rs` module
- Replace inline validation checks in `comments.rs`, `identifications.rs`, and `interactions.rs` with calls to the helper
- No behavioral change: same error messages and status codes

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (all 200+ tests)
- [x] `cargo fmt` clean