### PR TITLE
refactor: extract useFormSubmit hook

### DIFF
--- a/frontend/src/hooks/useFormSubmit.ts
+++ b/frontend/src/hooks/useFormSubmit.ts
@@ -1,0 +1,55 @@
+import { useState, useCallback } from "react";
+import { useAppDispatch } from "../store";
+import { addToast } from "../store/uiSlice";
+
+interface UseFormSubmitOptions {
+  /** Toast message shown on success. If omitted, no success toast is dispatched. */
+  successMessage?: string;
+  /** Called after the submit function resolves successfully (use for form reset, etc.) */
+  onSuccess?: () => void | Promise<void>;
+  /** Custom error handler. If provided, replaces the default error toast. */
+  onError?: (error: unknown) => void;
+}
+
+/**
+ * Manages the common form submission lifecycle: loading state, try/catch, and toast notifications.
+ *
+ * @param submitFn - Async function that performs the actual submission.
+ * @param options - Optional callbacks and toast configuration.
+ * @returns `isSubmitting` flag and a `handleSubmit` function.
+ */
+export function useFormSubmit(
+  submitFn: () => Promise<unknown>,
+  options: UseFormSubmitOptions = {},
+) {
+  const dispatch = useAppDispatch();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    setIsSubmitting(true);
+    try {
+      await submitFn();
+
+      if (options.successMessage) {
+        dispatch(addToast({ message: options.successMessage, type: "success" }));
+      }
+
+      await options.onSuccess?.();
+    } catch (error) {
+      if (options.onError) {
+        options.onError(error);
+      } else {
+        dispatch(
+          addToast({
+            message: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+            type: "error",
+          }),
+        );
+      }
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [submitFn, options, dispatch]);
+
+  return { isSubmitting, handleSubmit };
+}


### PR DESCRIPTION
## Summary
- Introduces a `useFormSubmit` hook in `frontend/src/hooks/useFormSubmit.ts` that encapsulates the repeated form submission lifecycle: `isSubmitting` state management, try/catch, success/error toast dispatches, and cleanup callbacks.
- Refactors `CommentSection`, `IdentificationPanel`, and `InteractionPanel` to use the new hook, removing duplicated submission boilerplate from each component.
- The hook accepts an optional `onError` callback for components that use local error state instead of the global toast system (e.g., `InteractionPanel`).

## Test plan
- [ ] Verify comment submission still works (success toast, form reset, error toast on failure)
- [ ] Verify identification agree button still works (success toast, onSuccess callback)
- [ ] Verify identification suggest form still works (validation, dynamic success message, form reset)
- [ ] Verify interaction submission still works (form reset, interaction list reload, inline error display on failure)
- [ ] Confirm `npx tsc` passes with no errors
- [ ] Confirm `npx oxlint` reports no new warnings