### PR TITLE
enhance: memoize FeedItem to prevent unnecessary re-renders

### DIFF
--- a/frontend/src/components/feed/ExploreGridCard.tsx
+++ b/frontend/src/components/feed/ExploreGridCard.tsx
@@ -1,0 +1,74 @@
+import { memo } from "react";
+import { Link } from "react-router-dom";
+import { Box, Typography, Card, CardActionArea, CardMedia, CardContent } from "@mui/material";
+import type { Occurrence } from "../../services/types";
+import { getImageUrl } from "../../services/api";
+import { formatTimeAgo, getObservationUrl } from "../../lib/utils";
+
+interface ExploreGridCardProps {
+  observation: Occurrence;
+}
+
+export const ExploreGridCard = memo(function ExploreGridCard({
+  observation,
+}: ExploreGridCardProps) {
+  const species = observation.communityId || observation.effectiveTaxonomy?.scientificName;
+
+  return (
+    <Card sx={{ display: "flex", flexDirection: "column" }}>
+      <CardActionArea
+        component={Link}
+        to={getObservationUrl(observation.uri)}
+        sx={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "stretch",
+        }}
+      >
+        {observation.images[0] ? (
+          <CardMedia
+            component="img"
+            image={getImageUrl(observation.images[0])}
+            alt={species || "Observation"}
+            loading="lazy"
+            sx={{ aspectRatio: "1", objectFit: "cover" }}
+          />
+        ) : (
+          <Box
+            sx={{
+              aspectRatio: "1",
+              bgcolor: "action.hover",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Typography color="text.disabled" variant="body2">
+              No image
+            </Typography>
+          </Box>
+        )}
+        <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
+          <Typography
+            variant="body2"
+            sx={{
+              fontStyle: "italic",
+              color: "primary.main",
+              fontWeight: 500,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {species || "Unknown species"}
+          </Typography>
+          <Typography variant="caption" color="text.disabled" noWrap>
+            {formatTimeAgo(new Date(observation.createdAt))}
+            {observation.verbatimLocality && ` · ${observation.verbatimLocality}`}
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+});

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { memo, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import {
   Box,
@@ -36,7 +36,7 @@ interface FeedItemProps {
 
 const REMARKS_TRUNCATE_LENGTH = 200;
 
-export function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
+export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   const [remarksExpanded, setRemarksExpanded] = useState(false);
   const { liked, likeCount, handleLikeToggle } = useLikeToggle(
@@ -341,4 +341,4 @@ export function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
       </CardActions>
     </Card>
   );
-}
+});

--- a/frontend/src/components/feed/FeedView.tsx
+++ b/frontend/src/components/feed/FeedView.tsx
@@ -1,16 +1,6 @@
 import { useEffect, useRef, useCallback } from "react";
 import { Link } from "react-router-dom";
-import {
-  Box,
-  Container,
-  Typography,
-  Button,
-  CircularProgress,
-  Card,
-  CardActionArea,
-  CardMedia,
-  CardContent,
-} from "@mui/material";
+import { Box, Container, Typography, Button, CircularProgress } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { loadFeed, loadInitialFeed, switchTab } from "../../store/feedSlice";
@@ -20,8 +10,7 @@ import { FeedItem } from "./FeedItem";
 import { FeedSkeletonList } from "./FeedItemSkeleton";
 import { ProfileObservationCardSkeleton } from "../profile/ProfileObservationCardSkeleton";
 import { ExploreFilterPanel } from "./ExploreFilterPanel";
-import { getImageUrl } from "../../services/api";
-import { formatTimeAgo, getObservationUrl } from "../../lib/utils";
+import { ExploreGridCard } from "./ExploreGridCard";
 
 interface FeedViewProps {
   tab?: FeedTab;
@@ -108,66 +97,9 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
                   p: 1.5,
                 }}
               >
-                {observations.map((obs) => {
-                  const species = obs.communityId || obs.effectiveTaxonomy?.scientificName;
-                  return (
-                    <Card key={obs.uri} sx={{ display: "flex", flexDirection: "column" }}>
-                      <CardActionArea
-                        component={Link}
-                        to={getObservationUrl(obs.uri)}
-                        sx={{
-                          flex: 1,
-                          display: "flex",
-                          flexDirection: "column",
-                          alignItems: "stretch",
-                        }}
-                      >
-                        {obs.images[0] ? (
-                          <CardMedia
-                            component="img"
-                            image={getImageUrl(obs.images[0])}
-                            alt={species || "Observation"}
-                            loading="lazy"
-                            sx={{ aspectRatio: "1", objectFit: "cover" }}
-                          />
-                        ) : (
-                          <Box
-                            sx={{
-                              aspectRatio: "1",
-                              bgcolor: "action.hover",
-                              display: "flex",
-                              alignItems: "center",
-                              justifyContent: "center",
-                            }}
-                          >
-                            <Typography color="text.disabled" variant="body2">
-                              No image
-                            </Typography>
-                          </Box>
-                        )}
-                        <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
-                          <Typography
-                            variant="body2"
-                            sx={{
-                              fontStyle: "italic",
-                              color: "primary.main",
-                              fontWeight: 500,
-                              overflow: "hidden",
-                              textOverflow: "ellipsis",
-                              whiteSpace: "nowrap",
-                            }}
-                          >
-                            {species || "Unknown species"}
-                          </Typography>
-                          <Typography variant="caption" color="text.disabled" noWrap>
-                            {formatTimeAgo(new Date(obs.createdAt))}
-                            {obs.verbatimLocality && ` · ${obs.verbatimLocality}`}
-                          </Typography>
-                        </CardContent>
-                      </CardActionArea>
-                    </Card>
-                  );
-                })}
+                {observations.map((obs) => (
+                  <ExploreGridCard key={obs.uri} observation={obs} />
+                ))}
 
                 {isLoading && observations.length === 0 && (
                   <>


### PR DESCRIPTION
## Summary
- Wrapped `FeedItem` in `React.memo` so it skips re-rendering when its props (`observation`, `onEdit`, `onDelete`) haven't changed. This matters because 20+ FeedItem instances are rendered in the feed `.map()` and all re-render when the parent FeedView state changes (e.g., loading indicators).
- Extracted the inline explore grid card JSX from `FeedView.tsx` into a new memoized `ExploreGridCard` component, applying the same optimization to the explore tab's grid view.

## Test plan
- [ ] Verify the home feed renders and scrolls correctly with no visual regressions
- [ ] Verify the explore grid renders correctly with cards linking to observation detail
- [ ] Confirm editing and deleting observations still works from the feed
- [ ] Use React DevTools Profiler to verify reduced re-renders on FeedItem when parent state changes