### PR TITLE
test: mock taxa search API in species-input e2e tests

### DIFF
--- a/e2e/helpers/mock-taxa.ts
+++ b/e2e/helpers/mock-taxa.ts
@@ -1,0 +1,69 @@
+import type { Page, Route } from "@playwright/test";
+import type { TaxaResult } from "../../frontend/src/bindings/TaxaResult";
+
+/** Canned taxa results keyed by query substring (lowercase). */
+const TAXA_FIXTURES: Record<string, TaxaResult[]> = {
+  "california poppy": [
+    {
+      id: "3189396",
+      scientificName: "Eschscholzia californica",
+      commonName: "California Poppy",
+      rank: "SPECIES",
+      kingdom: "Plantae",
+      family: "Papaveraceae",
+      genus: "Eschscholzia",
+      source: "gbif",
+    },
+  ],
+  quercus: [
+    {
+      id: "2877951",
+      scientificName: "Quercus alba",
+      commonName: "White Oak",
+      rank: "SPECIES",
+      kingdom: "Plantae",
+      family: "Fagaceae",
+      genus: "Quercus",
+      source: "gbif",
+    },
+    {
+      id: "2878688",
+      scientificName: "Quercus robur",
+      commonName: "English Oak",
+      rank: "SPECIES",
+      kingdom: "Plantae",
+      family: "Fagaceae",
+      genus: "Quercus",
+      source: "gbif",
+    },
+  ],
+};
+
+/** Find matching fixture by checking if any key is a prefix of the query. */
+function findResults(query: string): TaxaResult[] {
+  const q = query.toLowerCase();
+  for (const [key, results] of Object.entries(TAXA_FIXTURES)) {
+    if (q.startsWith(key) || key.startsWith(q)) {
+      return results;
+    }
+  }
+  return [];
+}
+
+/**
+ * Intercepts /api/taxa/search and returns typed fixture data.
+ * The fixtures are typed against the Rust-generated TaxaResult binding,
+ * so `npx tsc -p e2e/tsconfig.json` will catch shape mismatches when
+ * the backend changes.
+ */
+export async function mockTaxaSearchRoute(page: Page) {
+  await page.route("**/api/taxa/search*", (route: Route) => {
+    const url = new URL(route.request().url());
+    const query = url.searchParams.get("q") || "";
+    return route.fulfill({
+      status: 200,
+      contentType: "application/json",
+      body: JSON.stringify({ results: findResults(query) }),
+    });
+  });
+}

--- a/e2e/tests/species-input.spec.ts
+++ b/e2e/tests/species-input.spec.ts
@@ -1,9 +1,8 @@
 import { test as authTest, expect as authExpect } from "../fixtures/auth";
 import { openUploadModal } from "../helpers/navigation";
+import { mockTaxaSearchRoute } from "../helpers/mock-taxa";
 
-/** Type into the species input and wait for the taxa search response that
- *  matches the full query. Filters by query-param length so we skip early
- *  responses triggered by partial (debounced) input. */
+/** Type into the species input and wait for the autocomplete options to appear. */
 async function searchSpecies(page: import("@playwright/test").Page, query: string) {
   const speciesInput = page.getByLabel(/Species/i);
   await speciesInput.click();
@@ -27,6 +26,7 @@ async function searchSpecies(page: import("@playwright/test").Page, query: strin
 
 authTest.describe("Species Input", () => {
   authTest.beforeEach(async ({ authenticatedPage: page }) => {
+    await mockTaxaSearchRoute(page);
     await page.goto("/");
     await openUploadModal(page);
   });

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "exactOptionalPropertyTypes": false,
+    "noPropertyAccessFromIndexSignature": false,
+    "noUncheckedIndexedAccess": false
+  },
+  "include": ["./**/*"]
+}


### PR DESCRIPTION
## Summary
- Mock `/api/taxa/search` in species-input e2e tests using `page.route()` to eliminate flaky CI failures from GBIF API timeouts
- Mock fixtures are typed against the Rust-generated `TaxaResult` binding, so `npx tsc -p e2e/tsconfig.json` catches shape mismatches when the backend changes
- Add `e2e/tsconfig.json` to enable typechecking e2e files (relaxes strict settings that conflict with Playwright types)

Fixes flaky merge queue failure: https://github.com/observ-ing/core/actions/runs/22649486768

## Test plan
- [ ] CI passes (species-input tests use mocked API)
- [ ] Verify `npx tsc -p e2e/tsconfig.json` catches type errors if `TaxaResult` shape changes