### PR TITLE
refactor: deduplicate sliceToFive and extract MAX_AUTOCOMPLETE_RESULTS

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -4,6 +4,7 @@ import { searchTaxa } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ConservationStatus } from "./ConservationStatus";
 import { useAutocomplete } from "../../hooks/useAutocomplete";
+import { MAX_AUTOCOMPLETE_RESULTS } from "../../lib/utils";
 
 interface TaxaAutocompleteProps {
   value: string;
@@ -13,8 +14,6 @@ interface TaxaAutocompleteProps {
   size?: "small" | "medium";
   margin?: "normal" | "dense" | "none";
 }
-
-const sliceToFive = (results: TaxaResult[]) => results.slice(0, 5);
 
 export function TaxaAutocomplete({
   value,
@@ -27,7 +26,7 @@ export function TaxaAutocomplete({
   const searchFn = useCallback((query: string) => searchTaxa(query), []);
   const { options, loading, handleSearch, clearOptions } = useAutocomplete<TaxaResult>({
     searchFn,
-    filterResults: sliceToFive,
+    filterResults: (results) => results.slice(0, MAX_AUTOCOMPLETE_RESULTS),
   });
 
   return (

--- a/frontend/src/components/interaction/InteractionPanel.tsx
+++ b/frontend/src/components/interaction/InteractionPanel.tsx
@@ -27,7 +27,7 @@ import {
 } from "../../services/api";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
 import type { Subject, TaxaResult } from "../../services/types";
-import { formatDate } from "../../lib/utils";
+import { formatDate, MAX_AUTOCOMPLETE_RESULTS } from "../../lib/utils";
 
 // Known interaction types with human-readable labels
 const INTERACTION_TYPES = [
@@ -100,7 +100,7 @@ export function InteractionPanel({ observation, subjects, onSuccess }: Interacti
     setSubjectBTaxon(query);
     if (query.length >= 2) {
       const results = await searchTaxa(query);
-      setTaxonSuggestions(results.slice(0, 5));
+      setTaxonSuggestions(results.slice(0, MAX_AUTOCOMPLETE_RESULTS));
     } else {
       setTaxonSuggestions([]);
     }

--- a/frontend/src/hooks/useDebouncedTaxaSearch.ts
+++ b/frontend/src/hooks/useDebouncedTaxaSearch.ts
@@ -1,9 +1,8 @@
 import { useCallback } from "react";
 import { searchTaxa } from "../services/api";
 import type { TaxaResult } from "../services/types";
+import { MAX_AUTOCOMPLETE_RESULTS } from "../lib/utils";
 import { useAutocomplete } from "./useAutocomplete";
-
-const sliceToFive = (results: TaxaResult[]) => results.slice(0, 5);
 
 /**
  * Debounced taxa search hook. Waits for the user to stop typing before
@@ -18,7 +17,7 @@ export function useDebouncedTaxaSearch(debounceMs = 300) {
     clearOptions: clearSuggestions,
   } = useAutocomplete<TaxaResult>({
     searchFn,
-    filterResults: sliceToFive,
+    filterResults: (results) => results.slice(0, MAX_AUTOCOMPLETE_RESULTS),
     debounceMs,
   });
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -2,6 +2,9 @@
  * Shared utility functions for the Observ.ing frontend
  */
 
+/** Maximum number of results shown in autocomplete dropdowns. */
+export const MAX_AUTOCOMPLETE_RESULTS = 5;
+
 /**
  * Format a Date as a compact relative time string (e.g., "now", "5m", "2h", "3d")
  * For dates older than a week, returns a formatted date string.


### PR DESCRIPTION
## Summary
- Removed duplicate `sliceToFive` helper functions from `useDebouncedTaxaSearch.ts` and `TaxaAutocomplete.tsx`
- Extracted a shared `MAX_AUTOCOMPLETE_RESULTS` constant in `frontend/src/lib/utils.ts`
- Replaced the inline magic number `5` in `InteractionPanel.tsx` with the new constant

## Test plan
- [ ] Verify autocomplete dropdowns still show at most 5 results
- [ ] `npx tsc --noEmit` passes
- [ ] `npm run fmt:check` passes