### PR TITLE
fix: update @xmldom/xmldom to resolve high-severity vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@mui/material": "^7.3.7",
         "@mui/x-date-pickers": "^8.27.0",
         "@reduxjs/toolkit": "^2.11.2",
+        "@xmldom/xmldom": "^0.9.9",
         "date-fns": "^4.1.0",
         "dompurify": "^3.3.1",
         "exifreader": "^4.36.1",
@@ -2504,11 +2505,10 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
-      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "version": "0.9.9",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
+      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
       "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=14.6"
       }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@mui/material": "^7.3.7",
     "@mui/x-date-pickers": "^8.27.0",
     "@reduxjs/toolkit": "^2.11.2",
+    "@xmldom/xmldom": "^0.9.9",
     "date-fns": "^4.1.0",
     "dompurify": "^3.3.1",
     "exifreader": "^4.36.1",


### PR DESCRIPTION
## Summary
- Updates `@xmldom/xmldom` from 0.9.8 to 0.9.9
- Fixes [GHSA-wh4c-j3r5-mjhp](https://github.com/advisories/GHSA-wh4c-j3r5-mjhp): XML injection via unsafe CDATA serialization
- Resolves the `frontend-audit` CI failure

## Test plan
- [ ] Verify `npm audit` reports 0 vulnerabilities
- [ ] Verify frontend builds and typechecks cleanly