### PR TITLE
feat: add open-in-new-tab link for AI suggestion taxa

### DIFF
--- a/frontend/src/components/identification/AiSuggestions.tsx
+++ b/frontend/src/components/identification/AiSuggestions.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect, useRef } from "react";
-import { Box, Button, Chip, CircularProgress, Stack, Typography } from "@mui/material";
+import { Box, Button, Chip, CircularProgress, IconButton, Stack, Typography } from "@mui/material";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import { identifySpecies, type SpeciesSuggestion } from "../../services/api";
+import { nameToSlug } from "../../lib/taxonSlug";
 import { useAppDispatch } from "../../store";
 import { addToast } from "../../store/uiSlice";
 
@@ -116,21 +118,46 @@ export function AiSuggestions({
               <Chip
                 key={s.scientificName}
                 label={
-                  <Box component="span" sx={{ display: "flex", alignItems: "baseline", gap: 0.5 }}>
-                    <span style={{ fontStyle: "italic" }}>{s.scientificName}</span>
-                    {s.commonName && (
-                      <Typography variant="caption" component="span" color="text.secondary">
-                        {s.commonName}
-                      </Typography>
-                    )}
-                    <Typography
-                      variant="caption"
+                  <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                    <Box
                       component="span"
-                      color="text.secondary"
-                      sx={{ ml: "auto" }}
+                      sx={{
+                        display: "flex",
+                        alignItems: "baseline",
+                        gap: 0.5,
+                        flex: 1,
+                        minWidth: 0,
+                      }}
                     >
-                      {Math.round(s.confidence * 100)}%
-                    </Typography>
+                      <span style={{ fontStyle: "italic" }}>{s.scientificName}</span>
+                      {s.commonName && (
+                        <Typography variant="caption" component="span" color="text.secondary">
+                          {s.commonName}
+                        </Typography>
+                      )}
+                      <Typography
+                        variant="caption"
+                        component="span"
+                        color="text.secondary"
+                        sx={{ ml: "auto" }}
+                      >
+                        {Math.round(s.confidence * 100)}%
+                      </Typography>
+                    </Box>
+                    {s.kingdom && (
+                      <IconButton
+                        size="small"
+                        component="a"
+                        href={`/taxon/${s.kingdom}/${nameToSlug(s.scientificName)}`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                        sx={{ p: 0, ml: 0.5 }}
+                        title="Open taxon in new tab"
+                      >
+                        <OpenInNewIcon sx={{ fontSize: 14 }} />
+                      </IconButton>
+                    )}
                   </Box>
                 }
                 size="small"


### PR DESCRIPTION
## Summary
- Adds a small "open in new tab" icon button to each AI species suggestion chip
- Clicking the icon navigates to `/taxon/{kingdom}/{name-slug}` in a new tab
- The existing chip click behavior (selecting the suggestion) is preserved via `stopPropagation`

## Screenshot

![AI suggestion taxon links](https://files.catbox.moe/78g9b9.png)

## Test plan
- [ ] Trigger AI species identification on an observation
- [ ] Verify the open-in-new-tab icon appears on each suggestion chip
- [ ] Click the icon and confirm the taxon page opens in a new tab
- [ ] Click elsewhere on the chip and confirm it still selects the suggestion