### PR TITLE
enhance: add security response headers

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod constants;
 mod enrichment;
 mod error;
+mod middleware;
 mod oauth_store;
 mod resolver;
 mod routes;
@@ -14,9 +15,8 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
-use axum::http::{header, HeaderValue, Method};
-use axum::middleware;
-use axum::response::Response;
+use axum::http::{header, Method};
+use axum::middleware as axum_middleware;
 use axum::routing::{get, post};
 use axum::Router;
 use sqlx::postgres::PgPoolOptions;
@@ -183,23 +183,9 @@ async fn main() {
         .route("/media/{*path}", get(routes::media::proxy))
         .layer(DefaultBodyLimit::max(150 * 1024 * 1024)) // 150MB for base64-encoded images
         .layer(cors)
-        .layer(middleware::map_response({
+        .layer(axum_middleware::map_response({
             let is_production = config.public_url.is_some();
-            move |mut response: Response| async move {
-                let headers = response.headers_mut();
-                headers.insert(
-                    "X-Content-Type-Options",
-                    HeaderValue::from_static("nosniff"),
-                );
-                headers.insert("X-Frame-Options", HeaderValue::from_static("DENY"));
-                if is_production {
-                    headers.insert(
-                        "Strict-Transport-Security",
-                        HeaderValue::from_static("max-age=63072000; includeSubDomains"),
-                    );
-                }
-                response
-            }
+            move |response| middleware::security_headers(response, is_production)
         }))
         .with_state(state);
 

--- a/crates/observing-appview/src/middleware.rs
+++ b/crates/observing-appview/src/middleware.rs
@@ -1,0 +1,23 @@
+use axum::http::HeaderValue;
+use axum::response::Response;
+
+/// Adds security headers to all responses.
+///
+/// - `X-Content-Type-Options: nosniff` — prevents MIME-type sniffing
+/// - `X-Frame-Options: DENY` — prevents clickjacking
+/// - `Strict-Transport-Security` — enforces HTTPS (production only)
+pub async fn security_headers(mut response: Response, is_production: bool) -> Response {
+    let headers = response.headers_mut();
+    headers.insert(
+        "X-Content-Type-Options",
+        HeaderValue::from_static("nosniff"),
+    );
+    headers.insert("X-Frame-Options", HeaderValue::from_static("DENY"));
+    if is_production {
+        headers.insert(
+            "Strict-Transport-Security",
+            HeaderValue::from_static("max-age=63072000; includeSubDomains"),
+        );
+    }
+    response
+}


### PR DESCRIPTION
## Summary
- Adds `X-Content-Type-Options: nosniff` to all responses (prevents MIME type sniffing)
- Adds `X-Frame-Options: DENY` to all responses (prevents clickjacking)
- Adds `Strict-Transport-Security: max-age=63072000; includeSubDomains` only when `PUBLIC_URL` is set (i.e. production)
- Uses `axum::middleware::map_response` — no new dependencies needed

## Test plan
- [ ] Verify headers appear on API responses (e.g. `curl -I https://observ.ing/health`)
- [ ] Verify HSTS header is absent in local dev (no `PUBLIC_URL`)
- [ ] Verify HSTS header is present in production (with `PUBLIC_URL`)