### PR TITLE
fix: copy only .so files from ONNX Runtime v1.22.0 lib dir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -137,7 +137,7 @@ RUN apt-get update && apt-get install -y curl && \
     curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 -o /tmp/ort.tgz \
       https://github.com/microsoft/onnxruntime/releases/download/v1.22.0/onnxruntime-linux-x64-1.22.0.tgz && \
     tar xzf /tmp/ort.tgz && \
-    cp onnxruntime-linux-x64-1.22.0/lib/* /usr/lib/ && \
+    cp onnxruntime-linux-x64-1.22.0/lib/libonnxruntime*.so* /usr/lib/ && \
     rm -rf onnxruntime-* /tmp/ort.tgz
 
 # Download model artifacts (separate layer for better caching)


### PR DESCRIPTION
## Summary
- v1.22.0 added `cmake/` and `pkgconfig/` subdirectories in `lib/` that cause `cp *` to fail without `-r`
- Only copy the shared library files (`.so*`) instead of everything in `lib/`
- Also fixes the version bump from v1.21.1 (removed) to v1.22.0

## Test plan
- [ ] CI species-id Docker build succeeds
- [ ] Deploy completes successfully