### PR TITLE
refactor: extract feed reset and meta helpers in feedSlice

### DIFF
--- a/frontend/src/store/feedSlice.ts
+++ b/frontend/src/store/feedSlice.ts
@@ -26,6 +26,19 @@ function isHomeFeedMeta(value: unknown): value is HomeFeedMeta {
   );
 }
 
+function resetFeedState(state: FeedState) {
+  state.observations = [];
+  state.cursor = undefined;
+  state.hasMore = true;
+  state.homeFeedMeta = null;
+}
+
+function applyHomeFeedMeta(state: FeedState, payload: ExploreFeedResponse | HomeFeedResponse) {
+  if ("meta" in payload && isHomeFeedMeta(payload.meta)) {
+    state.homeFeedMeta = payload.meta;
+  }
+}
+
 interface ThunkApiConfig {
   state: { feed: FeedState; auth: { user: unknown } };
 }
@@ -53,13 +66,6 @@ const initialState: FeedState = {
   userLocation: null,
   homeFeedMeta: null,
 };
-
-function extractHomeFeedMeta(payload: ExploreFeedResponse | HomeFeedResponse): HomeFeedMeta | null {
-  if ("meta" in payload && isHomeFeedMeta(payload.meta)) {
-    return payload.meta;
-  }
-  return null;
-}
 
 function fetchFeedData(state: { feed: FeedState; auth: { user: unknown } }, cursor?: string) {
   const { currentTab, filters, userLocation } = state.feed;
@@ -97,22 +103,14 @@ const feedSlice = createSlice({
   reducers: {
     switchTab: (state, action: PayloadAction<FeedTab>) => {
       state.currentTab = action.payload;
-      state.observations = [];
-      state.cursor = undefined;
-      state.hasMore = true;
-      state.homeFeedMeta = null;
+      resetFeedState(state);
     },
     resetFeed: (state) => {
-      state.observations = [];
-      state.cursor = undefined;
-      state.hasMore = true;
-      state.homeFeedMeta = null;
+      resetFeedState(state);
     },
     setFilters: (state, action: PayloadAction<FeedFilters>) => {
       state.filters = action.payload;
-      state.observations = [];
-      state.cursor = undefined;
-      state.hasMore = true;
+      resetFeedState(state);
     },
     setUserLocation: (state, action: PayloadAction<{ lat: number; lng: number } | null>) => {
       state.userLocation = action.payload;
@@ -128,7 +126,7 @@ const feedSlice = createSlice({
         state.cursor = action.payload.cursor;
         state.hasMore = !!action.payload.cursor;
         state.isLoading = false;
-        state.homeFeedMeta = extractHomeFeedMeta(action.payload);
+        applyHomeFeedMeta(state, action.payload);
       })
       .addCase(loadFeed.rejected, (state) => {
         state.isLoading = false;
@@ -143,7 +141,7 @@ const feedSlice = createSlice({
         state.cursor = action.payload.cursor;
         state.hasMore = !!action.payload.cursor;
         state.isLoading = false;
-        state.homeFeedMeta = extractHomeFeedMeta(action.payload);
+        applyHomeFeedMeta(state, action.payload);
       })
       .addCase(loadInitialFeed.rejected, (state) => {
         state.isLoading = false;


### PR DESCRIPTION
## Summary
- Extract `resetFeedState()` helper to deduplicate the reset pattern shared by `switchTab`, `resetFeed`, and `setFilters` reducers
- Extract `applyHomeFeedMeta()` helper to deduplicate the meta-extraction logic shared by `loadFeed.fulfilled` and `loadInitialFeed.fulfilled` handlers
- Make `setFilters` consistently reset `homeFeedMeta` (it already reset observations, cursor, and hasMore but was missing homeFeedMeta)

## Test plan
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)
- [ ] Confirm feed tab switching, filter changes, and feed reset still clear state correctly
- [ ] Confirm home feed meta is still populated after loading a home feed