### PR TITLE
Fix taxon page showing 'not found' on cold starts

### DIFF
--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -361,6 +361,7 @@ async fn resolve_effective_taxonomy(
     if let Some(detail) = taxonomy
         .get_by_name(effective_name, occurrence_kingdom)
         .await
+        .unwrap_or(None)
     {
         return Some(EffectiveTaxonomy {
             scientific_name: detail.scientific_name,

--- a/crates/observing-appview/src/error.rs
+++ b/crates/observing-appview/src/error.rs
@@ -45,3 +45,9 @@ impl From<sqlx::Error> for AppError {
         AppError::Database(e)
     }
 }
+
+impl From<crate::taxonomy_client::TaxonomyClientError> for AppError {
+    fn from(e: crate::taxonomy_client::TaxonomyClientError) -> Self {
+        AppError::Internal(e.to_string())
+    }
+}

--- a/crates/observing-appview/src/routes/taxonomy.rs
+++ b/crates/observing-appview/src/routes/taxonomy.rs
@@ -80,7 +80,7 @@ pub async fn get_taxon_by_kingdom_name(
     let detail = state
         .taxonomy
         .get_by_name(&name, Some(&kingdom))
-        .await
+        .await?
         .ok_or_else(|| AppError::NotFound("Taxon not found".into()))?;
 
     let count = observing_db::feeds::count_occurrences_by_taxon(
@@ -107,6 +107,7 @@ pub async fn get_children_by_kingdom_name(
         .taxonomy
         .get_children(&name, Some(&kingdom))
         .await
+        .unwrap_or(None)
         .unwrap_or_default();
     Ok(Json(children))
 }
@@ -124,7 +125,11 @@ pub async fn get_taxon_occurrences_by_kingdom_name(
     let name = name.replace('-', " ");
 
     // Look up taxon to get rank
-    let detail = state.taxonomy.get_by_name(&name, Some(&kingdom)).await;
+    let detail = state
+        .taxonomy
+        .get_by_name(&name, Some(&kingdom))
+        .await
+        .unwrap_or(None);
     let rank = detail
         .as_ref()
         .map(|d| d.rank.clone())
@@ -170,7 +175,7 @@ pub async fn get_taxon_by_id(
     let detail = state
         .taxonomy
         .get_by_id(&id)
-        .await
+        .await?
         .ok_or_else(|| AppError::NotFound("Taxon not found".into()))?;
 
     let count = observing_db::feeds::count_occurrences_by_taxon(
@@ -200,7 +205,7 @@ pub async fn get_taxon_occurrences_by_id(
         .min(constants::MAX_FEED_LIMIT);
 
     // Look up taxon to get name + rank
-    let detail = state.taxonomy.get_by_id(&id).await;
+    let detail = state.taxonomy.get_by_id(&id).await.unwrap_or(None);
 
     let (name, rank, kingdom) = match detail {
         Some(ref d) => (d.scientific_name.clone(), d.rank.clone(), d.kingdom.clone()),

--- a/crates/observing-appview/src/taxonomy_client.rs
+++ b/crates/observing-appview/src/taxonomy_client.rs
@@ -280,10 +280,7 @@ impl TaxonomyClient {
     }
 
     /// Get taxon by GBIF ID or name
-    pub async fn get_by_id(
-        &self,
-        id: &str,
-    ) -> Result<Option<TaxonDetail>, TaxonomyClientError> {
+    pub async fn get_by_id(&self, id: &str) -> Result<Option<TaxonDetail>, TaxonomyClientError> {
         let url = format!("{}/taxon/{}", self.base_url, id);
 
         match self.client.get(&url).send().await {

--- a/crates/observing-appview/src/taxonomy_client.rs
+++ b/crates/observing-appview/src/taxonomy_client.rs
@@ -1,8 +1,19 @@
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
+use std::fmt;
 use std::time::Duration;
 use tracing::error;
 use ts_rs::TS;
+
+/// Error from the taxonomy service (timeout, connection failure, 5xx, etc.)
+#[derive(Debug)]
+pub struct TaxonomyClientError(pub String);
+
+impl fmt::Display for TaxonomyClientError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "taxonomy service error: {}", self.0)
+    }
+}
 
 /// HTTP client for the taxonomy Rust service
 pub struct TaxonomyClient {
@@ -269,17 +280,38 @@ impl TaxonomyClient {
     }
 
     /// Get taxon by GBIF ID or name
-    pub async fn get_by_id(&self, id: &str) -> Option<TaxonDetail> {
+    pub async fn get_by_id(
+        &self,
+        id: &str,
+    ) -> Result<Option<TaxonDetail>, TaxonomyClientError> {
         let url = format!("{}/taxon/{}", self.base_url, id);
 
         match self.client.get(&url).send().await {
-            Ok(resp) if resp.status().is_success() => resp.json().await.ok(),
-            _ => None,
+            Ok(resp) if resp.status().is_success() => Ok(resp
+                .json()
+                .await
+                .map_err(|e| TaxonomyClientError(e.to_string()))?),
+            Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => Ok(None),
+            Ok(resp) => {
+                error!(status = %resp.status(), "Taxonomy get_by_id failed");
+                Err(TaxonomyClientError(format!(
+                    "upstream returned {}",
+                    resp.status()
+                )))
+            }
+            Err(e) => {
+                error!(error = %e, "Taxonomy get_by_id request failed");
+                Err(TaxonomyClientError(e.to_string()))
+            }
         }
     }
 
     /// Get taxon by name with optional kingdom.
-    pub async fn get_by_name(&self, name: &str, kingdom: Option<&str>) -> Option<TaxonDetail> {
+    pub async fn get_by_name(
+        &self,
+        name: &str,
+        kingdom: Option<&str>,
+    ) -> Result<Option<TaxonDetail>, TaxonomyClientError> {
         let encoded_name = urlencoding::encode(name);
         let mut url = format!("{}/taxon/{}", self.base_url, encoded_name);
         if let Some(k) = kingdom {
@@ -287,8 +319,22 @@ impl TaxonomyClient {
         }
 
         match self.client.get(&url).send().await {
-            Ok(resp) if resp.status().is_success() => resp.json().await.ok(),
-            _ => None,
+            Ok(resp) if resp.status().is_success() => Ok(resp
+                .json()
+                .await
+                .map_err(|e| TaxonomyClientError(e.to_string()))?),
+            Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => Ok(None),
+            Ok(resp) => {
+                error!(status = %resp.status(), %name, "Taxonomy get_by_name failed");
+                Err(TaxonomyClientError(format!(
+                    "upstream returned {}",
+                    resp.status()
+                )))
+            }
+            Err(e) => {
+                error!(error = %e, %name, "Taxonomy get_by_name request failed");
+                Err(TaxonomyClientError(e.to_string()))
+            }
         }
     }
 
@@ -297,7 +343,7 @@ impl TaxonomyClient {
         &self,
         name: &str,
         kingdom: Option<&str>,
-    ) -> Option<Vec<TaxonResult>> {
+    ) -> Result<Option<Vec<TaxonResult>>, TaxonomyClientError> {
         let encoded_name = urlencoding::encode(name);
         let mut url = format!("{}/taxon/{}/children", self.base_url, encoded_name);
         if let Some(k) = kingdom {
@@ -305,8 +351,23 @@ impl TaxonomyClient {
         }
 
         match self.client.get(&url).send().await {
-            Ok(resp) if resp.status().is_success() => resp.json().await.ok(),
-            _ => None,
+            Ok(resp) if resp.status().is_success() => Ok(Some(
+                resp.json()
+                    .await
+                    .map_err(|e| TaxonomyClientError(e.to_string()))?,
+            )),
+            Ok(resp) if resp.status() == reqwest::StatusCode::NOT_FOUND => Ok(None),
+            Ok(resp) => {
+                error!(status = %resp.status(), %name, "Taxonomy get_children failed");
+                Err(TaxonomyClientError(format!(
+                    "upstream returned {}",
+                    resp.status()
+                )))
+            }
+            Err(e) => {
+                error!(error = %e, %name, "Taxonomy get_children request failed");
+                Err(TaxonomyClientError(e.to_string()))
+            }
         }
     }
 }

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -241,10 +241,16 @@ export function TaxonExplorer() {
       setError(null);
 
       let result: TaxonDetail | null;
-      if (lookupKingdom && lookupName) {
-        result = await fetchTaxon(lookupKingdom, lookupName);
-      } else {
-        result = await fetchTaxon(lookupId ?? lookupKingdom ?? "");
+      try {
+        if (lookupKingdom && lookupName) {
+          result = await fetchTaxon(lookupKingdom, lookupName);
+        } else {
+          result = await fetchTaxon(lookupId ?? lookupKingdom ?? "");
+        }
+      } catch (e) {
+        setError(e instanceof Error ? e.message : "Failed to load taxon");
+        setLoading(false);
+        return;
       }
 
       if (result) {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -323,20 +323,18 @@ export async function submitComment(data: {
  * - legacy ID: fetchTaxon("gbif:12345")
  */
 export async function fetchTaxon(kingdomOrId: string, name?: string): Promise<TaxonDetail | null> {
-  try {
-    let url: string;
-    if (name) {
-      url = `${API_BASE}/api/taxa/${encodeURIComponent(kingdomOrId)}/${encodeURIComponent(name)}`;
-    } else {
-      url = `${API_BASE}/api/taxa/${encodeURIComponent(kingdomOrId)}`;
-    }
-    const response = await fetch(url);
-    if (!response.ok) return null;
-    return response.json();
-  } catch (e) {
-    console.error("fetchTaxon error:", e);
-    return null;
+  let url: string;
+  if (name) {
+    url = `${API_BASE}/api/taxa/${encodeURIComponent(kingdomOrId)}/${encodeURIComponent(name)}`;
+  } else {
+    url = `${API_BASE}/api/taxa/${encodeURIComponent(kingdomOrId)}`;
   }
+  const response = await fetch(url);
+  if (response.status === 404) return null;
+  if (!response.ok) {
+    throw new Error(`Failed to load taxon (${response.status})`);
+  }
+  return response.json();
 }
 
 /**


### PR DESCRIPTION
## Summary

- `TaxonomyClient` methods (`get_by_id`, `get_by_name`, `get_children`) now return `Result<Option<T>, TaxonomyClientError>` instead of `Option<T>`, distinguishing upstream failures (timeouts, 5xx, connection errors) from genuine 404s
- Taxonomy route handlers return 500 for upstream errors instead of incorrectly returning 404 "Taxon not found"
- Frontend `fetchTaxon` now throws on non-404 errors so `TaxonExplorer` can display the actual error message (e.g. "Failed to load taxon (500)") instead of the misleading "Taxon not found"

Fixes the issue where visiting a valid taxon URL on a cold start (e.g. Cloud Run spin-up) would show "Taxon not found" because the taxonomy service timeout was silently treated as a 404.

## Test plan

- [x] `cargo build` passes
- [x] `cargo test` passes (208 tests)
- [x] `npx tsc` passes
- [ ] Visit a taxon page after a cold deploy — should show a retryable error instead of "Taxon not found"