### PR TITLE
refactor: log silently-dropped errors with tracing::warn

### DIFF
--- a/crates/file-blob-cache/src/cache.rs
+++ b/crates/file-blob-cache/src/cache.rs
@@ -176,8 +176,10 @@ impl BlobCache {
         if let Some(entry) = entry {
             self.current_size.fetch_sub(entry.size, Ordering::Relaxed);
 
-            // Try to remove the file (ignore errors)
-            let _ = fs::remove_file(&entry.path).await;
+            // Try to remove the file
+            if let Err(e) = fs::remove_file(&entry.path).await {
+                warn!(path = ?entry.path, error = %e, "Failed to remove cached file from disk");
+            }
         }
     }
 

--- a/crates/jetstream-client/src/subscription.rs
+++ b/crates/jetstream-client/src/subscription.rs
@@ -91,10 +91,13 @@ impl JetstreamSubscription {
                 }
                 Err(e) => {
                     error!("Jetstream error: {}", e);
-                    let _ = self
+                    if let Err(e) = self
                         .event_tx
                         .send(JetstreamEvent::Error(e.to_string()))
-                        .await;
+                        .await
+                    {
+                        warn!(error = %e, "Failed to send error event to channel");
+                    }
 
                     reconnect_attempts += 1;
                     if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
@@ -121,7 +124,9 @@ impl JetstreamSubscription {
         let (ws_stream, _) = connect_async(&url).await?;
         let (mut _write, mut read) = ws_stream.split();
 
-        let _ = self.event_tx.send(JetstreamEvent::Connected).await;
+        if let Err(e) = self.event_tx.send(JetstreamEvent::Connected).await {
+            warn!(error = %e, "Failed to send connected event to channel");
+        }
         info!("Jetstream connection established");
 
         while let Some(msg) = read.next().await {
@@ -133,7 +138,9 @@ impl JetstreamSubscription {
                 }
                 Ok(Message::Close(_)) => {
                     info!("Received close frame");
-                    let _ = self.event_tx.send(JetstreamEvent::Disconnected).await;
+                    if let Err(e) = self.event_tx.send(JetstreamEvent::Disconnected).await {
+                        warn!(error = %e, "Failed to send disconnected event to channel");
+                    }
                     break;
                 }
                 Ok(_) => {
@@ -141,7 +148,9 @@ impl JetstreamSubscription {
                 }
                 Err(e) => {
                     error!("WebSocket error: {}", e);
-                    let _ = self.event_tx.send(JetstreamEvent::Disconnected).await;
+                    if let Err(e) = self.event_tx.send(JetstreamEvent::Disconnected).await {
+                        warn!(error = %e, "Failed to send disconnected event to channel");
+                    }
                     return Err(e.into());
                 }
             }
@@ -187,10 +196,13 @@ impl JetstreamSubscription {
         self.last_timing = Some(TimingInfo { seq, time });
         if self.last_timing_sent.elapsed() >= TIMING_UPDATE_INTERVAL {
             if let Some(ref timing) = self.last_timing {
-                let _ = self
+                if let Err(e) = self
                     .event_tx
                     .send(JetstreamEvent::TimingUpdate(timing.clone()))
-                    .await;
+                    .await
+                {
+                    warn!(error = %e, "Failed to send timing update to channel");
+                }
             }
             self.last_timing_sent = Instant::now();
         }
@@ -219,10 +231,13 @@ impl JetstreamSubscription {
                 "[{}] {}: {}",
                 commit_info.collection, commit_info.operation, commit_info.uri
             );
-            let _ = self
+            if let Err(e) = self
                 .event_tx
                 .send(JetstreamEvent::Commit(commit_info))
-                .await;
+                .await
+            {
+                warn!(error = %e, "Failed to send commit event to channel");
+            }
         }
 
         // Update cursor

--- a/crates/observing-appview/src/routes/identifications.rs
+++ b/crates/observing-appview/src/routes/identifications.rs
@@ -5,7 +5,7 @@ use jacquard_common::types::string::Datetime;
 use observing_lexicons::org_rwell::test::identification::{Identification, Taxon};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use tracing::info;
+use tracing::{info, warn};
 use ts_rs::TS;
 
 use crate::auth::{self, AuthUser};
@@ -162,7 +162,9 @@ pub async fn delete_identification(
         })?;
 
     // Delete from local DB (refreshes community IDs)
-    let _ = observing_db::identifications::delete(&state.pool, &uri).await;
+    if let Err(e) = observing_db::identifications::delete(&state.pool, &uri).await {
+        warn!(error = %e, "Failed to delete identification from local DB");
+    }
 
     Ok(Json(json!({ "success": true })))
 }

--- a/crates/observing-appview/src/routes/likes.rs
+++ b/crates/observing-appview/src/routes/likes.rs
@@ -7,7 +7,7 @@ use observing_db::types::CreateLikeParams;
 use observing_lexicons::org_rwell::test::like::Like;
 use serde::Deserialize;
 use serde_json::{json, Value};
-use tracing::info;
+use tracing::{info, warn};
 use ts_rs::TS;
 
 use crate::auth::{self, AuthUser};
@@ -58,7 +58,9 @@ pub async fn create_like(
         subject_cid: body.occurrence_cid,
         created_at: now.naive_utc(),
     };
-    let _ = observing_db::likes::create(&state.pool, &params).await;
+    if let Err(e) = observing_db::likes::create(&state.pool, &params).await {
+        warn!(error = %e, "Failed to insert like into local DB");
+    }
 
     Ok(Json(json!({
         "success": true,

--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -5,7 +5,7 @@ use jacquard_common::types::string::Datetime;
 use observing_lexicons::org_rwell::test::occurrence::{Location, Occurrence};
 use serde::Deserialize;
 use serde_json::{json, Value};
-use tracing::info;
+use tracing::{info, warn};
 use ts_rs::TS;
 
 use crate::auth::{self, AuthUser};
@@ -187,17 +187,25 @@ pub async fn create_occurrence(
         cid.clone(),
         user.did.clone(),
     ) {
-        let _ = observing_db::occurrences::upsert(&state.pool, &params).await;
+        if let Err(e) = observing_db::occurrences::upsert(&state.pool, &params).await {
+            warn!(error = %e, "Failed to upsert occurrence into local DB");
+        }
     }
 
     // Save private location data
-    let _ =
+    if let Err(e) =
         observing_db::private_data::save(&state.pool, &uri, body.latitude, body.longitude, "open")
-            .await;
+            .await
+    {
+        warn!(error = %e, "Failed to save private location data");
+    }
 
     // Sync observers
     let co_observers = body.recorded_by.unwrap_or_default();
-    let _ = observing_db::observers::sync(&state.pool, &uri, &user.did, &co_observers).await;
+    if let Err(e) = observing_db::observers::sync(&state.pool, &uri, &user.did, &co_observers).await
+    {
+        warn!(error = %e, "Failed to sync observers");
+    }
 
     // Auto-create first identification if a scientific name was provided
     if let Some(ref scientific_name) = body.scientific_name {
@@ -222,7 +230,11 @@ pub async fn create_occurrence(
                         user.did.clone(),
                         chrono::Utc::now(),
                     ) {
-                        let _ = observing_db::identifications::upsert(&state.pool, &params).await;
+                        if let Err(e) =
+                            observing_db::identifications::upsert(&state.pool, &params).await
+                        {
+                            warn!(error = %e, "Failed to upsert auto-created identification into local DB");
+                        }
                     }
                 }
                 Err(e) => {
@@ -250,8 +262,14 @@ pub async fn post_occurrence_catch_all(
         let observer_did = body["did"]
             .as_str()
             .ok_or_else(|| AppError::BadRequest("did is required".into()))?;
-        let _ = observing_db::observers::add(&state.pool, uri, &user.did, "owner").await;
-        let _ = observing_db::observers::add(&state.pool, uri, observer_did, "co-observer").await;
+        if let Err(e) = observing_db::observers::add(&state.pool, uri, &user.did, "owner").await {
+            warn!(error = %e, "Failed to add owner observer");
+        }
+        if let Err(e) =
+            observing_db::observers::add(&state.pool, uri, observer_did, "co-observer").await
+        {
+            warn!(error = %e, "Failed to add co-observer");
+        }
         return Ok(Json(json!({ "success": true })));
     }
 
@@ -269,7 +287,9 @@ pub async fn delete_occurrence_catch_all(
         let idx = full_path.rfind("/observers/").unwrap();
         let uri = &full_path[..idx];
         let observer_did = &full_path[idx + "/observers/".len()..];
-        let _ = observing_db::observers::remove(&state.pool, uri, observer_did).await;
+        if let Err(e) = observing_db::observers::remove(&state.pool, uri, observer_did).await {
+            warn!(error = %e, "Failed to remove observer");
+        }
         return Ok(Json(json!({ "success": true })));
     }
 
@@ -316,7 +336,9 @@ pub async fn delete_occurrence_catch_all(
             }
         })?;
 
-    let _ = observing_db::occurrences::delete(&state.pool, uri).await;
+    if let Err(e) = observing_db::occurrences::delete(&state.pool, uri).await {
+        warn!(error = %e, "Failed to delete occurrence from local DB");
+    }
 
     Ok(Json(json!({ "success": true })))
 }


### PR DESCRIPTION
## Summary
- Replace `let _ = ...` patterns with `if let Err(e) = ... { tracing::warn!(...) }` across 5 files where errors were silently dropped
- Covers DB operations (upserts, deletes, syncs), mpsc channel sends, and file cleanup
- Each warning includes a descriptive message identifying which operation failed

## Files changed
- `crates/observing-appview/src/routes/occurrences/write.rs` — 8 DB operations (occurrences, private_data, observers, identifications)
- `crates/observing-appview/src/routes/identifications.rs` — 1 DB delete
- `crates/observing-appview/src/routes/likes.rs` — 1 DB insert
- `crates/jetstream-client/src/subscription.rs` — 6 channel sends (connected, disconnected, error, timing, commit events)
- `crates/file-blob-cache/src/cache.rs` — 1 file removal

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo fmt --all` applied