### PR TITLE
refactor: extract serialize_at_record helper for $type injection

### DIFF
--- a/crates/observing-appview/src/auth.rs
+++ b/crates/observing-appview/src/auth.rs
@@ -3,6 +3,7 @@ use std::str::FromStr;
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
 use axum_extra::extract::CookieJar;
+use jacquard_common::types::collection::Collection;
 use jacquard_common::types::string::{AtUri, Cid};
 use observing_lexicons::com_atproto::repo::strong_ref::StrongRef;
 use serde_json::Value;
@@ -83,6 +84,15 @@ pub async fn require_agent(
     })?;
     let agent = atrium_api::agent::Agent::new(session);
     Ok((agent, did_parsed))
+}
+
+/// Serialize a lexicon record to a [`serde_json::Value`] with the `$type` field set.
+pub fn serialize_at_record<T: Collection + serde::Serialize>(
+    record: &T,
+) -> Result<Value, AppError> {
+    let mut value = serde_json::to_value(record).map_err(|e| AppError::Internal(e.to_string()))?;
+    value["$type"] = serde_json::json!(T::NSID);
+    Ok(value)
 }
 
 /// Create an AT Protocol record via the PDS agent.

--- a/crates/observing-appview/src/routes/comments.rs
+++ b/crates/observing-appview/src/routes/comments.rs
@@ -48,9 +48,7 @@ pub async fn create_comment(
         .maybe_reply_to(reply_to)
         .build();
 
-    let mut record_value =
-        serde_json::to_value(&record).map_err(|e| AppError::Internal(e.to_string()))?;
-    record_value["$type"] = json!(Comment::NSID);
+    let record_value = auth::serialize_at_record(&record)?;
 
     let (agent, did_parsed) = auth::require_agent(&state.oauth_client, &user.did).await?;
     let resp = auth::create_at_record(&agent, did_parsed, Comment::NSID, record_value).await?;

--- a/crates/observing-appview/src/routes/identifications.rs
+++ b/crates/observing-appview/src/routes/identifications.rs
@@ -99,9 +99,7 @@ pub async fn create_identification(
         .maybe_taxon_id(fields.taxon_id.as_deref().map(Into::into))
         .build();
 
-    let mut record_value =
-        serde_json::to_value(&record).map_err(|e| AppError::Internal(e.to_string()))?;
-    record_value["$type"] = json!(Identification::NSID);
+    let record_value = auth::serialize_at_record(&record)?;
 
     let (agent, did_parsed) = auth::require_agent(&state.oauth_client, &user.did).await?;
     let resp =

--- a/crates/observing-appview/src/routes/interactions.rs
+++ b/crates/observing-appview/src/routes/interactions.rs
@@ -110,9 +110,7 @@ pub async fn create_interaction(
         .maybe_comment(body.comment.as_deref().map(Into::into))
         .build();
 
-    let mut record_value =
-        serde_json::to_value(&record).map_err(|e| AppError::Internal(e.to_string()))?;
-    record_value["$type"] = json!(Interaction::NSID);
+    let record_value = auth::serialize_at_record(&record)?;
 
     let (agent, did_parsed) = auth::require_agent(&state.oauth_client, &user.did).await?;
     let resp = auth::create_at_record(&agent, did_parsed, Interaction::NSID, record_value).await?;

--- a/crates/observing-appview/src/routes/likes.rs
+++ b/crates/observing-appview/src/routes/likes.rs
@@ -37,9 +37,7 @@ pub async fn create_like(
         .subject(subject)
         .build();
 
-    let mut record_value =
-        serde_json::to_value(&record).map_err(|e| AppError::Internal(e.to_string()))?;
-    record_value["$type"] = json!(Like::NSID);
+    let record_value = auth::serialize_at_record(&record)?;
 
     let (agent, did_parsed) = auth::require_agent(&state.oauth_client, &user.did).await?;
     let output = auth::create_at_record(&agent, did_parsed, Like::NSID, record_value).await?;

--- a/crates/observing-appview/src/routes/occurrences/auto_id.rs
+++ b/crates/observing-appview/src/routes/occurrences/auto_id.rs
@@ -1,7 +1,7 @@
 use jacquard_common::types::collection::Collection;
 use jacquard_common::types::string::Datetime;
 use observing_lexicons::org_rwell::test::identification::{Identification, Taxon};
-use serde_json::{json, Value};
+use serde_json::Value;
 
 use crate::auth;
 use crate::error::AppError;
@@ -63,9 +63,7 @@ pub async fn build_identification_record(
         .maybe_taxon_id(taxon_id.as_deref().map(Into::into))
         .build();
 
-    let mut id_value =
-        serde_json::to_value(&id_record).map_err(|e| AppError::Internal(e.to_string()))?;
-    id_value["$type"] = json!(Identification::NSID);
+    let id_value = auth::serialize_at_record(&id_record)?;
 
     Ok(id_value)
 }

--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -159,9 +159,7 @@ pub async fn create_occurrence(
             .maybe_recorded_by(recorded_by_cowstrs)
             .build();
 
-        let mut rv =
-            serde_json::to_value(&record).map_err(|e| AppError::Internal(e.to_string()))?;
-        rv["$type"] = json!(Occurrence::NSID);
+        let mut rv = auth::serialize_at_record(&record)?;
         if !blobs.is_empty() {
             rv["blobs"] = json!(blobs);
         }


### PR DESCRIPTION
## Summary

- Adds a `serialize_at_record<T: Collection + Serialize>` helper to `auth.rs` that serializes a lexicon record to `serde_json::Value` and injects the `$type` field from the `Collection::NSID` associated constant.
- Replaces 6 identical inline occurrences of this pattern across all write routes: occurrences, identifications, comments, likes, interactions, and auto-id.
- The occurrence write route continues to add `blobs` after the helper call, since that is specific to that endpoint.

## Test plan

- [x] `cargo build` passes with no warnings
- [x] `cargo test` passes (all 222 tests)
- [x] `cargo fmt` produces no changes