### PR TITLE
refactor: type extract_co_observers to accept typed data instead of raw JSON

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -187,13 +187,13 @@ pub async fn create_occurrence(
 
     // Immediate DB upsert for visibility — uses the same shared conversion
     // as the ingester so field mapping is always consistent.
-    if let Ok(params) = observing_db::processing::occurrence_from_json(
+    if let Ok(parsed) = observing_db::processing::occurrence_from_json(
         &record_value_for_db,
         uri.clone(),
         cid.clone(),
         user.did.clone(),
     ) {
-        if let Err(e) = observing_db::occurrences::upsert(&state.pool, &params).await {
+        if let Err(e) = observing_db::occurrences::upsert(&state.pool, &parsed.params).await {
             warn!(error = %e, "Failed to upsert occurrence into local DB");
         }
     }

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -49,16 +49,27 @@ pub fn parse_naive_datetime(s: &str) -> Option<NaiveDateTime> {
         .ok()
 }
 
+/// Result of parsing an occurrence record, containing both the database
+/// params and the typed `recorded_by` field for co-observer processing.
+pub struct ParsedOccurrence {
+    pub params: UpsertOccurrenceParams,
+    /// The `recordedBy` DIDs from the lexicon record (if present).
+    pub recorded_by: Option<Vec<String>>,
+}
+
 /// Convert an occurrence record JSON to database params.
 ///
 /// The `record_json` should be the full AT Protocol record value (a `serde_json::Value`).
 /// Fields like `blobs` are extracted from the raw JSON to populate `associated_media`.
+///
+/// Returns a [`ParsedOccurrence`] containing the upsert params and the typed
+/// `recorded_by` list so callers can process co-observers without re-parsing JSON.
 pub fn occurrence_from_json(
     record_json: &Value,
     uri: String,
     cid: String,
     did: String,
-) -> Result<UpsertOccurrenceParams, ProcessingError> {
+) -> Result<ParsedOccurrence, ProcessingError> {
     let record_str = record_json.to_string();
     let record: Occurrence<'_> =
         serde_json::from_str(&record_str).map_err(ProcessingError::Deserialization)?;
@@ -90,48 +101,55 @@ pub fn occurrence_from_json(
 
     let created_at = parse_datetime(&record.created_at.to_string()).unwrap_or(event_date);
 
-    Ok(UpsertOccurrenceParams {
-        uri,
-        cid,
-        did,
-        scientific_name: None,
-        event_date,
-        longitude: lng,
-        latitude: lat,
-        coordinate_uncertainty_meters: record
-            .location
-            .coordinate_uncertainty_in_meters
-            .map(|v| v as i32),
-        continent: record.location.continent.map(|v| v.to_string()),
-        country: record.location.country.map(Into::into),
-        country_code: record.location.country_code.map(Into::into),
-        state_province: record.location.state_province.map(Into::into),
-        county: record.location.county.map(Into::into),
-        municipality: record.location.municipality.map(Into::into),
-        locality: record.location.locality.map(Into::into),
-        water_body: record.location.water_body.map(Into::into),
-        verbatim_locality: record.verbatim_locality.map(Into::into),
-        occurrence_remarks: record.notes.map(Into::into),
-        associated_media: record_json.get("blobs").and_then(|v| {
-            // Validate blobs parse as typed BlobEntry structs, then store as Value
-            let blobs: Vec<BlobEntry> = serde_json::from_value(v.clone()).ok()?;
-            if blobs.is_empty() {
-                None
-            } else {
-                Some(v.clone())
-            }
-        }),
-        recorded_by: None,
-        taxon_id: None,
-        taxon_rank: None,
-        vernacular_name: None,
-        kingdom: None,
-        phylum: None,
-        class: None,
-        order: None,
-        family: None,
-        genus: None,
-        created_at,
+    let recorded_by = record
+        .recorded_by
+        .map(|v| v.into_iter().map(|s| s.to_string()).collect());
+
+    Ok(ParsedOccurrence {
+        params: UpsertOccurrenceParams {
+            uri,
+            cid,
+            did,
+            scientific_name: None,
+            event_date,
+            longitude: lng,
+            latitude: lat,
+            coordinate_uncertainty_meters: record
+                .location
+                .coordinate_uncertainty_in_meters
+                .map(|v| v as i32),
+            continent: record.location.continent.map(|v| v.to_string()),
+            country: record.location.country.map(Into::into),
+            country_code: record.location.country_code.map(Into::into),
+            state_province: record.location.state_province.map(Into::into),
+            county: record.location.county.map(Into::into),
+            municipality: record.location.municipality.map(Into::into),
+            locality: record.location.locality.map(Into::into),
+            water_body: record.location.water_body.map(Into::into),
+            verbatim_locality: record.verbatim_locality.map(Into::into),
+            occurrence_remarks: record.notes.map(Into::into),
+            associated_media: record_json.get("blobs").and_then(|v| {
+                // Validate blobs parse as typed BlobEntry structs, then store as Value
+                let blobs: Vec<BlobEntry> = serde_json::from_value(v.clone()).ok()?;
+                if blobs.is_empty() {
+                    None
+                } else {
+                    Some(v.clone())
+                }
+            }),
+            recorded_by: None,
+            taxon_id: None,
+            taxon_rank: None,
+            vernacular_name: None,
+            kingdom: None,
+            phylum: None,
+            class: None,
+            order: None,
+            family: None,
+            genus: None,
+            created_at,
+        },
+        recorded_by,
     })
 }
 
@@ -298,15 +316,16 @@ pub fn like_from_json(
     })
 }
 
-/// Extract co-observer DIDs from an occurrence record JSON,
+/// Extract co-observer DIDs from a typed `recorded_by` list,
 /// filtering out the primary author.
-pub fn extract_co_observers(record_json: &Value, author_did: &str) -> Vec<String> {
-    record_json
-        .get("recordedBy")
-        .and_then(|v| v.as_array())
+pub fn extract_co_observers<T: AsRef<str>>(
+    recorded_by: Option<&[T]>,
+    author_did: &str,
+) -> Vec<String> {
+    recorded_by
         .map(|arr| {
             arr.iter()
-                .filter_map(|v| v.as_str())
+                .map(AsRef::as_ref)
                 .filter(|did| *did != author_did)
                 .map(|s| s.to_string())
                 .collect()
@@ -369,17 +388,25 @@ mod tests {
 
     #[test]
     fn test_extract_co_observers() {
-        let json = serde_json::json!({
-            "recordedBy": ["did:plc:author", "did:plc:coobs1", "did:plc:coobs2"]
-        });
-        let result = extract_co_observers(&json, "did:plc:author");
+        let recorded_by = vec![
+            "did:plc:author".to_string(),
+            "did:plc:coobs1".to_string(),
+            "did:plc:coobs2".to_string(),
+        ];
+        let result = extract_co_observers(Some(recorded_by.as_slice()), "did:plc:author");
         assert_eq!(result, vec!["did:plc:coobs1", "did:plc:coobs2"]);
     }
 
     #[test]
+    fn test_extract_co_observers_none() {
+        let result: Vec<String> = extract_co_observers(None::<&[String]>, "did:plc:author");
+        assert!(result.is_empty());
+    }
+
+    #[test]
     fn test_extract_co_observers_empty() {
-        let json = serde_json::json!({});
-        let result = extract_co_observers(&json, "did:plc:author");
+        let recorded_by: Vec<String> = vec![];
+        let result = extract_co_observers(Some(recorded_by.as_slice()), "did:plc:author");
         assert!(result.is_empty());
     }
 }

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -100,7 +100,7 @@ impl Database {
 
         let record_json = require_record!(commit, "occurrence");
 
-        let params = process_or_warn!(
+        let parsed = process_or_warn!(
             commit,
             occurrence_from_json,
             "occurrence",
@@ -110,10 +110,11 @@ impl Database {
             commit.did.clone(),
         );
 
-        observing_db::occurrences::upsert(&self.pool, &params).await?;
+        observing_db::occurrences::upsert(&self.pool, &parsed.params).await?;
 
-        // Sync occurrence_observers
-        let co_observers = processing::extract_co_observers(record_json, &commit.did);
+        // Sync occurrence_observers using typed recorded_by data
+        let co_observers =
+            processing::extract_co_observers(parsed.recorded_by.as_deref(), &commit.did);
         observing_db::observers::sync(&self.pool, &commit.uri, &commit.did, &co_observers).await?;
 
         Ok(())


### PR DESCRIPTION
## Summary

- Refactors `extract_co_observers()` in `observing-db/processing.rs` to accept `Option<&[T]>` (where `T: AsRef<str>`) instead of `&serde_json::Value`, eliminating manual JSON traversal on already-deserialized data.
- Introduces `ParsedOccurrence` so `occurrence_from_json` returns both the DB params and the typed `recorded_by` list extracted from the `Occurrence` lexicon struct.
- Updates both callers (ingester `database.rs`, appview `write.rs`) to use the new return type.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (all 199 tests)
- [x] `cargo fmt` clean
- [x] New `test_extract_co_observers_none` test added for the `None` input case