### PR TITLE
Fix flaky e2e: use pressSequentially for taxon autocomplete test

### DIFF
--- a/tests/explore-filters.spec.ts
+++ b/tests/explore-filters.spec.ts
@@ -59,7 +59,15 @@ test.describe("Explore Filters", () => {
     await page.getByRole("heading", { name: "Filters" }).click();
     const taxonInput = page.getByLabel("Taxon");
     await expect(taxonInput).toBeVisible();
-    await taxonInput.fill("Quercus");
+
+    // Use pressSequentially to simulate real keystrokes; fill() sets the
+    // value in one shot which can miss the input events that trigger the
+    // debounced search.
+    const searchResponse = page.waitForResponse((r) =>
+      r.url().includes("/api/taxa/search") && r.status() === 200,
+    );
+    await taxonInput.pressSequentially("Quercus", { delay: 50 });
+    await searchResponse;
 
     await expect(page.locator(".MuiAutocomplete-popper")).toBeVisible();
   });

--- a/tests/explore-filters.spec.ts
+++ b/tests/explore-filters.spec.ts
@@ -63,8 +63,8 @@ test.describe("Explore Filters", () => {
     // Use pressSequentially to simulate real keystrokes; fill() sets the
     // value in one shot which can miss the input events that trigger the
     // debounced search.
-    const searchResponse = page.waitForResponse((r) =>
-      r.url().includes("/api/taxa/search") && r.status() === 200,
+    const searchResponse = page.waitForResponse(
+      (r) => r.url().includes("/api/taxa/search") && r.status() === 200,
     );
     await taxonInput.pressSequentially("Quercus", { delay: 50 });
     await searchResponse;


### PR DESCRIPTION
## Summary

- `fill()` sets the input value in one shot which can miss the input events that trigger the debounced taxa search
- Switch to `pressSequentially` to simulate real keystrokes
- Wait for the `/api/taxa/search` response before asserting the popper is visible

Closes #254

## Test plan

- [ ] Verify the e2e suite passes in CI