### PR TITLE
fix: use registry cache for Docker builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,8 +252,12 @@ jobs:
           build-args: SERVICE=observing-${{ matrix.service }}
           push: true
           tags: ${{ env.REGISTRY }}/observing-${{ matrix.service }}:latest
-          cache-from: type=gha,scope=${{ matrix.service }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.service }}
+          cache-from: |
+            type=gha,scope=${{ matrix.service }}
+            type=registry,ref=${{ env.REGISTRY }}/observing-${{ matrix.service }}:buildcache
+          cache-to: |
+            type=gha,mode=max,scope=${{ matrix.service }}
+            type=registry,ref=${{ env.REGISTRY }}/observing-${{ matrix.service }}:buildcache,mode=max
 
   deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- The merge queue and main push both trigger a species-id Docker build
- The merge queue succeeds, but the main push gets rate-limited downloading onnxruntime (exit code 22)
- Add registry-based Docker layer cache so the main push reuses layers already pushed by the merge queue, skipping the download entirely
- This also benefits all other services — any unchanged layer is pulled from the registry cache instead of being rebuilt

## Test plan
- [ ] Merge queue build succeeds and pushes cache to registry
- [ ] Main push build hits registry cache and skips onnxruntime/model downloads
- [ ] Deploy succeeds and species-id service is live