### PR TITLE
refactor: use useAppSelector consistently in FeedItem

### DIFF
--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { useSelector } from "react-redux";
 import {
   Box,
   Avatar,
@@ -22,7 +21,7 @@ import MoreVertIcon from "@mui/icons-material/MoreVert";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import type { Occurrence } from "../../services/types";
-import type { RootState } from "../../store";
+import { useAppSelector } from "../../store";
 import { getImageUrl } from "../../services/api";
 import { useLikeToggle } from "../../hooks/useLikeToggle";
 import { TaxonLink } from "../common/TaxonLink";
@@ -45,7 +44,7 @@ export function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
   );
   const menuOpen = Boolean(anchorEl);
   const navigate = useNavigate();
-  const currentUser = useSelector((state: RootState) => state.auth.user);
+  const currentUser = useAppSelector((state) => state.auth.user);
   const isOwnPost = currentUser?.did === observation.observer.did;
 
   // Get owner and co-observers


### PR DESCRIPTION
## Summary
- Replace raw `useSelector` (react-redux) and `RootState` type import in `FeedItem.tsx` with the typed `useAppSelector` wrapper from the store
- This was the only component still using the untyped pattern; all other 12 components already use `useAppSelector`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run fmt` passes
- No behavioral change — `useAppSelector` is a typed alias for `useSelector`