### PR TITLE
enhance: add lazy loading to remaining image elements

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -93,6 +93,7 @@ export function TaxaAutocomplete({
                 component="img"
                 src={option.photoUrl}
                 alt=""
+                loading="lazy"
                 sx={{
                   width: 40,
                   height: 40,

--- a/frontend/src/components/common/WikiTaxonThumbnail.tsx
+++ b/frontend/src/components/common/WikiTaxonThumbnail.tsx
@@ -25,6 +25,7 @@ export function WikiTaxonThumbnail({ src, size = 24 }: WikiTaxonThumbnailProps) 
       component="img"
       src={src}
       alt=""
+      loading="lazy"
       sx={{
         width: size,
         height: size,

--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -186,6 +186,7 @@ export function ExploreFilterPanel() {
                       component="img"
                       src={option.photoUrl}
                       alt=""
+                      loading="lazy"
                       sx={{
                         width: 32,
                         height: 32,

--- a/frontend/src/components/interaction/InteractionPanel.tsx
+++ b/frontend/src/components/interaction/InteractionPanel.tsx
@@ -352,6 +352,7 @@ export function InteractionPanel({ observation, subjects, onSuccess }: Interacti
                           component="img"
                           src={taxon.photoUrl}
                           alt=""
+                          loading="lazy"
                           sx={{
                             width: 36,
                             height: 36,


### PR DESCRIPTION
## Summary
- Add `loading="lazy"` to image elements that were missing it: taxon autocomplete thumbnails (TaxaAutocomplete, ExploreFilterPanel, InteractionPanel) and the WikiTaxonThumbnail component
- Feed item images, explore grid cards, profile observation grid cards, and WikiCommonsGallery images already had `loading="lazy"` in place
- Logos and avatar images are intentionally left without lazy loading (above the fold / too small to matter)

## Test plan
- [ ] Verify explore grid images still render correctly
- [ ] Verify feed item images still render correctly
- [ ] Verify taxon autocomplete dropdown shows thumbnails
- [ ] Verify interaction panel taxon suggestions show thumbnails
- [ ] Check Network tab to confirm images below the fold are deferred