### PR TITLE
fix: split species-id Docker layers for reliable builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -132,15 +132,23 @@ CMD ["/app/observing-media-proxy"]
 # ---------------------------------------------------------------------------
 FROM runtime-base AS runtime-observing-species-id
 
-# Install ONNX Runtime shared library and download model artifacts
-RUN apt-get update && apt-get install -y wget curl && \
-    wget -q https://github.com/microsoft/onnxruntime/releases/download/v1.21.1/onnxruntime-linux-x64-1.21.1.tgz && \
+# Install ONNX Runtime shared library
+RUN apt-get update && apt-get install -y wget && \
+    wget --retry-connrefused --waitretry=1 --tries=3 -q \
+      https://github.com/microsoft/onnxruntime/releases/download/v1.21.1/onnxruntime-linux-x64-1.21.1.tgz && \
     tar xzf onnxruntime-linux-x64-1.21.1.tgz && \
     cp onnxruntime-linux-x64-1.21.1/lib/* /usr/lib/ && \
-    rm -rf onnxruntime-* && \
-    mkdir -p /app/models/bioclip && \
-    curl -L https://github.com/observ-ing/bioclip-models/releases/download/v2.0.0/bioclip-2.5-models.tar.gz | tar xz -C /app/models/bioclip && \
-    apt-get remove -y wget curl && apt-get autoremove -y && \
+    rm -rf onnxruntime-*
+
+# Download model artifacts (separate layer for better caching)
+RUN mkdir -p /app/models/bioclip && \
+    wget --retry-connrefused --waitretry=1 --tries=3 -q -O /tmp/models.tar.gz \
+      https://github.com/observ-ing/bioclip-models/releases/download/v2.0.0/bioclip-2.5-models.tar.gz && \
+    tar xzf /tmp/models.tar.gz -C /app/models/bioclip && \
+    rm /tmp/models.tar.gz
+
+# Clean up
+RUN apt-get remove -y wget && apt-get autoremove -y && \
     rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /app/target/release/observing-species-id /app/observing-species-id


### PR DESCRIPTION
## Summary
- The species-id Docker build from #167 failed with exit code 8 (wget server error)
- Split the single large RUN into separate layers: ONNX Runtime install, model download, cleanup
- Use `wget` with `--retry-connrefused --tries=3` instead of `curl | tar` pipe
- Download model to file first then extract, avoiding pipe failures
- Separate layers also improve Docker cache — the 1.4 GB model download won't re-run unless the URL changes

## Test plan
- [ ] CI builds the species-id Docker image successfully
- [ ] Species-id service deploys and `POST /api/species-id` returns results