### PR TITLE
Add settings page with dark mode control

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ import { ToastContainer } from "./components/common/Toast";
 import { NotFound } from "./components/common/NotFound";
 import { LexiconView } from "./components/lexicon/LexiconView";
 import { NotificationsPage } from "./components/notifications/NotificationsPage";
+import { SettingsPage } from "./components/settings/SettingsPage";
 import "./styles/global.css";
 
 function AppContent() {
@@ -117,6 +118,7 @@ function AppContent() {
           <Route path="/taxon/:kingdom/:name" element={<TaxonExplorer />} />
           <Route path="/taxon/:id" element={<TaxonExplorer />} />
           <Route path="/lexicons" element={<LexiconView />} />
+          <Route path="/settings" element={<SettingsPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Box>

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -20,11 +20,19 @@ import {
   Divider,
   alpha,
 } from "@mui/material";
-import { Person, Login, Logout, GitHub, Schema, Menu as MenuIcon } from "@mui/icons-material";
+import {
+  Person,
+  Login,
+  Logout,
+  GitHub,
+  Schema,
+  Settings,
+  Menu as MenuIcon,
+} from "@mui/icons-material";
 import { getDisplayName } from "../../lib/utils";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
-import { getNavItems, getThemeIcon } from "./NavConfig";
+import { getNavItems } from "./NavConfig";
 
 interface TopBarProps {
   onMobileMenuClick: () => void;
@@ -34,16 +42,7 @@ interface TopBarProps {
 export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
-  const {
-    user,
-    isAuthLoading,
-    themeMode,
-    isActive,
-    handleLogin,
-    handleLogout,
-    cycleTheme,
-    getThemeTooltip,
-  } = useNavigation();
+  const { user, isAuthLoading, isActive, handleLogin, handleLogout } = useNavigation();
 
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
 
@@ -180,9 +179,9 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
               </Tooltip>
             )}
 
-            <Tooltip title={getThemeTooltip()}>
-              <IconButton onClick={cycleTheme} color="inherit">
-                {getThemeIcon(themeMode)}
+            <Tooltip title="Settings">
+              <IconButton component={Link} to="/settings" color="inherit">
+                <Settings />
               </IconButton>
             </Tooltip>
 
@@ -239,6 +238,12 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
                       <Person fontSize="small" />
                     </ListItemIcon>
                     <ListItemText primary="Profile" />
+                  </MenuItem>
+                  <MenuItem component={Link} to="/settings">
+                    <ListItemIcon>
+                      <Settings fontSize="small" />
+                    </ListItemIcon>
+                    <ListItemText primary="Settings" />
                   </MenuItem>
                   <MenuItem onClick={onLogout}>
                     <ListItemIcon>

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -1,0 +1,70 @@
+import {
+  Box,
+  Container,
+  Typography,
+  ToggleButtonGroup,
+  ToggleButton,
+  Paper,
+} from "@mui/material";
+import { LightMode, DarkMode, SettingsBrightness } from "@mui/icons-material";
+import { usePageTitle } from "../../hooks/usePageTitle";
+import { useAppDispatch, useAppSelector } from "../../store";
+import { setThemeMode, type ThemeMode } from "../../store/uiSlice";
+
+export function SettingsPage() {
+  usePageTitle("Settings");
+  const dispatch = useAppDispatch();
+  const themeMode = useAppSelector((state) => state.ui.themeMode);
+
+  const handleThemeChange = (_: React.MouseEvent<HTMLElement>, value: ThemeMode | null) => {
+    if (value) dispatch(setThemeMode(value));
+  };
+
+  return (
+    <Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
+      <Container maxWidth="sm" sx={{ py: 3 }}>
+        <Typography variant="h5" fontWeight={700} sx={{ mb: 3 }}>
+          Settings
+        </Typography>
+
+        <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+          <Typography variant="subtitle1" fontWeight={600} sx={{ mb: 0.5 }}>
+            Appearance
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Choose how Observ.ing looks to you. Select a single theme, or sync with your system
+            settings.
+          </Typography>
+          <ToggleButtonGroup
+            value={themeMode}
+            exclusive
+            onChange={handleThemeChange}
+            aria-label="Theme mode"
+            sx={{
+              "& .MuiToggleButton-root": {
+                px: 3,
+                py: 1,
+                gap: 1,
+                textTransform: "none",
+                fontWeight: 500,
+              },
+            }}
+          >
+            <ToggleButton value="light" aria-label="Light mode">
+              <LightMode fontSize="small" />
+              Light
+            </ToggleButton>
+            <ToggleButton value="dark" aria-label="Dark mode">
+              <DarkMode fontSize="small" />
+              Dark
+            </ToggleButton>
+            <ToggleButton value="system" aria-label="System theme">
+              <SettingsBrightness fontSize="small" />
+              System
+            </ToggleButton>
+          </ToggleButtonGroup>
+        </Paper>
+      </Container>
+    </Box>
+  );
+}

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -1,11 +1,4 @@
-import {
-  Box,
-  Container,
-  Typography,
-  ToggleButtonGroup,
-  ToggleButton,
-  Paper,
-} from "@mui/material";
+import { Box, Container, Typography, ToggleButtonGroup, ToggleButton, Paper } from "@mui/material";
 import { LightMode, DarkMode, SettingsBrightness } from "@mui/icons-material";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useAppDispatch, useAppSelector } from "../../store";


### PR DESCRIPTION
## Summary
- Add `/settings` page with an Appearance section for controlling theme (light/dark/system)
- Replace the theme cycle icon in the top bar with a settings gear icon linking to the settings page
- Settings page is extensible for future settings sections

## Test plan
- [ ] Visit `/settings` and verify theme toggle works (light, dark, system)
- [ ] Verify settings gear icon appears in top bar and links to `/settings`
- [ ] Verify settings link appears in avatar dropdown menu for logged-in users