### PR TITLE
enhance: add remarks, location, and like button to FeedItemSkeleton

### DIFF
--- a/frontend/src/components/common/Skeletons.tsx
+++ b/frontend/src/components/common/Skeletons.tsx
@@ -14,6 +14,7 @@ export function FeedItemSkeleton() {
         },
       }}
     >
+      {/* CardHeader: avatar, name/handle, timestamp */}
       <Box sx={{ display: "flex", gap: 1, p: 2 }}>
         <Skeleton variant="circular" width={40} height={40} />
         <Box sx={{ flex: 1, minWidth: 0 }}>
@@ -24,9 +25,18 @@ export function FeedItemSkeleton() {
           <Skeleton variant="text" width="15%" height={16} />
         </Box>
       </Box>
+      {/* Image */}
       <Skeleton variant="rectangular" height={280} />
-      <Box sx={{ p: 2 }}>
+      {/* CardContent: species, remarks, location */}
+      <Box sx={{ px: 2, pt: 2, pb: 1 }}>
         <Skeleton variant="text" width="45%" height={24} />
+        <Skeleton variant="text" width="90%" height={18} sx={{ mt: 0.5 }} />
+        <Skeleton variant="text" width="70%" height={18} />
+        <Skeleton variant="text" width="35%" height={16} sx={{ mt: 0.5 }} />
+      </Box>
+      {/* CardActions: like button */}
+      <Box sx={{ px: 1, pb: 1 }}>
+        <Skeleton variant="circular" width={28} height={28} />
       </Box>
     </Card>
   );


### PR DESCRIPTION
## Summary
- Add skeleton lines for observation remarks (two text lines) and verbatim locality below the species name
- Add circular skeleton for the like button in the CardActions area
- Adjust padding to match actual FeedItem spacing (`px: 2, pt: 2, pb: 1` instead of `p: 2`)

Reduces layout shift when feed items finish loading by making the skeleton more closely match the real card.

## Test plan
- [ ] Verify skeleton appears on initial home feed load (slow network or throttled)
- [ ] Compare skeleton layout side-by-side with rendered FeedItem cards