### PR TITLE
enhance: tune database connection pool settings

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -12,6 +12,7 @@ mod validation;
 
 use std::path::PathBuf;
 use std::sync::Arc;
+use std::time::Duration;
 
 use axum::extract::DefaultBodyLimit;
 use axum::http::{header, Method};
@@ -42,7 +43,10 @@ async fn main() {
 
     // Connect to database
     let pool = PgPoolOptions::new()
-        .max_connections(20)
+        .max_connections(50)
+        .acquire_timeout(Duration::from_secs(5))
+        .idle_timeout(Some(Duration::from_secs(300)))
+        .max_lifetime(Some(Duration::from_secs(1800)))
         .connect(&config.database_url)
         .await
         .expect("Failed to connect to database");

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -80,6 +80,8 @@ impl Database {
         info!("Connecting to database...");
         let pool = PgPoolOptions::new()
             .max_connections(10)
+            .acquire_timeout(std::time::Duration::from_secs(5))
+            .idle_timeout(Some(std::time::Duration::from_secs(300)))
             .connect(database_url)
             .await?;
         info!("Database connection established");


### PR DESCRIPTION
## Summary
- Appview: increase max connections from 20 to 50, add 5s acquire timeout, 5min idle timeout, and 30min max lifetime
- Ingester: keep max connections at 10, add 5s acquire timeout and 5min idle timeout
- Prevents pool exhaustion under moderate load and ensures stale connections are recycled

## Test plan
- [ ] Deploy to staging and verify services start and connect to the database successfully
- [ ] Monitor connection pool metrics under load to confirm no pool exhaustion
- [ ] Verify idle connections are cleaned up after 5 minutes