### PR TITLE
deploy: add species-id service to Cloud Run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,7 +226,7 @@ jobs:
       REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/observing
     strategy:
       matrix:
-        service: [appview, ingester, media-proxy, taxonomy]
+        service: [appview, ingester, media-proxy, species-id, taxonomy]
     steps:
       - uses: actions/checkout@v4
 
@@ -289,11 +289,22 @@ jobs:
             --allow-unauthenticated \
             --set-env-vars=RUST_LOG=observing_taxonomy=info,LOG_FORMAT=json
 
+      - name: Deploy species-id
+        run: |
+          gcloud run deploy observing-species-id \
+            --image=$REGISTRY/observing-species-id:latest \
+            --region=$REGION \
+            --allow-unauthenticated \
+            --cpu=2 \
+            --memory=4Gi \
+            --set-env-vars=RUST_LOG=observing_species_id=info,LOG_FORMAT=json
+
       - name: Get service URLs
         id: urls
         run: |
           echo "media_proxy=$(gcloud run services describe observing-media-proxy --region=$REGION --format='value(status.url)')" >> $GITHUB_OUTPUT
           echo "taxonomy=$(gcloud run services describe observing-taxonomy --region=$REGION --format='value(status.url)')" >> $GITHUB_OUTPUT
+          echo "species_id=$(gcloud run services describe observing-species-id --region=$REGION --format='value(status.url)')" >> $GITHUB_OUTPUT
 
       - name: Deploy appview
         id: deploy-appview
@@ -303,7 +314,7 @@ jobs:
             --region=$REGION \
             --allow-unauthenticated \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,MEDIA_PROXY_URL=${{ steps.urls.outputs.media_proxy }},TAXONOMY_SERVICE_URL=${{ steps.urls.outputs.taxonomy }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b \
+            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,MEDIA_PROXY_URL=${{ steps.urls.outputs.media_proxy }},TAXONOMY_SERVICE_URL=${{ steps.urls.outputs.taxonomy }},SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b \
             --set-secrets=DB_PASSWORD=observing-db-password:latest \
             --format='value(status.url)')
           echo "url=$URL" >> $GITHUB_OUTPUT

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # when SERVICE=observing-appview.
 #
 # Supported SERVICE values:
-#   observing-appview, observing-ingester, observing-media-proxy, observing-taxonomy
+#   observing-appview, observing-ingester, observing-media-proxy, observing-species-id, observing-taxonomy
 
 ARG SERVICE=observing-appview
 
@@ -132,13 +132,15 @@ CMD ["/app/observing-media-proxy"]
 # ---------------------------------------------------------------------------
 FROM runtime-base AS runtime-observing-species-id
 
-# Install ONNX Runtime shared library
-RUN apt-get update && apt-get install -y wget && \
+# Install ONNX Runtime shared library and download model artifacts
+RUN apt-get update && apt-get install -y wget curl && \
     wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.21.1/onnxruntime-linux-x64-1.21.1.tgz && \
     tar xzf onnxruntime-linux-x64-1.21.1.tgz && \
     cp onnxruntime-linux-x64-1.21.1/lib/* /usr/lib/ && \
     rm -rf onnxruntime-* && \
-    apt-get remove -y wget && apt-get autoremove -y && \
+    mkdir -p /app/models/bioclip && \
+    curl -L https://github.com/observ-ing/bioclip-models/releases/download/v2.0.0/bioclip-2.5-models.tar.gz | tar xz -C /app/models/bioclip && \
+    apt-get remove -y wget curl && apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/observing-species-id /app/observing-species-id

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,6 +9,7 @@ Services deployed via GitHub Actions (`.github/workflows/ci.yml`):
 | observing-appview | `SERVICE=observing-appview` | Yes | Yes | REST API + OAuth + serves frontend |
 | observing-ingester | `SERVICE=observing-ingester` | Yes | Yes | min-instances=1 (always running) |
 | observing-media-proxy | `SERVICE=observing-media-proxy` | Yes | No | Stateless image cache |
+| observing-species-id | `SERVICE=observing-species-id` | Yes | No | BioCLIP species identification (2 CPU, 4 GiB) |
 | observing-taxonomy | `SERVICE=observing-taxonomy` | Yes | No | GBIF taxonomy lookups with caching |
 
 All services are built from the root `Dockerfile` using `--build-arg SERVICE=<name>`.
@@ -53,7 +54,16 @@ PORT=3000
 PUBLIC_URL=https://your-domain.run.app
 TAXONOMY_SERVICE_URL=https://observing-taxonomy-xxx.run.app
 MEDIA_PROXY_URL=https://observing-media-proxy-xxx.run.app
+SPECIES_ID_SERVICE_URL=https://observing-species-id-xxx.run.app  # Optional
 HIDDEN_DIDS=did:plc:abc123  # Comma-separated DIDs to hide from feeds
+```
+
+### Species ID
+
+```bash
+PORT=3005
+MODEL_DIR=/app/models/bioclip
+ORT_DYLIB_PATH=/usr/lib/libonnxruntime.so
 ```
 
 ### Taxonomy


### PR DESCRIPTION
## Summary
- The species-id service was built but never deployed to Cloud Run, causing `POST /api/species-id` to return 503 (Service Unavailable) on production
- Bake BioCLIP v2.0.0 model artifacts into the Docker image during build
- Add `species-id` to the CI build matrix and deploy pipeline
- Wire `SPECIES_ID_SERVICE_URL` into the appview's environment
- Deploy with 2 CPU / 4 GiB memory for ONNX inference

Note: the species-id Docker image will be ~3+ GB due to the model files. First build/push will be slow.

## Test plan
- [ ] CI builds the species-id Docker image successfully
- [ ] Deploy creates the `observing-species-id` Cloud Run service
- [ ] `POST /api/species-id` returns species suggestions instead of 503
- [ ] Upload form shows AI species suggestions after adding a photo