### PR TITLE
Trim identification lexicon to match upstream lexicons.bio

### DIFF
--- a/crates/observing-appview/src/routes/identifications.rs
+++ b/crates/observing-appview/src/routes/identifications.rs
@@ -84,13 +84,7 @@ pub async fn create_identification(
             .taxon_rank
             .as_deref()
             .map(|s| TaxonTaxonRank::from_value(s.into())),
-        vernacular_name: fields.vernacular_name.as_deref().map(Into::into),
         kingdom: fields.kingdom.as_deref().map(Into::into),
-        phylum: fields.phylum.as_deref().map(Into::into),
-        class: fields.class.as_deref().map(Into::into),
-        order: fields.order.as_deref().map(Into::into),
-        family: fields.family.as_deref().map(Into::into),
-        genus: fields.genus.as_deref().map(Into::into),
         ..Default::default()
     };
 

--- a/crates/observing-appview/src/routes/occurrences/auto_id.rs
+++ b/crates/observing-appview/src/routes/occurrences/auto_id.rs
@@ -21,25 +21,13 @@ pub async fn build_identification_record(
 ) -> Result<Value, AppError> {
     let mut taxon_id = None;
     let mut taxon_rank = None;
-    let mut vernacular_name = None;
     let mut kingdom = None;
-    let mut phylum = None;
-    let mut class = None;
-    let mut order = None;
-    let mut family = None;
-    let mut genus = None;
 
     if let Some(validation) = state.taxonomy.validate(scientific_name).await {
         if let Some(ref t) = validation.taxon {
             taxon_id = Some(t.id.clone());
             taxon_rank = Some(t.rank.clone());
-            vernacular_name = t.common_name.clone();
             kingdom = t.kingdom.clone();
-            phylum = t.phylum.clone();
-            class = t.class.clone();
-            order = t.order.clone();
-            family = t.family.clone();
-            genus = t.genus.clone();
         }
     }
 
@@ -50,13 +38,7 @@ pub async fn build_identification_record(
         taxon_rank: taxon_rank
             .as_deref()
             .map(|s| TaxonTaxonRank::from_value(s.into())),
-        vernacular_name: vernacular_name.as_deref().map(Into::into),
         kingdom: kingdom.as_deref().map(Into::into),
-        phylum: phylum.as_deref().map(Into::into),
-        class: class.as_deref().map(Into::into),
-        order: order.as_deref().map(Into::into),
-        family: family.as_deref().map(Into::into),
-        genus: genus.as_deref().map(Into::into),
         ..Default::default()
     };
 

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -209,13 +209,13 @@ pub fn identification_from_json(
         identification_remarks: record.comment.map(|s| s.to_string()),
         is_agreement: record.is_agreement.unwrap_or(false),
         date_identified,
-        vernacular_name: record.taxon.vernacular_name.map(|s| s.to_string()),
+        vernacular_name: None,
         kingdom: record.taxon.kingdom.map(|s| s.to_string()),
-        phylum: record.taxon.phylum.map(|s| s.to_string()),
-        class: record.taxon.class.map(|s| s.to_string()),
-        order: record.taxon.order.map(|s| s.to_string()),
-        family: record.taxon.family.map(|s| s.to_string()),
-        genus: record.taxon.genus.map(|s| s.to_string()),
+        phylum: None,
+        class: None,
+        order: None,
+        family: None,
+        genus: None,
     })
 }
 

--- a/crates/observing-lexicons/src/bio_lexicons/temp/identification.rs
+++ b/crates/observing-lexicons/src/bio_lexicons/temp/identification.rs
@@ -38,40 +38,19 @@ use serde::{Deserialize, Serialize};
     bound(deserialize = "S: Deserialize<'de> + BosStr")
 )]
 pub struct Identification<S: BosStr = DefaultStr> {
-    ///Taxonomic class (Darwin Core dwc:class).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub class: Option<S>,
-    ///Taxonomic family (Darwin Core dwc:family).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub family: Option<S>,
-    ///Taxonomic genus (Darwin Core dwc:genus).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub genus: Option<S>,
     ///Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub identification_remarks: Option<S>,
-    ///Taxonomic kingdom (Darwin Core dwc:kingdom).
+    ///Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kingdom: Option<S>,
-    ///Taxonomic order (Darwin Core dwc:order).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<S>,
-    ///Taxonomic phylum (Darwin Core dwc:phylum).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub phylum: Option<S>,
-    ///The full scientific name (Darwin Core dwc:scientificName).
+    ///A strong reference (CID + URI) to the occurrence being identified.
+    pub occurrence: StrongRef<S>,
+    ///The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).
     pub scientific_name: S,
-    ///The authorship information for the scientificName (Darwin Core dwc:scientificNameAuthorship).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scientific_name_authorship: Option<S>,
-    ///A strong reference (CID + URI) to the observation being identified.
-    pub subject: StrongRef<S>,
     ///The taxonomic rank of the identification (Darwin Core dwc:taxonRank).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub taxon_rank: Option<IdentificationTaxonRank<S>>,
-    ///Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vernacular_name: Option<S>,
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub extra_data: Option<BTreeMap<SmolStr, Data<S>>>,
 }
