### PR TITLE
enhance: add Cache-Control headers for static assets

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -14,7 +14,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 
 use axum::extract::DefaultBodyLimit;
-use axum::http::{header, Method};
+use axum::http::{header, HeaderValue, Method, Uri};
+use axum::middleware;
+use axum::response::Response;
 use axum::routing::{get, post};
 use axum::Router;
 use sqlx::postgres::PgPoolOptions;
@@ -199,7 +201,11 @@ async fn main() {
     let spa_fallback =
         ServeDir::new(&public_path).fallback(ServeFile::new(format!("{}/index.html", public_path)));
 
-    let app = app.fallback_service(spa_fallback);
+    let spa_with_cache = Router::new()
+        .fallback_service(spa_fallback)
+        .layer(middleware::map_response(cache_control_middleware));
+
+    let app = app.fallback_service(spa_with_cache);
 
     let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", config.port))
         .await
@@ -208,4 +214,21 @@ async fn main() {
     info!(port = config.port, "Listening");
 
     axum::serve(listener, app).await.expect("Server failed");
+}
+
+/// Sets Cache-Control headers for static assets.
+///
+/// Vite-produced files under `/assets/` have content hashes in their filenames,
+/// so they can be cached indefinitely. All other files (index.html, favicon, etc.)
+/// must be revalidated on every request to ensure users get fresh content.
+async fn cache_control_middleware(uri: Uri, mut response: Response) -> Response {
+    let cache_value = if uri.path().contains("/assets/") {
+        HeaderValue::from_static("public, max-age=31536000, immutable")
+    } else {
+        HeaderValue::from_static("public, max-age=0, must-revalidate")
+    };
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, cache_value);
+    response
 }


### PR DESCRIPTION
## Summary

- Adds a `map_response` middleware to the SPA fallback service that sets `Cache-Control` headers based on the request path
- Paths containing `/assets/` (Vite hashed files) get `public, max-age=31536000, immutable` (1 year, safe because filenames include content hashes)
- All other static files (index.html, favicon, etc.) get `public, max-age=0, must-revalidate` so browsers always check for updates

## Test plan

- [ ] Verify `curl -I localhost:3000/assets/index-abc123.js` returns `Cache-Control: public, max-age=31536000, immutable`
- [ ] Verify `curl -I localhost:3000/` returns `Cache-Control: public, max-age=0, must-revalidate`
- [ ] Verify `curl -I localhost:3000/favicon.ico` returns `Cache-Control: public, max-age=0, must-revalidate`
- [ ] Confirm client-side routing still works (SPA fallback to index.html)