### PR TITLE
fix: move photos field back to top of upload modal

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -449,104 +449,7 @@ export function UploadModal() {
       </Typography>
 
       <form onSubmit={handleSubmit}>
-        <TaxaAutocomplete
-          value={species}
-          onChange={setSpecies}
-          label="Species (optional)"
-          placeholder="e.g. Eschscholzia californica - leave blank if unknown"
-        />
-
-        {isIdentifying && (
-          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1 }}>
-            <CircularProgress size={16} />
-            <Typography variant="caption" color="text.secondary">
-              Identifying species...
-            </Typography>
-          </Box>
-        )}
-
-        {aiSuggestions.length > 0 && !species && (
-          <Box sx={{ mt: 1 }}>
-            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 0.5 }}>
-              <AutoFixHighIcon sx={{ fontSize: 14, color: "text.secondary" }} />
-              <Typography variant="caption" color="text.secondary">
-                AI suggestions
-              </Typography>
-            </Box>
-            <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
-              {aiSuggestions.map((s) => (
-                <Chip
-                  key={s.scientificName}
-                  label={s.commonName ? `${s.scientificName} (${s.commonName})` : s.scientificName}
-                  size="small"
-                  onClick={() => {
-                    setSpecies(s.scientificName);
-                    setAiSuggestions([]);
-                  }}
-                  variant="outlined"
-                  color="primary"
-                  sx={{ fontStyle: "italic" }}
-                />
-              ))}
-            </Stack>
-          </Box>
-        )}
-
-        <TextField
-          fullWidth
-          label="Notes (optional)"
-          value={notes}
-          onChange={(e) => setNotes(e.target.value)}
-          placeholder="Describe what you observed..."
-          multiline
-          rows={2}
-          margin="normal"
-        />
-
-        <FormControl fullWidth margin="normal">
-          <InputLabel id="license-label">License</InputLabel>
-          <Select
-            labelId="license-label"
-            value={license}
-            label="License"
-            onChange={(e) => setLicense(e.target.value)}
-          >
-            {LICENSE_OPTIONS.map((opt) => (
-              <MenuItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
-          Co-observers (optional)
-        </Typography>
-
-        <ActorAutocomplete
-          onSelect={handleAddCoObserver}
-          excludeDids={[...(user?.did ? [user.did] : []), ...coObservers.map((co) => co.did)]}
-        />
-
-        {coObservers.length > 0 && (
-          <Stack direction="row" spacing={0.5} sx={{ mt: 1, flexWrap: "wrap", gap: 0.5 }}>
-            {coObservers.map((co) => (
-              <Chip
-                key={co.did}
-                avatar={<Avatar src={co.avatar ?? ""} sx={{ width: 24, height: 24 }} />}
-                label={co.displayName || `@${co.handle}`}
-                size="small"
-                onDelete={() => handleRemoveCoObserver(co.did)}
-              />
-            ))}
-          </Stack>
-        )}
-
-        <Typography variant="caption" color="text.disabled" sx={{ display: "block", mt: 0.5 }}>
-          Add other observers who participated in this sighting
-        </Typography>
-
-        <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
+        <Typography variant="body2" color="text.secondary" sx={{ mb: 1 }}>
           Photos (optional)
         </Typography>
 
@@ -661,6 +564,103 @@ export function UploadModal() {
 
         <Typography variant="caption" color="text.disabled" sx={{ display: "block", mt: 0.5 }}>
           JPG, PNG, or WebP - Max 10MB each - Up to {MAX_IMAGES} photos
+        </Typography>
+
+        <TaxaAutocomplete
+          value={species}
+          onChange={setSpecies}
+          label="Species (optional)"
+          placeholder="e.g. Eschscholzia californica - leave blank if unknown"
+        />
+
+        {isIdentifying && (
+          <Box sx={{ display: "flex", alignItems: "center", gap: 1, mt: 1 }}>
+            <CircularProgress size={16} />
+            <Typography variant="caption" color="text.secondary">
+              Identifying species...
+            </Typography>
+          </Box>
+        )}
+
+        {aiSuggestions.length > 0 && !species && (
+          <Box sx={{ mt: 1 }}>
+            <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 0.5 }}>
+              <AutoFixHighIcon sx={{ fontSize: 14, color: "text.secondary" }} />
+              <Typography variant="caption" color="text.secondary">
+                AI suggestions
+              </Typography>
+            </Box>
+            <Stack direction="row" spacing={0.5} sx={{ flexWrap: "wrap", gap: 0.5 }}>
+              {aiSuggestions.map((s) => (
+                <Chip
+                  key={s.scientificName}
+                  label={s.commonName ? `${s.scientificName} (${s.commonName})` : s.scientificName}
+                  size="small"
+                  onClick={() => {
+                    setSpecies(s.scientificName);
+                    setAiSuggestions([]);
+                  }}
+                  variant="outlined"
+                  color="primary"
+                  sx={{ fontStyle: "italic" }}
+                />
+              ))}
+            </Stack>
+          </Box>
+        )}
+
+        <TextField
+          fullWidth
+          label="Notes (optional)"
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          placeholder="Describe what you observed..."
+          multiline
+          rows={2}
+          margin="normal"
+        />
+
+        <FormControl fullWidth margin="normal">
+          <InputLabel id="license-label">License</InputLabel>
+          <Select
+            labelId="license-label"
+            value={license}
+            label="License"
+            onChange={(e) => setLicense(e.target.value)}
+          >
+            {LICENSE_OPTIONS.map((opt) => (
+              <MenuItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+
+        <Typography variant="body2" color="text.secondary" sx={{ mt: 2, mb: 1 }}>
+          Co-observers (optional)
+        </Typography>
+
+        <ActorAutocomplete
+          onSelect={handleAddCoObserver}
+          excludeDids={[...(user?.did ? [user.did] : []), ...coObservers.map((co) => co.did)]}
+        />
+
+        {coObservers.length > 0 && (
+          <Stack direction="row" spacing={0.5} sx={{ mt: 1, flexWrap: "wrap", gap: 0.5 }}>
+            {coObservers.map((co) => (
+              <Chip
+                key={co.did}
+                avatar={<Avatar src={co.avatar ?? ""} sx={{ width: 24, height: 24 }} />}
+                label={co.displayName || `@${co.handle}`}
+                size="small"
+                onDelete={() => handleRemoveCoObserver(co.did)}
+              />
+            ))}
+          </Stack>
+        )}
+
+        <Typography variant="caption" color="text.disabled" sx={{ display: "block", mt: 0.5 }}>
+          Add other observers who participated in this sighting
         </Typography>
 
         <TextField


### PR DESCRIPTION
## Summary
- Restores photos as the first field in the upload form, before species input
- The species-id PR had moved species above photos, but photos-first is the better UX since AI identification triggers on photo upload

## Test plan
- [ ] `npx tsc`
- [ ] Upload modal shows photos field first, then species, notes, etc.