### PR TITLE
chore: update bioclip-models to v2.0.0

### DIFF
--- a/scripts/download-models.sh
+++ b/scripts/download-models.sh
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 MODEL_DIR="models/bioclip"
-RELEASE_URL="https://github.com/observ-ing/bioclip-models/releases/download/v1.0.0/bioclip-2.5-models.tar.gz"
+RELEASE_URL="https://github.com/observ-ing/bioclip-models/releases/download/v2.0.0/bioclip-2.5-models.tar.gz"
 
 if [ -f "$MODEL_DIR/vision_encoder.onnx" ]; then
   echo "Models already present in $MODEL_DIR — skipping download."


### PR DESCRIPTION
## Summary
- Update model download URL from v1.0.0 to v2.0.0 in `scripts/download-models.sh`
- v2.0.0 uses iNat-ordered species selection (100k species ordered by observation frequency) and fixed taxonomic embeddings matching BioCLIP 2.5's training format

## Test plan
- [ ] Delete local `models/bioclip/` and re-run `./scripts/download-models.sh` to verify download
- [ ] Run species-id service and verify identification results