### PR TITLE
Fix taxon explorer crashes and incorrect lookups

### DIFF
--- a/crates/observing-taxonomy/src/gbif.rs
+++ b/crates/observing-taxonomy/src/gbif.rs
@@ -95,10 +95,7 @@ impl GbifClient {
         scientific_name: &str,
     ) -> bool {
         let Some(m) = gbif_match else { return false };
-        let match_type = m
-            .diagnostics
-            .as_ref()
-            .and_then(|d| d.match_type.as_deref());
+        let match_type = m.diagnostics.as_ref().and_then(|d| d.match_type.as_deref());
         if match_type != Some("HIGHERRANK") {
             return false;
         }

--- a/crates/observing-taxonomy/src/gbif.rs
+++ b/crates/observing-taxonomy/src/gbif.rs
@@ -86,6 +86,31 @@ impl GbifClient {
         Ok(results)
     }
 
+    /// Check if a GBIF match is a HIGHERRANK fallback that doesn't match the query.
+    /// E.g. searching "Fakeus speciesus" in Animalia returns Animalia itself.
+    /// But searching "Corvus" correctly returns the Corvus genus as HIGHERRANK
+    /// (since GBIF expects species-level queries) — we want to keep those.
+    fn is_mismatched_higher_rank(
+        gbif_match: &Option<gbif_api::V2MatchResult>,
+        scientific_name: &str,
+    ) -> bool {
+        let Some(m) = gbif_match else { return false };
+        let match_type = m
+            .diagnostics
+            .as_ref()
+            .and_then(|d| d.match_type.as_deref());
+        if match_type != Some("HIGHERRANK") {
+            return false;
+        }
+        // If the returned canonical name matches the input, keep it
+        let canonical = m
+            .usage
+            .as_ref()
+            .and_then(|u| u.canonical_name.as_deref())
+            .unwrap_or("");
+        !canonical.eq_ignore_ascii_case(scientific_name)
+    }
+
     /// Validate a scientific name
     pub async fn validate(&self, name: &str) -> Result<ValidationResult> {
         let Some(gbif_match) = self.api.match_name(name, None).await? else {
@@ -284,6 +309,11 @@ impl GbifClient {
         kingdom: Option<&str>,
     ) -> Result<Option<TaxonDetail>> {
         let gbif_match = self.api.match_name(scientific_name, kingdom).await?;
+
+        if Self::is_mismatched_higher_rank(&gbif_match, scientific_name) {
+            return Ok(None);
+        }
+
         let usage_key = gbif_match
             .as_ref()
             .and_then(|m| m.usage.as_ref())
@@ -304,6 +334,11 @@ impl GbifClient {
         limit: u32,
     ) -> Result<Vec<TaxonResult>> {
         let gbif_match = self.api.match_name(scientific_name, kingdom).await?;
+
+        if Self::is_mismatched_higher_rank(&gbif_match, scientific_name) {
+            return Ok(vec![]);
+        }
+
         let usage_key = gbif_match
             .as_ref()
             .and_then(|m| m.usage.as_ref())
@@ -333,7 +368,12 @@ impl GbifClient {
         };
 
         let data = self.api.get_children(key, limit).await?;
-        let results: Vec<TaxonResult> = data.iter().map(|item| self.gbif_to_taxon(item)).collect();
+        let mut seen = std::collections::HashSet::new();
+        let results: Vec<TaxonResult> = data
+            .iter()
+            .map(|item| self.gbif_to_taxon(item))
+            .filter(|t| seen.insert(t.scientific_name.clone()))
+            .collect();
 
         self.cache
             .insert(cache_key, CachedValue::Children(results.clone()))

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -127,7 +127,9 @@ export function TaxonExplorer() {
 
       // Add the current taxon node
       const currentId = nodeId(k, detail.scientificName);
-      const currentChildren = (detail.children ?? []).map((c) => nodeId(k, c.scientificName));
+      const currentChildren = [
+        ...new Set((detail.children ?? []).map((c) => nodeId(k, c.scientificName))),
+      ];
       const existing = nodes.get(currentId);
       if (existing) {
         existing.childrenLoaded = true;


### PR DESCRIPTION
## Summary
- **Deduplicate GBIF children**: The GBIF API returns duplicate children for some taxa (e.g., `Barringtonia acutangula` appears twice with different `commonName` values). This crashes MUI's `SimpleTreeView` which requires unique item IDs, rendering the entire taxon page blank.
- **Reject mismatched HIGHERRANK matches**: GBIF's name match API returns `matchType: HIGHERRANK` for unrecognized names, falling back to the kingdom (e.g., `/taxon/Animalia/Fakeus-speciesus` would show the Animalia page). Now correctly returns 404 when the matched canonical name doesn't match the query, while still allowing legitimate genus/family lookups like `/taxon/Animalia/Corvus`.
- **Frontend safety net**: Deduplicate tree item IDs on the frontend as a defense-in-depth measure.

## Test plan
- [ ] Navigate to `/taxon/Plantae/Barringtonia` — page loads without crash, tree shows 18 unique species
- [ ] Navigate to `/taxon/Animalia/Fakeus-speciesus` — shows "Taxon not found" error
- [ ] Navigate to `/taxon/Animalia/Corvus` — genus page loads correctly with species tree
- [ ] Navigate to `/taxon/Animalia/Corvus-cornix` — species page loads, click breadcrumb links
- [ ] Mobile: tree drawer toggle works