### PR TITLE
refactor: add explanatory comments to empty catch blocks

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -66,7 +66,9 @@ export function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
     const poll = () => {
       fetchUnreadCount()
         .then((data) => setUnreadCount(data.count))
-        .catch(() => {});
+        .catch(() => {
+          // Ignore polling failures — count stays at its last known value
+        });
     };
     poll();
     intervalRef.current = setInterval(poll, 30_000);

--- a/frontend/src/components/notifications/NotificationsPage.tsx
+++ b/frontend/src/components/notifications/NotificationsPage.tsx
@@ -39,7 +39,7 @@ export function NotificationsPage() {
       setCursor(data.cursor ?? undefined);
       setHasMore(data.notifications.length === 20);
     } catch {
-      // ignore
+      // Ignore fetch errors — previously loaded notifications remain visible
     } finally {
       setIsLoading(false);
     }

--- a/frontend/src/components/taxon/TaxonDetail.tsx
+++ b/frontend/src/components/taxon/TaxonDetail.tsx
@@ -98,6 +98,7 @@ export function TaxonDetail() {
           setCursor(obsResult.cursor);
           setHasMore(!!obsResult.cursor);
         } catch {
+          // Show empty state if observations fail to load
           setObservations([]);
           setHasMore(false);
         }
@@ -133,6 +134,7 @@ export function TaxonDetail() {
       setCursor(result.cursor);
       setHasMore(!!result.cursor);
     } catch {
+      // Stop pagination on error — existing observations remain visible
       setHasMore(false);
     }
     setLoadingMore(false);

--- a/frontend/src/hooks/useLikeToggle.ts
+++ b/frontend/src/hooks/useLikeToggle.ts
@@ -17,6 +17,7 @@ export function useLikeToggle(initialLiked = false, initialCount = 0) {
         await likeObservation(uri, cid);
       }
     } catch {
+      // Revert optimistic update on failure
       setLiked(wasLiked);
       setLikeCount((c) => c + (wasLiked ? 1 : -1));
     }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -52,6 +52,7 @@ export async function checkAuth(): Promise<User | null> {
     }
     return null;
   } catch {
+    // Network failure during auth check — treat as logged out
     return null;
   }
 }


### PR DESCRIPTION
## Summary
- Added explanatory comments to all empty or under-documented catch blocks across the frontend
- 6 files touched: `Sidebar.tsx`, `api.ts`, `useLikeToggle.ts`, `NotificationsPage.tsx`, `TaxonDetail.tsx` (2 catches), `InteractionPanel.tsx` was already documented
- Each comment briefly explains why the error is safe to swallow (e.g., polling failure keeps last value, optimistic update reverts, decorative data is non-critical)
- 3 catches already had adequate comments and were left as-is (`useWikidataThumbnails.ts`, `api.ts:extractErrorMessage`, `InteractionPanel.tsx`)

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run fmt` applied (oxfmt)
- [ ] Visual check: no behavior changes, comments only