### PR TITLE
fix: prevent double-submit causing duplicate identifications

### DIFF
--- a/frontend/src/hooks/useFormSubmit.ts
+++ b/frontend/src/hooks/useFormSubmit.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useCallback, useRef } from "react";
 import { useAppDispatch } from "../store";
 import { addToast } from "../store/uiSlice";
 import { getErrorMessage } from "../lib/utils";
@@ -25,8 +25,11 @@ export function useFormSubmit(
 ) {
   const dispatch = useAppDispatch();
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const submittingRef = useRef(false);
 
   const handleSubmit = useCallback(async () => {
+    if (submittingRef.current) return;
+    submittingRef.current = true;
     setIsSubmitting(true);
     try {
       await submitFn();
@@ -48,6 +51,7 @@ export function useFormSubmit(
         );
       }
     } finally {
+      submittingRef.current = false;
       setIsSubmitting(false);
     }
   }, [submitFn, options, dispatch]);


### PR DESCRIPTION
## Summary
- Adds a `useRef` guard to `useFormSubmit` to prevent concurrent submissions
- The existing `useState`-based `isSubmitting` flag only disables the button after React re-renders, so rapid taps (especially on mobile) could fire multiple API calls before the button visually disables
- Each call created a separate AT Protocol record with a unique URI, so the ingester indexed both as distinct identifications

## How it works
A `submittingRef` is checked and set synchronously at the top of `handleSubmit`, blocking re-entry even if React hasn't re-rendered yet. The ref is cleared in the `finally` block alongside the state update.

Fixes #150