### PR TITLE
refactor: extract useLikeToggle hook

### DIFF
--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -23,7 +23,8 @@ import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import type { Occurrence } from "../../services/types";
 import type { RootState } from "../../store";
-import { getImageUrl, likeObservation, unlikeObservation } from "../../services/api";
+import { getImageUrl } from "../../services/api";
+import { useLikeToggle } from "../../hooks/useLikeToggle";
 import { TaxonLink } from "../common/TaxonLink";
 import { formatTimeAgo, getPdslsUrl, getObservationUrl } from "../../lib/utils";
 
@@ -38,8 +39,10 @@ const REMARKS_TRUNCATE_LENGTH = 200;
 export function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [remarksExpanded, setRemarksExpanded] = useState(false);
-  const [liked, setLiked] = useState(observation.viewerHasLiked ?? false);
-  const [likeCount, setLikeCount] = useState(observation.likeCount ?? 0);
+  const { liked, likeCount, handleLikeToggle } = useLikeToggle(
+    observation.viewerHasLiked ?? false,
+    observation.likeCount ?? 0,
+  );
   const menuOpen = Boolean(anchorEl);
   const navigate = useNavigate();
   const currentUser = useSelector((state: RootState) => state.auth.user);
@@ -100,27 +103,6 @@ export function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
       return;
     }
     navigate(observationUrl);
-  };
-
-  const handleLikeToggle = async () => {
-    if (!currentUser) return;
-
-    const wasLiked = liked;
-    // Optimistic update
-    setLiked(!wasLiked);
-    setLikeCount((c) => c + (wasLiked ? -1 : 1));
-
-    try {
-      if (wasLiked) {
-        await unlikeObservation(observation.uri);
-      } else {
-        await likeObservation(observation.uri, observation.cid);
-      }
-    } catch {
-      // Revert on failure
-      setLiked(wasLiked);
-      setLikeCount((c) => c + (wasLiked ? 1 : -1));
-    }
   };
 
   const avatarEl = hasCoObservers ? (
@@ -350,7 +332,7 @@ export function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
           <span>
             <IconButton
               size="small"
-              onClick={handleLikeToggle}
+              onClick={() => handleLikeToggle(observation.uri, observation.cid)}
               disabled={!currentUser}
               aria-label={liked ? "Unlike" : "Like"}
               sx={{

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -29,15 +29,10 @@ import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import LocationOnIcon from "@mui/icons-material/LocationOn";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
 import NotesIcon from "@mui/icons-material/Notes";
-import {
-  fetchObservation,
-  getImageUrl,
-  deleteIdentification,
-  likeObservation,
-  unlikeObservation,
-} from "../../services/api";
+import { fetchObservation, getImageUrl, deleteIdentification } from "../../services/api";
 import { useAppSelector, useAppDispatch } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
+import { useLikeToggle } from "../../hooks/useLikeToggle";
 import { openDeleteConfirm, openEditModal, addToast } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
 import type { Occurrence, Identification, Comment } from "../../services/types";
@@ -63,8 +58,7 @@ export function ObservationDetail() {
   const [error, setError] = useState<string | null>(null);
   const [activeImageIndex, setActiveImageIndex] = useState(0);
   const [selectedSubject, setSelectedSubject] = useState(0);
-  const [liked, setLiked] = useState(false);
-  const [likeCount, setLikeCount] = useState(0);
+  const { liked, setLiked, likeCount, setLikeCount, handleLikeToggle } = useLikeToggle();
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const menuOpen = Boolean(anchorEl);
 
@@ -101,7 +95,7 @@ export function ObservationDetail() {
     }
 
     loadObservation();
-  }, [atUri]);
+  }, [atUri, setLiked, setLikeCount]);
 
   const handleBack = () => {
     if (window.history.length > 1) {
@@ -150,25 +144,6 @@ export function ObservationDetail() {
     handleMenuClose();
     if (observation) {
       dispatch(openDeleteConfirm(observation));
-    }
-  };
-
-  const handleLikeToggle = async () => {
-    if (!user || !observation) return;
-
-    const wasLiked = liked;
-    setLiked(!wasLiked);
-    setLikeCount((c) => c + (wasLiked ? -1 : 1));
-
-    try {
-      if (wasLiked) {
-        await unlikeObservation(observation.uri);
-      } else {
-        await likeObservation(observation.uri, observation.cid);
-      }
-    } catch {
-      setLiked(wasLiked);
-      setLikeCount((c) => c + (wasLiked ? 1 : -1));
     }
   };
 
@@ -313,7 +288,7 @@ export function ObservationDetail() {
             <span>
               <IconButton
                 size="small"
-                onClick={handleLikeToggle}
+                onClick={() => observation && handleLikeToggle(observation.uri, observation.cid)}
                 disabled={!user}
                 aria-label={liked ? "Unlike" : "Like"}
                 sx={{

--- a/frontend/src/hooks/useLikeToggle.ts
+++ b/frontend/src/hooks/useLikeToggle.ts
@@ -1,0 +1,26 @@
+import { useState } from "react";
+import { likeObservation, unlikeObservation } from "../services/api";
+
+export function useLikeToggle(initialLiked = false, initialCount = 0) {
+  const [liked, setLiked] = useState(initialLiked);
+  const [likeCount, setLikeCount] = useState(initialCount);
+
+  const handleLikeToggle = async (uri: string, cid: string) => {
+    const wasLiked = liked;
+    setLiked(!wasLiked);
+    setLikeCount((c) => c + (wasLiked ? -1 : 1));
+
+    try {
+      if (wasLiked) {
+        await unlikeObservation(uri);
+      } else {
+        await likeObservation(uri, cid);
+      }
+    } catch {
+      setLiked(wasLiked);
+      setLikeCount((c) => c + (wasLiked ? 1 : -1));
+    }
+  };
+
+  return { liked, setLiked, likeCount, setLikeCount, handleLikeToggle };
+}


### PR DESCRIPTION
## Summary
- Extract duplicated optimistic like/unlike toggle logic from `FeedItem` and `ObservationDetail` into a shared `useLikeToggle` hook
- The hook manages `liked`/`likeCount` state and handles optimistic updates with automatic rollback on API failure
- Exposes `setLiked`/`setLikeCount` setters for components like `ObservationDetail` that load data asynchronously

## Test plan
- [ ] Verify liking/unliking works on feed items
- [ ] Verify liking/unliking works on observation detail page
- [ ] Verify optimistic update reverts on network failure