### PR TITLE
Type auth state in feedSlice as User | null

### DIFF
--- a/frontend/src/store/feedSlice.ts
+++ b/frontend/src/store/feedSlice.ts
@@ -5,6 +5,7 @@ import type {
   FeedFilters,
   ExploreFeedResponse,
   HomeFeedResponse,
+  User,
 } from "../services/types";
 import * as api from "../services/api";
 
@@ -15,7 +16,7 @@ function resetFeedState(state: FeedState) {
 }
 
 interface ThunkApiConfig {
-  state: { feed: FeedState; auth: { user: unknown } };
+  state: { feed: FeedState; auth: { user: User | null } };
 }
 
 interface FeedState {
@@ -40,9 +41,12 @@ const initialState: FeedState = {
   userLocation: null,
 };
 
-function fetchFeedData(state: { feed: FeedState; auth: { user: unknown } }, cursor?: string) {
+function fetchFeedData(
+  state: { feed: FeedState; auth: { user: User | null } },
+  cursor?: string,
+) {
   const { currentTab, filters } = state.feed;
-  const isAuthenticated = !!state.auth?.user;
+  const isAuthenticated = state.auth.user !== null;
 
   if (currentTab === "home" && isAuthenticated) {
     return api.fetchHomeFeed(cursor);

--- a/frontend/src/store/feedSlice.ts
+++ b/frontend/src/store/feedSlice.ts
@@ -41,10 +41,7 @@ const initialState: FeedState = {
   userLocation: null,
 };
 
-function fetchFeedData(
-  state: { feed: FeedState; auth: { user: User | null } },
-  cursor?: string,
-) {
+function fetchFeedData(state: { feed: FeedState; auth: { user: User | null } }, cursor?: string) {
   const { currentTab, filters } = state.feed;
   const isAuthenticated = state.auth.user !== null;
 


### PR DESCRIPTION
## Summary

\`ThunkApiConfig\` and the \`fetchFeedData\` helper in \`frontend/src/store/feedSlice.ts\` typed the auth user as \`unknown\`, forcing an unsafe \`!!state.auth?.user\` coercion. Every consumer had to blindly narrow.

The real type \`User | null\` already exists in \`services/types\` (and is used by \`authSlice\` itself). Replace \`unknown\` with it and check for null explicitly.

## Test plan

- [ ] \`npx tsc\` passes
- [ ] Logged-in home feed still loads; logged-out users still get explore feed