### PR TITLE
refactor: replace raw JSON traversal with typed blob structs

### DIFF
--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -197,29 +197,9 @@ fn profile_summary(did: &str, profiles: &HashMap<String, Arc<Profile>>) -> Profi
 }
 
 fn extract_images(row: &OccurrenceRow) -> Vec<String> {
-    let Some(ref media) = row.associated_media else {
-        return Vec::new();
-    };
-
-    let blobs = match media {
-        serde_json::Value::Array(arr) => arr.clone(),
-        _ => return Vec::new(),
-    };
-
-    blobs
+    row.blob_entries()
         .iter()
-        .filter_map(|blob| {
-            let image = blob.get("image")?;
-            let ref_val = image.get("ref")?;
-            let cid = if let Some(link) = ref_val.get("$link") {
-                link.as_str()?.to_string()
-            } else if let Some(s) = ref_val.as_str() {
-                s.to_string()
-            } else {
-                return None;
-            };
-            Some(format!("/media/blob/{}/{}", row.did, cid))
-        })
+        .map(|blob| format!("/media/blob/{}/{}", row.did, blob.image.ref_.cid()))
         .collect()
 }
 
@@ -536,7 +516,7 @@ pub async fn enrich_observers(
 mod tests {
     use super::*;
     use chrono::Utc;
-    use serde_json::json;
+    use observing_db::types::{BlobEntry, BlobImage, BlobRef};
 
     fn make_row(media: Option<serde_json::Value>) -> OccurrenceRow {
         OccurrenceRow {
@@ -576,6 +556,26 @@ mod tests {
         }
     }
 
+    fn blob_entry(cid: &str, mime: &str, ref_style: &str) -> BlobEntry {
+        let ref_ = match ref_style {
+            "link" => BlobRef::Link {
+                link: cid.to_string(),
+            },
+            _ => BlobRef::Bare(cid.to_string()),
+        };
+        BlobEntry {
+            image: BlobImage {
+                ref_,
+                mime_type: mime.to_string(),
+            },
+            alt: None,
+        }
+    }
+
+    fn blobs_to_json(entries: Vec<BlobEntry>) -> serde_json::Value {
+        serde_json::to_value(entries).unwrap()
+    }
+
     #[test]
     fn test_extract_images_no_media() {
         let row = make_row(None);
@@ -584,39 +584,43 @@ mod tests {
 
     #[test]
     fn test_extract_images_non_array() {
-        let row = make_row(Some(json!("not an array")));
+        let row = make_row(Some(serde_json::json!("not an array")));
         assert!(extract_images(&row).is_empty());
     }
 
     #[test]
     fn test_extract_images_empty_array() {
-        let row = make_row(Some(json!([])));
+        let row = make_row(Some(blobs_to_json(vec![])));
         assert!(extract_images(&row).is_empty());
     }
 
     #[test]
     fn test_extract_images_with_link() {
-        let row = make_row(Some(json!([
-            {"image": {"ref": {"$link": "bafkreiabc123"}, "mimeType": "image/jpeg"}}
-        ])));
+        let row = make_row(Some(blobs_to_json(vec![blob_entry(
+            "bafkreiabc123",
+            "image/jpeg",
+            "link",
+        )])));
         let images = extract_images(&row);
         assert_eq!(images, vec!["/media/blob/did:plc:test/bafkreiabc123"]);
     }
 
     #[test]
     fn test_extract_images_with_string_ref() {
-        let row = make_row(Some(json!([
-            {"image": {"ref": "bafkreixyz789", "mimeType": "image/jpeg"}}
-        ])));
+        let row = make_row(Some(blobs_to_json(vec![blob_entry(
+            "bafkreixyz789",
+            "image/jpeg",
+            "bare",
+        )])));
         let images = extract_images(&row);
         assert_eq!(images, vec!["/media/blob/did:plc:test/bafkreixyz789"]);
     }
 
     #[test]
     fn test_extract_images_multiple() {
-        let row = make_row(Some(json!([
-            {"image": {"ref": {"$link": "cid1"}, "mimeType": "image/jpeg"}},
-            {"image": {"ref": {"$link": "cid2"}, "mimeType": "image/png"}}
+        let row = make_row(Some(blobs_to_json(vec![
+            blob_entry("cid1", "image/jpeg", "link"),
+            blob_entry("cid2", "image/png", "link"),
         ])));
         let images = extract_images(&row);
         assert_eq!(images.len(), 2);
@@ -626,7 +630,8 @@ mod tests {
 
     #[test]
     fn test_extract_images_missing_image_field() {
-        let row = make_row(Some(json!([
+        // Invalid blob entries that can't deserialize just get skipped by blob_entries()
+        let row = make_row(Some(serde_json::json!([
             {"notImage": {"ref": {"$link": "cid1"}}}
         ])));
         assert!(extract_images(&row).is_empty());
@@ -634,10 +639,26 @@ mod tests {
 
     #[test]
     fn test_extract_images_missing_ref_field() {
-        let row = make_row(Some(json!([
+        let row = make_row(Some(serde_json::json!([
             {"image": {"mimeType": "image/jpeg"}}
         ])));
         assert!(extract_images(&row).is_empty());
+    }
+
+    #[test]
+    fn test_blob_entry_roundtrip_link_format() {
+        let json_str =
+            r#"{"image":{"ref":{"$link":"bafkreiabc123"},"mimeType":"image/jpeg"},"alt":""}"#;
+        let entry: BlobEntry = serde_json::from_str(json_str).unwrap();
+        assert_eq!(entry.image.ref_.cid(), "bafkreiabc123");
+        assert_eq!(entry.image.mime_type, "image/jpeg");
+    }
+
+    #[test]
+    fn test_blob_entry_roundtrip_bare_format() {
+        let json_str = r#"{"image":{"ref":"bafkreixyz789","mimeType":"image/jpeg"}}"#;
+        let entry: BlobEntry = serde_json::from_str(json_str).unwrap();
+        assert_eq!(entry.image.ref_.cid(), "bafkreixyz789");
     }
 
     #[test]

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -5,8 +5,8 @@
 //! the ingester (asynchronous firehose path).
 
 use crate::types::{
-    CreateLikeParams, UpsertCommentParams, UpsertIdentificationParams, UpsertInteractionParams,
-    UpsertOccurrenceParams,
+    BlobEntry, CreateLikeParams, UpsertCommentParams, UpsertIdentificationParams,
+    UpsertInteractionParams, UpsertOccurrenceParams,
 };
 use chrono::{DateTime, NaiveDateTime, Utc};
 use observing_lexicons::org_rwell::test::{
@@ -112,7 +112,15 @@ pub fn occurrence_from_json(
         water_body: record.location.water_body.map(Into::into),
         verbatim_locality: record.verbatim_locality.map(Into::into),
         occurrence_remarks: record.notes.map(Into::into),
-        associated_media: record_json.get("blobs").cloned(),
+        associated_media: record_json.get("blobs").and_then(|v| {
+            // Validate blobs parse as typed BlobEntry structs, then store as Value
+            let blobs: Vec<BlobEntry> = serde_json::from_value(v.clone()).ok()?;
+            if blobs.is_empty() {
+                None
+            } else {
+                Some(v.clone())
+            }
+        }),
         recorded_by: None,
         taxon_id: None,
         taxon_rank: None,

--- a/crates/observing-db/src/types.rs
+++ b/crates/observing-db/src/types.rs
@@ -3,6 +3,44 @@ use serde::{Deserialize, Serialize};
 use sqlx::FromRow;
 use ts_rs::TS;
 
+/// A single blob/image entry as stored in the `associated_media` JSONB column.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BlobEntry {
+    pub image: BlobImage,
+    #[serde(default)]
+    pub alt: Option<String>,
+}
+
+/// Image metadata within a blob entry.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BlobImage {
+    #[serde(rename = "ref")]
+    pub ref_: BlobRef,
+    pub mime_type: String,
+}
+
+/// The CID reference for a blob, supporting both `{"$link": "cid"}` and `"cid"` formats.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum BlobRef {
+    Link {
+        #[serde(rename = "$link")]
+        link: String,
+    },
+    Bare(String),
+}
+
+impl BlobRef {
+    /// Extract the CID string regardless of format.
+    pub fn cid(&self) -> &str {
+        match self {
+            BlobRef::Link { link } => link,
+            BlobRef::Bare(s) => s,
+        }
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize, TS)]
 #[ts(export, export_to = "bindings/")]
 pub enum ObserverRole {
@@ -66,6 +104,17 @@ pub struct OccurrenceRow {
     /// Only present in profile feed queries
     #[sqlx(default)]
     pub observer_role: Option<String>,
+}
+
+impl OccurrenceRow {
+    /// Parse `associated_media` JSONB into typed blob entries.
+    /// Returns an empty vec if the field is `None` or cannot be deserialized.
+    pub fn blob_entries(&self) -> Vec<BlobEntry> {
+        self.associated_media
+            .as_ref()
+            .and_then(|v| serde_json::from_value::<Vec<BlobEntry>>(v.clone()).ok())
+            .unwrap_or_default()
+    }
 }
 
 /// Identification row returned from SELECT queries
@@ -247,6 +296,17 @@ pub struct UpsertOccurrenceParams {
     pub family: Option<String>,
     pub genus: Option<String>,
     pub created_at: DateTime<Utc>,
+}
+
+impl UpsertOccurrenceParams {
+    /// Set `associated_media` from typed blob entries.
+    pub fn set_blobs(&mut self, blobs: Vec<BlobEntry>) {
+        self.associated_media = if blobs.is_empty() {
+            None
+        } else {
+            serde_json::to_value(blobs).ok()
+        };
+    }
 }
 
 /// Parameters for upserting an identification


### PR DESCRIPTION
## Summary

- Adds `BlobEntry`, `BlobImage`, and `BlobRef` typed structs in `observing-db/src/types.rs` for the `associated_media` JSONB column
- `BlobRef` uses `#[serde(untagged)]` enum to handle both `{"$link": "cid"}` and bare `"cid"` formats
- Adds `OccurrenceRow::blob_entries()` helper to parse raw JSON into typed structs
- Adds `UpsertOccurrenceParams::set_blobs()` helper to serialize typed structs for storage
- `processing.rs` now validates incoming blobs parse as `Vec<BlobEntry>` before storing
- `extract_images()` in `enrichment.rs` uses `blob_entries()` instead of manual JSON field traversal

The DB column type remains `Option<serde_json::Value>` to maintain sqlx offline-mode cache compatibility, while all access goes through typed helpers.

## Test plan

- [x] `cargo build` compiles cleanly
- [x] `cargo test` -- all 190 tests pass, including updated enrichment tests
- [x] Tests cover both `$link` (object) and bare string blob ref formats
- [x] Tests cover serde roundtrip for both formats
- [x] Edge cases (no media, empty array, invalid JSON) handled gracefully via `blob_entries()` returning empty vec