### PR TITLE
Remove geolocation button from view-observation map

### DIFF
--- a/frontend/src/components/map/LocationMap.tsx
+++ b/frontend/src/components/map/LocationMap.tsx
@@ -33,12 +33,16 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
       map.current = null;
     }
 
-    const { map: mapInstance } = createMap(mapContainer.current, {
-      center: [longitude, latitude],
-      zoom: 14,
-      interactive: true,
-      scrollZoom: false,
-    }, { geolocate: false });
+    const { map: mapInstance } = createMap(
+      mapContainer.current,
+      {
+        center: [longitude, latitude],
+        zoom: 14,
+        interactive: true,
+        scrollZoom: false,
+      },
+      { geolocate: false },
+    );
 
     mapInstance.on("load", () => {
       // Add marker

--- a/frontend/src/components/map/LocationMap.tsx
+++ b/frontend/src/components/map/LocationMap.tsx
@@ -38,7 +38,7 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
       zoom: 14,
       interactive: true,
       scrollZoom: false,
-    });
+    }, { geolocate: false });
 
     mapInstance.on("load", () => {
       // Add marker

--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -154,7 +154,7 @@ export function LocationPicker({
     });
 
     // Update marker and inputs when user geolocates via the built-in control
-    geolocateControl.on("geolocate", (e: GeolocationPosition) => {
+    geolocateControl?.on("geolocate", (e: GeolocationPosition) => {
       const { latitude: lat, longitude: lng } = e.coords;
       updateMarker(lng, lat);
       onChange(lat, lng);

--- a/frontend/src/components/map/mapUtils.ts
+++ b/frontend/src/components/map/mapUtils.ts
@@ -6,13 +6,14 @@ export const METERS_PER_DEGREE = 111320;
 
 interface CreateMapResult {
   map: maplibregl.Map;
-  geolocateControl: maplibregl.GeolocateControl;
+  geolocateControl: maplibregl.GeolocateControl | undefined;
 }
 
 /** Create a map instance with standard controls. */
 export function createMap(
   container: HTMLElement,
   options: Omit<maplibregl.MapOptions, "container" | "style">,
+  { geolocate = true }: { geolocate?: boolean } = {},
 ): CreateMapResult {
   const map = new maplibregl.Map({
     ...options,
@@ -22,10 +23,13 @@ export function createMap(
 
   map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "top-right");
 
-  const geolocateControl = new maplibregl.GeolocateControl({
-    positionOptions: { enableHighAccuracy: true },
-  });
-  map.addControl(geolocateControl, "top-left");
+  let geolocateControl: maplibregl.GeolocateControl | undefined;
+  if (geolocate) {
+    geolocateControl = new maplibregl.GeolocateControl({
+      positionOptions: { enableHighAccuracy: true },
+    });
+    map.addControl(geolocateControl, "top-left");
+  }
 
   return { map, geolocateControl };
 }


### PR DESCRIPTION
## Summary
- Adds a `geolocate` option to `createMap()` (defaults to `true`) to control whether the "find my location" button is rendered
- Disables it in `LocationMap` (view-observation) while keeping it in `LocationPicker` (new/edit observation)

## Test plan
- [ ] View an observation — verify no geolocation button appears on the map
- [ ] Create/edit an observation — verify the geolocation button still appears and works