### PR TITLE
Narrow API response shapes at trust boundaries

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -33,6 +33,12 @@ async function extractErrorMessage(response: Response, defaultMessage: string): 
   return defaultMessage;
 }
 
+/**
+ * Generic JSON fetch helper. NOTE: the `T` type parameter is NOT verified
+ * at runtime — callers are trusting that the server returns the right
+ * shape. For sites where the server response crosses a trust boundary
+ * or is likely to drift, narrow the result explicitly at the call site.
+ */
 async function fetchApi<T>(url: string, errorMessage: string, init?: RequestInit): Promise<T> {
   const response = await fetch(url, init);
   if (!response.ok) {
@@ -47,8 +53,12 @@ export async function checkAuth(): Promise<User | null> {
       credentials: "include",
     });
     if (response.ok) {
-      const data = await response.json();
-      return data.user ?? null;
+      const data: unknown = await response.json();
+      if (typeof data === "object" && data !== null && "user" in data) {
+        const user = (data as { user: unknown }).user;
+        return (user ?? null) as User | null;
+      }
+      return null;
     }
     return null;
   } catch {
@@ -174,8 +184,12 @@ export async function searchActors(query: string): Promise<ActorSearchResult[]> 
   const response = await fetch(`${API_BASE}/api/actors/search?q=${encodeURIComponent(query)}`);
   if (!response.ok) return [];
 
-  const data = await response.json();
-  return data.actors || [];
+  const data: unknown = await response.json();
+  if (typeof data === "object" && data !== null && "actors" in data) {
+    const actors = (data as { actors: unknown }).actors;
+    if (Array.isArray(actors)) return actors as ActorSearchResult[];
+  }
+  return [];
 }
 
 export async function searchTaxa(query: string): Promise<TaxaResult[]> {
@@ -184,8 +198,12 @@ export async function searchTaxa(query: string): Promise<TaxaResult[]> {
   const response = await fetch(`${API_BASE}/api/taxa/search?q=${encodeURIComponent(query)}`);
   if (!response.ok) return [];
 
-  const data = await response.json();
-  return data.results || [];
+  const data: unknown = await response.json();
+  if (typeof data === "object" && data !== null && "results" in data) {
+    const results = (data as { results: unknown }).results;
+    if (Array.isArray(results)) return results as TaxaResult[];
+  }
+  return [];
 }
 
 export async function submitObservation(data: {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -16,6 +16,46 @@ import type {
 const API_BASE = import.meta.env["VITE_API_URL"] || "";
 const DEFAULT_PAGE_SIZE = "20";
 
+// ---------------------------------------------------------------------------
+// Runtime shape guards for trust-boundary responses.
+//
+// The `consistent-type-assertions` lint rule bans `as` casts, so every
+// narrowing from `unknown` to a concrete type goes through a type predicate
+// here. The predicates do shallow validation of the fields TypeScript needs
+// for downstream code — they are not full schema validators.
+// ---------------------------------------------------------------------------
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isActorSearchResult(value: unknown): value is ActorSearchResult {
+  return isObject(value) && typeof value["did"] === "string" && typeof value["handle"] === "string";
+}
+
+function isTaxaResult(value: unknown): value is TaxaResult {
+  return (
+    isObject(value) &&
+    typeof value["id"] === "string" &&
+    typeof value["scientificName"] === "string" &&
+    typeof value["rank"] === "string" &&
+    typeof value["source"] === "string"
+  );
+}
+
+function toUser(value: unknown): User | null {
+  if (!isObject(value)) return null;
+  const did = value["did"];
+  const handle = value["handle"];
+  if (typeof did !== "string" || typeof handle !== "string") return null;
+  const user: User = { did, handle };
+  const displayName = value["displayName"];
+  if (typeof displayName === "string") user.displayName = displayName;
+  const avatar = value["avatar"];
+  if (typeof avatar === "string") user.avatar = avatar;
+  return user;
+}
+
 /**
  * Extract an error message from a failed fetch response.
  * Tries to parse the response body as JSON and extract `.error`,
@@ -54,9 +94,8 @@ export async function checkAuth(): Promise<User | null> {
     });
     if (response.ok) {
       const data: unknown = await response.json();
-      if (typeof data === "object" && data !== null && "user" in data) {
-        const user = (data as { user: unknown }).user;
-        return (user ?? null) as User | null;
+      if (isObject(data)) {
+        return toUser(data["user"]);
       }
       return null;
     }
@@ -185,9 +224,8 @@ export async function searchActors(query: string): Promise<ActorSearchResult[]> 
   if (!response.ok) return [];
 
   const data: unknown = await response.json();
-  if (typeof data === "object" && data !== null && "actors" in data) {
-    const actors = (data as { actors: unknown }).actors;
-    if (Array.isArray(actors)) return actors as ActorSearchResult[];
+  if (isObject(data) && Array.isArray(data["actors"])) {
+    return data["actors"].filter(isActorSearchResult);
   }
   return [];
 }
@@ -199,9 +237,8 @@ export async function searchTaxa(query: string): Promise<TaxaResult[]> {
   if (!response.ok) return [];
 
   const data: unknown = await response.json();
-  if (typeof data === "object" && data !== null && "results" in data) {
-    const results = (data as { results: unknown }).results;
-    if (Array.isArray(results)) return results as TaxaResult[];
+  if (isObject(data) && Array.isArray(data["results"])) {
+    return data["results"].filter(isTaxaResult);
   }
   return [];
 }


### PR DESCRIPTION
## Summary

\`fetchApi<T>()\` in \`frontend/src/services/api.ts\` claims to return \`T\` but just casts \`response.json()\` — the generic is fiction. This PR doesn't try to solve the generic problem (that would need a validation library), but it:

- Documents the limitation loudly in a JSDoc on \`fetchApi\`
- Tightens the three call sites where we dig into a JSON property with zero check:
  - \`checkAuth()\` accessing \`data.user\`
  - \`searchActors()\` accessing \`data.actors\`
  - \`searchTaxa()\` accessing \`data.results\`

Each now narrows to \`unknown\` and validates the shape before casting.

## Test plan

- [ ] \`npx tsc\` passes
- [ ] Auth, actor search, and taxa search still work in the dev app