### PR TITLE
fix: use ONNX Runtime 1.24.4 to match ort-sys and add startup CPU boost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,8 @@ jobs:
             --allow-unauthenticated \
             --cpu=2 \
             --memory=4Gi \
+            --cpu-boost \
+            --timeout=300 \
             --set-env-vars=RUST_LOG=observing_species_id=info,LOG_FORMAT=json
 
       - name: Get service URLs


### PR DESCRIPTION
## Summary
- `ort-sys` 2.0.0-rc.12 binds to ONNX Runtime **1.24**, but we were shipping 1.22 (previously 1.21.1 which was removed)
- The ABI mismatch caused the container to crash on startup, which Cloud Run reported as "failed to start and listen on PORT=8080"
- Updated to ONNX Runtime v1.24.4 (latest 1.24.x)
- Added `--cpu-boost` and `--timeout=300` for the heavy model loading at startup

## Test plan
- [ ] CI species-id Docker build succeeds
- [ ] Deploy succeeds after merge
- [ ] Species-id responds on `/health`
- [ ] Species identification works on observ.ing