### PR TITLE
Replace strip_prefix().unwrap() with if-let pattern

### DIFF
--- a/crates/atproto-identity/src/resolver.rs
+++ b/crates/atproto-identity/src/resolver.rs
@@ -156,8 +156,8 @@ impl IdentityResolver {
     async fn get_did_document(&self, did: &str) -> Option<DidDocument> {
         let url = if did.starts_with("did:plc:") {
             format!("https://plc.directory/{did}")
-        } else if did.starts_with("did:web:") {
-            let domain = did.strip_prefix("did:web:").unwrap().replace("%3A", ":");
+        } else if let Some(rest) = did.strip_prefix("did:web:") {
+            let domain = rest.replace("%3A", ":");
             format!("https://{domain}/.well-known/did.json")
         } else {
             return None;

--- a/crates/observing-ingester/src/bin/backfill.rs
+++ b/crates/observing-ingester/src/bin/backfill.rs
@@ -91,8 +91,8 @@ fn did_from_uri(uri: &str) -> Option<&str> {
 async fn resolve_pds(client: &Client, did: &str) -> Option<String> {
     let url = if did.starts_with("did:plc:") {
         format!("https://plc.directory/{did}")
-    } else if did.starts_with("did:web:") {
-        let domain = did.strip_prefix("did:web:").unwrap().replace("%3A", ":");
+    } else if let Some(rest) = did.strip_prefix("did:web:") {
+        let domain = rest.replace("%3A", ":");
         format!("https://{domain}/.well-known/did.json")
     } else {
         return None;


### PR DESCRIPTION
## Summary
- Two call sites in DID document resolution used `did.starts_with(\"did:web:\")` immediately followed by `did.strip_prefix(\"did:web:\").unwrap()`.
- The unwraps are technically safe today — the `starts_with` check guarantees them — but having the prefix check and extraction as two separate calls is fragile to refactoring (change one, forget the other, get a runtime panic).
- Replaced with `if let Some(rest) = did.strip_prefix(\"did:web:\")` so there is a single source of truth for both the check and the captured suffix.

Affected files:
- `crates/atproto-identity/src/resolver.rs` — `get_did_document()`
- `crates/observing-ingester/src/bin/backfill.rs` — `resolve_pds()`

## Test plan
- [x] `cargo check -p atproto-identity -p observing-ingester` passes
- [ ] CI green