### PR TITLE
Type Playwright params in test helpers instead of any

### DIFF
--- a/tests/comments.spec.ts
+++ b/tests/comments.spec.ts
@@ -1,16 +1,16 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page, type Request } from "@playwright/test";
 import { test as authTest, expect as authExpect } from "./fixtures/mock-auth";
 import { navigateToMockedDetail } from "./helpers/mock-observation";
 
 /** Navigate to the mock observation detail page. */
-async function navigateToDetail(page: any, _expectFn: any) {
+async function navigateToDetail(page: Page) {
   await navigateToMockedDetail(page);
 }
 
 test.describe("Comments - Logged Out", () => {
   // TC-CMT-001: Login prompt for comments
   test("shows login prompt when logged out", async ({ page }) => {
-    await navigateToDetail(page, expect);
+    await navigateToDetail(page);
     await expect(page.getByText("Log in to add a comment")).toBeVisible();
   });
 });
@@ -18,7 +18,7 @@ test.describe("Comments - Logged Out", () => {
 authTest.describe("Comments - Logged In", () => {
   // TC-CMT-002: Add button opens comment form
   authTest("Add button opens comment form", async ({ authenticatedPage: page }) => {
-    await navigateToDetail(page, authExpect);
+    await navigateToDetail(page);
     const addBtn = page
       .locator("text=Discussion")
       .locator("..")
@@ -33,7 +33,7 @@ authTest.describe("Comments - Logged In", () => {
 
   // TC-CMT-003: Cancel closes comment form
   authTest("Cancel closes comment form", async ({ authenticatedPage: page }) => {
-    await navigateToDetail(page, authExpect);
+    await navigateToDetail(page);
     const addBtn = page
       .locator("text=Discussion")
       .locator("..")
@@ -59,7 +59,7 @@ authTest.describe("Comments - Logged In", () => {
       }
       return route.continue();
     });
-    await navigateToDetail(page, authExpect);
+    await navigateToDetail(page);
     const addBtn = page
       .locator("text=Discussion")
       .locator("..")
@@ -73,7 +73,7 @@ authTest.describe("Comments - Logged In", () => {
       .fill("This is a test comment");
 
     const postRequest = page.waitForRequest(
-      (req: any) => req.method() === "POST" && req.url().includes("/api/comments"),
+      (req: Request) => req.method() === "POST" && req.url().includes("/api/comments"),
     );
     await page.getByRole("button", { name: "Post" }).click();
     const req = await postRequest;

--- a/tests/identification.spec.ts
+++ b/tests/identification.spec.ts
@@ -1,4 +1,4 @@
-import { type Page } from "@playwright/test";
+import { type Page, type Request } from "@playwright/test";
 import { test as authTest, expect as authExpect } from "./fixtures/mock-auth";
 import { navigateToMockedDetail } from "./helpers/mock-observation";
 
@@ -15,7 +15,7 @@ function muiSelect(page: Page, label: string) {
 }
 
 /** Navigate to the mock observation detail page. */
-async function navigateToDetail(page: any) {
+async function navigateToDetail(page: Page) {
   await navigateToMockedDetail(page);
 }
 
@@ -37,7 +37,7 @@ authTest.describe("Identification - Logged In", () => {
     await authExpect(agreeBtn).toBeVisible({ timeout: 10000 });
 
     const postRequest = page.waitForRequest(
-      (req: any) => req.method() === "POST" && req.url().includes("/api/identifications"),
+      (req: Request) => req.method() === "POST" && req.url().includes("/api/identifications"),
     );
     await agreeBtn.click();
     const req = await postRequest;
@@ -87,7 +87,7 @@ authTest.describe("Identification - Logged In", () => {
       await speciesInput.fill("Quercus rubra");
 
       const postRequest = page.waitForRequest(
-        (req: any) => req.method() === "POST" && req.url().includes("/api/identifications"),
+        (req: Request) => req.method() === "POST" && req.url().includes("/api/identifications"),
       );
       await page.getByRole("button", { name: "Submit ID" }).click();
       const req = await postRequest;

--- a/tests/interactions.spec.ts
+++ b/tests/interactions.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { test, expect, type Page, type Request } from "@playwright/test";
 import { test as authTest, expect as authExpect } from "./fixtures/mock-auth";
 import { navigateToMockedDetail } from "./helpers/mock-observation";
 
@@ -15,14 +15,14 @@ function muiSelect(page: Page, label: string) {
 }
 
 /** Navigate to the mock observation detail page. */
-async function navigateToDetail(page: any, _expectFn: any) {
+async function navigateToDetail(page: Page) {
   await navigateToMockedDetail(page);
 }
 
 test.describe("Interactions - Logged Out", () => {
   // TC-INT-001: Login prompt
   test("shows login prompt when logged out", async ({ page }) => {
-    await navigateToDetail(page, expect);
+    await navigateToDetail(page);
     await expect(page.getByText("Log in to add interactions")).toBeVisible();
   });
 });
@@ -30,13 +30,13 @@ test.describe("Interactions - Logged Out", () => {
 authTest.describe("Interactions - Logged In", () => {
   // TC-INT-002: Section visible
   authTest("Species Interactions section is visible", async ({ authenticatedPage: page }) => {
-    await navigateToDetail(page, authExpect);
+    await navigateToDetail(page);
     await authExpect(page.getByText("Species Interactions")).toBeVisible();
   });
 
   // TC-INT-003: Add button opens form
   authTest("Add button opens interaction form", async ({ authenticatedPage: page }) => {
-    await navigateToDetail(page, authExpect);
+    await navigateToDetail(page);
     // Find the Add button near the Species Interactions heading
     const addBtn = page
       .getByRole("heading", { name: "Species Interactions" })
@@ -64,7 +64,7 @@ authTest.describe("Interactions - Logged In", () => {
         }
         return route.continue();
       });
-      await navigateToDetail(page, authExpect);
+      await navigateToDetail(page);
       const addBtn = page
         .getByRole("heading", { name: "Species Interactions" })
         .locator("xpath=ancestor::div[1]")
@@ -75,7 +75,7 @@ authTest.describe("Interactions - Logged In", () => {
       await page.getByLabel("Other organism (Subject B)").fill("Apis mellifera");
 
       const postRequest = page.waitForRequest(
-        (req: any) => req.method() === "POST" && req.url().includes("/api/interactions"),
+        (req: Request) => req.method() === "POST" && req.url().includes("/api/interactions"),
       );
       await page.getByRole("button", { name: "Add Interaction" }).click();
       const req = await postRequest;
@@ -86,7 +86,7 @@ authTest.describe("Interactions - Logged In", () => {
 
   // TC-INT-005: Cancel closes form
   authTest("Cancel closes the interaction form", async ({ authenticatedPage: page }) => {
-    await navigateToDetail(page, authExpect);
+    await navigateToDetail(page);
     const addBtn = page
       .getByRole("heading", { name: "Species Interactions" })
       .locator("xpath=ancestor::div[1]")

--- a/tests/observation-detail.spec.ts
+++ b/tests/observation-detail.spec.ts
@@ -1,8 +1,8 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { navigateToMockedDetail } from "./helpers/mock-observation";
 
 /** Navigate to the mock observation detail page. */
-async function navigateToDetail(page: any) {
+async function navigateToDetail(page: Page) {
   await navigateToMockedDetail(page);
 }
 

--- a/tests/profile.spec.ts
+++ b/tests/profile.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page, type Route } from "@playwright/test";
 import {
   mockOwnObservationFeed,
   mockObservationDetailRoute,
@@ -6,11 +6,11 @@ import {
 } from "./helpers/mock-observation";
 
 /** Navigate from explore grid to an observation detail page, then to the observer's profile. */
-async function navigateToProfile(page: any) {
+async function navigateToProfile(page: Page) {
   await mockOwnObservationFeed(page);
   await mockObservationDetailRoute(page);
   await mockInteractionsRoute(page);
-  await page.route("**/api/profiles/*", (route: any) =>
+  await page.route("**/api/profiles/*", (route: Route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
@@ -23,14 +23,14 @@ async function navigateToProfile(page: any) {
       }),
     }),
   );
-  await page.route("**/api/feeds/profile/**", (route: any) =>
+  await page.route("**/api/feeds/profile/**", (route: Route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",
       body: JSON.stringify({ occurrences: [], cursor: null }),
     }),
   );
-  await page.route("**/api/identifications/by-observer/**", (route: any) =>
+  await page.route("**/api/identifications/by-observer/**", (route: Route) =>
     route.fulfill({
       status: 200,
       contentType: "application/json",


### PR DESCRIPTION
## Summary

Five spec files had navigation helpers and \`waitForRequest\`/\`route\` callbacks typed as \`any\`, silently discarding all Playwright type safety. Replaced with the imported \`Page\`/\`Route\`/\`Request\` types.

Files touched:
- \`tests/identification.spec.ts\`
- \`tests/profile.spec.ts\`
- \`tests/comments.spec.ts\`
- \`tests/observation-detail.spec.ts\`
- \`tests/interactions.spec.ts\`

Also removed the unused \`_expectFn\` parameter from \`navigateToDetail\` in \`comments.spec.ts\` and \`interactions.spec.ts\` — it was never used and call sites passed the top-level \`expect\` for no reason.

## Test plan

- [ ] \`npx tsc\` passes
- [ ] e2e integration suite still passes