### PR TITLE
refactor: use typed response structs in species-id route

### DIFF
--- a/crates/observing-appview/src/routes/species_id.rs
+++ b/crates/observing-appview/src/routes/species_id.rs
@@ -1,5 +1,5 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 use crate::auth::AuthUser;
 use crate::state::AppState;
@@ -17,6 +17,11 @@ pub struct IdentifyRequest {
     limit: Option<usize>,
 }
 
+#[derive(Serialize)]
+pub struct ErrorResponse {
+    error: String,
+}
+
 /// POST /api/species-id
 ///
 /// Proxies to the species identification service.
@@ -31,9 +36,9 @@ pub async fn identify(
         None => {
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
-                Json(serde_json::json!({
-                    "error": "Species identification service not configured"
-                })),
+                Json(ErrorResponse {
+                    error: "Species identification service not configured".into(),
+                }),
             )
                 .into_response();
         }
@@ -43,17 +48,12 @@ pub async fn identify(
         .identify(&body.image, body.latitude, body.longitude, body.limit)
         .await
     {
-        Some(response) => Json(serde_json::json!({
-            "suggestions": response.suggestions,
-            "modelVersion": response.model_version,
-            "inferenceTimeMs": response.inference_time_ms,
-        }))
-        .into_response(),
+        Some(response) => Json(response).into_response(),
         None => (
             StatusCode::BAD_GATEWAY,
-            Json(serde_json::json!({
-                "error": "Species identification failed"
-            })),
+            Json(ErrorResponse {
+                error: "Species identification failed".into(),
+            }),
         )
             .into_response(),
     }

--- a/crates/observing-appview/src/species_id_client.rs
+++ b/crates/observing-appview/src/species_id_client.rs
@@ -32,7 +32,7 @@ pub struct SpeciesSuggestion {
     pub genus: Option<String>,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentifyResponse {
     pub suggestions: Vec<SpeciesSuggestion>,


### PR DESCRIPTION
## Summary
- Add `Serialize` derive to `IdentifyResponse` in `species_id_client.rs` so it can be serialized directly by Axum's `Json` extractor
- Replace `json!()` macro wrappers in the species-id route with typed structs: `Json(response)` for the success case and a new `ErrorResponse` struct for error cases
- Removes the manual field-by-field JSON reconstruction, relying on the existing `#[serde(rename_all = "camelCase")]` attribute for correct field naming

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (all 222 tests)
- [x] `cargo fmt` clean
- Verify CI passes