### PR TITLE
refactor: improve test assertion quality

### DIFF
--- a/crates/at-uri-parser/src/lib.rs
+++ b/crates/at-uri-parser/src/lib.rs
@@ -34,7 +34,8 @@ mod tests {
 
     #[test]
     fn test_parse_valid_uri() {
-        let uri = AtUri::parse("at://did:plc:abc123/org.rwell.test.occurrence/rkey1").unwrap();
+        let uri = AtUri::parse("at://did:plc:abc123/org.rwell.test.occurrence/rkey1")
+            .expect("valid AT URI should parse successfully");
         assert_eq!(uri.did, "did:plc:abc123");
         assert_eq!(uri.collection, "org.rwell.test.occurrence");
         assert_eq!(uri.rkey, "rkey1");
@@ -62,7 +63,8 @@ mod tests {
 
     #[test]
     fn test_parse_did_web() {
-        let uri = AtUri::parse("at://did:web:example.com/app.bsky.feed.like/abc").unwrap();
+        let uri = AtUri::parse("at://did:web:example.com/app.bsky.feed.like/abc")
+            .expect("AT URI with did:web should parse successfully");
         assert_eq!(uri.did, "did:web:example.com");
         assert_eq!(uri.collection, "app.bsky.feed.like");
         assert_eq!(uri.rkey, "abc");

--- a/crates/file-blob-cache/src/cache.rs
+++ b/crates/file-blob-cache/src/cache.rs
@@ -217,9 +217,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_put_and_get() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("should create temp directory");
         let cache = BlobCache::new(dir.path().to_path_buf(), 1024 * 1024, 3600);
-        cache.init().await.unwrap();
+        cache.init().await.expect("cache init should succeed");
 
         let did = "did:plc:test123";
         let cid = "bafytest";
@@ -227,22 +227,26 @@ mod tests {
         let content_type = "text/plain";
 
         // Put data
-        cache.put(did, cid, data, content_type).await.unwrap();
+        cache
+            .put(did, cid, data, content_type)
+            .await
+            .expect("cache put should succeed");
 
         // Get data back
         let result = cache.get(did, cid).await;
         assert!(result.is_some());
 
-        let (retrieved_data, retrieved_type) = result.unwrap();
+        let (retrieved_data, retrieved_type) =
+            result.expect("cache get should return previously stored data");
         assert_eq!(retrieved_data, data);
         assert_eq!(retrieved_type, content_type);
     }
 
     #[tokio::test]
     async fn test_cache_miss() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("should create temp directory");
         let cache = BlobCache::new(dir.path().to_path_buf(), 1024 * 1024, 3600);
-        cache.init().await.unwrap();
+        cache.init().await.expect("cache init should succeed");
 
         let result = cache.get("did:plc:nonexistent", "bafynonexistent").await;
         assert!(result.is_none());
@@ -250,9 +254,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_stats() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("should create temp directory");
         let cache = BlobCache::new(dir.path().to_path_buf(), 1024 * 1024, 3600);
-        cache.init().await.unwrap();
+        cache.init().await.expect("cache init should succeed");
 
         // Initial stats
         let stats = cache.stats().await;
@@ -263,7 +267,7 @@ mod tests {
         cache
             .put("did:plc:test", "bafytest", b"test data", "text/plain")
             .await
-            .unwrap();
+            .expect("cache put should succeed");
 
         let stats = cache.stats().await;
         assert_eq!(stats.entries, 1);
@@ -272,9 +276,9 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_hit_miss_counters() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("should create temp directory");
         let cache = BlobCache::new(dir.path().to_path_buf(), 1024 * 1024, 3600);
-        cache.init().await.unwrap();
+        cache.init().await.expect("cache init should succeed");
 
         // Miss
         cache.get("did:plc:test", "bafytest").await;
@@ -286,7 +290,7 @@ mod tests {
         cache
             .put("did:plc:test", "bafytest", b"data", "text/plain")
             .await
-            .unwrap();
+            .expect("cache put should succeed");
         cache.get("did:plc:test", "bafytest").await;
 
         let stats = cache.stats().await;
@@ -296,22 +300,22 @@ mod tests {
 
     #[tokio::test]
     async fn test_cache_eviction() {
-        let dir = tempdir().unwrap();
+        let dir = tempdir().expect("should create temp directory");
         // Small cache: only 20 bytes
         let cache = BlobCache::new(dir.path().to_path_buf(), 20, 3600);
-        cache.init().await.unwrap();
+        cache.init().await.expect("cache init should succeed");
 
         // Add first entry (10 bytes)
         cache
             .put("did:plc:1", "cid1", b"0123456789", "text/plain")
             .await
-            .unwrap();
+            .expect("first cache put should succeed");
 
         // Add second entry (10 bytes) - should fit
         cache
             .put("did:plc:2", "cid2", b"abcdefghij", "text/plain")
             .await
-            .unwrap();
+            .expect("second cache put should succeed");
 
         // Both should exist
         assert!(cache.get("did:plc:1", "cid1").await.is_some());
@@ -321,7 +325,7 @@ mod tests {
         cache
             .put("did:plc:3", "cid3", b"ABCDEFGHIJ", "text/plain")
             .await
-            .unwrap();
+            .expect("third cache put should succeed");
 
         // Third should exist, first might be evicted
         assert!(cache.get("did:plc:3", "cid3").await.is_some());

--- a/crates/jetstream-client/src/event.rs
+++ b/crates/jetstream-client/src/event.rs
@@ -58,11 +58,12 @@ mod tests {
             record: Some(serde_json::json!({"key": "value"})),
         };
 
-        let json = serde_json::to_string(&commit).unwrap();
+        let json = serde_json::to_string(&commit).expect("CommitInfo should serialize to JSON");
         assert!(json.contains("did:plc:abc123"));
         assert!(json.contains("app.example.record"));
 
-        let deserialized: CommitInfo = serde_json::from_str(&json).unwrap();
+        let deserialized: CommitInfo =
+            serde_json::from_str(&json).expect("JSON should deserialize back into CommitInfo");
         assert_eq!(deserialized.did, commit.did);
         assert_eq!(deserialized.uri, commit.uri);
         assert_eq!(deserialized.operation, commit.operation);
@@ -82,7 +83,8 @@ mod tests {
             record: None,
         };
 
-        let json = serde_json::to_string(&commit).unwrap();
+        let json = serde_json::to_string(&commit)
+            .expect("CommitInfo without record should serialize to JSON");
         // record field should be omitted when None
         assert!(!json.contains("\"record\""));
     }
@@ -92,10 +94,11 @@ mod tests {
         let time = Utc::now();
         let timing = TimingInfo { seq: 999, time };
 
-        let json = serde_json::to_string(&timing).unwrap();
+        let json = serde_json::to_string(&timing).expect("TimingInfo should serialize to JSON");
         assert!(json.contains("999"));
 
-        let deserialized: TimingInfo = serde_json::from_str(&json).unwrap();
+        let deserialized: TimingInfo =
+            serde_json::from_str(&json).expect("JSON should deserialize back into TimingInfo");
         assert_eq!(deserialized.seq, 999);
     }
 }

--- a/crates/jetstream-client/src/subscription.rs
+++ b/crates/jetstream-client/src/subscription.rs
@@ -327,10 +327,11 @@ mod tests {
             }
         }"#;
 
-        let event: RawJetstreamEvent = serde_json::from_str(json).unwrap();
+        let event: RawJetstreamEvent =
+            serde_json::from_str(json).expect("valid JSON should parse into RawJetstreamEvent");
         assert_eq!(event.did, "did:plc:abc123");
         assert!(event.commit.is_some());
-        let commit = event.commit.unwrap();
+        let commit = event.commit.expect("event should contain a commit");
         assert_eq!(commit.collection, "app.example.record");
         assert_eq!(commit.operation, "create");
     }
@@ -342,7 +343,8 @@ mod tests {
             "time_us": 1704067200000000
         }"#;
 
-        let event: RawJetstreamEvent = serde_json::from_str(json).unwrap();
+        let event: RawJetstreamEvent =
+            serde_json::from_str(json).expect("valid JSON should parse into RawJetstreamEvent");
         assert!(event.commit.is_none());
     }
 
@@ -363,18 +365,21 @@ mod tests {
                 "cid": "bafyrei..."
             }
         }"#;
-        sub.handle_message(msg).await.unwrap();
+        sub.handle_message(msg)
+            .await
+            .expect("handle_message should process a valid commit message");
 
-        let event = rx.try_recv().unwrap();
-        match event {
-            JetstreamEvent::Commit(commit) => {
-                assert_eq!(commit.did, "did:plc:abc123");
-                assert_eq!(commit.collection, "app.example.record");
-                assert_eq!(commit.rkey, "123");
-                assert_eq!(commit.operation, "create");
-                assert_eq!(commit.uri, "at://did:plc:abc123/app.example.record/123");
-            }
-            _ => panic!("Expected Commit event"),
-        }
+        let event = rx
+            .try_recv()
+            .expect("channel should contain the emitted event");
+        let commit = match event {
+            JetstreamEvent::Commit(commit) => commit,
+            other => panic!("Expected Commit event, got {:?}", other),
+        };
+        assert_eq!(commit.did, "did:plc:abc123");
+        assert_eq!(commit.collection, "app.example.record");
+        assert_eq!(commit.rkey, "123");
+        assert_eq!(commit.operation, "create");
+        assert_eq!(commit.uri, "at://did:plc:abc123/app.example.record/123");
     }
 }


### PR DESCRIPTION
## Summary
- Replace bare `.unwrap()` calls in tests with `.expect("descriptive message")` across `jetstream-client`, `file-blob-cache`, and `at-uri-parser` crates
- Replace `panic!("Expected Commit event")` with pattern matching that includes the actual variant in the failure message for better debugging
- All 200+ workspace tests continue to pass

## Test plan
- [x] `cargo test --workspace` passes with all tests green
- [x] `cargo fmt --all` applied (no formatting changes needed)