### PR TITLE
fix: correct heading hierarchy for accessibility

### DIFF
--- a/frontend/src/components/common/NotFound.tsx
+++ b/frontend/src/components/common/NotFound.tsx
@@ -44,7 +44,7 @@ export function NotFound() {
       >
         404
       </Typography>
-      <Typography variant="h6" color="text.secondary" sx={{ mb: 1 }}>
+      <Typography variant="h6" component="h2" color="text.secondary" sx={{ mb: 1 }}>
         Page not found
       </Typography>
       <Typography variant="body2" color="text.disabled" sx={{ mb: 4, maxWidth: 300 }}>

--- a/frontend/src/components/landing/LandingPage.tsx
+++ b/frontend/src/components/landing/LandingPage.tsx
@@ -112,7 +112,7 @@ export function LandingPage() {
               }}
             >
               <CardContent>
-                <Typography variant="h6" sx={{ mb: 0.5, fontWeight: 700 }}>
+                <Typography variant="h6" component="h2" sx={{ mb: 0.5, fontWeight: 700 }}>
                   {feature.title}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -162,6 +162,7 @@ export function Sidebar({ mobileOpen, onMobileClose }: SidebarProps) {
         <img src={logoSvg} alt="" width={28} height={28} />
         <Typography
           variant="h6"
+          component="span"
           sx={{
             fontWeight: 700,
             color: "primary.main",

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -133,7 +133,7 @@ export function ProfileView() {
           {counts && (
             <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
               <Box sx={PROFILE_STAT_BOX_SX}>
-                <Typography variant="h6" fontWeight={700} color="primary.main">
+                <Typography variant="h6" component="span" fontWeight={700} color="primary.main">
                   {counts.observations.toLocaleString()}
                 </Typography>
                 <Stack
@@ -150,7 +150,7 @@ export function ProfileView() {
                 </Stack>
               </Box>
               <Box sx={PROFILE_STAT_BOX_SX}>
-                <Typography variant="h6" fontWeight={700} color="secondary.main">
+                <Typography variant="h6" component="span" fontWeight={700} color="secondary.main">
                   {counts.identifications.toLocaleString()}
                 </Typography>
                 <Stack
@@ -167,7 +167,7 @@ export function ProfileView() {
                 </Stack>
               </Box>
               <Box sx={PROFILE_STAT_BOX_SX}>
-                <Typography variant="h6" fontWeight={700} color="success.main">
+                <Typography variant="h6" component="span" fontWeight={700} color="success.main">
                   {counts.species.toLocaleString()}
                 </Typography>
                 <Stack

--- a/frontend/src/components/taxon/TaxonDetail.tsx
+++ b/frontend/src/components/taxon/TaxonDetail.tsx
@@ -219,7 +219,7 @@ export function TaxonDetail() {
 
           {/* Common Name */}
           {taxon.commonName && (
-            <Typography variant="h6" color="text.secondary" sx={{ mt: 0.5 }}>
+            <Typography variant="h6" component="p" color="text.secondary" sx={{ mt: 0.5 }}>
               {taxon.commonName}
             </Typography>
           )}


### PR DESCRIPTION
## Summary
- Fixes heading level violations where `variant="h6"` on MUI `Typography` produced `<h6>` elements that skipped levels h2-h5, breaking screen reader navigation
- Adds explicit `component` props to separate visual styling from semantic HTML: feature card titles on the landing page now render as `<h2>`, non-heading text (sidebar brand, profile stats, taxon common name) renders as `<span>` or `<p>`

## Test plan
- [ ] Verify the landing page heading hierarchy is h1 followed by h2 (inspect DOM or use a screen reader / accessibility audit tool)
- [ ] Verify the 404 page has h1 -> h2 hierarchy
- [ ] Verify the sidebar brand name no longer renders as `<h6>`
- [ ] Verify profile stat numbers no longer render as `<h6>`
- [ ] Confirm no visual regressions on any of the affected pages