### PR TITLE
refactor: extract getDisplayName utility

### DIFF
--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -25,7 +25,7 @@ import type { Occurrence } from "../../services/types";
 import type { RootState } from "../../store";
 import { getImageUrl, likeObservation, unlikeObservation } from "../../services/api";
 import { TaxonLink } from "../common/TaxonLink";
-import { formatTimeAgo, getPdslsUrl, getObservationUrl } from "../../lib/utils";
+import { formatTimeAgo, getDisplayName, getPdslsUrl, getObservationUrl } from "../../lib/utils";
 
 interface FeedItemProps {
   observation: Occurrence;
@@ -51,7 +51,7 @@ export function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
   const coObservers = observers.filter((o) => o.role === "co-observer");
   const hasCoObservers = coObservers.length > 0;
 
-  const displayName = owner.displayName || owner.handle || owner.did.slice(0, 20);
+  const displayName = getDisplayName(owner);
   const handle = owner.handle ? `@${owner.handle}` : "";
   const timeAgo = formatTimeAgo(new Date(observation.createdAt));
 
@@ -64,9 +64,7 @@ export function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
   const pdslsUrl = getPdslsUrl(observation.uri);
 
   // Build tooltip for co-observers
-  const coObserverNames = coObservers
-    .map((o) => o.displayName || o.handle || o.did.slice(0, 15))
-    .join(", ");
+  const coObserverNames = coObservers.map((o) => getDisplayName(o)).join(", ");
 
   const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
     event.preventDefault();

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -36,6 +36,7 @@ import { useAppSelector, useAppDispatch } from "../../store";
 import { logout } from "../../store/authSlice";
 import { openLoginModal, setThemeMode, type ThemeMode } from "../../store/uiSlice";
 import { fetchUnreadCount } from "../../services/api";
+import { getDisplayName } from "../../lib/utils";
 import logoSvg from "../../assets/logo.svg";
 
 export const DRAWER_WIDTH = 240;
@@ -286,7 +287,7 @@ export function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
               />
               <Box sx={{ flex: 1, minWidth: 0 }}>
                 <Typography variant="body2" fontWeight={600} noWrap>
-                  {user.displayName || user.handle || "User"}
+                  {getDisplayName(user, "User")}
                 </Typography>
                 {user.handle && (
                   <Typography variant="caption" color="text.secondary" noWrap>

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -48,7 +48,13 @@ import { InteractionPanel } from "../interaction/InteractionPanel";
 import { LocationMap } from "../map/LocationMap";
 import { TaxonLink } from "../common/TaxonLink";
 import { ObservationDetailSkeleton } from "../common/Skeletons";
-import { formatDate, getPdslsUrl, buildOccurrenceAtUri, getErrorMessage } from "../../lib/utils";
+import {
+  formatDate,
+  getDisplayName,
+  getPdslsUrl,
+  buildOccurrenceAtUri,
+  getErrorMessage,
+} from "../../lib/utils";
 
 export function ObservationDetail() {
   const { did, rkey } = useParams<{ did: string; rkey: string }>();
@@ -206,10 +212,7 @@ export function ObservationDetail() {
     );
   }
 
-  const displayName =
-    observation.observer.displayName ||
-    observation.observer.handle ||
-    observation.observer.did.slice(0, 20);
+  const displayName = getDisplayName(observation.observer);
   const handle = observation.observer.handle ? `@${observation.observer.handle}` : "";
 
   // Find the current subject's data

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -21,7 +21,7 @@ import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import GrassIcon from "@mui/icons-material/Grass";
 import { fetchProfileFeed, getImageUrl } from "../../services/api";
 import type { ProfileFeedResponse, Occurrence, Identification } from "../../services/types";
-import { formatTimeAgo, getObservationUrl } from "../../lib/utils";
+import { formatTimeAgo, getDisplayName, getObservationUrl } from "../../lib/utils";
 import {
   ProfileHeaderSkeleton,
   ProfileObservationCardSkeleton,
@@ -124,7 +124,7 @@ export function ProfileView() {
             />
             <Box>
               <Typography variant="h5" fontWeight={600}>
-                {profile?.displayName || profile?.handle || did.slice(0, 20)}
+                {getDisplayName({ ...profile, did })}
               </Typography>
               {profile?.handle && <Typography color="text.disabled">@{profile.handle}</Typography>}
             </Box>

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -90,6 +90,14 @@ export function buildOccurrenceAtUri(did: string, rkey: string): string {
   return `at://${did}/org.rwell.test.occurrence/${rkey}`;
 }
 
+/** Get a display name for an actor, with consistent fallback chain */
+export function getDisplayName(
+  actor: { displayName?: string | null; handle?: string | null; did?: string },
+  fallback = "Unknown",
+): string {
+  return actor.displayName || actor.handle || actor.did?.slice(0, 20) || fallback;
+}
+
 /**
  * Extract a human-readable error message from an unknown caught value.
  */


### PR DESCRIPTION
## Summary
- Add `getDisplayName(actor, fallback)` helper to `frontend/src/lib/utils.ts` that standardizes the `displayName || handle || did.slice(0, 20) || fallback` pattern
- Replace 5 inline occurrences across `FeedItem.tsx`, `ObservationDetail.tsx`, `ProfileView.tsx`, and `Sidebar.tsx` with calls to the new utility
- Fixes inconsistent DID slice lengths (some used 15, others 20) and inconsistent fallback strings ("Unknown" vs "User") by centralizing the logic with a configurable fallback parameter

## Test plan
- [ ] Verify display names render correctly in the feed (FeedItem cards)
- [ ] Verify observer name renders on observation detail pages
- [ ] Verify profile header shows correct name/handle/DID fallback
- [ ] Verify sidebar user section shows display name with "User" fallback
- [ ] Verify co-observer tooltip names in feed items