### PR TITLE
enhance: add gzip/brotli response compression

### DIFF
--- a/crates/observing-appview/Cargo.toml
+++ b/crates/observing-appview/Cargo.toml
@@ -22,7 +22,7 @@ tokio = { workspace = true }
 # Web framework
 axum = { workspace = true, features = ["macros"] }
 axum-extra = { version = "0.10", features = ["cookie"] }
-tower-http = { workspace = true, features = ["cors", "fs"] }
+tower-http = { workspace = true, features = ["cors", "compression-full", "fs"] }
 tower = { workspace = true }
 
 # Database

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -18,6 +18,7 @@ use axum::http::{header, Method};
 use axum::routing::{get, post};
 use axum::Router;
 use sqlx::postgres::PgPoolOptions;
+use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
 use tracing::info;
@@ -180,6 +181,7 @@ async fn main() {
         // Media proxy
         .route("/media/{*path}", get(routes::media::proxy))
         .layer(DefaultBodyLimit::max(150 * 1024 * 1024)) // 150MB for base64-encoded images
+        .layer(CompressionLayer::new())
         .layer(cors)
         .with_state(state);
 


### PR DESCRIPTION
## Summary
- Enables `compression-full` feature on `tower-http` (gzip, brotli, deflate, zstd)
- Adds `CompressionLayer::new()` to the Axum router middleware stack
- Typical 70-80% size reduction on JSON API responses

## Test plan
- [ ] Verify API responses include `Content-Encoding: gzip` (or `br`) when the request sends `Accept-Encoding`
- [ ] Confirm no regression on static file serving or media proxy