### PR TITLE
fix: only italicize species/genus-level taxon names

### DIFF
--- a/frontend/src/components/common/TaxonLink.tsx
+++ b/frontend/src/components/common/TaxonLink.tsx
@@ -2,6 +2,20 @@ import { Link } from "react-router-dom";
 import { Chip, Typography } from "@mui/material";
 import { nameToSlug } from "../../lib/taxonSlug";
 
+const ITALICIZED_RANKS = new Set(["species", "genus", "subspecies", "variety"]);
+
+/**
+ * Determine whether a taxon name should be italicized.
+ * When rank is known, italicize species/genus/subspecies/variety.
+ * When rank is unknown, use word count as a heuristic:
+ * multi-word names are typically species (binomial) or below → italic.
+ */
+export function shouldItalicizeTaxonName(name: string, rank?: string): boolean {
+  if (rank) return ITALICIZED_RANKS.has(rank);
+  // Heuristic: binomial/trinomial names (2+ words) are species-level
+  return name.trim().includes(" ");
+}
+
 export interface TaxonLinkProps {
   /** The taxon name to display */
   name: string;
@@ -32,11 +46,8 @@ export function TaxonLink({
   italic,
   onClick,
 }: TaxonLinkProps) {
-  // Default italic behavior: italicize species and genus ranks
-  const shouldItalicize =
-    italic !== undefined
-      ? italic
-      : rank === "species" || rank === "genus" || rank === "subspecies" || rank === "variety";
+  // Default italic behavior: italicize species/genus/subspecies/variety ranks
+  const shouldItalicize = italic !== undefined ? italic : shouldItalicizeTaxonName(name, rank);
 
   // Build the URL using kingdom/name pattern with hyphenated slugs
   // All non-kingdom taxa require a kingdom prefix

--- a/frontend/src/components/feed/ExploreGridCard.tsx
+++ b/frontend/src/components/feed/ExploreGridCard.tsx
@@ -4,6 +4,7 @@ import { Box, Typography, Card, CardActionArea, CardMedia, CardContent } from "@
 import type { Occurrence } from "../../services/types";
 import { getImageUrl } from "../../services/api";
 import { formatTimeAgo, getObservationUrl } from "../../lib/utils";
+import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 
 interface ExploreGridCardProps {
   observation: Occurrence;
@@ -53,7 +54,7 @@ export const ExploreGridCard = memo(function ExploreGridCard({
           <Typography
             variant="body2"
             sx={{
-              fontStyle: "italic",
+              fontStyle: species && shouldItalicizeTaxonName(species) ? "italic" : "normal",
               color: "primary.main",
               fontWeight: 500,
               overflow: "hidden",

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -250,7 +250,6 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
                     <TaxonLink
                       name={subject.communityId}
                       kingdom={taxonomy?.kingdom}
-                      rank="species"
                       onClick={(e) => e.stopPropagation()}
                     />
                   ) : (
@@ -272,7 +271,7 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
                 <TaxonLink
                   name={species}
                   kingdom={taxonomy?.kingdom}
-                  rank="species"
+                  rank={undefined}
                   onClick={(e) => e.stopPropagation()}
                 />
               ) : (

--- a/frontend/src/components/identification/IdentificationHistory.tsx
+++ b/frontend/src/components/identification/IdentificationHistory.tsx
@@ -184,7 +184,6 @@ export function IdentificationHistory({
                   <TaxonLink
                     name={observerInitialId.scientificName}
                     kingdom={observerInitialId.kingdom || kingdom}
-                    rank="species"
                   />
                 </Box>
               </Box>
@@ -242,7 +241,7 @@ export function IdentificationHistory({
                     <TaxonLink
                       name={id.scientific_name}
                       kingdom={id.kingdom || kingdom}
-                      rank={id.taxon_rank || "species"}
+                      rank={id.taxon_rank}
                     />
                   </Box>
                   {id.identification_remarks && (

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -6,6 +6,7 @@ import NatureIcon from "@mui/icons-material/Nature";
 import { submitIdentification } from "../../services/api";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { AiSuggestions } from "./AiSuggestions";
+import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { useAppDispatch } from "../../store";
 import { addToast } from "../../store/uiSlice";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
@@ -121,7 +122,14 @@ export function IdentificationPanel({
           <Typography variant="caption" color="text.secondary">
             Community ID
           </Typography>
-          <Typography sx={{ fontStyle: "italic", color: "primary.main" }}>{currentId}</Typography>
+          <Typography
+            sx={{
+              fontStyle: shouldItalicizeTaxonName(currentId) ? "italic" : "normal",
+              color: "primary.main",
+            }}
+          >
+            {currentId}
+          </Typography>
         </Box>
       </Stack>
 

--- a/frontend/src/components/interaction/InteractionPanel.tsx
+++ b/frontend/src/components/interaction/InteractionPanel.tsx
@@ -27,6 +27,7 @@ import {
 } from "../../services/api";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
 import type { Subject, TaxaResult } from "../../services/types";
+import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { formatDate, MAX_AUTOCOMPLETE_RESULTS } from "../../lib/utils";
 
 // Known interaction types with human-readable labels
@@ -363,7 +364,14 @@ export function InteractionPanel({ observation, subjects, onSuccess }: Interacti
                         />
                       )}
                       <Box sx={{ minWidth: 0 }}>
-                        <Typography variant="body2" sx={{ fontStyle: "italic" }}>
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
+                              ? "italic"
+                              : "normal",
+                          }}
+                        >
                           {taxon.scientificName}
                         </Typography>
                         {taxon.commonName && (

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -269,7 +269,7 @@ export function ObservationDetail() {
         {/* Species Header */}
         <Box sx={{ px: 3, pt: 2, pb: 1 }}>
           {species ? (
-            <TaxonLink name={species} kingdom={taxonomy?.kingdom} rank="species" />
+            <TaxonLink name={species} kingdom={taxonomy?.kingdom} />
           ) : (
             <Typography
               variant="h5"
@@ -485,7 +485,10 @@ export function ObservationDetail() {
                             <Chip
                               label={subject.communityId}
                               size="small"
-                              sx={{ fontStyle: "italic", maxWidth: 120 }}
+                              sx={{
+                                fontStyle: subject.communityId.includes(" ") ? "italic" : "normal",
+                                maxWidth: 120,
+                              }}
                             />
                           )}
                         </Stack>

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -22,6 +22,7 @@ import GrassIcon from "@mui/icons-material/Grass";
 import { fetchProfileFeed, getImageUrl } from "../../services/api";
 import type { ProfileFeedResponse, Occurrence, Identification } from "../../services/types";
 import { formatTimeAgo, getDisplayName, getObservationUrl } from "../../lib/utils";
+import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { ProfileHeaderSkeleton } from "./ProfileHeaderSkeleton";
 import { ProfileObservationCardSkeleton } from "./ProfileObservationCardSkeleton";
 import { ProfileIdentificationCardSkeleton } from "./ProfileIdentificationCardSkeleton";
@@ -263,7 +264,11 @@ export function ProfileView() {
                   <Typography
                     variant="body2"
                     sx={{
-                      fontStyle: "italic",
+                      fontStyle: shouldItalicizeTaxonName(
+                        occ.communityId || occ.effectiveTaxonomy?.scientificName || "",
+                      )
+                        ? "italic"
+                        : "normal",
                       color: "primary.main",
                       fontWeight: 500,
                       overflow: "hidden",
@@ -328,7 +333,9 @@ export function ProfileView() {
                   <Typography
                     variant="body2"
                     sx={{
-                      fontStyle: "italic",
+                      fontStyle: shouldItalicizeTaxonName(id.scientific_name, id.taxon_rank)
+                        ? "italic"
+                        : "normal",
                       color: "primary.main",
                       fontWeight: 500,
                     }}

--- a/frontend/src/components/taxon/TaxonDetail.tsx
+++ b/frontend/src/components/taxon/TaxonDetail.tsx
@@ -25,7 +25,7 @@ import { fetchTaxon, fetchTaxonObservations } from "../../services/api";
 import type { TaxonDetail as TaxonDetailType, Occurrence } from "../../services/types";
 import { slugToName } from "../../lib/taxonSlug";
 import { ConservationStatus } from "../common/ConservationStatus";
-import { TaxonLink } from "../common/TaxonLink";
+import { TaxonLink, shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useWikidataThumbnails } from "../../hooks/useWikidataThumbnails";
 import { WikiTaxonThumbnail } from "../common/WikiTaxonThumbnail";
@@ -209,7 +209,9 @@ export function TaxonDetail() {
           <Typography
             variant="h5"
             sx={{
-              fontStyle: taxon.rank === "species" || taxon.rank === "genus" ? "italic" : "normal",
+              fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
+                ? "italic"
+                : "normal",
               color: "primary.main",
               fontWeight: 600,
             }}
@@ -300,12 +302,9 @@ export function TaxonDetail() {
                       <Typography
                         sx={{
                           fontWeight: 700,
-                          fontStyle:
-                            taxon.rank === "species" ||
-                            taxon.rank === "genus" ||
-                            taxon.rank === "subspecies"
-                              ? "italic"
-                              : "normal",
+                          fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
+                            ? "italic"
+                            : "normal",
                         }}
                       >
                         {taxon.scientificName}


### PR DESCRIPTION
## Summary
- Adds a shared `shouldItalicizeTaxonName()` helper that italicizes based on actual taxonomic rank (species, genus, subspecies, variety) when available, or falls back to a word-count heuristic (multi-word = binomial nomenclature = italic)
- Removes hardcoded `rank="species"` and `fontStyle: "italic"` from 9 components that display taxon names
- Higher-rank names (family, order, class, etc.) are no longer incorrectly italicized

Closes #148

## Test plan
- [ ] View an observation identified at a higher rank (e.g., family/order) — name should NOT be italicized
- [ ] View an observation identified at species level — name should still be italicized
- [ ] Check taxon detail page for species vs. family ranks
- [ ] Check explore grid, feed, profile, identification history, and interaction panel