### PR TITLE
fix: update ONNX Runtime to v1.22.0 (v1.21.1 removed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -135,9 +135,9 @@ FROM runtime-base AS runtime-observing-species-id
 # Install ONNX Runtime shared library
 RUN apt-get update && apt-get install -y curl && \
     curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 -o /tmp/ort.tgz \
-      https://github.com/microsoft/onnxruntime/releases/download/v1.21.1/onnxruntime-linux-x64-1.21.1.tgz && \
+      https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz && \
     tar xzf /tmp/ort.tgz && \
-    cp onnxruntime-linux-x64-1.21.1/lib/* /usr/lib/ && \
+    cp onnxruntime-linux-x64-1.22.0/lib/* /usr/lib/ && \
     rm -rf onnxruntime-* /tmp/ort.tgz
 
 # Download model artifacts (separate layer for better caching)


### PR DESCRIPTION
## Summary
- ONNX Runtime v1.21.1 was removed from GitHub releases, causing species-id Docker builds to fail with 404
- Update to v1.22.0, the nearest available stable release
- Compatible with `ort` crate v2.0.0-rc.12 (uses `load-dynamic`)

## Test plan
- [ ] CI species-id Docker build succeeds
- [ ] Species-id service deploys and responds to `/health`