### PR TITLE
refactor: extract cookie/session duration constants

### DIFF
--- a/crates/observing-appview/src/routes/oauth.rs
+++ b/crates/observing-appview/src/routes/oauth.rs
@@ -9,6 +9,8 @@ use tracing::{error, info};
 use crate::error::AppError;
 use crate::state::AppState;
 
+const SESSION_MAX_AGE_SECS: i64 = 14 * 24 * 60 * 60;
+
 #[derive(Deserialize)]
 pub struct LoginParams {
     handle: Option<String>,
@@ -87,9 +89,7 @@ pub async fn callback(
                     };
                     let cookie = format!(
                         "session_did={}; HttpOnly; Path=/; Max-Age={}{}",
-                        did_str,
-                        14 * 24 * 60 * 60, // 14 days
-                        secure,
+                        did_str, SESSION_MAX_AGE_SECS, secure,
                     );
                     (
                         [(axum::http::header::SET_COOKIE, cookie)],

--- a/crates/observing-media-proxy/src/types.rs
+++ b/crates/observing-media-proxy/src/types.rs
@@ -3,6 +3,8 @@
 use serde::Serialize;
 use std::path::PathBuf;
 
+const DEFAULT_CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+
 /// Configuration for the media proxy
 #[derive(Debug, Clone)]
 pub struct MediaProxyConfig {
@@ -18,7 +20,7 @@ impl Default for MediaProxyConfig {
             port: 3001,
             cache_dir: PathBuf::from("./cache/media"),
             max_cache_size: 1024 * 1024 * 1024, // 1GB
-            cache_ttl_secs: 24 * 60 * 60,       // 24 hours
+            cache_ttl_secs: DEFAULT_CACHE_TTL_SECS,
         }
     }
 }


### PR DESCRIPTION
## Summary
- Extract inline `14 * 24 * 60 * 60` (14-day session cookie) into `SESSION_MAX_AGE_SECS` constant in `observing-appview`
- Extract inline `24 * 60 * 60` (24-hour cache TTL) into `DEFAULT_CACHE_TTL_SECS` constant in `observing-media-proxy`

## Test plan
- [x] `cargo check -p observing-appview -p observing-media-proxy` passes
- [x] `cargo fmt` applied