### PR TITLE
fix: set PORT=3005 for species-id Cloud Run deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,7 +301,7 @@ jobs:
             --allow-unauthenticated \
             --cpu=2 \
             --memory=4Gi \
-            --set-env-vars=RUST_LOG=observing_species_id=info,LOG_FORMAT=json
+            --set-env-vars=RUST_LOG=observing_species_id=info,LOG_FORMAT=json,PORT=3005
 
       - name: Get service URLs
         id: urls


### PR DESCRIPTION
## Summary
- Species-id container listens on port 3005 (set in Dockerfile) but Cloud Run defaults to 8080
- Container failed health check on startup: "failed to start and listen on the port defined by PORT=8080"
- Add `PORT=3005` to the deploy env vars

## Test plan
- [ ] Deploy succeeds after merge
- [ ] Species-id responds on `/health`