### PR TITLE
enhance: add SEO meta tags and Open Graph metadata

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -5,6 +5,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <title>Observ.ing</title>
+    <meta
+      name="description"
+      content="A decentralized platform for biodiversity observations, built on the AT Protocol. Record what you see, keep what you create."
+    />
+    <meta name="theme-color" content="#15803d" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="Observ.ing - Observe nature. Own your data." />
+    <meta
+      property="og:description"
+      content="A decentralized platform for biodiversity observations, built on the AT Protocol. Record what you see, keep what you create."
+    />
+    <meta property="og:url" content="https://observ.ing" />
+    <meta property="og:site_name" content="Observ.ing" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Observ.ing - Observe nature. Own your data." />
+    <meta
+      name="twitter:description"
+      content="A decentralized platform for biodiversity observations, built on the AT Protocol."
+    />
+
+    <link rel="canonical" href="https://observ.ing" />
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Add meta description, theme-color, Open Graph, and Twitter Card meta tags to `index.html`
- Add canonical link pointing to https://observ.ing
- Theme color `#15803d` matches the existing green-700 primary color defined in `frontend/src/theme/index.ts`

## Test plan
- [ ] Verify meta tags render correctly in page source
- [ ] Validate with https://metatags.io or similar Open Graph preview tool
- [ ] Confirm theme-color applies on mobile browsers