### PR TITLE
Center feed image vertically in observation card

### DIFF
--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -222,7 +222,7 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
           <ImageWithSkeleton
             src={imageUrl}
             alt={species || "Observation photo"}
-            sx={{ maxHeight: FEED_IMAGE_MAX_HEIGHT }}
+            sx={{ height: FEED_IMAGE_MAX_HEIGHT }}
           />
         )}
 


### PR DESCRIPTION
## Summary
- The feed image container used `maxHeight` with no fixed height, so the image rendered at its natural aspect ratio and got clipped at the bottom by `overflow:hidden` — effectively a top-aligned crop.
- Switching to a fixed `height` lets `objectFit:cover` crop evenly from top and bottom, centering the middle of the observation.

## Test plan
- [ ] Visually verify feed cards on `http://localhost:3000` show centered crops for tall images
- [ ] Verify skeleton height still matches (already uses `FEED_IMAGE_MAX_HEIGHT`)