### PR TITLE
refactor: typed struct for species-id client request body

### DIFF
--- a/crates/observing-appview/src/species_id_client.rs
+++ b/crates/observing-appview/src/species_id_client.rs
@@ -32,6 +32,15 @@ pub struct SpeciesSuggestion {
     pub genus: Option<String>,
 }
 
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct IdentifyRequestBody {
+    image: String,
+    latitude: Option<f64>,
+    longitude: Option<f64>,
+    limit: usize,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct IdentifyResponse {
@@ -63,12 +72,12 @@ impl SpeciesIdClient {
     ) -> Option<IdentifyResponse> {
         let url = format!("{}/identify", self.base_url);
 
-        let body = serde_json::json!({
-            "image": image_base64,
-            "latitude": latitude,
-            "longitude": longitude,
-            "limit": limit.unwrap_or(5),
-        });
+        let body = IdentifyRequestBody {
+            image: image_base64.to_string(),
+            latitude,
+            longitude,
+            limit: limit.unwrap_or(5),
+        };
 
         match self.client.post(&url).json(&body).send().await {
             Ok(resp) if resp.status().is_success() => resp.json().await.ok(),


### PR DESCRIPTION
## Summary
- Replace `serde_json::json!()` in `SpeciesIdClient::identify()` with a typed `IdentifyRequestBody` struct that derives `Serialize`
- Provides compile-time field validation and consistent camelCase serialization via `#[serde(rename_all = "camelCase")]`
- Internal (non-pub) struct kept in `species_id_client.rs`, separate from the route's `IdentifyRequest` which serves a different purpose (deserializing incoming API requests)

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (all 222 tests)
- [x] `cargo fmt` clean