### PR TITLE
Add iNaturalist as secondary source for taxa search

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2002,6 +2002,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "inaturalist"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d702c4081eb2d5e3e81002e710d3a7f2969506a3b7d9f16d3e433de68e896bb"
+dependencies = [
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tokio",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2861,7 +2876,9 @@ dependencies = [
  "chrono",
  "futures",
  "gbif-api",
+ "inaturalist",
  "moka",
+ "reqwest 0.12.28",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
@@ -3497,6 +3514,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -3508,6 +3526,7 @@ dependencies = [
  "js-sys",
  "log",
  "mime",
+ "mime_guess",
  "native-tls",
  "percent-encoding",
  "pin-project-lite",
@@ -3521,12 +3540,14 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -3570,7 +3591,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -5103,6 +5124,19 @@ dependencies = [
  "indexmap",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/crates/observing-taxonomy/Cargo.toml
+++ b/crates/observing-taxonomy/Cargo.toml
@@ -9,6 +9,16 @@ license = "MIT OR Apache-2.0"
 # GBIF API client
 gbif-api = { path = "../gbif-api" }
 
+# iNaturalist API client (secondary taxa source for clades like Angiospermae)
+inaturalist = "0.9.0"
+
+# `inaturalist` pulls in reqwest 0.12 with default-features=false and no TLS,
+# so its default Client fails on HTTPS ("scheme is not http"). Aliased here
+# purely to unify features — cargo merges feature sets across direct+transitive
+# deps, so adding rustls-tls via this alias enables it on the shared 0.12
+# instance that `inaturalist` already uses. Not referenced in code.
+reqwest_0_12_tls_enabler = { package = "reqwest", version = "0.12", default-features = false, features = ["rustls-tls"] }
+
 # Wikidata SPARQL client
 wikidata-client = { path = "../wikidata-client" }
 

--- a/crates/observing-taxonomy/src/gbif.rs
+++ b/crates/observing-taxonomy/src/gbif.rs
@@ -1,6 +1,7 @@
 //! GBIF-based taxonomy client with caching
 
 use crate::error::Result;
+use crate::inat::InatClient;
 use crate::types::*;
 use crate::wikidata::WikidataClient;
 use gbif_api::{
@@ -10,6 +11,85 @@ use moka::future::Cache;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
 use tracing::warn;
+
+/// Merge GBIF and iNat search results.
+///
+/// GBIF's `/species/search` is full-text over descriptions and vernacular names,
+/// so queries like "angiosperm" return genera that merely *mention* angiosperms
+/// in their descriptions (Agnoea, Meloidodera, …) while missing the clade itself,
+/// because Angiospermae isn't in GBIF's backbone. iNaturalist's taxonomy includes
+/// those informal high-rank clades and uses prefix matching on names.
+///
+/// Strategy: use iNat purely to fill clade-level gaps in GBIF.
+///
+/// 1. If GBIF already has any above-genus result in its hits, trust GBIF —
+///    for queries like "carnivora" where GBIF returns the Carnivora order
+///    directly, promoting iNat would only surface less-relevant ancestors.
+/// 2. Otherwise, promote iNat's above-genus results (kingdom through tribe)
+///    to the front, skipping any that duplicate GBIF scientific names.
+/// 3. Lower-rank iNat results (genus/species/subspecies) are never merged:
+///    GBIF covers those well and interleaving iNat species above GBIF genus
+///    hits degrades the UX for queries like "corvus" and "oak".
+///
+/// Dedupe is by scientific name, case-insensitive. GBIF wins ties.
+fn merge_results(gbif: Vec<TaxonResult>, inat: Vec<TaxonResult>, limit: u32) -> Vec<TaxonResult> {
+    let limit = limit as usize;
+
+    let gbif_has_above_genus = gbif.iter().any(|t| is_above_genus_rank(&t.rank));
+
+    let promoted: Vec<TaxonResult> = if gbif_has_above_genus {
+        Vec::new()
+    } else {
+        let gbif_names: std::collections::HashSet<String> = gbif
+            .iter()
+            .map(|t| t.scientific_name.to_lowercase())
+            .collect();
+        inat.into_iter()
+            .filter(|t| is_above_genus_rank(&t.rank))
+            .filter(|t| !gbif_names.contains(&t.scientific_name.to_lowercase()))
+            .collect()
+    };
+
+    let mut merged = promoted;
+    for taxon in gbif {
+        if merged.len() >= limit {
+            break;
+        }
+        merged.push(taxon);
+    }
+    merged.truncate(limit);
+    merged
+}
+
+/// Returns true when a rank sits above genus on the Linnaean ladder.
+fn is_above_genus_rank(rank: &str) -> bool {
+    matches!(
+        rank,
+        "stateofmatter"
+            | "kingdom"
+            | "subkingdom"
+            | "phylum"
+            | "subphylum"
+            | "superclass"
+            | "class"
+            | "subclass"
+            | "infraclass"
+            | "superorder"
+            | "order"
+            | "suborder"
+            | "infraorder"
+            | "parvorder"
+            | "zoosection"
+            | "zoosubsection"
+            | "superfamily"
+            | "epifamily"
+            | "family"
+            | "subfamily"
+            | "supertribe"
+            | "tribe"
+            | "subtribe"
+    )
+}
 
 /// Build a path-based taxon identifier: "{kingdom}/{name}" or just "{name}" for kingdom rank
 fn build_taxon_path(scientific_name: &str, rank: &str, kingdom: Option<&str>) -> String {
@@ -24,9 +104,12 @@ fn build_taxon_path(scientific_name: &str, rank: &str, kingdom: Option<&str>) ->
     }
 }
 
-/// Taxonomy client that wraps GBIF API with caching and app-specific type conversion
+/// Taxonomy client that wraps GBIF API with caching and app-specific type conversion.
+/// Also queries iNaturalist as a secondary source for taxa that GBIF's backbone
+/// omits (e.g. informal clades like Angiospermae).
 pub struct GbifClient {
     api: GbifApiClient,
+    inat: InatClient,
     wikidata: WikidataClient,
     cache: Cache<String, CachedValue>,
     hits: AtomicU64,
@@ -45,6 +128,7 @@ impl GbifClient {
 
     pub fn new() -> Self {
         let api = GbifApiClient::new();
+        let inat = InatClient::new();
         let wikidata = WikidataClient::new();
 
         let cache = Cache::builder()
@@ -54,6 +138,7 @@ impl GbifClient {
 
         Self {
             api,
+            inat,
             wikidata,
             cache,
             hits: AtomicU64::new(0),
@@ -69,7 +154,11 @@ impl GbifClient {
         }
     }
 
-    /// Search for taxa matching a query
+    /// Search for taxa matching a query.
+    ///
+    /// Queries GBIF and iNaturalist in parallel and merges the results.
+    /// GBIF is authoritative for most searches, but iNat fills gaps for
+    /// informal clades (e.g. Angiospermae) that GBIF's backbone omits.
     pub async fn search(&self, query: &str, limit: u32) -> Result<Vec<TaxonResult>> {
         let cache_key = format!("search:{}:{}", query.to_lowercase(), limit);
 
@@ -79,11 +168,18 @@ impl GbifClient {
         }
         self.misses.fetch_add(1, Ordering::Relaxed);
 
-        let results = self.search_gbif(query, limit).await?;
+        let (gbif_results, inat_results) = tokio::join!(
+            self.search_gbif(query, limit),
+            self.inat.search(query, limit)
+        );
+
+        let gbif_results = gbif_results?;
+        let merged = merge_results(gbif_results, inat_results, limit);
+
         self.cache
-            .insert(cache_key, CachedValue::SearchResults(results.clone()))
+            .insert(cache_key, CachedValue::SearchResults(merged.clone()))
             .await;
-        Ok(results)
+        Ok(merged)
     }
 
     /// Check if a GBIF match is a HIGHERRANK fallback that doesn't match the query.
@@ -108,51 +204,66 @@ impl GbifClient {
         !canonical.eq_ignore_ascii_case(scientific_name)
     }
 
-    /// Validate a scientific name
+    /// Validate a scientific name. Tries GBIF first; if GBIF has no exact
+    /// match, falls back to iNaturalist to cover taxa missing from GBIF's
+    /// backbone (e.g. Angiospermae).
     pub async fn validate(&self, name: &str) -> Result<ValidationResult> {
-        let Some(gbif_match) = self.api.match_name(name, None).await? else {
-            return Ok(ValidationResult {
-                valid: false,
-                matched_name: None,
-                taxon: None,
-                suggestions: Some(vec![]),
-            });
-        };
+        let gbif_result = self.api.match_name(name, None).await?;
 
-        let Some(usage) = &gbif_match.usage else {
-            return Ok(ValidationResult {
-                valid: false,
-                matched_name: None,
-                taxon: None,
-                suggestions: Some(vec![]),
-            });
-        };
+        if let Some(gbif_match) = gbif_result {
+            if let Some(usage) = &gbif_match.usage {
+                let match_type = gbif_match
+                    .diagnostics
+                    .as_ref()
+                    .and_then(|d| d.match_type.as_deref());
+                let taxon = self.gbif_v2_to_taxon(
+                    usage,
+                    gbif_match.additional_status.as_deref(),
+                    gbif_match.classification.as_deref(),
+                );
 
-        let match_type = gbif_match
-            .diagnostics
-            .as_ref()
-            .and_then(|d| d.match_type.as_deref());
-        let taxon = self.gbif_v2_to_taxon(
-            usage,
-            gbif_match.additional_status.as_deref(),
-            gbif_match.classification.as_deref(),
-        );
+                if match_type == Some("EXACT") {
+                    return Ok(ValidationResult {
+                        valid: true,
+                        matched_name: usage.canonical_name.clone().or_else(|| usage.name.clone()),
+                        taxon: Some(taxon),
+                        suggestions: None,
+                    });
+                }
 
-        if match_type == Some("EXACT") {
-            Ok(ValidationResult {
-                valid: true,
-                matched_name: usage.canonical_name.clone().or_else(|| usage.name.clone()),
-                taxon: Some(taxon),
-                suggestions: None,
-            })
-        } else {
-            Ok(ValidationResult {
-                valid: false,
-                matched_name: None,
-                taxon: None,
-                suggestions: Some(vec![taxon]),
-            })
+                if let Some(inat_taxon) = self.inat.find_exact(name).await {
+                    return Ok(ValidationResult {
+                        valid: true,
+                        matched_name: Some(inat_taxon.scientific_name.clone()),
+                        taxon: Some(inat_taxon),
+                        suggestions: None,
+                    });
+                }
+
+                return Ok(ValidationResult {
+                    valid: false,
+                    matched_name: None,
+                    taxon: None,
+                    suggestions: Some(vec![taxon]),
+                });
+            }
         }
+
+        if let Some(inat_taxon) = self.inat.find_exact(name).await {
+            return Ok(ValidationResult {
+                valid: true,
+                matched_name: Some(inat_taxon.scientific_name.clone()),
+                taxon: Some(inat_taxon),
+                suggestions: None,
+            });
+        }
+
+        Ok(ValidationResult {
+            valid: false,
+            matched_name: None,
+            taxon: None,
+            suggestions: Some(vec![]),
+        })
     }
 
     /// Get detailed taxon information by GBIF ID
@@ -822,5 +933,95 @@ mod tests {
         );
         let result = client.search_result_to_taxon(&item);
         assert_eq!(result.common_name.as_deref(), Some("Powdery Mildew Fungi"));
+    }
+
+    fn stub_taxon(name: &str, rank: &str, source: &str) -> TaxonResult {
+        TaxonResult {
+            id: format!("{}:{}", source, name),
+            scientific_name: name.to_string(),
+            common_name: None,
+            photo_url: None,
+            rank: rank.to_string(),
+            kingdom: None,
+            phylum: None,
+            class: None,
+            order: None,
+            family: None,
+            genus: None,
+            species: None,
+            source: source.to_string(),
+            conservation_status: None,
+            is_synonym: false,
+            accepted_name: None,
+        }
+    }
+
+    #[test]
+    fn merge_promotes_inat_clade_when_gbif_has_only_low_rank_noise() {
+        let gbif = vec![
+            stub_taxon("Agnoea", "genus", "gbif"),
+            stub_taxon("Meloidodera", "genus", "gbif"),
+        ];
+        let inat = vec![
+            stub_taxon("Angiospermae", "subphylum", "inat"),
+            stub_taxon("Heliotropium angiospermum", "species", "inat"),
+        ];
+        let merged = merge_results(gbif, inat, 10);
+        assert_eq!(merged[0].scientific_name, "Angiospermae");
+        assert_eq!(merged[0].source, "inat");
+        assert_eq!(merged[1].scientific_name, "Agnoea");
+        assert!(merged
+            .iter()
+            .all(|t| t.scientific_name != "Heliotropium angiospermum"));
+    }
+
+    #[test]
+    fn merge_skips_inat_when_gbif_already_has_above_genus_hit() {
+        let gbif = vec![
+            stub_taxon("Carnivora", "order", "gbif"),
+            stub_taxon("Rhipicephalus carnivoralis", "species", "gbif"),
+        ];
+        let inat = vec![
+            stub_taxon("Laurasiatheria", "superorder", "inat"),
+            stub_taxon("Eupleridae", "family", "inat"),
+        ];
+        let merged = merge_results(gbif, inat, 10);
+        assert_eq!(merged[0].scientific_name, "Carnivora");
+        assert!(merged.iter().all(|t| t.source == "gbif"));
+    }
+
+    #[test]
+    fn merge_never_promotes_low_rank_inat_results() {
+        let gbif = vec![
+            stub_taxon("Corvus", "genus", "gbif"),
+            stub_taxon("Corvus corax", "species", "gbif"),
+        ];
+        let inat = vec![
+            stub_taxon("Corvus brachyrhynchos", "species", "inat"),
+            stub_taxon("Corvus corone", "species", "inat"),
+        ];
+        let merged = merge_results(gbif, inat, 10);
+        assert!(merged.iter().all(|t| t.source == "gbif"));
+        assert_eq!(merged[0].scientific_name, "Corvus");
+    }
+
+    #[test]
+    fn merge_dedupes_by_scientific_name_case_insensitive() {
+        let gbif = vec![stub_taxon("aves", "class", "gbif")];
+        let inat = vec![stub_taxon("Aves", "class", "inat")];
+        let merged = merge_results(gbif, inat, 10);
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].source, "gbif");
+    }
+
+    #[test]
+    fn merge_respects_limit() {
+        let gbif: Vec<TaxonResult> = (0..10)
+            .map(|i| stub_taxon(&format!("Genus{}", i), "genus", "gbif"))
+            .collect();
+        let inat = vec![stub_taxon("SomeClade", "order", "inat")];
+        let merged = merge_results(gbif, inat, 5);
+        assert_eq!(merged.len(), 5);
+        assert_eq!(merged[0].scientific_name, "SomeClade");
     }
 }

--- a/crates/observing-taxonomy/src/inat.rs
+++ b/crates/observing-taxonomy/src/inat.rs
@@ -99,7 +99,10 @@ fn autocomplete_to_taxon(item: &AutocompleteTaxon) -> Option<TaxonResult> {
         common_name: item.preferred_common_name.clone(),
         photo_url,
         rank,
-        kingdom: item.iconic_taxon_name.as_deref().and_then(iconic_to_kingdom),
+        kingdom: item
+            .iconic_taxon_name
+            .as_deref()
+            .and_then(iconic_to_kingdom),
         phylum: None,
         class: None,
         order: None,

--- a/crates/observing-taxonomy/src/inat.rs
+++ b/crates/observing-taxonomy/src/inat.rs
@@ -1,0 +1,129 @@
+//! iNaturalist taxa client — secondary source for search and validation.
+//!
+//! GBIF's backbone taxonomy omits informal clades like Angiospermae (flowering
+//! plants), so searches for common group names return unrelated fuzzy matches.
+//! iNaturalist's taxonomy includes these groups, so we use it as a fallback to
+//! fill gaps in what GBIF can find.
+
+use crate::types::TaxonResult;
+use inaturalist::apis::{
+    configuration::Configuration,
+    taxa_api::{taxa_autocomplete_get, TaxaAutocompleteGetParams},
+};
+use inaturalist::models::AutocompleteTaxon;
+use tracing::warn;
+
+/// iNaturalist API client.
+pub struct InatClient {
+    config: Configuration,
+}
+
+impl InatClient {
+    pub fn new() -> Self {
+        let mut config = Configuration::new();
+        // The crate's default base_path is "/v1" (relative) — point it at the real host.
+        config.base_path = "https://api.inaturalist.org/v1".to_string();
+        config.user_agent = Some("observ.ing-taxonomy/0.1".to_string());
+        // The crate's default reqwest Client has HTTPS thanks to feature unification
+        // via the `reqwest_0_12_tls_enabler` alias in our Cargo.toml.
+        Self { config }
+    }
+
+    /// Autocomplete-style search. Returns `TaxonResult`s converted from iNat
+    /// taxa, filtered to active taxa only. Errors are logged and swallowed —
+    /// iNat is a supplementary source and its unavailability must not break
+    /// the primary GBIF search.
+    pub async fn search(&self, query: &str, limit: u32) -> Vec<TaxonResult> {
+        let params = TaxaAutocompleteGetParams {
+            q: query.to_string(),
+            is_active: Some(true),
+            taxon_id: None,
+            rank: None,
+            rank_level: None,
+            per_page: Some(limit.to_string()),
+            locale: None,
+            preferred_place_id: None,
+            all_names: None,
+        };
+
+        let response = match taxa_autocomplete_get(&self.config, params).await {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(query = %query, error = ?e, "iNat autocomplete failed");
+                return Vec::new();
+            }
+        };
+
+        response
+            .results
+            .iter()
+            .filter_map(autocomplete_to_taxon)
+            .collect()
+    }
+
+    /// Look up an exact scientific name via iNat autocomplete. Used as a
+    /// fallback from `validate()` when GBIF has no match.
+    pub async fn find_exact(&self, name: &str) -> Option<TaxonResult> {
+        let results = self.search(name, 10).await;
+        results
+            .into_iter()
+            .find(|t| t.scientific_name.eq_ignore_ascii_case(name))
+    }
+}
+
+/// Convert an iNat `AutocompleteTaxon` into our internal `TaxonResult`.
+///
+/// Drops entries without an id or name (both required for a useful result).
+/// Populates `kingdom` from iNat's `iconic_taxon_name` when it's one of the
+/// Linnaean kingdoms — iNat's iconic taxa are a small curated set of high-level
+/// groups (Animalia, Plantae, Fungi, Protozoa, Chromista, Bacteria, as well as
+/// some class-level shortcuts like Aves that we ignore here).
+fn autocomplete_to_taxon(item: &AutocompleteTaxon) -> Option<TaxonResult> {
+    let id = item.id?;
+    let name = item.name.as_deref().filter(|s| !s.is_empty())?;
+
+    let rank = item
+        .rank
+        .as_deref()
+        .map(|r| r.to_lowercase())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let photo_url = item
+        .default_photo
+        .as_ref()
+        .and_then(|p| p.medium_url.clone().or_else(|| p.square_url.clone()));
+
+    Some(TaxonResult {
+        id: format!("inat:{}", id),
+        scientific_name: name.to_string(),
+        common_name: item.preferred_common_name.clone(),
+        photo_url,
+        rank,
+        kingdom: item.iconic_taxon_name.as_deref().and_then(iconic_to_kingdom),
+        phylum: None,
+        class: None,
+        order: None,
+        family: None,
+        genus: None,
+        species: None,
+        source: "inat".to_string(),
+        conservation_status: None,
+        is_synonym: false,
+        accepted_name: None,
+    })
+}
+
+/// Map iNat's `iconic_taxon_name` to a Linnaean kingdom when it is one.
+/// iNat also uses lower-rank iconic groups (Aves, Reptilia, Mollusca, …)
+/// which don't have a clean kingdom mapping here — return None for those.
+fn iconic_to_kingdom(iconic: &str) -> Option<String> {
+    match iconic {
+        "Animalia" | "Plantae" | "Fungi" | "Protozoa" | "Chromista" | "Bacteria" | "Archaea" => {
+            Some(iconic.to_string())
+        }
+        // Class- or phylum-level iconic taxa — all under Animalia in iNat.
+        "Aves" | "Amphibia" | "Reptilia" | "Mammalia" | "Actinopterygii" | "Mollusca"
+        | "Arachnida" | "Insecta" => Some("Animalia".to_string()),
+        _ => None,
+    }
+}

--- a/crates/observing-taxonomy/src/main.rs
+++ b/crates/observing-taxonomy/src/main.rs
@@ -4,6 +4,7 @@
 
 mod error;
 mod gbif;
+mod inat;
 mod server;
 mod types;
 mod wikidata;


### PR DESCRIPTION
## Summary

- GBIF's backbone taxonomy omits informal clades like Angiospermae (Flowering Plants), so searching "angiosperm" in the Taxon filter returned unrelated genera (Agnoea, Meloidodera, Nymphaea, …) matched on description text rather than the clade itself. "fern", "oak", "carnivora" and similar queries were similarly degraded.
- Added iNaturalist as a secondary taxa source in `observing-taxonomy`, merged into both `search()` (autocomplete) and `validate()` (observation-creation taxonomy validation). iNat fills GBIF's clade-level gaps without affecting species/genus queries GBIF already serves well.
- Promotion rule: iNat results are surfaced only at above-genus ranks (kingdom → tribe), and only when GBIF has no above-genus hit of its own. This keeps "corvus" → Corvus and "carnivora" → Carnivora served by GBIF, while fixing "angiosperm" → Angiospermae and "fern" → Polypodiopsida.
- Handled the `inaturalist` crate's lack of TLS features by adding an aliased `reqwest` 0.12 dep to force cargo feature unification — no runtime workaround needed.

## Query behavior

| Query | Top result before | Top result after |
|---|---|---|
| angiosperm | Agnoea (genus) | **Angiospermae — Flowering Plants** (iNat) |
| fern | Luzula somedana (species) | **Polypodiopsida — Ferns** (iNat) |
| oak | Quercus — Oaks (genus) | **Cynipini — Oak Gall Wasps** (iNat), then Quercus |
| corvus | Corvus — Crows And Ravens | Corvus — Crows And Ravens *(unchanged)* |
| carnivora | Carnivora (order) | Carnivora (order) *(unchanged)* |
| panthera | Panthera — Roaring Cats | Panthera — Roaring Cats *(unchanged)* |

## Notes for @frewsxcv (crate maintainer)

`inaturalist` 0.9.0 pulls in reqwest with `default-features = false` and no TLS feature, which breaks the default `Configuration::new()` for HTTPS out of the box (\"scheme is not http\"). Users hit this until they either hand-build a client or force feature unification. Adding `rustls-tls` to the default features (or a `default-tls` convenience feature) would save downstream users the workaround.

## Test plan

- [x] 5 new unit tests in `gbif.rs` covering the merge rules (promote on clade noise, skip when GBIF has a clade hit, never merge species-rank iNat, dedupe case-insensitive, respect limit)
- [x] `cargo test -p observing-taxonomy` — 15 tests pass
- [x] `cargo build` / `cargo test` workspace-wide pass
- [x] `npx tsc` clean
- [x] End-to-end verified in browser: "angiosperm" in the Explore filter's Taxon autocomplete surfaces "Angiospermae — Flowering Plants" as the top suggestion
- [ ] Verify observation upload modal also shows the new result (same autocomplete backend, should inherit automatically — please smoke-test before merging)