### PR TITLE
refactor: move shared Cargo dependencies to workspace-level inheritance

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,7 +205,7 @@ name = "atproto-identity"
 version = "0.1.0"
 dependencies = [
  "moka",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "tokio",
@@ -2516,7 +2516,7 @@ version = "0.1.0"
 dependencies = [
  "lazy_static",
  "moka",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "tokio",
  "tracing",
@@ -2604,7 +2604,7 @@ dependencies = [
  "nominatim-client",
  "observing-db",
  "observing-lexicons",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "sqlx",
@@ -3206,7 +3206,6 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3231,14 +3230,12 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
- "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
  "web-sys",
  "webpki-roots",
 ]
@@ -3253,6 +3250,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3274,12 +3272,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams",
  "web-sys",
 ]
 
@@ -4812,9 +4812,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
 dependencies = [
  "futures-util",
  "js-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,5 +5,45 @@ members = ["crates/*"]
 [workspace.dependencies]
 ts-rs = { version = "12", features = ["chrono-impl", "serde-json-impl"] }
 
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Async runtime
+tokio = { version = "1", features = ["full"] }
+
+# Web framework
+axum = "0.8"
+tower-http = { version = "0.6", features = ["cors"] }
+tower = "0.5"
+
+# HTTP client
+reqwest = { version = "0.13", features = ["json"] }
+
+# Database
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgres", "chrono"] }
+
+# Logging
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
+tracing-stackdriver = "0.10"
+
+# Time
+chrono = { version = "0.4", features = ["serde"] }
+
+# Caching
+moka = { version = "0.12", features = ["future"] }
+
+# URL utilities
+urlencoding = "2"
+url = "2"
+
+# Async utilities
+futures = "0.3"
+futures-util = "0.3"
+
+# Testing
+tempfile = "3"
+
 [profile.release]
 debug = true

--- a/crates/atproto-blob-resolver/Cargo.toml
+++ b/crates/atproto-blob-resolver/Cargo.toml
@@ -7,17 +7,17 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 # HTTP client
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # URL encoding
-urlencoding = "2"
+urlencoding = { workspace = true }
 
 [dev-dependencies]
-tokio = { version = "1", features = ["macros", "rt"] }
+tokio = { workspace = true }

--- a/crates/atproto-identity/Cargo.toml
+++ b/crates/atproto-identity/Cargo.toml
@@ -7,17 +7,17 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 # HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Caching
-moka = { version = "0.12", features = ["future"] }
+moka = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # Async
-tokio = { version = "1", features = ["time"] }
+tokio = { workspace = true }

--- a/crates/file-blob-cache/Cargo.toml
+++ b/crates/file-blob-cache/Cargo.toml
@@ -6,14 +6,14 @@ description = "File-based blob cache with TTL expiration and LRU eviction"
 license = "AGPL-3.0-only"
 
 [dependencies]
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 hex = "0.4"
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true }
 sha2 = "0.10"
-tokio = { version = "1", features = ["fs", "sync"] }
-tracing = "0.1"
+tokio = { workspace = true }
+tracing = { workspace = true }
 
 [dev-dependencies]
-serde_json = "1"
-tempfile = "3"
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
+serde_json = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }

--- a/crates/gbif-api/Cargo.toml
+++ b/crates/gbif-api/Cargo.toml
@@ -7,14 +7,14 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 # HTTP client
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # URL encoding
-urlencoding = "2"
+urlencoding = { workspace = true }
 
 # Async runtime (for timeout)
-tokio = { version = "1", features = ["time"] }
+tokio = { workspace = true }

--- a/crates/jetstream-client/Cargo.toml
+++ b/crates/jetstream-client/Cargo.toml
@@ -7,18 +7,18 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1", features = ["time", "sync"] }
+tokio = { workspace = true }
 
 # WebSocket
 tokio-tungstenite = { version = "0.28", features = ["native-tls"] }
-futures-util = "0.3"
+futures-util = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # Time
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }

--- a/crates/nominatim-client/Cargo.toml
+++ b/crates/nominatim-client/Cargo.toml
@@ -7,19 +7,19 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 # HTTP client
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+reqwest = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true }
 
 # Caching
-moka = { version = "0.12", features = ["future"] }
+moka = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # Async
-tokio = { version = "1", features = ["sync", "time"] }
+tokio = { workspace = true }
 
 # Static initialization
 lazy_static = "1"

--- a/crates/observing-appview/Cargo.toml
+++ b/crates/observing-appview/Cargo.toml
@@ -17,33 +17,33 @@ at-uri-parser = { path = "../at-uri-parser" }
 jacquard-common = "0.9"
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }
 
 # Web framework
-axum = { version = "0.8", features = ["macros"] }
+axum = { workspace = true, features = ["macros"] }
 axum-extra = { version = "0.10", features = ["cookie"] }
-tower-http = { version = "0.6", features = ["cors", "fs"] }
-tower = "0.5"
+tower-http = { workspace = true, features = ["cors", "fs"] }
+tower = { workspace = true }
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgres", "chrono"] }
+sqlx = { workspace = true }
 
 # HTTP client (for taxonomy service + internal agent RPC)
-reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls", "stream"] }
+reqwest = { workspace = true, features = ["stream"] }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # TypeScript type generation
 ts-rs = { workspace = true }
 
 # Logging
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 
 # Time
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 
 # Base64 for blob uploads
 base64 = "0.22"
@@ -59,10 +59,10 @@ hickory-resolver = "0.24"
 async-trait = "0.1"
 
 # URL encoding
-urlencoding = "2"
+urlencoding = { workspace = true }
 
 # Async combinators
-futures = "0.3"
+futures = { workspace = true }
 
 [[bin]]
 name = "observing-appview"

--- a/crates/observing-db/Cargo.toml
+++ b/crates/observing-db/Cargo.toml
@@ -11,20 +11,20 @@ processing = ["observing-lexicons"]
 
 [dependencies]
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgres", "chrono", "json", "migrate"] }
+sqlx = { workspace = true, features = ["json", "migrate"] }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # TypeScript type generation
 ts-rs = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # Time
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 
 # Optional: AT Protocol lexicon types for record processing
 observing-lexicons = { path = "../observing-lexicons", optional = true }

--- a/crates/observing-ingester/Cargo.toml
+++ b/crates/observing-ingester/Cargo.toml
@@ -7,40 +7,40 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }
 
 # Jetstream client
 jetstream-client = { path = "../jetstream-client" }
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgres", "chrono"] }
+sqlx = { workspace = true }
 observing-db = { path = "../observing-db", features = ["processing"] }
 observing-lexicons = { path = "../observing-lexicons" }
 
 # HTTP server
-axum = "0.8"
-tower-http = { version = "0.6", features = ["cors"] }
+axum = { workspace = true }
+tower-http = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Logging
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
-tracing-stackdriver = "0.10"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-stackdriver = { workspace = true }
 
 # Time
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 
 # CLI
 clap = { version = "4", features = ["derive"] }
 
 # URL parsing
-url = "2"
+url = { workspace = true }
 
 [dev-dependencies]
-tower = { version = "0.5", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 
 [[bin]]
 name = "observing-ingester"

--- a/crates/observing-lexicons/Cargo.toml
+++ b/crates/observing-lexicons/Cargo.toml
@@ -22,4 +22,4 @@ jacquard-common = "0.9"
 jacquard-derive = "0.9"
 jacquard-lexicon = "0.9"
 rustversion = "1"
-serde = { version = "1", features = ["derive"] }
+serde = { workspace = true }

--- a/crates/observing-media-proxy/Cargo.toml
+++ b/crates/observing-media-proxy/Cargo.toml
@@ -7,11 +7,11 @@ license = "AGPL-3.0-only"
 
 [dependencies]
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }
 
 # HTTP server
-axum = "0.8"
-tower-http = { version = "0.6", features = ["cors"] }
+axum = { workspace = true }
+tower-http = { workspace = true }
 
 # AT Protocol blob resolution
 atproto-blob-resolver = { path = "../atproto-blob-resolver" }
@@ -20,23 +20,23 @@ atproto-blob-resolver = { path = "../atproto-blob-resolver" }
 file-blob-cache = { path = "../file-blob-cache" }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Logging
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
-tracing-stackdriver = "0.10"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-stackdriver = { workspace = true }
 
 # Time
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 
 # URL parsing
-url = "2"
+url = { workspace = true }
 
 [dev-dependencies]
-tower = { version = "0.5", features = ["util"] }
-tempfile = "3"
+tower = { workspace = true, features = ["util"] }
+tempfile = { workspace = true }
 
 [[bin]]
 name = "observing-media-proxy"

--- a/crates/observing-taxonomy/Cargo.toml
+++ b/crates/observing-taxonomy/Cargo.toml
@@ -10,38 +10,38 @@ license = "AGPL-3.0-only"
 gbif-api = { path = "../gbif-api" }
 
 # Async runtime
-tokio = { version = "1", features = ["full"] }
+tokio = { workspace = true }
 
 # HTTP server
-axum = "0.8"
-tower-http = { version = "0.6", features = ["cors"] }
+axum = { workspace = true }
+tower-http = { workspace = true }
 
 # HTTP client (still needed for error type re-export)
-reqwest = { version = "0.13", features = ["json"] }
+reqwest = { workspace = true }
 
 # Serialization
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 # Logging
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "json", "registry"] }
-tracing-stackdriver = "0.10"
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-stackdriver = { workspace = true }
 
 # Time
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 
 # Caching
-moka = { version = "0.12", features = ["future"] }
+moka = { workspace = true }
 
 # URL encoding
-urlencoding = "2"
+urlencoding = { workspace = true }
 
 # Async utilities
-futures = "0.3"
+futures = { workspace = true }
 
 [dev-dependencies]
-tower = { version = "0.5", features = ["util"] }
+tower = { workspace = true, features = ["util"] }
 
 [[bin]]
 name = "observing-taxonomy"


### PR DESCRIPTION
## Summary

- Centralizes 17 commonly-used dependencies in `[workspace.dependencies]` in the root `Cargo.toml`, replacing duplicate version specifications across 12 crates with `{ workspace = true }` references
- Standardizes `reqwest` on v0.13 across the workspace (previously split between 0.12 and 0.13); the `rustls-tls` feature was dropped as reqwest 0.13 uses rustls by default
- Crates needing extra features beyond the workspace default use `{ workspace = true, features = [...] }` (e.g., `axum` with `macros`, `sqlx` with `json`/`migrate`, `reqwest` with `stream`, `tower-http` with `fs`)

Dependencies moved to workspace level: `serde`, `serde_json`, `tokio`, `axum`, `reqwest`, `tracing`, `tracing-subscriber`, `tracing-stackdriver`, `chrono`, `moka`, `tower-http`, `tower`, `sqlx`, `urlencoding`, `url`, `futures`, `futures-util`, `tempfile`

## Test plan

- [x] `cargo check --workspace` passes
- [ ] CI build and tests pass