### PR TITLE
Remove test-file overrides from oxlint config

### DIFF
--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -18,17 +18,5 @@
     "react/no-direct-mutation-state": "error",
     "react/jsx-no-target-blank": "error",
     "react/no-danger": "error"
-  },
-  "overrides": [
-    {
-      "files": ["**/*.test.ts", "**/*.test.tsx", "e2e/**/*.ts", "scripts/**/*.ts"],
-      "rules": {
-        "typescript/consistent-type-assertions": "off",
-        "typescript/no-explicit-any": "off",
-        "typescript/no-non-null-assertion": "off",
-        "typescript/consistent-type-imports": "off",
-        "no-await-in-loop": "off"
-      }
-    }
-  ]
+  }
 }

--- a/frontend/src/lib/identification.test.ts
+++ b/frontend/src/lib/identification.test.ts
@@ -1,45 +1,85 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { IdentificationService } from "./identification.js";
-import type { AtpAgent } from "@atproto/api";
+import { IdentificationService, type IdentificationAgent } from "./identification.js";
 
 describe("IdentificationService", () => {
-  let mockAgent: Partial<AtpAgent>;
+  let createRecord: ReturnType<
+    typeof vi.fn<IdentificationAgent["com"]["atproto"]["repo"]["createRecord"]>
+  >;
+  let deleteRecord: ReturnType<
+    typeof vi.fn<IdentificationAgent["com"]["atproto"]["repo"]["deleteRecord"]>
+  >;
+  let getRecord: ReturnType<
+    typeof vi.fn<IdentificationAgent["com"]["atproto"]["repo"]["getRecord"]>
+  >;
+  let putRecord: ReturnType<
+    typeof vi.fn<IdentificationAgent["com"]["atproto"]["repo"]["putRecord"]>
+  >;
+  let listRecords: ReturnType<
+    typeof vi.fn<IdentificationAgent["com"]["atproto"]["repo"]["listRecords"]>
+  >;
   let service: IdentificationService;
 
-  beforeEach(() => {
-    mockAgent = {
-      session: { did: "did:plc:test", handle: "test.bsky.social" } as AtpAgent["session"],
+  function makeAgent(session: IdentificationAgent["session"]): IdentificationAgent {
+    return {
+      session,
       com: {
         atproto: {
-          repo: {
-            createRecord: vi.fn().mockResolvedValue({
-              data: { uri: "at://did:plc:test/ing.observ.temp.identification/1", cid: "test-cid" },
-            }),
-            deleteRecord: vi.fn().mockResolvedValue({}),
-            getRecord: vi.fn().mockResolvedValue({
-              data: {
-                value: {
-                  $type: "ing.observ.temp.identification",
-                  subject: {
-                    uri: "at://did:plc:test/bio.lexicons.temp.occurrence/1",
-                    cid: "subject-cid",
-                  },
-                  taxon: { scientificName: "Quercus alba", taxonRank: "species" },
-                  createdAt: "2024-01-01T00:00:00Z",
-                },
-              },
-            }),
-            putRecord: vi.fn().mockResolvedValue({
-              data: { uri: "at://did:plc:test/ing.observ.temp.identification/1", cid: "new-cid" },
-            }),
-            listRecords: vi.fn().mockResolvedValue({
-              data: { records: [] },
-            }),
-          },
+          repo: { createRecord, deleteRecord, getRecord, putRecord, listRecords },
         },
-      } as unknown as AtpAgent["com"],
+      },
     };
-    service = new IdentificationService(mockAgent as AtpAgent);
+  }
+  const defaultSession = { did: "did:plc:test" };
+
+  beforeEach(() => {
+    createRecord = vi.fn(async () => ({
+      success: true,
+      data: {
+        uri: "at://did:plc:test/ing.observ.temp.identification/1",
+        cid: "test-cid",
+        commit: { cid: "commit-cid", rev: "rev-1" },
+        validationStatus: "valid",
+      },
+      headers: {},
+    }));
+    deleteRecord = vi.fn(async () => ({
+      success: true,
+      data: { commit: { cid: "commit-cid", rev: "rev-1" } },
+      headers: {},
+    }));
+    getRecord = vi.fn(async () => ({
+      success: true,
+      data: {
+        uri: "at://did:plc:test/ing.observ.temp.identification/1",
+        cid: "test-cid",
+        value: {
+          $type: "ing.observ.temp.identification",
+          subject: {
+            uri: "at://did:plc:test/bio.lexicons.temp.occurrence/1",
+            cid: "subject-cid",
+          },
+          taxon: { scientificName: "Quercus alba", taxonRank: "species" },
+          createdAt: "2024-01-01T00:00:00Z",
+        },
+      },
+      headers: {},
+    }));
+    putRecord = vi.fn(async () => ({
+      success: true,
+      data: {
+        uri: "at://did:plc:test/ing.observ.temp.identification/1",
+        cid: "new-cid",
+        commit: { cid: "commit-cid", rev: "rev-1" },
+        validationStatus: "valid",
+      },
+      headers: {},
+    }));
+    listRecords = vi.fn(async () => ({
+      success: true,
+      data: { records: [] },
+      headers: {},
+    }));
+    service = new IdentificationService(makeAgent(defaultSession));
   });
 
   describe("validateInput", () => {
@@ -71,7 +111,7 @@ describe("IdentificationService", () => {
       it("accepts valid at:// URI", async () => {
         await service.identify(validInput);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
     });
 
@@ -85,7 +125,7 @@ describe("IdentificationService", () => {
       it("accepts valid CID", async () => {
         await service.identify(validInput);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
     });
 
@@ -113,19 +153,19 @@ describe("IdentificationService", () => {
         const maxName = "A".repeat(256);
         await service.identify({ ...validInput, scientificName: maxName });
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts typical species name", async () => {
         await service.identify({ ...validInput, scientificName: "Homo sapiens" });
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts subspecies with three parts", async () => {
         await service.identify({ ...validInput, scientificName: "Canis lupus familiaris" });
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
     });
 
@@ -141,21 +181,20 @@ describe("IdentificationService", () => {
         const maxComment = "A".repeat(3000);
         await service.identify({ ...validInput, comment: maxComment });
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts empty comment (optional field)", async () => {
         await service.identify({ ...validInput, comment: undefined });
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
     });
   });
 
   describe("identify", () => {
     it("throws if not logged in", async () => {
-      const noSessionAgent = { session: undefined } as AtpAgent;
-      const noSessionService = new IdentificationService(noSessionAgent);
+      const noSessionService = new IdentificationService(makeAgent(undefined));
 
       await expect(
         noSessionService.identify({
@@ -189,7 +228,7 @@ describe("IdentificationService", () => {
         isAgreement: true,
       });
 
-      expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalledWith(
+      expect(createRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           repo: "did:plc:test",
           collection: "ing.observ.temp.identification",
@@ -217,7 +256,7 @@ describe("IdentificationService", () => {
         scientificName: "Quercus alba",
       });
 
-      expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalledWith(
+      expect(createRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           record: expect.objectContaining({
             taxon: expect.objectContaining({
@@ -238,7 +277,7 @@ describe("IdentificationService", () => {
         "Quercus alba",
       );
 
-      expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalledWith(
+      expect(createRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           record: expect.objectContaining({
             taxon: expect.objectContaining({
@@ -259,7 +298,7 @@ describe("IdentificationService", () => {
         "Quercus rubra",
       );
 
-      expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalledWith(
+      expect(createRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           record: expect.objectContaining({
             taxon: expect.objectContaining({
@@ -282,7 +321,7 @@ describe("IdentificationService", () => {
         },
       );
 
-      expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalledWith(
+      expect(createRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           record: expect.objectContaining({
             taxon: expect.objectContaining({
@@ -298,8 +337,7 @@ describe("IdentificationService", () => {
 
   describe("withdraw", () => {
     it("throws if not logged in", async () => {
-      const noSessionAgent = { session: undefined } as AtpAgent;
-      const noSessionService = new IdentificationService(noSessionAgent);
+      const noSessionService = new IdentificationService(makeAgent(undefined));
 
       await expect(
         noSessionService.withdraw("at://did:plc:test/ing.observ.temp.identification/abc123"),
@@ -309,7 +347,7 @@ describe("IdentificationService", () => {
     it("extracts rkey from URI and deletes record", async () => {
       await service.withdraw("at://did:plc:test/ing.observ.temp.identification/abc123");
 
-      expect(mockAgent.com!.atproto.repo.deleteRecord).toHaveBeenCalledWith({
+      expect(deleteRecord).toHaveBeenCalledWith({
         repo: "did:plc:test",
         collection: "ing.observ.temp.identification",
         rkey: "abc123",
@@ -319,8 +357,7 @@ describe("IdentificationService", () => {
 
   describe("update", () => {
     it("throws if not logged in", async () => {
-      const noSessionAgent = { session: undefined } as AtpAgent;
-      const noSessionService = new IdentificationService(noSessionAgent);
+      const noSessionService = new IdentificationService(makeAgent(undefined));
 
       await expect(
         noSessionService.update("at://did:plc:test/ing.observ.temp.identification/abc123", {
@@ -335,12 +372,12 @@ describe("IdentificationService", () => {
         { scientificName: "Quercus rubra" },
       );
 
-      expect(mockAgent.com!.atproto.repo.getRecord).toHaveBeenCalledWith({
+      expect(getRecord).toHaveBeenCalledWith({
         repo: "did:plc:test",
         collection: "ing.observ.temp.identification",
         rkey: "abc123",
       });
-      expect(mockAgent.com!.atproto.repo.putRecord).toHaveBeenCalledWith(
+      expect(putRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           repo: "did:plc:test",
           collection: "ing.observ.temp.identification",
@@ -363,7 +400,7 @@ describe("IdentificationService", () => {
         comment: "New comment",
       });
 
-      expect(mockAgent.com!.atproto.repo.putRecord).toHaveBeenCalledWith(
+      expect(putRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           record: expect.objectContaining({
             taxon: expect.objectContaining({
@@ -381,7 +418,7 @@ describe("IdentificationService", () => {
         comment: "",
       });
 
-      expect(mockAgent.com!.atproto.repo.putRecord).toHaveBeenCalledWith(
+      expect(putRecord).toHaveBeenCalledWith(
         expect.objectContaining({
           record: expect.objectContaining({
             comment: "",
@@ -393,8 +430,7 @@ describe("IdentificationService", () => {
 
   describe("getMyIdentifications", () => {
     it("throws if not logged in", async () => {
-      const noSessionAgent = { session: undefined } as AtpAgent;
-      const noSessionService = new IdentificationService(noSessionAgent);
+      const noSessionService = new IdentificationService(makeAgent(undefined));
 
       await expect(noSessionService.getMyIdentifications()).rejects.toThrow("Not logged in");
     });
@@ -402,7 +438,7 @@ describe("IdentificationService", () => {
     it("lists records with default limit", async () => {
       await service.getMyIdentifications();
 
-      expect(mockAgent.com!.atproto.repo.listRecords).toHaveBeenCalledWith({
+      expect(listRecords).toHaveBeenCalledWith({
         repo: "did:plc:test",
         collection: "ing.observ.temp.identification",
         limit: 50,
@@ -412,7 +448,7 @@ describe("IdentificationService", () => {
     it("lists records with custom limit", async () => {
       await service.getMyIdentifications(100);
 
-      expect(mockAgent.com!.atproto.repo.listRecords).toHaveBeenCalledWith({
+      expect(listRecords).toHaveBeenCalledWith({
         repo: "did:plc:test",
         collection: "ing.observ.temp.identification",
         limit: 100,
@@ -424,9 +460,11 @@ describe("IdentificationService", () => {
         { uri: "at://test/1", cid: "cid1", value: { taxon: { scientificName: "Species A" } } },
         { uri: "at://test/2", cid: "cid2", value: { taxon: { scientificName: "Species B" } } },
       ];
-      vi.mocked(mockAgent.com!.atproto.repo.listRecords).mockResolvedValueOnce({
+      listRecords.mockResolvedValueOnce({
+        success: true,
         data: { records: mockRecords },
-      } as never);
+        headers: {},
+      });
 
       const result = await service.getMyIdentifications();
 

--- a/frontend/src/lib/identification.ts
+++ b/frontend/src/lib/identification.ts
@@ -10,6 +10,27 @@ import { getErrorMessage } from "./utils";
 
 const IDENTIFICATION_COLLECTION = "ing.observ.temp.identification";
 
+type AtpRepoOps = AtpAgent["com"]["atproto"]["repo"];
+
+/**
+ * The subset of AtpAgent required by IdentificationService.
+ * Defined structurally so tests can provide narrow mocks.
+ */
+export interface IdentificationAgent {
+  session?: { did: string } | undefined;
+  com: {
+    atproto: {
+      repo: {
+        createRecord: AtpRepoOps["createRecord"];
+        deleteRecord: AtpRepoOps["deleteRecord"];
+        getRecord: AtpRepoOps["getRecord"];
+        putRecord: AtpRepoOps["putRecord"];
+        listRecords: AtpRepoOps["listRecords"];
+      };
+    };
+  };
+}
+
 interface IdentificationInput {
   /** URI of the occurrence being identified */
   occurrenceUri: string;
@@ -67,9 +88,9 @@ interface IdentificationResult {
 }
 
 export class IdentificationService {
-  private agent: AtpAgent;
+  private agent: IdentificationAgent;
 
-  constructor(agent: AtpAgent) {
+  constructor(agent: IdentificationAgent) {
     this.agent = agent;
   }
 

--- a/frontend/src/lib/uploader.test.ts
+++ b/frontend/src/lib/uploader.test.ts
@@ -1,38 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { OccurrenceUploader } from "./uploader.js";
-import type { AtpAgent } from "@atproto/api";
+import { BlobRef } from "@atproto/api";
+import { OccurrenceUploader, type UploaderAgent } from "./uploader.js";
 
-// Mock File class for Node.js environment
-class MockFile {
-  name: string;
-  type: string;
-  size: number;
-  lastModified: number;
-
-  constructor(
-    parts: BlobPart[],
-    name: string,
-    options: { type?: string; lastModified?: number } = {},
-  ) {
-    this.name = name;
-    this.type = options.type || "";
-    this.lastModified = options.lastModified || Date.now();
-    // Calculate size from parts
-    this.size = parts.reduce((acc, part) => {
-      if (typeof part === "string") return acc + part.length;
-      if (part instanceof ArrayBuffer) return acc + part.byteLength;
-      return acc;
-    }, 0);
-  }
-
-  async arrayBuffer(): Promise<ArrayBuffer> {
-    return new ArrayBuffer(this.size);
-  }
+// Helper to create mock files using native File (Node 20+)
+function createMockFile(name: string, type: string, sizeInBytes: number): File {
+  return new File(["x".repeat(sizeInBytes)], name, { type });
 }
 
-// Helper to create mock files
-function createMockFile(name: string, type: string, sizeInBytes: number): File {
-  const file = new MockFile(["x".repeat(sizeInBytes)], name, { type }) as unknown as File;
+// Helper to create a File with specific bytes and optional lastModified timestamp
+function createMockFileWithBytes(bytes: number[], lastModified?: number): File {
+  const buffer = new Uint8Array(bytes);
+  const options: FilePropertyBag = { type: "image/jpeg" };
+  if (lastModified !== undefined) {
+    options.lastModified = lastModified;
+  }
+  return new File([buffer], "test.jpg", options);
+}
+
+// Helper to create a File whose arrayBuffer() rejects, for error-path testing
+function createErrorFile(): File {
+  const file = new File(["ignored"], "test.jpg", { type: "image/jpeg" });
+  // Override arrayBuffer to simulate a read error
+  Object.defineProperty(file, "arrayBuffer", {
+    value: () => Promise.reject(new Error("Read error")),
+  });
   return file;
 }
 
@@ -52,26 +43,43 @@ function createValidOccurrence(
 }
 
 describe("OccurrenceUploader", () => {
-  let mockAgent: Partial<AtpAgent>;
+  let createRecord: ReturnType<
+    typeof vi.fn<UploaderAgent["com"]["atproto"]["repo"]["createRecord"]>
+  >;
+  let uploadBlob: ReturnType<typeof vi.fn<UploaderAgent["uploadBlob"]>>;
   let uploader: OccurrenceUploader;
 
-  beforeEach(() => {
-    mockAgent = {
-      session: { did: "did:plc:test", handle: "test.bsky.social" } as AtpAgent["session"],
-      uploadBlob: vi.fn().mockResolvedValue({
-        data: { blob: { ref: { $link: "blobref" }, mimeType: "image/jpeg", size: 1000 } },
-      }),
-      com: {
-        atproto: {
-          repo: {
-            createRecord: vi.fn().mockResolvedValue({
-              data: { uri: "at://did:plc:test/bio.lexicons.temp.occurrence/1", cid: "test-cid" },
-            }),
-          },
-        },
-      } as unknown as AtpAgent["com"],
+  function makeAgent(session: UploaderAgent["session"]): UploaderAgent {
+    return {
+      session,
+      uploadBlob,
+      com: { atproto: { repo: { createRecord } } },
     };
-    uploader = new OccurrenceUploader(mockAgent as AtpAgent);
+  }
+  const defaultSession = { did: "did:plc:test" };
+
+  beforeEach(() => {
+    createRecord = vi.fn(async () => ({
+      success: true,
+      data: {
+        uri: "at://did:plc:test/bio.lexicons.temp.occurrence/1",
+        cid: "test-cid",
+        commit: { cid: "commit-cid", rev: "rev-1" },
+        validationStatus: "valid",
+      },
+      headers: {},
+    }));
+    uploadBlob = vi.fn(async () => ({
+      success: true,
+      data: {
+        blob: BlobRef.fromJsonRef({
+          cid: "bafkreihdwdcefgh4dqkjv67uzcmw7ojee6xedzdetojuzjevtenxquvyku",
+          mimeType: "image/jpeg",
+        }),
+      },
+      headers: {},
+    }));
+    uploader = new OccurrenceUploader(makeAgent(defaultSession));
   });
 
   describe("validateOccurrence", () => {
@@ -101,7 +109,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts today's date", async () => {
@@ -110,7 +118,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
     });
 
@@ -166,7 +174,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts latitude at boundary 90", async () => {
@@ -176,7 +184,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts longitude at boundary -180", async () => {
@@ -186,7 +194,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts longitude at boundary 180", async () => {
@@ -196,7 +204,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
     });
 
@@ -239,7 +247,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts png images", async () => {
@@ -249,7 +257,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts webp images", async () => {
@@ -259,7 +267,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts image at exactly 10MB", async () => {
@@ -270,7 +278,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.com!.atproto.repo.createRecord).toHaveBeenCalled();
+        expect(createRecord).toHaveBeenCalled();
       });
 
       it("accepts multiple valid images", async () => {
@@ -284,7 +292,7 @@ describe("OccurrenceUploader", () => {
 
         await uploader.upload(data);
 
-        expect(mockAgent.uploadBlob).toHaveBeenCalledTimes(3);
+        expect(uploadBlob).toHaveBeenCalledTimes(3);
       });
 
       it("throws if any image in array is invalid type", async () => {
@@ -325,25 +333,6 @@ describe("OccurrenceUploader", () => {
   });
 
   describe("extractExif", () => {
-    // Helper to create a mock file with specific bytes
-    function createMockFileWithBytes(bytes: number[], lastModified?: number): File {
-      const buffer = new ArrayBuffer(bytes.length);
-      const view = new Uint8Array(buffer);
-      bytes.forEach((b, i) => {
-        view[i] = b;
-      });
-
-      const file = {
-        name: "test.jpg",
-        type: "image/jpeg",
-        size: bytes.length,
-        lastModified: lastModified || Date.now(),
-        arrayBuffer: () => Promise.resolve(buffer),
-      } as unknown as File;
-
-      return file;
-    }
-
     it("returns empty object for non-JPEG file", async () => {
       // PNG file signature (not JPEG)
       const pngFile = createMockFileWithBytes([0x89, 0x50, 0x4e, 0x47]);
@@ -423,13 +412,7 @@ describe("OccurrenceUploader", () => {
     });
 
     it("handles error during parsing gracefully", async () => {
-      const errorFile = {
-        name: "test.jpg",
-        type: "image/jpeg",
-        size: 100,
-        lastModified: Date.now(),
-        arrayBuffer: () => Promise.reject(new Error("Read error")),
-      } as unknown as File;
+      const errorFile = createErrorFile();
 
       const result = await uploader.extractExif(errorFile);
 

--- a/frontend/src/lib/uploader.ts
+++ b/frontend/src/lib/uploader.ts
@@ -13,6 +13,22 @@ import type { AtpAgent, BlobRef } from "@atproto/api";
 const OCCURRENCE_COLLECTION = "bio.lexicons.temp.occurrence";
 const MEDIA_COLLECTION = "bio.lexicons.temp.media";
 
+/**
+ * The subset of AtpAgent required by OccurrenceUploader.
+ * Defined structurally so tests can provide narrow mocks.
+ */
+export interface UploaderAgent {
+  session?: { did: string } | undefined;
+  com: {
+    atproto: {
+      repo: {
+        createRecord: AtpAgent["com"]["atproto"]["repo"]["createRecord"];
+      };
+    };
+  };
+  uploadBlob: AtpAgent["uploadBlob"];
+}
+
 interface UploadConfig {
   pdsUrl: string;
 }
@@ -39,10 +55,10 @@ interface ExifData {
 }
 
 export class OccurrenceUploader {
-  private agent: AtpAgent;
+  private agent: UploaderAgent;
   private config: UploadConfig;
 
-  constructor(agent: AtpAgent, config: Partial<UploadConfig> = {}) {
+  constructor(agent: UploaderAgent, config: Partial<UploadConfig> = {}) {
     this.agent = agent;
     this.config = {
       pdsUrl: config.pdsUrl || "https://bsky.social",

--- a/frontend/src/store/feedSlice.test.ts
+++ b/frontend/src/store/feedSlice.test.ts
@@ -9,6 +9,14 @@ import feedReducer, {
   setUserLocation,
 } from "./feedSlice";
 import authReducer from "./authSlice";
+import type {
+  Occurrence,
+  ExploreFeedResponse,
+  HomeFeedResponse,
+  User,
+  FeedTab,
+  FeedFilters,
+} from "../services/types";
 
 vi.mock("../services/api", () => ({
   fetchHomeFeed: vi.fn(),
@@ -19,28 +27,74 @@ vi.mock("../services/api", () => ({
 
 import * as api from "../services/api";
 
+function makeOccurrence(overrides: Partial<Occurrence> = {}): Occurrence {
+  return {
+    uri: "at://test",
+    cid: "test-cid",
+    observer: { did: "did:plc:default", handle: "default.bsky.social" },
+    observers: [],
+    subjects: [],
+    eventDate: "2024-01-01",
+    location: { latitude: 0, longitude: 0 },
+    images: [],
+    createdAt: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeFeedResponse(
+  occurrences: Occurrence[] = [],
+  cursor?: string,
+): ExploreFeedResponse & HomeFeedResponse {
+  return cursor === undefined ? { occurrences } : { occurrences, cursor };
+}
+
+interface FeedOverrides {
+  observations?: Occurrence[];
+  cursor?: string | undefined;
+  isLoading?: boolean;
+  currentTab?: FeedTab;
+  hasMore?: boolean;
+  filters?: FeedFilters;
+  isAuthenticated?: boolean;
+  userLocation?: { lat: number; lng: number } | null;
+}
+
+interface AuthOverrides {
+  user: User | null;
+  isLoading: boolean;
+}
+
+interface FeedStateShape {
+  observations: Occurrence[];
+  cursor: string | undefined;
+  isLoading: boolean;
+  currentTab: FeedTab;
+  hasMore: boolean;
+  filters: FeedFilters;
+  isAuthenticated: boolean;
+  userLocation: { lat: number; lng: number } | null;
+}
+
 describe("feedSlice", () => {
-  const defaultFeedState = {
+  const defaultFeedState: FeedStateShape = {
     observations: [],
     cursor: undefined,
     isLoading: false,
-    currentTab: "explore" as const,
+    currentTab: "explore",
     hasMore: true,
     filters: {},
     isAuthenticated: false,
     userLocation: null,
   };
 
-  const createTestStore = (preloadedState?: {
-    feed?: Partial<typeof defaultFeedState>;
-    auth?: { user: { did: string; handle: string } | null; isLoading: boolean };
-  }) =>
+  const createTestStore = (preloadedState?: { feed?: FeedOverrides; auth?: AuthOverrides }) =>
     configureStore({
       reducer: { feed: feedReducer, auth: authReducer },
       preloadedState: {
         feed: { ...defaultFeedState, ...preloadedState?.feed },
         auth: preloadedState?.auth ?? { user: null, isLoading: false },
-      } as any,
+      },
     });
 
   beforeEach(() => {
@@ -66,7 +120,7 @@ describe("feedSlice", () => {
     it("switches tab and resets state", () => {
       const store = createTestStore({
         feed: {
-          observations: [{ uri: "test" } as any],
+          observations: [makeOccurrence({ uri: "test" })],
           cursor: "abc",
           currentTab: "explore",
           hasMore: false,
@@ -87,7 +141,7 @@ describe("feedSlice", () => {
     it("resets feed state", () => {
       const store = createTestStore({
         feed: {
-          observations: [{ uri: "test" } as any],
+          observations: [makeOccurrence({ uri: "test" })],
           cursor: "abc",
           hasMore: false,
         },
@@ -106,7 +160,7 @@ describe("feedSlice", () => {
     it("sets filters and resets feed", () => {
       const store = createTestStore({
         feed: {
-          observations: [{ uri: "test" } as any],
+          observations: [makeOccurrence({ uri: "test" })],
           cursor: "abc",
           hasMore: false,
           filters: {},
@@ -147,11 +201,11 @@ describe("feedSlice", () => {
 
   describe("loadFeed thunk", () => {
     it("loads explore feed when not authenticated", async () => {
-      const mockResponse = {
-        occurrences: [{ uri: "at://test1" }, { uri: "at://test2" }],
-        cursor: "next123",
-      };
-      vi.mocked(api.fetchExploreFeed).mockResolvedValue(mockResponse as any);
+      const mockResponse = makeFeedResponse(
+        [makeOccurrence({ uri: "at://test1" }), makeOccurrence({ uri: "at://test2" })],
+        "next123",
+      );
+      vi.mocked(api.fetchExploreFeed).mockResolvedValue(mockResponse);
 
       const store = createTestStore({
         auth: { user: null, isLoading: false },
@@ -167,11 +221,13 @@ describe("feedSlice", () => {
     });
 
     it("loads explore feed when on explore tab even if authenticated", async () => {
-      const mockResponse = { occurrences: [], cursor: undefined };
-      vi.mocked(api.fetchExploreFeed).mockResolvedValue(mockResponse as any);
+      vi.mocked(api.fetchExploreFeed).mockResolvedValue(makeFeedResponse());
 
       const store = createTestStore({
-        auth: { user: { did: "did:plc:test", handle: "test" }, isLoading: false },
+        auth: {
+          user: { did: "did:plc:test", handle: "test" },
+          isLoading: false,
+        },
         feed: { currentTab: "explore" },
       });
 
@@ -182,14 +238,14 @@ describe("feedSlice", () => {
     });
 
     it("loads home feed when authenticated and on home tab", async () => {
-      const mockResponse = {
-        occurrences: [{ uri: "at://home1" }],
-        cursor: "homecursor",
-      };
-      vi.mocked(api.fetchHomeFeed).mockResolvedValue(mockResponse as any);
+      const mockResponse = makeFeedResponse([makeOccurrence({ uri: "at://home1" })], "homecursor");
+      vi.mocked(api.fetchHomeFeed).mockResolvedValue(mockResponse);
 
       const store = createTestStore({
-        auth: { user: { did: "did:plc:test", handle: "test" }, isLoading: false },
+        auth: {
+          user: { did: "did:plc:test", handle: "test" },
+          isLoading: false,
+        },
         feed: { currentTab: "home" },
       });
 
@@ -198,7 +254,7 @@ describe("feedSlice", () => {
       expect(api.fetchHomeFeed).toHaveBeenCalledWith(undefined);
     });
 
-    it("sets isLoading during request", async () => {
+    it("sets isLoading during request", () => {
       vi.mocked(api.fetchExploreFeed).mockImplementation(
         () => new Promise(() => {}), // Never resolves
       );
@@ -213,16 +269,13 @@ describe("feedSlice", () => {
     });
 
     it("appends to existing occurrences on load more", async () => {
-      const mockResponse = {
-        occurrences: [{ uri: "at://new" }],
-        cursor: undefined,
-      };
-      vi.mocked(api.fetchExploreFeed).mockResolvedValue(mockResponse as any);
+      const mockResponse = makeFeedResponse([makeOccurrence({ uri: "at://new" })]);
+      vi.mocked(api.fetchExploreFeed).mockResolvedValue(mockResponse);
 
       const store = createTestStore({
         auth: { user: null, isLoading: false },
         feed: {
-          observations: [{ uri: "at://existing" } as any],
+          observations: [makeOccurrence({ uri: "at://existing" })],
           cursor: "prev",
         },
       });
@@ -235,10 +288,7 @@ describe("feedSlice", () => {
     });
 
     it("sets hasMore to false when no cursor", async () => {
-      vi.mocked(api.fetchExploreFeed).mockResolvedValue({
-        occurrences: [],
-        cursor: undefined,
-      } as any);
+      vi.mocked(api.fetchExploreFeed).mockResolvedValue(makeFeedResponse());
 
       const store = createTestStore({
         auth: { user: null, isLoading: false },
@@ -264,14 +314,13 @@ describe("feedSlice", () => {
 
   describe("loadInitialFeed thunk", () => {
     it("clears occurrences before loading", async () => {
-      vi.mocked(api.fetchExploreFeed).mockResolvedValue({
-        occurrences: [{ uri: "at://new" }],
-        cursor: undefined,
-      } as any);
+      vi.mocked(api.fetchExploreFeed).mockResolvedValue(
+        makeFeedResponse([makeOccurrence({ uri: "at://new" })]),
+      );
 
       const store = createTestStore({
         auth: { user: null, isLoading: false },
-        feed: { occurrences: [{ uri: "at://old" } as any] },
+        feed: { observations: [makeOccurrence({ uri: "at://old" })] },
       });
 
       await store.dispatch(loadInitialFeed());
@@ -282,13 +331,13 @@ describe("feedSlice", () => {
     });
 
     it("loads home feed for authenticated user on home tab", async () => {
-      vi.mocked(api.fetchHomeFeed).mockResolvedValue({
-        occurrences: [],
-        cursor: undefined,
-      } as any);
+      vi.mocked(api.fetchHomeFeed).mockResolvedValue(makeFeedResponse());
 
       const store = createTestStore({
-        auth: { user: { did: "did:plc:user", handle: "user" }, isLoading: false },
+        auth: {
+          user: { did: "did:plc:user", handle: "user" },
+          isLoading: false,
+        },
         feed: { currentTab: "home" },
       });
 
@@ -298,10 +347,7 @@ describe("feedSlice", () => {
     });
 
     it("passes filters for explore feed", async () => {
-      vi.mocked(api.fetchExploreFeed).mockResolvedValue({
-        occurrences: [],
-        cursor: undefined,
-      } as any);
+      vi.mocked(api.fetchExploreFeed).mockResolvedValue(makeFeedResponse());
 
       const store = createTestStore({
         auth: { user: null, isLoading: false },
@@ -318,7 +364,7 @@ describe("feedSlice", () => {
 
       const store = createTestStore({
         auth: { user: null, isLoading: false },
-        feed: { cursor: "oldcursor", occurrences: [{ uri: "old" } as any] },
+        feed: { cursor: "oldcursor", observations: [makeOccurrence({ uri: "old" })] },
       });
 
       store.dispatch(loadInitialFeed());


### PR DESCRIPTION
## Summary
- Tests should follow the same lint rules as production code, so remove the blanket overrides in `.oxlintrc.json` that disabled `consistent-type-assertions`, `no-explicit-any`, `no-non-null-assertion`, `consistent-type-imports`, and `no-await-in-loop` for `**/*.test.ts`, `e2e/**/*.ts`, and `scripts/**/*.ts`.
- Extract narrow structural interfaces (`IdentificationAgent`, `UploaderAgent`) from `AtpAgent` so tests can pass typed mocks without assertions. The interfaces are derived via indexed access types (e.g. `AtpRepoOps[\"createRecord\"]`) so real `AtpAgent` instances still satisfy them — no production call-site changes.
- Refactor the 3 affected test files (`feedSlice.test.ts`, `identification.test.ts`, `uploader.test.ts`) to use typed `vi.fn()` references, proper `Occurrence`/`FeedResponse` fixtures, native `File`, and a real `BlobRef.fromJsonRef()` — eliminating the 79 errors (`as any`, `mock!.foo.bar`, `as unknown as X`, `as never`) that the overrides were hiding.

## Test plan
- [x] `npx oxlint frontend/src` → 0 errors (was 79)
- [x] `npx tsc --noEmit` → clean
- [x] `vitest run` on the three modified test files → all pass