### PR TITLE
enhance: add compound indexes for profile feed pagination

### DIFF
--- a/crates/observing-db/migrations/20260319000000_profile_feed_indexes.sql
+++ b/crates/observing-db/migrations/20260319000000_profile_feed_indexes.sql
@@ -1,0 +1,9 @@
+-- Compound indexes for profile feed pagination queries.
+-- These replace sequential scans + sorts with index scans for
+-- WHERE did = $1 ORDER BY <timestamp> DESC patterns.
+
+CREATE INDEX IF NOT EXISTS idx_occurrences_did_created_at
+    ON occurrences (did, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_identifications_did_date_identified
+    ON identifications (did, date_identified DESC);


### PR DESCRIPTION
## Summary
- Adds a compound index `(did, created_at DESC)` on `occurrences` to speed up profile feed queries that filter by DID and sort by creation time
- Adds a compound index `(did, date_identified DESC)` on `identifications` for the same pagination pattern on identification queries
- Both replace sequential scan + sort with index scans for `WHERE did = $1 ORDER BY <timestamp> DESC` patterns

## Test plan
- [ ] Run migrations against a dev database and verify both indexes are created
- [ ] Confirm `EXPLAIN ANALYZE` shows index scan instead of sequential scan for profile feed queries