### PR TITLE
fix: increase species-id startup probe timeout for model loading

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -302,7 +302,7 @@ jobs:
             --cpu=2 \
             --memory=4Gi \
             --cpu-boost \
-            --timeout=300 \
+            --startup-probe=tcpSocket.port=8080,periodSeconds=10,failureThreshold=30,timeoutSeconds=5 \
             --set-env-vars=RUST_LOG=observing_species_id=info,LOG_FORMAT=json
 
       - name: Get service URLs


### PR DESCRIPTION
## Summary
- GCP logs show the service starts correctly but the ~1.4GB ONNX model load takes >4 min
- The default Cloud Run startup probe timeout is 240s (4 min), which it exceeds
- Configure startup probe to allow 5 min (30 checks * 10s period)
- Replace `--timeout=300` (request timeout, not startup timeout) with proper `--startup-probe` config

## Test plan
- [ ] Species-id deploys successfully on Cloud Run
- [ ] Service responds on `/health` after startup