### PR TITLE
enhance: add code splitting to reduce initial bundle size

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,26 +1,60 @@
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { Provider } from "react-redux";
-import { ThemeProvider, CssBaseline, Box, Alert } from "@mui/material";
+import { ThemeProvider, CssBaseline, Box, Alert, CircularProgress } from "@mui/material";
 import { getTheme } from "./theme";
 import { store, useAppDispatch, useAppSelector } from "./store";
 import { checkAuth } from "./store/authSlice";
 import { updateSystemTheme } from "./store/uiSlice";
 import { Sidebar, DRAWER_WIDTH } from "./components/layout/Sidebar";
-import { LandingPage } from "./components/landing/LandingPage";
-import { FeedView } from "./components/feed/FeedView";
-import { ObservationDetail } from "./components/observation/ObservationDetail";
-import { ProfileView } from "./components/profile/ProfileView";
-import { TaxonDetail } from "./components/taxon/TaxonDetail";
 import { LoginModal } from "./components/modals/LoginModal";
-import { UploadModal } from "./components/modals/UploadModal";
-import { DeleteConfirmDialog } from "./components/modals/DeleteConfirmDialog";
 import { FAB } from "./components/common/FAB";
 import { ToastContainer } from "./components/common/Toast";
 import { NotFound } from "./components/common/NotFound";
-import { LexiconView } from "./components/lexicon/LexiconView";
-import { NotificationsPage } from "./components/notifications/NotificationsPage";
 import "./styles/global.css";
+
+// Lazy-loaded route components
+const LandingPage = lazy(() =>
+  import("./components/landing/LandingPage").then((m) => ({ default: m.LandingPage })),
+);
+const FeedView = lazy(() =>
+  import("./components/feed/FeedView").then((m) => ({ default: m.FeedView })),
+);
+const ObservationDetail = lazy(() =>
+  import("./components/observation/ObservationDetail").then((m) => ({
+    default: m.ObservationDetail,
+  })),
+);
+const ProfileView = lazy(() =>
+  import("./components/profile/ProfileView").then((m) => ({ default: m.ProfileView })),
+);
+const TaxonDetail = lazy(() =>
+  import("./components/taxon/TaxonDetail").then((m) => ({ default: m.TaxonDetail })),
+);
+const UploadModal = lazy(() =>
+  import("./components/modals/UploadModal").then((m) => ({ default: m.UploadModal })),
+);
+const DeleteConfirmDialog = lazy(() =>
+  import("./components/modals/DeleteConfirmDialog").then((m) => ({
+    default: m.DeleteConfirmDialog,
+  })),
+);
+const LexiconView = lazy(() =>
+  import("./components/lexicon/LexiconView").then((m) => ({ default: m.LexiconView })),
+);
+const NotificationsPage = lazy(() =>
+  import("./components/notifications/NotificationsPage").then((m) => ({
+    default: m.NotificationsPage,
+  })),
+);
+
+function PageLoading() {
+  return (
+    <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", flex: 1 }}>
+      <CircularProgress />
+    </Box>
+  );
+}
 
 function AppContent() {
   const dispatch = useAppDispatch();
@@ -81,23 +115,27 @@ function AppContent() {
             width: showLanding ? "100%" : { md: `calc(100% - ${DRAWER_WIDTH}px)` },
           }}
         >
-          <Routes>
-            <Route path="/" element={showLanding ? <LandingPage /> : <FeedView tab="home" />} />
-            <Route path="/explore" element={<FeedView tab="explore" />} />
-            <Route path="/observation/:did/:rkey" element={<ObservationDetail />} />
-            <Route path="/profile/:did" element={<ProfileView />} />
-            <Route path="/notifications" element={<NotificationsPage />} />
-            <Route path="/taxon/:kingdom/:name" element={<TaxonDetail />} />
-            <Route path="/taxon/:id" element={<TaxonDetail />} />
-            <Route path="/lexicons" element={<LexiconView />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
+          <Suspense fallback={<PageLoading />}>
+            <Routes>
+              <Route path="/" element={showLanding ? <LandingPage /> : <FeedView tab="home" />} />
+              <Route path="/explore" element={<FeedView tab="explore" />} />
+              <Route path="/observation/:did/:rkey" element={<ObservationDetail />} />
+              <Route path="/profile/:did" element={<ProfileView />} />
+              <Route path="/notifications" element={<NotificationsPage />} />
+              <Route path="/taxon/:kingdom/:name" element={<TaxonDetail />} />
+              <Route path="/taxon/:id" element={<TaxonDetail />} />
+              <Route path="/lexicons" element={<LexiconView />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
         </Box>
       </Box>
       {!showLanding && <FAB />}
       <LoginModal />
-      <UploadModal />
-      <DeleteConfirmDialog />
+      <Suspense>
+        <UploadModal />
+        <DeleteConfirmDialog />
+      </Suspense>
       <ToastContainer />
     </>
   );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,6 +17,16 @@ export default defineConfig({
   build: {
     outDir: path.resolve(__dirname, "../dist/public"),
     emptyOutDir: true,
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          "vendor-react": ["react", "react-dom", "react-router-dom"],
+          "vendor-mui": ["@mui/material", "@mui/icons-material"],
+          "vendor-map": ["maplibre-gl"],
+          "vendor-redux": ["@reduxjs/toolkit", "react-redux"],
+        },
+      },
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
## Summary

- Add Vite `manualChunks` config to split vendor libraries into dedicated chunks (`vendor-react`, `vendor-mui`, `vendor-map`, `vendor-redux`)
- Add `React.lazy()` and `Suspense` for route-level code splitting on all page components (FeedView, ObservationDetail, ProfileView, TaxonDetail, LexiconView, NotificationsPage, LandingPage) and heavy modals (UploadModal, DeleteConfirmDialog)
- The single ~2096KB bundle is now split into 20+ chunks, with the entry chunk reduced to ~210KB

## Before / After

| | Before | After (largest chunks) |
|---|---|---|
| Entry JS | 2096 KB (single file) | 210 KB |
| vendor-map (maplibre-gl) | bundled | 1021 KB |
| vendor-mui | bundled | 422 KB |
| vendor-react | bundled | 47 KB |
| vendor-redux | bundled | 28 KB |
| Route chunks | N/A | 2-198 KB each |

## Test plan

- [ ] `npm run build` succeeds and produces multiple chunk files
- [ ] App loads correctly in the browser with no console errors
- [ ] Navigation between routes triggers lazy chunk loading
- [ ] Loading spinner appears briefly when navigating to a new route for the first time
- [ ] Upload modal and delete dialog still function correctly