### PR TITLE
refactor: narrow #[allow(dead_code)] on IngesterError variants

### DIFF
--- a/crates/observing-ingester/src/error.rs
+++ b/crates/observing-ingester/src/error.rs
@@ -3,14 +3,16 @@
 use std::fmt;
 
 #[derive(Debug)]
-#[allow(dead_code)]
 pub enum IngesterError {
     Jetstream(jetstream_client::JetstreamError),
     Database(Box<sqlx::Error>),
     CborDecode(String),
+    #[allow(dead_code)]
     InvalidFrame(String),
+    #[allow(dead_code)]
     ConnectionClosed,
     Config(String),
+    #[allow(dead_code)]
     Parse(String),
 }
 


### PR DESCRIPTION
## Summary
- Removed the blanket `#[allow(dead_code)]` from the entire `IngesterError` enum
- Applied targeted `#[allow(dead_code)]` to only the three variants that are currently unused outside of tests: `InvalidFrame`, `ConnectionClosed`, and `Parse`
- The remaining variants (`Jetstream`, `Database`, `CborDecode`, `Config`) are actively used via direct construction or `From` impls

## Test plan
- [x] `cargo check -p observing-ingester` compiles with zero warnings
- [x] `cargo fmt` produces no changes