### PR TITLE
fix: increase species-id memory to 8Gi

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -300,7 +300,7 @@ jobs:
             --region=$REGION \
             --allow-unauthenticated \
             --cpu=2 \
-            --memory=4Gi \
+            --memory=8Gi \
             --cpu-boost \
             --startup-probe=tcpSocket.port=8080,periodSeconds=10,failureThreshold=30,timeoutSeconds=5 \
             --set-env-vars=RUST_LOG=observing_species_id=info,LOG_FORMAT=json


### PR DESCRIPTION
## Summary
- Deploy now fails with "container ran out of memory" instead of startup timeout (progress!)
- The ~1.4GB ONNX model plus ONNX Runtime overhead exceeds 4Gi
- Bump memory to 8Gi

## Test plan
- [ ] Deploy succeeds
- [ ] Species-id responds on `/health`