### PR TITLE
refactor: remove console.error from production frontend

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -127,8 +127,8 @@ export function LocationPicker({
           setSearchResults(data);
         }
       } catch (error) {
-        if (!(error instanceof Error && error.name === "AbortError")) {
-          console.error("Geocoding error:", error);
+        if (error instanceof Error && error.name === "AbortError") {
+          // Expected when the previous request is cancelled
         }
       } finally {
         setIsSearching(false);

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -239,8 +239,8 @@ export function UploadModal() {
           );
         }
       }
-    } catch (error) {
-      console.error("EXIF extraction error:", error);
+    } catch {
+      // EXIF extraction is best-effort; silently continue without EXIF data
     }
   };
 

--- a/frontend/src/lib/uploader.ts
+++ b/frontend/src/lib/uploader.ts
@@ -226,8 +226,8 @@ export class OccurrenceUploader {
       if (!exifData.dateTime && file.lastModified) {
         exifData.dateTime = new Date(file.lastModified);
       }
-    } catch (error) {
-      console.error("EXIF extraction error:", error);
+    } catch {
+      // EXIF extraction is best-effort; fall through with whatever data we have
     }
 
     return exifData;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -144,8 +144,7 @@ export async function fetchObservation(uri: string): Promise<OccurrenceDetailRes
     const response = await fetch(url);
     if (!response.ok) return null;
     return response.json();
-  } catch (e) {
-    console.error("fetchObservation error:", e);
+  } catch {
     return null;
   }
 }
@@ -344,8 +343,7 @@ export async function fetchTaxon(kingdomOrId: string, name?: string): Promise<Ta
     const response = await fetch(url);
     if (!response.ok) return null;
     return response.json();
-  } catch (e) {
-    console.error("fetchTaxon error:", e);
+  } catch {
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Remove `console.error` calls from `api.ts`, `uploader.ts`, `LocationPicker.tsx`, and `UploadModal.tsx`
- All removed statements were in catch blocks that already handle errors gracefully (returning null, falling through, etc.)
- No replacement logging added; errors are silently swallowed as intended

## Test plan
- [x] `npx tsc --noEmit` passes with no errors
- [x] `npm run fmt` applied (oxfmt)