### PR TITLE
Fix species-id 413 by increasing body size limit

### DIFF
--- a/crates/observing-species-id/src/server.rs
+++ b/crates/observing-species-id/src/server.rs
@@ -3,7 +3,7 @@
 use crate::model::BioclipModel;
 use crate::types::{HealthResponse, IdentifyRequest, IdentifyResponse};
 use axum::{
-    extract::State,
+    extract::{DefaultBodyLimit, State},
     http::StatusCode,
     response::{IntoResponse, Json, Response},
     routing::{get, post},
@@ -33,6 +33,7 @@ pub fn create_router(state: SharedState) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/identify", post(identify))
+        .layer(DefaultBodyLimit::max(20 * 1024 * 1024)) // 20MB for base64-encoded images
         .layer(CorsLayer::permissive())
         .with_state(state)
 }


### PR DESCRIPTION
## Summary
- Axum's default body limit is 2MB, but base64-encoded images sent to `/identify` are ~4.6MB, causing **413 Request Entity Too Large** responses
- This was the root cause of AI suggestions returning 502 in production
- Increase the limit to 20MB on the species-id router

## Test plan
- [ ] Deploy to production
- [ ] Verify AI suggestions work on https://observ.ing/observation/did:plc:vozr2os4b4sxrxr6opde5js5/3mfionrqaog2p