@@ -242,36 +221,6 @@ impl<S: BosStr> LexiconSchema for Identification<S> {
         lexicon_doc_bio_lexicons_temp_identification()
     }
     fn validate(&self) -> Result<(), ConstraintError> {
-        if let Some(ref value) = self.class {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("class"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.family {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("family"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.genus {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("genus"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
         if let Some(ref value) = self.identification_remarks {
             #[allow(unused_comparisons)]
             if <str>::len(value.as_ref()) > 3000usize {
@@ -292,26 +241,6 @@ impl<S: BosStr> LexiconSchema for Identification<S> {
                 });
             }
         }
-        if let Some(ref value) = self.order {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("order"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.phylum {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("phylum"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
         {
             let value = &self.scientific_name;
             #[allow(unused_comparisons)]
@@ -323,32 +252,12 @@ impl<S: BosStr> LexiconSchema for Identification<S> {
                 });
             }
         }
-        if let Some(ref value) = self.scientific_name_authorship {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 256usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("scientific_name_authorship"),
-                    max: 256usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
         if let Some(ref value) = self.taxon_rank {
             #[allow(unused_comparisons)]
             if <str>::len(value.as_ref()) > 32usize {
                 return Err(ConstraintError::MaxLength {
                     path: ValidationPath::from_field("taxon_rank"),
                     max: 32usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.vernacular_name {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 256usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("vernacular_name"),
-                    max: 256usize,
                     actual: <str>::len(value.as_ref()),
                 });
             }
@@ -367,37 +276,37 @@ pub mod identification_state {
     }
     /// State trait tracking which required fields have been set
     pub trait State: sealed::Sealed {
+        type Occurrence;
         type ScientificName;
-        type Subject;
     }
     /// Empty state - all required fields are unset
     pub struct Empty(());
     impl sealed::Sealed for Empty {}
     impl State for Empty {
+        type Occurrence = Unset;
         type ScientificName = Unset;
-        type Subject = Unset;
+    }
+    ///State transition - sets the `occurrence` field to Set
+    pub struct SetOccurrence<St: State = Empty>(PhantomData<fn() -> St>);
+    impl<St: State> sealed::Sealed for SetOccurrence<St> {}
+    impl<St: State> State for SetOccurrence<St> {
+        type Occurrence = Set<members::occurrence>;
+        type ScientificName = St::ScientificName;
     }
     ///State transition - sets the `scientific_name` field to Set
     pub struct SetScientificName<St: State = Empty>(PhantomData<fn() -> St>);
     impl<St: State> sealed::Sealed for SetScientificName<St> {}
     impl<St: State> State for SetScientificName<St> {
+        type Occurrence = St::Occurrence;
         type ScientificName = Set<members::scientific_name>;
-        type Subject = St::Subject;
-    }
-    ///State transition - sets the `subject` field to Set
-    pub struct SetSubject<St: State = Empty>(PhantomData<fn() -> St>);
-    impl<St: State> sealed::Sealed for SetSubject<St> {}
-    impl<St: State> State for SetSubject<St> {
-        type ScientificName = St::ScientificName;
-        type Subject = Set<members::subject>;
     }
     /// Marker types for field names
     #[allow(non_camel_case_types)]
     pub mod members {
+        ///Marker type for the `occurrence` field
+        pub struct occurrence(());
         ///Marker type for the `scientific_name` field
         pub struct scientific_name(());
-        ///Marker type for the `subject` field
-        pub struct subject(());
     }
 }
 
@@ -407,16 +316,9 @@ pub struct IdentificationBuilder<S: BosStr, St: identification_state::State> {
     _fields: (
         Option<S>,
         Option<S>,
-        Option<S>,
-        Option<S>,
-        Option<S>,
-        Option<S>,
-        Option<S>,
-        Option<S>,
-        Option<S>,
         Option<StrongRef<S>>,
-        Option<IdentificationTaxonRank<S>>,
         Option<S>,
+        Option<IdentificationTaxonRank<S>>,
     ),
     _type: PhantomData<fn() -> S>,
 }
@@ -433,62 +335,21 @@ impl<S: BosStr> IdentificationBuilder<S, identification_state::Empty> {
     pub fn new() -> Self {
         IdentificationBuilder {
             _state: PhantomData,
-            _fields: (
-                None, None, None, None, None, None, None, None, None, None, None, None,
-            ),
+            _fields: (None, None, None, None, None),
             _type: PhantomData,
         }
     }
 }
 
 impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
-    /// Set the `class` field (optional)
-    pub fn class(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.0 = value.into();
-        self
-    }
-    /// Set the `class` field to an Option value (optional)
-    pub fn maybe_class(mut self, value: Option<S>) -> Self {
-        self._fields.0 = value;
-        self
-    }
-}
-
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
-    /// Set the `family` field (optional)
-    pub fn family(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.1 = value.into();
-        self
-    }
-    /// Set the `family` field to an Option value (optional)
-    pub fn maybe_family(mut self, value: Option<S>) -> Self {
-        self._fields.1 = value;
-        self
-    }
-}
-
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
-    /// Set the `genus` field (optional)
-    pub fn genus(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.2 = value.into();
-        self
-    }
-    /// Set the `genus` field to an Option value (optional)
-    pub fn maybe_genus(mut self, value: Option<S>) -> Self {
-        self._fields.2 = value;
-        self
-    }
-}
-
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
     /// Set the `identificationRemarks` field (optional)
     pub fn identification_remarks(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.3 = value.into();
+        self._fields.0 = value.into();
         self
     }
     /// Set the `identificationRemarks` field to an Option value (optional)
     pub fn maybe_identification_remarks(mut self, value: Option<S>) -> Self {
-        self._fields.3 = value;
+        self._fields.0 = value;
         self
     }
 }
@@ -496,39 +357,32 @@ impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
 impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
     /// Set the `kingdom` field (optional)
     pub fn kingdom(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.4 = value.into();
+        self._fields.1 = value.into();
         self
     }
     /// Set the `kingdom` field to an Option value (optional)
     pub fn maybe_kingdom(mut self, value: Option<S>) -> Self {
-        self._fields.4 = value;
+        self._fields.1 = value;
         self
     }
 }
 
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
-    /// Set the `order` field (optional)
-    pub fn order(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.5 = value.into();
-        self
-    }
-    /// Set the `order` field to an Option value (optional)
-    pub fn maybe_order(mut self, value: Option<S>) -> Self {
-        self._fields.5 = value;
-        self
-    }
-}
-
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
-    /// Set the `phylum` field (optional)
-    pub fn phylum(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.6 = value.into();
-        self
-    }
-    /// Set the `phylum` field to an Option value (optional)
-    pub fn maybe_phylum(mut self, value: Option<S>) -> Self {
-        self._fields.6 = value;
-        self
+impl<S: BosStr, St> IdentificationBuilder<S, St>
+where
+    St: identification_state::State,
+    St::Occurrence: identification_state::IsUnset,
+{
+    /// Set the `occurrence` field (required)
+    pub fn occurrence(
+        mut self,
+        value: impl Into<StrongRef<S>>,
+    ) -> IdentificationBuilder<S, identification_state::SetOccurrence<St>> {
+        self._fields.2 = Option::Some(value.into());
+        IdentificationBuilder {
+            _state: PhantomData,
+            _fields: self._fields,
+            _type: PhantomData,
+        }
     }
 }
 
@@ -542,39 +396,7 @@ where
         mut self,
         value: impl Into<S>,
     ) -> IdentificationBuilder<S, identification_state::SetScientificName<St>> {
-        self._fields.7 = Option::Some(value.into());
-        IdentificationBuilder {
-            _state: PhantomData,
-            _fields: self._fields,
-            _type: PhantomData,
-        }
-    }
-}
-
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
-    /// Set the `scientificNameAuthorship` field (optional)
-    pub fn scientific_name_authorship(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.8 = value.into();
-        self
-    }
-    /// Set the `scientificNameAuthorship` field to an Option value (optional)
-    pub fn maybe_scientific_name_authorship(mut self, value: Option<S>) -> Self {
-        self._fields.8 = value;
-        self
-    }
-}
-
-impl<S: BosStr, St> IdentificationBuilder<S, St>
-where
-    St: identification_state::State,
-    St::Subject: identification_state::IsUnset,
-{
-    /// Set the `subject` field (required)
-    pub fn subject(
-        mut self,
-        value: impl Into<StrongRef<S>>,
-    ) -> IdentificationBuilder<S, identification_state::SetSubject<St>> {
-        self._fields.9 = Option::Some(value.into());
+        self._fields.3 = Option::Some(value.into());
         IdentificationBuilder {
             _state: PhantomData,
             _fields: self._fields,
@@ -586,25 +408,12 @@ where
 impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
     /// Set the `taxonRank` field (optional)
     pub fn taxon_rank(mut self, value: impl Into<Option<IdentificationTaxonRank<S>>>) -> Self {
-        self._fields.10 = value.into();
+        self._fields.4 = value.into();
         self
     }
     /// Set the `taxonRank` field to an Option value (optional)
     pub fn maybe_taxon_rank(mut self, value: Option<IdentificationTaxonRank<S>>) -> Self {
-        self._fields.10 = value;
-        self
-    }
-}
-
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
-    /// Set the `vernacularName` field (optional)
-    pub fn vernacular_name(mut self, value: impl Into<Option<S>>) -> Self {
-        self._fields.11 = value.into();
-        self
-    }
-    /// Set the `vernacularName` field to an Option value (optional)
-    pub fn maybe_vernacular_name(mut self, value: Option<S>) -> Self {
-        self._fields.11 = value;
+        self._fields.4 = value;
         self
     }
 }
@@ -612,42 +421,28 @@ impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
 impl<S: BosStr, St> IdentificationBuilder<S, St>
 where
     St: identification_state::State,
+    St::Occurrence: identification_state::IsSet,
     St::ScientificName: identification_state::IsSet,
-    St::Subject: identification_state::IsSet,
 {
     /// Build the final struct.
     pub fn build(self) -> Identification<S> {
         Identification {
-            class: self._fields.0,
-            family: self._fields.1,
-            genus: self._fields.2,
-            identification_remarks: self._fields.3,
-            kingdom: self._fields.4,
-            order: self._fields.5,
-            phylum: self._fields.6,
-            scientific_name: self._fields.7.unwrap(),
-            scientific_name_authorship: self._fields.8,
-            subject: self._fields.9.unwrap(),
-            taxon_rank: self._fields.10,
-            vernacular_name: self._fields.11,
+            identification_remarks: self._fields.0,
+            kingdom: self._fields.1,
+            occurrence: self._fields.2.unwrap(),
+            scientific_name: self._fields.3.unwrap(),
+            taxon_rank: self._fields.4,
             extra_data: Default::default(),
         }
     }
     /// Build the final struct with custom extra_data.
     pub fn build_with_data(self, extra_data: BTreeMap<SmolStr, Data<S>>) -> Identification<S> {
         Identification {
-            class: self._fields.0,
-            family: self._fields.1,
-            genus: self._fields.2,
-            identification_remarks: self._fields.3,
-            kingdom: self._fields.4,
-            order: self._fields.5,
-            phylum: self._fields.6,
-            scientific_name: self._fields.7.unwrap(),
-            scientific_name_authorship: self._fields.8,
-            subject: self._fields.9.unwrap(),
-            taxon_rank: self._fields.10,
-            vernacular_name: self._fields.11,
+            identification_remarks: self._fields.0,
+            kingdom: self._fields.1,
+            occurrence: self._fields.2.unwrap(),
+            scientific_name: self._fields.3.unwrap(),
+            taxon_rank: self._fields.4,
             extra_data: Some(extra_data),
         }
     }
@@ -675,49 +470,13 @@ fn lexicon_doc_bio_lexicons_temp_identification() -> LexiconDoc<'static> {
                     record: LexRecordRecord::Object(LexObject {
                         required: Some(
                             vec![
-                                SmolStr::new_static("subject"),
+                                SmolStr::new_static("occurrence"),
                                 SmolStr::new_static("scientificName")
                             ],
                         ),
                         properties: {
                             #[allow(unused_mut)]
                             let mut map = BTreeMap::new();
-                            map.insert(
-                                SmolStr::new_static("class"),
-                                LexObjectProperty::String(LexString {
-                                    description: Some(
-                                        CowStr::new_static(
-                                            "Taxonomic class (Darwin Core dwc:class).",
-                                        ),
-                                    ),
-                                    max_length: Some(64usize),
-                                    ..Default::default()
-                                }),
-                            );
-                            map.insert(
-                                SmolStr::new_static("family"),
-                                LexObjectProperty::String(LexString {
-                                    description: Some(
-                                        CowStr::new_static(
-                                            "Taxonomic family (Darwin Core dwc:family).",
-                                        ),
-                                    ),
-                                    max_length: Some(64usize),
-                                    ..Default::default()
-                                }),
-                            );
-                            map.insert(
-                                SmolStr::new_static("genus"),
-                                LexObjectProperty::String(LexString {
-                                    description: Some(
-                                        CowStr::new_static(
-                                            "Taxonomic genus (Darwin Core dwc:genus).",
-                                        ),
-                                    ),
-                                    max_length: Some(64usize),
-                                    ..Default::default()
-                                }),
-                            );
                             map.insert(
                                 SmolStr::new_static("identificationRemarks"),
                                 LexObjectProperty::String(LexString {
@@ -735,7 +494,7 @@ fn lexicon_doc_bio_lexicons_temp_identification() -> LexiconDoc<'static> {
                                 LexObjectProperty::String(LexString {
                                     description: Some(
                                         CowStr::new_static(
-                                            "Taxonomic kingdom (Darwin Core dwc:kingdom).",
+                                            "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
                                         ),
                                     ),
                                     max_length: Some(64usize),
@@ -743,26 +502,9 @@ fn lexicon_doc_bio_lexicons_temp_identification() -> LexiconDoc<'static> {
                                 }),
                             );
                             map.insert(
-                                SmolStr::new_static("order"),
-                                LexObjectProperty::String(LexString {
-                                    description: Some(
-                                        CowStr::new_static(
-                                            "Taxonomic order (Darwin Core dwc:order).",
-                                        ),
-                                    ),
-                                    max_length: Some(64usize),
-                                    ..Default::default()
-                                }),
-                            );
-                            map.insert(
-                                SmolStr::new_static("phylum"),
-                                LexObjectProperty::String(LexString {
-                                    description: Some(
-                                        CowStr::new_static(
-                                            "Taxonomic phylum (Darwin Core dwc:phylum).",
-                                        ),
-                                    ),
-                                    max_length: Some(64usize),
+                                SmolStr::new_static("occurrence"),
+                                LexObjectProperty::Ref(LexRef {
+                                    r#ref: CowStr::new_static("com.atproto.repo.strongRef"),
                                     ..Default::default()
                                 }),
                             );
@@ -771,29 +513,10 @@ fn lexicon_doc_bio_lexicons_temp_identification() -> LexiconDoc<'static> {
                                 LexObjectProperty::String(LexString {
                                     description: Some(
                                         CowStr::new_static(
-                                            "The full scientific name (Darwin Core dwc:scientificName).",
+                                            "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).",
                                         ),
                                     ),
                                     max_length: Some(256usize),
-                                    ..Default::default()
-                                }),
-                            );
-                            map.insert(
-                                SmolStr::new_static("scientificNameAuthorship"),
-                                LexObjectProperty::String(LexString {
-                                    description: Some(
-                                        CowStr::new_static(
-                                            "The authorship information for the scientificName (Darwin Core dwc:scientificNameAuthorship).",
-                                        ),
-                                    ),
-                                    max_length: Some(256usize),
-                                    ..Default::default()
-                                }),
-                            );
-                            map.insert(
-                                SmolStr::new_static("subject"),
-                                LexObjectProperty::Ref(LexRef {
-                                    r#ref: CowStr::new_static("com.atproto.repo.strongRef"),
                                     ..Default::default()
                                 }),
                             );
@@ -806,18 +529,6 @@ fn lexicon_doc_bio_lexicons_temp_identification() -> LexiconDoc<'static> {
                                         ),
                                     ),
                                     max_length: Some(32usize),
-                                    ..Default::default()
-                                }),
-                            );
-                            map.insert(
-                                SmolStr::new_static("vernacularName"),
-                                LexObjectProperty::String(LexString {
-                                    description: Some(
-                                        CowStr::new_static(
-                                            "Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).",
-                                        ),
-                                    ),
-                                    max_length: Some(256usize),
                                     ..Default::default()
                                 }),
                             );

--- a/crates/observing-lexicons/src/ing_observ/temp/identification.rs
+++ b/crates/observing-lexicons/src/ing_observ/temp/identification.rs
@@ -82,35 +82,14 @@ pub struct IdentificationGetRecordOutput<S: BosStr = DefaultStr> {
     bound(deserialize = "S: Deserialize<'de> + BosStr")
 )]
 pub struct Taxon<S: BosStr = DefaultStr> {
-    ///Taxonomic class (Darwin Core dwc:class).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub class: Option<S>,
-    ///Taxonomic family (Darwin Core dwc:family).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub family: Option<S>,
-    ///Taxonomic genus (Darwin Core dwc:genus).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub genus: Option<S>,
-    ///Taxonomic kingdom (Darwin Core dwc:kingdom).
+    ///Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kingdom: Option<S>,
-    ///Taxonomic order (Darwin Core dwc:order).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<S>,
-    ///Taxonomic phylum (Darwin Core dwc:phylum).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub phylum: Option<S>,
-    ///The full scientific name (Darwin Core dwc:scientificName).
+    ///The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).
     pub scientific_name: S,
-    ///The authorship information for the scientificName (Darwin Core dwc:scientificNameAuthorship).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scientific_name_authorship: Option<S>,
     ///The taxonomic rank of the identification (Darwin Core dwc:taxonRank).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub taxon_rank: Option<TaxonTaxonRank<S>>,
-    ///Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub vernacular_name: Option<S>,
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub extra_data: Option<BTreeMap<SmolStr, Data<S>>>,
 }
@@ -323,61 +302,11 @@ impl<S: BosStr> LexiconSchema for Taxon<S> {
         lexicon_doc_ing_observ_temp_identification()
     }
     fn validate(&self) -> Result<(), ConstraintError> {
-        if let Some(ref value) = self.class {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("class"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.family {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("family"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.genus {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("genus"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
         if let Some(ref value) = self.kingdom {
             #[allow(unused_comparisons)]
             if <str>::len(value.as_ref()) > 64usize {
                 return Err(ConstraintError::MaxLength {
                     path: ValidationPath::from_field("kingdom"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.order {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("order"),
-                    max: 64usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.phylum {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 64usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("phylum"),
                     max: 64usize,
                     actual: <str>::len(value.as_ref()),
                 });
@@ -394,32 +323,12 @@ impl<S: BosStr> LexiconSchema for Taxon<S> {
                 });
             }
         }
-        if let Some(ref value) = self.scientific_name_authorship {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 256usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("scientific_name_authorship"),
-                    max: 256usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
         if let Some(ref value) = self.taxon_rank {
             #[allow(unused_comparisons)]
             if <str>::len(value.as_ref()) > 32usize {
                 return Err(ConstraintError::MaxLength {
                     path: ValidationPath::from_field("taxon_rank"),
                     max: 32usize,
-                    actual: <str>::len(value.as_ref()),
-                });
-            }
-        }
-        if let Some(ref value) = self.vernacular_name {
-            #[allow(unused_comparisons)]
-            if <str>::len(value.as_ref()) > 256usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("vernacular_name"),
-                    max: 256usize,
                     actual: <str>::len(value.as_ref()),
                 });
             }
@@ -785,71 +694,11 @@ fn lexicon_doc_ing_observ_temp_identification() -> LexiconDoc<'static> {
                         #[allow(unused_mut)]
                         let mut map = BTreeMap::new();
                         map.insert(
-                            SmolStr::new_static("class"),
-                            LexObjectProperty::String(LexString {
-                                description: Some(
-                                    CowStr::new_static(
-                                        "Taxonomic class (Darwin Core dwc:class).",
-                                    ),
-                                ),
-                                max_length: Some(64usize),
-                                ..Default::default()
-                            }),
-                        );
-                        map.insert(
-                            SmolStr::new_static("family"),
-                            LexObjectProperty::String(LexString {
-                                description: Some(
-                                    CowStr::new_static(
-                                        "Taxonomic family (Darwin Core dwc:family).",
-                                    ),
-                                ),
-                                max_length: Some(64usize),
-                                ..Default::default()
-                            }),
-                        );
-                        map.insert(
-                            SmolStr::new_static("genus"),
-                            LexObjectProperty::String(LexString {
-                                description: Some(
-                                    CowStr::new_static(
-                                        "Taxonomic genus (Darwin Core dwc:genus).",
-                                    ),
-                                ),
-                                max_length: Some(64usize),
-                                ..Default::default()
-                            }),
-                        );
-                        map.insert(
                             SmolStr::new_static("kingdom"),
                             LexObjectProperty::String(LexString {
                                 description: Some(
                                     CowStr::new_static(
-                                        "Taxonomic kingdom (Darwin Core dwc:kingdom).",
-                                    ),
-                                ),
-                                max_length: Some(64usize),
-                                ..Default::default()
-                            }),
-                        );
-                        map.insert(
-                            SmolStr::new_static("order"),
-                            LexObjectProperty::String(LexString {
-                                description: Some(
-                                    CowStr::new_static(
-                                        "Taxonomic order (Darwin Core dwc:order).",
-                                    ),
-                                ),
-                                max_length: Some(64usize),
-                                ..Default::default()
-                            }),
-                        );
-                        map.insert(
-                            SmolStr::new_static("phylum"),
-                            LexObjectProperty::String(LexString {
-                                description: Some(
-                                    CowStr::new_static(
-                                        "Taxonomic phylum (Darwin Core dwc:phylum).",
+                                        "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
                                     ),
                                 ),
                                 max_length: Some(64usize),
@@ -861,19 +710,7 @@ fn lexicon_doc_ing_observ_temp_identification() -> LexiconDoc<'static> {
                             LexObjectProperty::String(LexString {
                                 description: Some(
                                     CowStr::new_static(
-                                        "The full scientific name (Darwin Core dwc:scientificName).",
-                                    ),
-                                ),
-                                max_length: Some(256usize),
-                                ..Default::default()
-                            }),
-                        );
-                        map.insert(
-                            SmolStr::new_static("scientificNameAuthorship"),
-                            LexObjectProperty::String(LexString {
-                                description: Some(
-                                    CowStr::new_static(
-                                        "The authorship information for the scientificName (Darwin Core dwc:scientificNameAuthorship).",
+                                        "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).",
                                     ),
                                 ),
                                 max_length: Some(256usize),
@@ -889,18 +726,6 @@ fn lexicon_doc_ing_observ_temp_identification() -> LexiconDoc<'static> {
                                     ),
                                 ),
                                 max_length: Some(32usize),
-                                ..Default::default()
-                            }),
-                        );
-                        map.insert(
-                            SmolStr::new_static("vernacularName"),
-                            LexObjectProperty::String(LexString {
-                                description: Some(
-                                    CowStr::new_static(
-                                        "Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).",
-                                    ),
-                                ),
-                                max_length: Some(256usize),
                                 ..Default::default()
                             }),
                         );

--- a/docs/darwin-core.md
+++ b/docs/darwin-core.md
@@ -94,16 +94,9 @@ A taxonomic determination (dwc:Identification) for an occurrence. The identifica
     "cid": "bafyrei..."
   },
   "taxon": {
-    "scientificName": "Eschscholzia californica",
-    "scientificNameAuthorship": "Cham.",
+    "scientificName": "Eschscholzia californica Cham.",
     "taxonRank": "species",
-    "vernacularName": "California Poppy",
-    "kingdom": "Plantae",
-    "phylum": "Tracheophyta",
-    "class": "Magnoliopsida",
-    "order": "Ranunculales",
-    "family": "Papaveraceae",
-    "genus": "Eschscholzia"
+    "kingdom": "Plantae"
   },
   "comment": "Distinctive orange petals and feathery leaves",
   "isAgreement": false,
@@ -133,17 +126,17 @@ A taxonomic determination (dwc:Identification) for an occurrence. The identifica
 
 | Observ.ing Field | GBIF / Darwin Core | Status | Description |
 |--------------|-------------------|--------|-------------|
-| `taxon.scientificName` | dwc:scientificName | ✅ | The full scientific name |
-| `taxon.scientificNameAuthorship` | dwc:scientificNameAuthorship | ✅ | Authorship of the scientific name |
+| `taxon.scientificName` | dwc:scientificName | ✅ | The full scientific name, with authorship if known |
 | `taxon.taxonRank` | dwc:taxonRank | ✅ | Taxonomic rank (species, genus, family) |
-| `taxon.vernacularName` | dwc:vernacularName | ✅ | Common name |
-| `taxon.kingdom` | dwc:kingdom | ✅ | Taxonomic kingdom |
-| `taxon.phylum` | dwc:phylum | ✅ | Taxonomic phylum |
-| `taxon.class` | dwc:class | ✅ | Taxonomic class |
-| `taxon.order` | dwc:order | ✅ | Taxonomic order |
-| `taxon.family` | dwc:family | ✅ | Taxonomic family |
-| `taxon.genus` | dwc:genus | ✅ | Taxonomic genus |
+| `taxon.kingdom` | dwc:kingdom | ✅ | Taxonomic kingdom (for homonym disambiguation) |
 | `taxonId` | dwc:taxonID | ⚠️ | DEPRECATED — External taxon ID (e.g., gbif:2878688) |
+| — | dwc:scientificNameAuthorship | ❌ | Removed — included in scientificName per DwC spec |
+| — | dwc:vernacularName | ❌ | Removed — derivable from taxonomy backbone |
+| — | dwc:phylum | ❌ | Removed — derivable from taxonomy backbone |
+| — | dwc:class | ❌ | Removed — derivable from taxonomy backbone |
+| — | dwc:order | ❌ | Removed — derivable from taxonomy backbone |
+| — | dwc:family | ❌ | Removed — derivable from taxonomy backbone |
+| — | dwc:genus | ❌ | Removed — derivable from taxonomy backbone |
 | — | dwc:specificEpithet | ❌ | Species epithet |
 | — | dwc:infraspecificEpithet | ❌ | Subspecies/variety epithet |
 

--- a/docs/lexicon-review.md
+++ b/docs/lexicon-review.md
@@ -29,7 +29,7 @@ Research comparing our lexicons against GBIF data models, Darwin Core standards,
 | GBIF Field | Why It Matters | Recommendation |
 |---|---|---|
 | **`identificationQualifier`** | Values like `cf.` (compare with) and `aff.` (has affinity with) — standard taxonomic hedging. GBIF treats these as first-class. | Add as optional string, `maxLength: 16`, `knownValues: ["cf.", "aff."]` |
-| **`scientificNameAuthorship`** | The authority citation (e.g., "L." for Linnaeus). GBIF stores this alongside every name. | Add as optional string, `maxLength: 256` |
+| **`scientificNameAuthorship`** | The authority citation (e.g., "L." for Linnaeus). GBIF stores this alongside every name. | Removed from lexicon — per DwC spec, `scientificName` should include authorship when known. |
 | **`taxonId` deprecation** | We deprecated `taxonId`, but GBIF's `taxonID` is how every occurrence links to the backbone taxonomy. Server-side resolution (kingdom + name → GBIF match) is fine, but storing the resolved `taxonKey` in the identification gives a stable anchor. | Consider un-deprecating or renaming to `gbifKey` — store the GBIF backbone key when the server resolves it. This makes GBIF export trivial. Alternatively, keep it server-side-only in the DB (not the lexicon). |
 
 ### 1C. Field Naming Alignment
@@ -134,7 +134,7 @@ Every system in the biodiversity data ecosystem — GBIF, Darwin Core, Catalogue
 7. Add per-image metadata (`license`, `created`) to `#imageEmbed`
 8. Switch `confidence` from `enum` to `knownValues`
 9. Add `island` / `islandGroup` to `#location`
-10. Add `scientificNameAuthorship` to identification
+10. ~~Add `scientificNameAuthorship` to identification~~ (removed — included in `scientificName` per DwC spec)
 
 ### Nice-to-have (ecosystem interop)
 

--- a/lexicons/bio/lexicons/temp/identification.json
+++ b/lexicons/bio/lexicons/temp/identification.json
@@ -8,21 +8,16 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["subject", "scientificName"],
+        "required": ["occurrence", "scientificName"],
         "properties": {
-          "subject": {
+          "occurrence": {
             "type": "ref",
             "ref": "com.atproto.repo.strongRef",
-            "description": "A strong reference (CID + URI) to the observation being identified."
+            "description": "A strong reference (CID + URI) to the occurrence being identified."
           },
           "scientificName": {
             "type": "string",
-            "description": "The full scientific name (Darwin Core dwc:scientificName).",
-            "maxLength": 256
-          },
-          "scientificNameAuthorship": {
-            "type": "string",
-            "description": "The authorship information for the scientificName (Darwin Core dwc:scientificNameAuthorship).",
+            "description": "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).",
             "maxLength": 256
           },
           "taxonRank": {
@@ -32,39 +27,9 @@
             "default": "species",
             "maxLength": 32
           },
-          "vernacularName": {
-            "type": "string",
-            "description": "Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).",
-            "maxLength": 256
-          },
           "kingdom": {
             "type": "string",
-            "description": "Taxonomic kingdom (Darwin Core dwc:kingdom).",
-            "maxLength": 64
-          },
-          "phylum": {
-            "type": "string",
-            "description": "Taxonomic phylum (Darwin Core dwc:phylum).",
-            "maxLength": 64
-          },
-          "class": {
-            "type": "string",
-            "description": "Taxonomic class (Darwin Core dwc:class).",
-            "maxLength": 64
-          },
-          "order": {
-            "type": "string",
-            "description": "Taxonomic order (Darwin Core dwc:order).",
-            "maxLength": 64
-          },
-          "family": {
-            "type": "string",
-            "description": "Taxonomic family (Darwin Core dwc:family).",
-            "maxLength": 64
-          },
-          "genus": {
-            "type": "string",
-            "description": "Taxonomic genus (Darwin Core dwc:genus).",
+            "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
             "maxLength": 64
           },
           "identificationRemarks": {

--- a/lexicons/ing/observ/temp/identification.json
+++ b/lexicons/ing/observ/temp/identification.json
@@ -57,12 +57,7 @@
       "properties": {
         "scientificName": {
           "type": "string",
-          "description": "The full scientific name (Darwin Core dwc:scientificName).",
-          "maxLength": 256
-        },
-        "scientificNameAuthorship": {
-          "type": "string",
-          "description": "The authorship information for the scientificName (Darwin Core dwc:scientificNameAuthorship).",
+          "description": "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).",
           "maxLength": 256
         },
         "taxonRank": {
@@ -72,39 +67,9 @@
           "default": "species",
           "maxLength": 32
         },
-        "vernacularName": {
-          "type": "string",
-          "description": "Common name for the taxon in the identifier's language (Darwin Core dwc:vernacularName).",
-          "maxLength": 256
-        },
         "kingdom": {
           "type": "string",
-          "description": "Taxonomic kingdom (Darwin Core dwc:kingdom).",
-          "maxLength": 64
-        },
-        "phylum": {
-          "type": "string",
-          "description": "Taxonomic phylum (Darwin Core dwc:phylum).",
-          "maxLength": 64
-        },
-        "class": {
-          "type": "string",
-          "description": "Taxonomic class (Darwin Core dwc:class).",
-          "maxLength": 64
-        },
-        "order": {
-          "type": "string",
-          "description": "Taxonomic order (Darwin Core dwc:order).",
-          "maxLength": 64
-        },
-        "family": {
-          "type": "string",
-          "description": "Taxonomic family (Darwin Core dwc:family).",
-          "maxLength": 64
-        },
-        "genus": {
-          "type": "string",
-          "description": "Taxonomic genus (Darwin Core dwc:genus).",
+          "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
           "maxLength": 64
         }
       }

--- a/scripts/import-inaturalist.ts
+++ b/scripts/import-inaturalist.ts
@@ -203,13 +203,7 @@ async function main() {
           scientificName: taxon.name,
         };
         if (taxon.rank) taxonObj["taxonRank"] = taxon.rank;
-        if (taxon.preferred_common_name) taxonObj["vernacularName"] = taxon.preferred_common_name;
         if (taxonomy["kingdom"]) taxonObj["kingdom"] = taxonomy["kingdom"];
-        if (taxonomy["phylum"]) taxonObj["phylum"] = taxonomy["phylum"];
-        if (taxonomy["class"]) taxonObj["class"] = taxonomy["class"];
-        if (taxonomy["order"]) taxonObj["order"] = taxonomy["order"];
-        if (taxonomy["family"]) taxonObj["family"] = taxonomy["family"];
-        if (taxonomy["genus"]) taxonObj["genus"] = taxonomy["genus"];
 
         const identRecord = {
           $type: IDENTIFICATION_COLLECTION,


### PR DESCRIPTION
## Summary
- Adopt the trimmed identification schema from [lexicons-bio/lexicons.bio#18](https://github.com/lexicons-bio/lexicons.bio/pull/18) and [lexicons-bio/lexicons.bio#19](https://github.com/lexicons-bio/lexicons.bio/pull/19)
- Remove fields derivable from taxonomy backbone: `vernacularName`, `scientificNameAuthorship`, `phylum`, `class`, `order`, `family`, `genus`
- Keep `kingdom` for homonym disambiguation
- Rename `subject` → `occurrence` in `bio.lexicons.temp.identification`
- Update `scientificName` description to include authorship per DwC spec
- DB columns and API responses unchanged — taxonomy hierarchy and vernacular names continue to be populated from GBIF enrichment

## Test plan
- [x] `cargo build` passes
- [x] `cargo test` passes (all 220 tests)
- [x] `npx tsc` passes
- [ ] Verify identification creation still works end-to-end
- [ ] Verify ingester correctly handles new records (without removed fields)
- [ ] Verify old records with removed fields still deserialize (via `extra_data` catch-all)