### PR TITLE
Embed AI suggestions inside species name field

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from "react";
+import { useCallback, type ReactNode } from "react";
 import { Autocomplete, Box, CircularProgress, Stack, TextField, Typography } from "@mui/material";
 import { searchTaxa } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
@@ -13,6 +13,8 @@ interface TaxaAutocompleteProps {
   placeholder?: string;
   size?: "small" | "medium";
   margin?: "normal" | "dense" | "none";
+  /** Content rendered below the input field (e.g. AI suggestions) */
+  bottomContent?: ReactNode;
 }
 
 export function TaxaAutocomplete({
@@ -22,6 +24,7 @@ export function TaxaAutocomplete({
   placeholder = "Search by common or scientific name...",
   size,
   margin = "normal",
+  bottomContent,
 }: TaxaAutocompleteProps) {
   const searchFn = useCallback((query: string) => searchTaxa(query), []);
   const { options, loading, handleSearch, clearOptions } = useAutocomplete<TaxaResult>({
@@ -30,113 +33,116 @@ export function TaxaAutocomplete({
   });
 
   return (
-    <Autocomplete
-      freeSolo
-      options={options}
-      loading={loading}
-      getOptionLabel={(option) => (typeof option === "string" ? option : option.scientificName)}
-      inputValue={value}
-      onInputChange={(_, v) => {
-        onChange(v);
-        handleSearch(v);
-      }}
-      onChange={(_, v) => {
-        if (v) {
-          const name = typeof v === "string" ? v : v.scientificName;
-          onChange(name);
-          clearOptions();
-        }
-      }}
-      filterOptions={(x) => x}
-      {...(size ? { size } : {})}
-      renderInput={(params) => {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const p = params as object;
-        return (
-          <TextField
-            {...p}
-            fullWidth
-            label={label}
-            placeholder={placeholder}
-            margin={margin}
-            slotProps={{
-              input: {
-                ...(params.InputProps || {}),
-                endAdornment: (
-                  <>
-                    {loading && <CircularProgress color="inherit" size={20} />}
-                    {params.InputProps?.endAdornment}
-                  </>
-                ),
-              },
-            }}
-          />
-        );
-      }}
-      renderOption={(props, option) => {
-        const { key, ...otherProps } = props;
-        return (
-          <Box
-            component="li"
-            key={key}
-            {...otherProps}
-            sx={{
-              display: "flex",
-              alignItems: "center",
-              gap: 1.5,
-              p: 1.5,
-            }}
-          >
-            {option.photoUrl && (
-              <Box
-                component="img"
-                src={option.photoUrl}
-                alt=""
-                loading="lazy"
-                sx={{
-                  width: 40,
-                  height: 40,
-                  borderRadius: 1,
-                  objectFit: "cover",
-                  flexShrink: 0,
-                }}
-              />
-            )}
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
-                <Typography fontWeight={600}>{option.scientificName}</Typography>
-                {option.isSynonym && (
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      bgcolor: "action.selected",
-                      px: 0.75,
-                      py: 0.25,
-                      borderRadius: 0.5,
-                      fontSize: "0.65rem",
-                    }}
-                  >
-                    synonym
+    <Box>
+      <Autocomplete
+        freeSolo
+        options={options}
+        loading={loading}
+        getOptionLabel={(option) => (typeof option === "string" ? option : option.scientificName)}
+        inputValue={value}
+        onInputChange={(_, v) => {
+          onChange(v);
+          handleSearch(v);
+        }}
+        onChange={(_, v) => {
+          if (v) {
+            const name = typeof v === "string" ? v : v.scientificName;
+            onChange(name);
+            clearOptions();
+          }
+        }}
+        filterOptions={(x) => x}
+        {...(size ? { size } : {})}
+        renderInput={(params) => {
+          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+          const p = params as object;
+          return (
+            <TextField
+              {...p}
+              fullWidth
+              label={label}
+              placeholder={placeholder}
+              margin={margin}
+              slotProps={{
+                input: {
+                  ...(params.InputProps || {}),
+                  endAdornment: (
+                    <>
+                      {loading && <CircularProgress color="inherit" size={20} />}
+                      {params.InputProps?.endAdornment}
+                    </>
+                  ),
+                },
+              }}
+            />
+          );
+        }}
+        renderOption={(props, option) => {
+          const { key, ...otherProps } = props;
+          return (
+            <Box
+              component="li"
+              key={key}
+              {...otherProps}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                p: 1.5,
+              }}
+            >
+              {option.photoUrl && (
+                <Box
+                  component="img"
+                  src={option.photoUrl}
+                  alt=""
+                  loading="lazy"
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: 1,
+                    objectFit: "cover",
+                    flexShrink: 0,
+                  }}
+                />
+              )}
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Stack direction="row" spacing={1} alignItems="center" flexWrap="wrap">
+                  <Typography fontWeight={600}>{option.scientificName}</Typography>
+                  {option.isSynonym && (
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        bgcolor: "action.selected",
+                        px: 0.75,
+                        py: 0.25,
+                        borderRadius: 0.5,
+                        fontSize: "0.65rem",
+                      }}
+                    >
+                      synonym
+                    </Typography>
+                  )}
+                  {option.conservationStatus && (
+                    <ConservationStatus status={option.conservationStatus} size="sm" />
+                  )}
+                </Stack>
+                {option.isSynonym && option.acceptedName && (
+                  <Typography variant="caption" color="text.disabled">
+                    → {option.acceptedName}
                   </Typography>
                 )}
-                {option.conservationStatus && (
-                  <ConservationStatus status={option.conservationStatus} size="sm" />
+                {option.commonName && !option.isSynonym && (
+                  <Typography variant="caption" color="text.disabled">
+                    {option.commonName}
+                  </Typography>
                 )}
-              </Stack>
-              {option.isSynonym && option.acceptedName && (
-                <Typography variant="caption" color="text.disabled">
-                  → {option.acceptedName}
-                </Typography>
-              )}
-              {option.commonName && !option.isSynonym && (
-                <Typography variant="caption" color="text.disabled">
-                  {option.commonName}
-                </Typography>
-              )}
+              </Box>
             </Box>
-          </Box>
-        );
-      }}
-    />
+          );
+        }}
+      />
+      {bottomContent}
+    </Box>
   );
 }

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -166,17 +166,22 @@ export function IdentificationPanel({
 
       {showSuggestForm && (
         <Box component="form" onSubmit={handleSubmit} sx={{ mt: 2 }}>
-          <TaxaAutocomplete value={taxonName} onChange={setTaxonName} size="small" />
-
-          {imageUrl && (
-            <AiSuggestions
-              imageUrl={imageUrl}
-              latitude={latitude}
-              longitude={longitude}
-              onSelect={(s) => setTaxonName(s.scientificName)}
-              disabled={isSubmitting}
-            />
-          )}
+          <TaxaAutocomplete
+            value={taxonName}
+            onChange={setTaxonName}
+            size="small"
+            bottomContent={
+              imageUrl ? (
+                <AiSuggestions
+                  imageUrl={imageUrl}
+                  latitude={latitude}
+                  longitude={longitude}
+                  onSelect={(s) => setTaxonName(s.scientificName)}
+                  disabled={isSubmitting}
+                />
+              ) : undefined
+            }
+          />
 
           <TextField
             fullWidth

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -538,19 +538,20 @@ export function UploadModal() {
           onChange={setSpecies}
           label="Species (optional)"
           placeholder="e.g. Eschscholzia californica - leave blank if unknown"
+          bottomContent={
+            aiImageUrl && !species ? (
+              <AiSuggestions
+                imageUrl={aiImageUrl}
+                latitude={lat ? parseFloat(lat) : undefined}
+                longitude={lng ? parseFloat(lng) : undefined}
+                onSelect={(s) => setSpecies(s.scientificName)}
+                disabled={isSubmitting}
+                autoFetch
+                quiet
+              />
+            ) : undefined
+          }
         />
-
-        {aiImageUrl && !species && (
-          <AiSuggestions
-            imageUrl={aiImageUrl}
-            latitude={lat ? parseFloat(lat) : undefined}
-            longitude={lng ? parseFloat(lng) : undefined}
-            onSelect={(s) => setSpecies(s.scientificName)}
-            disabled={isSubmitting}
-            autoFetch
-            quiet
-          />
-        )}
 
         <TextField
           fullWidth


### PR DESCRIPTION
## Summary
- Adds `bottomContent` prop to `TaxaAutocomplete` so AI suggestions render directly inside the species input area
- Extracts shared `AiSuggestions` component with `autoFetch` and `quiet` modes
- Uses `AiSuggestions` in both the "Suggest Different ID" form (button-triggered) and the upload modal (auto-triggered on first image)
- Builds on #179 which was merged earlier

## Test plan
- [x] Tested on observ.ing — "Suggest Different ID" shows AI Suggest button inside the form, chips populate species field
- [x] Tested on observ.ing — Upload modal auto-fetches AI suggestions when first photo is added
- [ ] Verify suggestions don't show in upload modal when species is already set