### PR TITLE
refactor: extract duplicated map uncertainty layer config

### DIFF
--- a/frontend/src/components/map/LocationMap.tsx
+++ b/frontend/src/components/map/LocationMap.tsx
@@ -3,6 +3,7 @@ import { Box, Typography, useTheme } from "@mui/material";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { mapStyle, darkMapFilter } from "./mapStyle";
+import { MAP_MARKER_COLOR, addUncertaintyLayers } from "./mapUtils";
 
 export interface LocationMapProps {
   latitude: number;
@@ -42,7 +43,7 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
 
     mapInstance.on("load", () => {
       // Add marker
-      new maplibregl.Marker({ color: "#22c55e" })
+      new maplibregl.Marker({ color: MAP_MARKER_COLOR })
         .setLngLat([longitude, latitude])
         .addTo(mapInstance);
 
@@ -53,26 +54,7 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
           data: createCircleGeoJSON(longitude, latitude, uncertaintyMeters),
         });
 
-        mapInstance.addLayer({
-          id: "uncertainty-fill",
-          type: "fill",
-          source: "uncertainty",
-          paint: {
-            "fill-color": "#22c55e",
-            "fill-opacity": 0.15,
-          },
-        });
-
-        mapInstance.addLayer({
-          id: "uncertainty-outline",
-          type: "line",
-          source: "uncertainty",
-          paint: {
-            "line-color": "#22c55e",
-            "line-width": 2,
-            "line-opacity": 0.5,
-          },
-        });
+        addUncertaintyLayers(mapInstance);
 
         // Fit map to uncertainty circle bounds
         const latOffset = uncertaintyMeters / 111320;

--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -13,6 +13,7 @@ import SearchIcon from "@mui/icons-material/Search";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { mapStyle, darkMapFilter } from "./mapStyle";
+import { MAP_MARKER_COLOR, addUncertaintyLayers } from "./mapUtils";
 
 interface LocationPickerProps {
   latitude: number;
@@ -110,7 +111,7 @@ export function LocationPicker({
       if (marker.current) {
         marker.current.setLngLat([lng, lat]);
       } else {
-        marker.current = new maplibregl.Marker({ color: "#22c55e" })
+        marker.current = new maplibregl.Marker({ color: MAP_MARKER_COLOR })
           .setLngLat([lng, lat])
           .addTo(map.current);
       }
@@ -204,26 +205,7 @@ export function LocationPicker({
         data: createCircleGeoJSON(longitude, latitude, uncertaintyMeters),
       });
 
-      mapInstance.addLayer({
-        id: "uncertainty-fill",
-        type: "fill",
-        source: "uncertainty",
-        paint: {
-          "fill-color": "#22c55e",
-          "fill-opacity": 0.15,
-        },
-      });
-
-      mapInstance.addLayer({
-        id: "uncertainty-outline",
-        type: "line",
-        source: "uncertainty",
-        paint: {
-          "line-color": "#22c55e",
-          "line-width": 2,
-          "line-opacity": 0.5,
-        },
-      });
+      addUncertaintyLayers(mapInstance);
 
       updateMarker(longitude, latitude);
     });

--- a/frontend/src/components/map/mapUtils.ts
+++ b/frontend/src/components/map/mapUtils.ts
@@ -1,0 +1,28 @@
+import type maplibregl from "maplibre-gl";
+
+/** Color used for uncertainty circles and map markers */
+export const MAP_MARKER_COLOR = "#22c55e";
+
+/** Add uncertainty circle layers to a map instance */
+export function addUncertaintyLayers(mapInstance: maplibregl.Map): void {
+  mapInstance.addLayer({
+    id: "uncertainty-fill",
+    type: "fill",
+    source: "uncertainty",
+    paint: {
+      "fill-color": MAP_MARKER_COLOR,
+      "fill-opacity": 0.15,
+    },
+  });
+
+  mapInstance.addLayer({
+    id: "uncertainty-outline",
+    type: "line",
+    source: "uncertainty",
+    paint: {
+      "line-color": MAP_MARKER_COLOR,
+      "line-width": 2,
+      "line-opacity": 0.5,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- Created `frontend/src/components/map/mapUtils.ts` with a shared `MAP_MARKER_COLOR` constant and `addUncertaintyLayers()` helper function
- Replaced duplicated uncertainty circle layer definitions in both `LocationPicker.tsx` and `LocationMap.tsx` with the shared helper
- Replaced hardcoded `"#22c55e"` color in marker creation with the `MAP_MARKER_COLOR` constant in both files

## Test plan
- [ ] Verify the location picker map renders the green uncertainty circle correctly when creating/editing an observation
- [ ] Verify the read-only location map renders the green uncertainty circle correctly on observation detail pages
- [ ] Confirm marker color remains green (#22c55e) in both components