### PR TITLE
refactor: extract getErrorMessage utility function

### DIFF
--- a/frontend/src/components/modals/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/modals/DeleteConfirmDialog.tsx
@@ -13,6 +13,7 @@ import { useAppDispatch, useAppSelector } from "../../store";
 import { closeDeleteConfirm, addToast } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
 import { deleteObservation } from "../../services/api";
+import { getErrorMessage } from "../../lib/utils";
 
 export function DeleteConfirmDialog() {
   const dispatch = useAppDispatch();
@@ -53,7 +54,7 @@ export function DeleteConfirmDialog() {
         window.location.reload();
       }
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to delete observation";
+      const message = getErrorMessage(error, "Failed to delete observation");
       dispatch(addToast({ message, type: "error" }));
       if (message.includes("Session expired")) {
         dispatch(checkAuth());

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -27,7 +27,7 @@ import { ModalOverlay } from "./ModalOverlay";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { ActorAutocomplete } from "../common/ActorAutocomplete";
 import { LocationPicker } from "../map/LocationPicker";
-import { getObservationUrl } from "../../lib/utils";
+import { getObservationUrl, getErrorMessage } from "../../lib/utils";
 
 interface ImagePreview {
   file: File;
@@ -363,7 +363,7 @@ export function UploadModal() {
     } catch (error) {
       dispatch(
         addToast({
-          message: `Failed to ${isEditMode ? "update" : "submit"}: ${error instanceof Error ? error.message : "Unknown error"}`,
+          message: `Failed to ${isEditMode ? "update" : "submit"}: ${getErrorMessage(error)}`,
           type: "error",
         }),
       );

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -48,7 +48,7 @@ import { InteractionPanel } from "../interaction/InteractionPanel";
 import { LocationMap } from "../map/LocationMap";
 import { TaxonLink } from "../common/TaxonLink";
 import { ObservationDetailSkeleton } from "../common/Skeletons";
-import { formatDate, getPdslsUrl, buildOccurrenceAtUri } from "../../lib/utils";
+import { formatDate, getPdslsUrl, buildOccurrenceAtUri, getErrorMessage } from "../../lib/utils";
 
 export function ObservationDetail() {
   const { did, rkey } = useParams<{ did: string; rkey: string }>();
@@ -531,8 +531,7 @@ export function ObservationDetail() {
                     dispatch(addToast({ message: "Identification deleted", type: "success" }));
                     await handleIdentificationSuccess();
                   } catch (error) {
-                    const message =
-                      error instanceof Error ? error.message : "Failed to delete identification";
+                    const message = getErrorMessage(error, "Failed to delete identification");
                     dispatch(addToast({ message, type: "error" }));
                     if (message.includes("Session expired")) {
                       dispatch(checkAuth());

--- a/frontend/src/hooks/useFormSubmit.ts
+++ b/frontend/src/hooks/useFormSubmit.ts
@@ -1,6 +1,7 @@
 import { useState, useCallback } from "react";
 import { useAppDispatch } from "../store";
 import { addToast } from "../store/uiSlice";
+import { getErrorMessage } from "../lib/utils";
 
 interface UseFormSubmitOptions {
   /** Toast message shown on success. If omitted, no success toast is dispatched. */
@@ -41,7 +42,7 @@ export function useFormSubmit(
       } else {
         dispatch(
           addToast({
-            message: `Error: ${error instanceof Error ? error.message : "Unknown error"}`,
+            message: `Error: ${getErrorMessage(error)}`,
             type: "error",
           }),
         );

--- a/frontend/src/lib/identification.ts
+++ b/frontend/src/lib/identification.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AtpAgent } from "@atproto/api";
+import { getErrorMessage } from "./utils";
 
 const IDENTIFICATION_COLLECTION = "org.rwell.test.identification";
 
@@ -341,7 +342,7 @@ export function createIdentificationUI(
       showToast?.("Your agreement has been recorded!", "success");
       onSuccess?.();
     } catch (error) {
-      showToast?.(`Error: ${error instanceof Error ? error.message : "Unknown error"}`, "error");
+      showToast?.(`Error: ${getErrorMessage(error)}`, "error");
     }
   });
 
@@ -375,7 +376,7 @@ export function createIdentificationUI(
       suggestForm?.classList.add("hidden");
       onSuccess?.();
     } catch (error) {
-      showToast?.(`Error: ${error instanceof Error ? error.message : "Unknown error"}`, "error");
+      showToast?.(`Error: ${getErrorMessage(error)}`, "error");
     }
   });
 }

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -86,3 +86,10 @@ export function getObservationUrl(atUri: string): string {
 export function buildOccurrenceAtUri(did: string, rkey: string): string {
   return `at://${did}/org.rwell.test.occurrence/${rkey}`;
 }
+
+/**
+ * Extract a human-readable error message from an unknown caught value.
+ */
+export function getErrorMessage(error: unknown, fallback = "Unknown error"): string {
+  return error instanceof Error ? error.message : fallback;
+}


### PR DESCRIPTION
## Summary
- Added a shared `getErrorMessage(error, fallback?)` utility to `frontend/src/lib/utils.ts` that extracts a message from an unknown caught value
- Replaced 6 occurrences of the `error instanceof Error ? error.message : "..."` pattern across 5 files with calls to the new helper

## Test plan
- [x] `npm run fmt` passes
- [x] `npx tsc --noEmit` passes (no type errors)
- [ ] Verify error toasts still display correct messages in the UI