### PR TITLE
migrate GCP deployment to observ-ing project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,14 +247,34 @@ jobs:
       REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/observing
       REGION: us-central1
       PUBLIC_URL: https://observ.ing
-      MEDIA_PROXY_URL: https://observing-media-proxy-378013734384.us-central1.run.app
-      TAXONOMY_URL: https://observing-taxonomy-378013734384.us-central1.run.app
     steps:
       - uses: google-github-actions/auth@v2
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Deploy media-proxy
+        run: |
+          gcloud run deploy observing-media-proxy \
+            --image=$REGISTRY/observing-media-proxy:latest \
+            --region=$REGION \
+            --allow-unauthenticated \
+            --set-env-vars=RUST_LOG=observing_media_proxy=info,LOG_FORMAT=json
+
+      - name: Deploy taxonomy
+        run: |
+          gcloud run deploy observing-taxonomy \
+            --image=$REGISTRY/observing-taxonomy:latest \
+            --region=$REGION \
+            --allow-unauthenticated \
+            --set-env-vars=RUST_LOG=observing_taxonomy=info,LOG_FORMAT=json
+
+      - name: Get service URLs
+        id: urls
+        run: |
+          echo "media_proxy=$(gcloud run services describe observing-media-proxy --region=$REGION --format='value(status.url)')" >> $GITHUB_OUTPUT
+          echo "taxonomy=$(gcloud run services describe observing-taxonomy --region=$REGION --format='value(status.url)')" >> $GITHUB_OUTPUT
 
       - name: Deploy appview
         id: deploy-appview
@@ -264,7 +284,7 @@ jobs:
             --region=$REGION \
             --allow-unauthenticated \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,MEDIA_PROXY_URL=$MEDIA_PROXY_URL,TAXONOMY_SERVICE_URL=$TAXONOMY_URL,HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b \
+            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,MEDIA_PROXY_URL=${{ steps.urls.outputs.media_proxy }},TAXONOMY_SERVICE_URL=${{ steps.urls.outputs.taxonomy }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b \
             --set-secrets=DB_PASSWORD=observing-db-password:latest \
             --format='value(status.url)')
           echo "url=$URL" >> $GITHUB_OUTPUT
@@ -283,19 +303,3 @@ jobs:
             --min-instances=1 \
             --max-instances=1 \
             --timeout=3600
-
-      - name: Deploy media-proxy
-        run: |
-          gcloud run deploy observing-media-proxy \
-            --image=$REGISTRY/observing-media-proxy:latest \
-            --region=$REGION \
-            --allow-unauthenticated \
-            --set-env-vars=RUST_LOG=observing_media_proxy=info,LOG_FORMAT=json
-
-      - name: Deploy taxonomy
-        run: |
-          gcloud run deploy observing-taxonomy \
-            --image=$REGISTRY/observing-taxonomy:latest \
-            --region=$REGION \
-            --allow-unauthenticated \
-            --set-env-vars=RUST_LOG=observing_taxonomy=info,LOG_FORMAT=json

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -2,7 +2,7 @@ version: "0.5"
 
 processes:
   cloud-sql-proxy:
-    command: cloud-sql-proxy --port 5432 frewsxcv:us-central1:observing-db
+    command: cloud-sql-proxy --port 5432 observ-ing:us-central1:observing-db
     readiness_probe:
       exec:
         command: pg_isready -h localhost -p 5432


### PR DESCRIPTION
## Summary
- Deploy media-proxy and taxonomy before appview so their URLs can be resolved dynamically (removes hardcoded old project number `378013734384`)
- Update Cloud SQL proxy in process-compose to use new `observ-ing` project ID

## Migration context
- New project `observ-ing` has been set up with: Artifact Registry, Cloud SQL, Secret Manager, service account
- Database has been exported from `frewsxcv` and imported into `observ-ing`
- GitHub secrets (`GCP_PROJECT_ID`, `GCP_SA_KEY`) already updated
- Old ingester has been stopped
- Domain mapping (`observ.ing`) still needs to be moved after first successful deploy