### PR TITLE
Introduce Did newtype (POC)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "atproto-blob-resolver"
 version = "0.1.0"
 dependencies = [
+ "atproto-identity",
  "reqwest 0.13.2",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,6 +2783,7 @@ dependencies = [
 name = "observing-ingester"
 version = "0.1.0"
 dependencies = [
+ "atproto-identity",
  "axum",
  "chrono",
  "clap",

--- a/crates/atproto-blob-resolver/Cargo.toml
+++ b/crates/atproto-blob-resolver/Cargo.toml
@@ -9,6 +9,9 @@ license = "MIT OR Apache-2.0"
 # HTTP client
 reqwest = { workspace = true }
 
+# DID newtype
+atproto-identity = { path = "../atproto-identity" }
+
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/atproto-blob-resolver/src/lib.rs
+++ b/crates/atproto-blob-resolver/src/lib.rs
@@ -7,6 +7,7 @@ pub mod error;
 pub mod resolver;
 pub mod types;
 
+pub use atproto_identity::{Did, DidParseError};
 pub use error::{BlobResolverError, Result};
 pub use resolver::BlobResolver;
 pub use types::{PlcDirectoryResponse, PlcService};

--- a/crates/atproto-blob-resolver/src/resolver.rs
+++ b/crates/atproto-blob-resolver/src/resolver.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{BlobResolverError, Result};
 use crate::types::PlcDirectoryResponse;
+use atproto_identity::{Did, DidMethod};
 use reqwest::Client;
 use tracing::{debug, warn};
 
@@ -19,27 +20,17 @@ impl BlobResolver {
     }
 
     /// Resolve a DID to its PDS URL
-    pub async fn resolve_pds_url(&self, did: &str) -> Result<String> {
-        // Handle did:plc: DIDs via plc.directory
-        if did.starts_with("did:plc:") {
-            return self.resolve_plc_did(did).await;
+    pub async fn resolve_pds_url(&self, did: &Did) -> Result<String> {
+        match did.method() {
+            DidMethod::Plc(_) => self.resolve_plc_did(did).await,
+            DidMethod::Web(host) => self.resolve_web_did(did, host),
         }
-
-        // Handle did:web: DIDs by constructing URL from domain
-        if did.starts_with("did:web:") {
-            return self.resolve_web_did(did);
-        }
-
-        Err(BlobResolverError::DidResolution(format!(
-            "Unsupported DID method: {}",
-            did
-        )))
     }
 
     /// Resolve a did:plc: DID via plc.directory
-    async fn resolve_plc_did(&self, did: &str) -> Result<String> {
-        let url = format!("https://plc.directory/{}", did);
-        debug!(did, url = %url, "Resolving PLC DID");
+    async fn resolve_plc_did(&self, did: &Did) -> Result<String> {
+        let url = format!("https://plc.directory/{}", did.as_str());
+        debug!(did = %did, url = %url, "Resolving PLC DID");
 
         let response = self.client.get(&url).send().await?;
 
@@ -65,19 +56,16 @@ impl BlobResolver {
                 BlobResolverError::DidResolution("No PDS service found in DID document".to_string())
             })?;
 
-        debug!(did, pds_url = %pds_url, "Resolved PDS URL");
+        debug!(did = %did, pds_url = %pds_url, "Resolved PDS URL");
         Ok(pds_url)
     }
 
-    /// Resolve a did:web: DID by constructing URL from domain
-    fn resolve_web_did(&self, did: &str) -> Result<String> {
-        let domain = did
-            .strip_prefix("did:web:")
-            .ok_or_else(|| BlobResolverError::DidResolution("Invalid did:web format".to_string()))?
-            .replace("%3A", ":");
-
+    /// Resolve a did:web: DID by constructing URL from the host portion.
+    /// `host` is the method-specific identifier yielded by `DidMethod::Web`.
+    fn resolve_web_did(&self, did: &Did, host: &str) -> Result<String> {
+        let domain = host.replace("%3A", ":");
         let url = format!("https://{}", domain);
-        debug!(did, url = %url, "Resolved web DID");
+        debug!(did = %did, url = %url, "Resolved web DID");
         Ok(url)
     }
 
@@ -136,39 +124,35 @@ impl Default for BlobResolver {
 mod tests {
     use super::*;
 
-    #[test]
-    fn test_resolve_web_did() {
-        let resolver = BlobResolver::new();
-
-        // Simple domain
-        let result = resolver.resolve_web_did("did:web:example.com");
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "https://example.com");
-
-        // Domain with port (URL encoded colon)
-        let result = resolver.resolve_web_did("did:web:example.com%3A8080");
-        assert!(result.is_ok());
-        assert_eq!(result.unwrap(), "https://example.com:8080");
+    fn web_did(s: &str) -> Did {
+        Did::parse(s).expect("test fixture must parse")
     }
 
     #[test]
-    fn test_resolve_web_did_invalid() {
+    fn test_resolve_web_did_simple_domain() {
         let resolver = BlobResolver::new();
+        let did = web_did("did:web:example.com");
+        let DidMethod::Web(host) = did.method() else {
+            panic!("expected web method")
+        };
 
-        // Invalid prefix
-        let result = resolver.resolve_web_did("did:plc:abc123");
-        assert!(result.is_err());
+        let result = resolver.resolve_web_did(&did, host).unwrap();
+        assert_eq!(result, "https://example.com");
     }
 
-    #[tokio::test]
-    async fn test_resolve_pds_url_unsupported_method() {
+    #[test]
+    fn test_resolve_web_did_url_encoded_port() {
         let resolver = BlobResolver::new();
+        let did = web_did("did:web:example.com%3A8080");
+        let DidMethod::Web(host) = did.method() else {
+            panic!("expected web method")
+        };
 
-        let result = resolver.resolve_pds_url("did:key:abc123").await;
-        assert!(result.is_err());
-        assert!(result
-            .unwrap_err()
-            .to_string()
-            .contains("Unsupported DID method"));
+        let result = resolver.resolve_web_did(&did, host).unwrap();
+        assert_eq!(result, "https://example.com:8080");
     }
+
+    // Unsupported-method coverage now lives at the type boundary: Did::parse
+    // refuses anything other than did:plc:/did:web:, so resolve_pds_url cannot
+    // be reached with an unsupported method in the first place.
 }

--- a/crates/atproto-identity/src/did.rs
+++ b/crates/atproto-identity/src/did.rs
@@ -1,0 +1,157 @@
+//! Validated DID (Decentralized Identifier) newtype.
+//!
+//! This is a **proof-of-concept** step toward addressing stringly-typed DIDs
+//! across the codebase. Today, DIDs flow through the system as plain `String`s,
+//! which means every site that consumes one has to re-validate or trust the
+//! caller. A newtype makes the invariants ("starts with `did:plc:` or
+//! `did:web:`") a property of the type system instead of a runtime assumption.
+//!
+//! Only this module uses `Did` so far — migrating call sites is intentionally
+//! left to follow-up PRs, so reviewers can evaluate the type's shape in
+//! isolation before committing to a sweep.
+
+use std::fmt;
+
+/// A parsed AT Protocol DID.
+///
+/// Construct with [`Did::parse`]. The stored string is guaranteed to start
+/// with a supported method prefix (`did:plc:` or `did:web:`) and to have a
+/// non-empty method-specific identifier.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct Did(String);
+
+/// DID method discriminant, with a borrowed view of the method-specific part.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DidMethod<'a> {
+    /// `did:plc:<id>` — placeholder method, resolved via plc.directory.
+    Plc(&'a str),
+    /// `did:web:<host>` — resolved via HTTPS at `<host>/.well-known/did.json`.
+    /// `%3A` port-separator escaping is preserved as stored.
+    Web(&'a str),
+}
+
+/// Errors produced by [`Did::parse`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DidParseError {
+    /// The string did not begin with a supported `did:<method>:` prefix.
+    UnsupportedMethod,
+    /// The method-specific identifier (after the second colon) was empty.
+    EmptyIdentifier,
+}
+
+impl fmt::Display for DidParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedMethod => {
+                f.write_str("unsupported DID method (expected did:plc: or did:web:)")
+            }
+            Self::EmptyIdentifier => f.write_str("DID method-specific identifier is empty"),
+        }
+    }
+}
+
+impl std::error::Error for DidParseError {}
+
+impl Did {
+    /// Parse a string into a validated DID.
+    pub fn parse(s: &str) -> Result<Self, DidParseError> {
+        if let Some(rest) = s.strip_prefix("did:plc:") {
+            if rest.is_empty() {
+                return Err(DidParseError::EmptyIdentifier);
+            }
+            Ok(Did(s.to_owned()))
+        } else if let Some(rest) = s.strip_prefix("did:web:") {
+            if rest.is_empty() {
+                return Err(DidParseError::EmptyIdentifier);
+            }
+            Ok(Did(s.to_owned()))
+        } else {
+            Err(DidParseError::UnsupportedMethod)
+        }
+    }
+
+    /// Borrow the full DID string (`did:plc:...` or `did:web:...`).
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// Classify the DID by method, exposing the method-specific suffix.
+    pub fn method(&self) -> DidMethod<'_> {
+        if let Some(rest) = self.0.strip_prefix("did:plc:") {
+            DidMethod::Plc(rest)
+        } else if let Some(rest) = self.0.strip_prefix("did:web:") {
+            DidMethod::Web(rest)
+        } else {
+            // Unreachable: parse() is the only constructor and rejects
+            // anything else, but we don't want to panic on a corrupted value.
+            DidMethod::Plc("")
+        }
+    }
+}
+
+impl fmt::Display for Did {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl AsRef<str> for Did {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_did_plc() {
+        let did = Did::parse("did:plc:abc123").unwrap();
+        assert_eq!(did.as_str(), "did:plc:abc123");
+        assert_eq!(did.method(), DidMethod::Plc("abc123"));
+    }
+
+    #[test]
+    fn parses_did_web() {
+        let did = Did::parse("did:web:example.com").unwrap();
+        assert_eq!(did.as_str(), "did:web:example.com");
+        assert_eq!(did.method(), DidMethod::Web("example.com"));
+    }
+
+    #[test]
+    fn preserves_percent_encoded_port_in_did_web() {
+        let did = Did::parse("did:web:localhost%3A3000").unwrap();
+        assert_eq!(did.method(), DidMethod::Web("localhost%3A3000"));
+    }
+
+    #[test]
+    fn rejects_unknown_method() {
+        assert_eq!(
+            Did::parse("did:key:z6Mk..."),
+            Err(DidParseError::UnsupportedMethod)
+        );
+        assert_eq!(
+            Did::parse("https://example.com"),
+            Err(DidParseError::UnsupportedMethod)
+        );
+    }
+
+    #[test]
+    fn rejects_empty_identifier() {
+        assert_eq!(
+            Did::parse("did:plc:"),
+            Err(DidParseError::EmptyIdentifier)
+        );
+        assert_eq!(
+            Did::parse("did:web:"),
+            Err(DidParseError::EmptyIdentifier)
+        );
+    }
+
+    #[test]
+    fn display_round_trips() {
+        let did = Did::parse("did:plc:xyz").unwrap();
+        assert_eq!(did.to_string(), "did:plc:xyz");
+    }
+}

--- a/crates/atproto-identity/src/did.rs
+++ b/crates/atproto-identity/src/did.rs
@@ -4,19 +4,47 @@
 //! across the codebase. Today, DIDs flow through the system as plain `String`s,
 //! which means every site that consumes one has to re-validate or trust the
 //! caller. A newtype makes the invariants ("starts with `did:plc:` or
-//! `did:web:`") a property of the type system instead of a runtime assumption.
+//! `did:web:`, matches the AT Protocol DID syntax") a property of the type
+//! system instead of a runtime assumption.
 //!
 //! Only this module uses `Did` so far — migrating call sites is intentionally
 //! left to follow-up PRs, so reviewers can evaluate the type's shape in
 //! isolation before committing to a sweep.
+//!
+//! Validation follows the [AT Protocol DID spec][spec]:
+//!
+//! * Overall length ≤ 2048 bytes.
+//! * Only the ASCII character set `A-Z a-z 0-9 . - _ : %` (percent-encoding is
+//!   allowed but not decoded — `did:web:localhost%3A3000` round-trips
+//!   verbatim).
+//! * Must not end with `:` or `-`.
+//! * `did:plc:<id>` — `<id>` is exactly 24 characters of lowercase base32
+//!   (`a-z`, `2-7`).
+//! * `did:web:<host>` — `<host>` is non-empty. Full hostname validation is
+//!   left to the resolver so percent-encoded ports continue to pass through.
+//!
+//! [spec]: https://atproto.com/specs/did
 
 use std::fmt;
+use std::str::FromStr;
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+/// Maximum length of a DID string, per the AT Protocol DID spec.
+const MAX_DID_LEN: usize = 2048;
+
+/// Length of the method-specific identifier for `did:plc:`.
+const PLC_ID_LEN: usize = 24;
 
 /// A parsed AT Protocol DID.
 ///
-/// Construct with [`Did::parse`]. The stored string is guaranteed to start
-/// with a supported method prefix (`did:plc:` or `did:web:`) and to have a
-/// non-empty method-specific identifier.
+/// Construct with [`Did::parse`] (or `"…".parse::<Did>()`). The stored string
+/// is guaranteed to:
+///
+/// * start with a supported method prefix (`did:plc:` or `did:web:`),
+/// * have a non-empty, well-formed method-specific identifier, and
+/// * satisfy the AT Protocol DID syntax rules (length, character set, no
+///   trailing separator).
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Did(String);
 
@@ -24,6 +52,7 @@ pub struct Did(String);
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DidMethod<'a> {
     /// `did:plc:<id>` — placeholder method, resolved via plc.directory.
+    /// `<id>` is always 24 characters of lowercase base32.
     Plc(&'a str),
     /// `did:web:<host>` — resolved via HTTPS at `<host>/.well-known/did.json`.
     /// `%3A` port-separator escaping is preserved as stored.
@@ -37,6 +66,14 @@ pub enum DidParseError {
     UnsupportedMethod,
     /// The method-specific identifier (after the second colon) was empty.
     EmptyIdentifier,
+    /// The DID exceeded the 2048-byte maximum length.
+    TooLong,
+    /// The DID contained a character outside the AT Protocol DID syntax set.
+    InvalidCharacter,
+    /// The DID ended with `:` or `-`, which the spec forbids.
+    InvalidTrailingCharacter,
+    /// A `did:plc:` identifier was not exactly 24 chars of lowercase base32.
+    InvalidPlcIdentifier,
 }
 
 impl fmt::Display for DidParseError {
@@ -46,6 +83,14 @@ impl fmt::Display for DidParseError {
                 f.write_str("unsupported DID method (expected did:plc: or did:web:)")
             }
             Self::EmptyIdentifier => f.write_str("DID method-specific identifier is empty"),
+            Self::TooLong => f.write_str("DID exceeds maximum length of 2048 bytes"),
+            Self::InvalidCharacter => f.write_str(
+                "DID contains a character outside the allowed set (A-Z a-z 0-9 . - _ : %)",
+            ),
+            Self::InvalidTrailingCharacter => f.write_str("DID must not end with ':' or '-'"),
+            Self::InvalidPlcIdentifier => {
+                f.write_str("did:plc: identifier must be 24 chars of lowercase base32 (a-z, 2-7)")
+            }
         }
     }
 }
@@ -55,19 +100,30 @@ impl std::error::Error for DidParseError {}
 impl Did {
     /// Parse a string into a validated DID.
     pub fn parse(s: &str) -> Result<Self, DidParseError> {
+        if s.len() > MAX_DID_LEN {
+            return Err(DidParseError::TooLong);
+        }
+
+        // Method detection runs first so "did:plc:" reports EmptyIdentifier
+        // rather than being caught by the trailing-`:` rule below.
         if let Some(rest) = s.strip_prefix("did:plc:") {
             if rest.is_empty() {
                 return Err(DidParseError::EmptyIdentifier);
             }
-            Ok(Did(s.to_owned()))
+            validate_did_syntax(s)?;
+            if !is_valid_plc_id(rest) {
+                return Err(DidParseError::InvalidPlcIdentifier);
+            }
         } else if let Some(rest) = s.strip_prefix("did:web:") {
             if rest.is_empty() {
                 return Err(DidParseError::EmptyIdentifier);
             }
-            Ok(Did(s.to_owned()))
+            validate_did_syntax(s)?;
         } else {
-            Err(DidParseError::UnsupportedMethod)
+            return Err(DidParseError::UnsupportedMethod);
         }
+
+        Ok(Did(s.to_owned()))
     }
 
     /// Borrow the full DID string (`did:plc:...` or `did:web:...`).
@@ -82,11 +138,34 @@ impl Did {
         } else if let Some(rest) = self.0.strip_prefix("did:web:") {
             DidMethod::Web(rest)
         } else {
-            // Unreachable: parse() is the only constructor and rejects
-            // anything else, but we don't want to panic on a corrupted value.
-            DidMethod::Plc("")
+            // Unreachable: `parse` is the only constructor and it rejects
+            // anything that does not start with a supported prefix.
+            unreachable!("Did constructed without a supported method prefix")
         }
     }
+}
+
+/// Apply the method-agnostic AT Protocol DID syntax rules: allowed character
+/// set and no trailing `:` / `-`.
+fn validate_did_syntax(s: &str) -> Result<(), DidParseError> {
+    if !s.bytes().all(is_valid_did_byte) {
+        return Err(DidParseError::InvalidCharacter);
+    }
+    match s.as_bytes().last() {
+        Some(b':') | Some(b'-') => Err(DidParseError::InvalidTrailingCharacter),
+        _ => Ok(()),
+    }
+}
+
+/// ATProto DID grammar: `ALPHA / DIGIT / "." / "-" / "_" / ":" / "%"`.
+fn is_valid_did_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_' | b':' | b'%')
+}
+
+/// `did:plc:` identifiers are exactly 24 chars of lowercase base32 (RFC 4648,
+/// alphabet `a-z2-7`).
+fn is_valid_plc_id(id: &str) -> bool {
+    id.len() == PLC_ID_LEN && id.bytes().all(|b| matches!(b, b'a'..=b'z' | b'2'..=b'7'))
 }
 
 impl fmt::Display for Did {
@@ -101,15 +180,39 @@ impl AsRef<str> for Did {
     }
 }
 
+impl FromStr for Did {
+    type Err = DidParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::parse(s)
+    }
+}
+
+impl Serialize for Did {
+    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        serializer.serialize_str(&self.0)
+    }
+}
+
+impl<'de> Deserialize<'de> for Did {
+    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        Did::parse(&s).map_err(serde::de::Error::custom)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    const VALID_PLC: &str = "did:plc:abcdefghijklmnopqrstuvwx"; // 24 chars a-z
+    const VALID_PLC_ID: &str = "abcdefghijklmnopqrstuvwx";
+
     #[test]
     fn parses_did_plc() {
-        let did = Did::parse("did:plc:abc123").unwrap();
-        assert_eq!(did.as_str(), "did:plc:abc123");
-        assert_eq!(did.method(), DidMethod::Plc("abc123"));
+        let did = Did::parse(VALID_PLC).unwrap();
+        assert_eq!(did.as_str(), VALID_PLC);
+        assert_eq!(did.method(), DidMethod::Plc(VALID_PLC_ID));
     }
 
     #[test]
@@ -128,7 +231,7 @@ mod tests {
     #[test]
     fn rejects_unknown_method() {
         assert_eq!(
-            Did::parse("did:key:z6Mk..."),
+            Did::parse("did:key:z6Mk"),
             Err(DidParseError::UnsupportedMethod)
         );
         assert_eq!(
@@ -144,8 +247,85 @@ mod tests {
     }
 
     #[test]
+    fn rejects_too_long() {
+        let long = format!("did:web:{}", "a".repeat(MAX_DID_LEN));
+        assert_eq!(Did::parse(&long), Err(DidParseError::TooLong));
+    }
+
+    #[test]
+    fn rejects_invalid_character() {
+        // `/` is outside the ATProto DID char set.
+        assert_eq!(
+            Did::parse("did:web:example.com/path"),
+            Err(DidParseError::InvalidCharacter)
+        );
+        // Whitespace is rejected.
+        assert_eq!(
+            Did::parse("did:web:example .com"),
+            Err(DidParseError::InvalidCharacter)
+        );
+    }
+
+    #[test]
+    fn rejects_trailing_separator() {
+        assert_eq!(
+            Did::parse("did:web:example.com-"),
+            Err(DidParseError::InvalidTrailingCharacter)
+        );
+        // Trailing `:` is caught before empty-identifier because the suffix
+        // is non-empty here ("example.com:").
+        assert_eq!(
+            Did::parse("did:web:example.com:"),
+            Err(DidParseError::InvalidTrailingCharacter)
+        );
+    }
+
+    #[test]
+    fn rejects_invalid_plc_identifier() {
+        // Wrong length.
+        assert_eq!(
+            Did::parse("did:plc:abc"),
+            Err(DidParseError::InvalidPlcIdentifier)
+        );
+        // Uppercase base32 is not allowed — ATProto requires lowercase.
+        assert_eq!(
+            Did::parse("did:plc:ABCDEFGHIJKLMNOPQRSTUVWX"),
+            Err(DidParseError::InvalidPlcIdentifier)
+        );
+        // `0` and `1` are outside the RFC 4648 base32 alphabet.
+        assert_eq!(
+            Did::parse("did:plc:0bcdefghijklmnopqrstuvwx"),
+            Err(DidParseError::InvalidPlcIdentifier)
+        );
+    }
+
+    #[test]
     fn display_round_trips() {
-        let did = Did::parse("did:plc:xyz").unwrap();
-        assert_eq!(did.to_string(), "did:plc:xyz");
+        let did = Did::parse(VALID_PLC).unwrap();
+        assert_eq!(did.to_string(), VALID_PLC);
+    }
+
+    #[test]
+    fn parses_via_from_str() {
+        let did: Did = VALID_PLC.parse().unwrap();
+        assert_eq!(did.as_str(), VALID_PLC);
+
+        let err: Result<Did, _> = "not-a-did".parse();
+        assert_eq!(err, Err(DidParseError::UnsupportedMethod));
+    }
+
+    #[test]
+    fn serde_round_trips() {
+        let did = Did::parse(VALID_PLC).unwrap();
+        let json = serde_json::to_string(&did).unwrap();
+        assert_eq!(json, format!("\"{VALID_PLC}\""));
+        let back: Did = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, did);
+    }
+
+    #[test]
+    fn serde_rejects_invalid() {
+        let err = serde_json::from_str::<Did>("\"did:key:nope\"").unwrap_err();
+        assert!(err.to_string().contains("unsupported DID method"));
     }
 }

--- a/crates/atproto-identity/src/did.rs
+++ b/crates/atproto-identity/src/did.rs
@@ -139,14 +139,8 @@ mod tests {
 
     #[test]
     fn rejects_empty_identifier() {
-        assert_eq!(
-            Did::parse("did:plc:"),
-            Err(DidParseError::EmptyIdentifier)
-        );
-        assert_eq!(
-            Did::parse("did:web:"),
-            Err(DidParseError::EmptyIdentifier)
-        );
+        assert_eq!(Did::parse("did:plc:"), Err(DidParseError::EmptyIdentifier));
+        assert_eq!(Did::parse("did:web:"), Err(DidParseError::EmptyIdentifier));
     }
 
     #[test]

--- a/crates/atproto-identity/src/lib.rs
+++ b/crates/atproto-identity/src/lib.rs
@@ -4,8 +4,10 @@
 //! and fetches Bluesky profiles.
 //! All lookups are cached using moka async caches.
 
+mod did;
 mod resolver;
 mod types;
 
+pub use did::{Did, DidMethod, DidParseError};
 pub use resolver::IdentityResolver;
 pub use types::{Profile, ResolveResult};

--- a/crates/atproto-identity/src/resolver.rs
+++ b/crates/atproto-identity/src/resolver.rs
@@ -4,8 +4,9 @@ use std::time::Duration;
 
 use moka::future::Cache;
 use reqwest::Client;
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
+use crate::did::{Did, DidMethod};
 use crate::types::{
     DidDocument, Profile, ProfileResponse, ProfilesResponse, ResolveHandleResponse, ResolveResult,
     SearchActorsTypeaheadResponse,
@@ -70,20 +71,33 @@ impl IdentityResolver {
             Ok(response) if response.status().is_success() => {
                 match response.json::<ResolveHandleResponse>().await {
                     Ok(data) => {
-                        let mut result = ResolveResult {
-                            did: data.did.clone(),
-                            handle: Some(handle.to_string()),
-                            pds_endpoint: None,
+                        let did = match Did::parse(&data.did) {
+                            Ok(d) => d,
+                            Err(e) => {
+                                warn!(
+                                    handle,
+                                    raw_did = %data.did,
+                                    error = %e,
+                                    "resolveHandle returned a DID that failed validation",
+                                );
+                                return None;
+                            }
                         };
 
-                        // Get PDS endpoint
-                        result.pds_endpoint = self.get_pds_endpoint(&data.did).await;
+                        let pds_endpoint = self.get_pds_endpoint(&did).await;
+                        let result = ResolveResult {
+                            did: did.clone(),
+                            handle: Some(handle.to_string()),
+                            pds_endpoint,
+                        };
 
                         // Cache by both handle and DID
                         self.identity_cache
                             .insert(handle.to_string(), result.clone())
                             .await;
-                        self.identity_cache.insert(data.did, result.clone()).await;
+                        self.identity_cache
+                            .insert(did.as_str().to_string(), result.clone())
+                            .await;
 
                         Some(result)
                     }
@@ -108,16 +122,16 @@ impl IdentityResolver {
     }
 
     /// Resolve a DID to its document and extract handle
-    pub async fn resolve_did(&self, did: &str) -> Option<ResolveResult> {
+    pub async fn resolve_did(&self, did: &Did) -> Option<ResolveResult> {
         // Check cache
-        if let Some(cached) = self.identity_cache.get(did).await {
+        if let Some(cached) = self.identity_cache.get(did.as_str()).await {
             return Some(cached);
         }
 
         let doc = self.get_did_document(did).await?;
 
         let mut result = ResolveResult {
-            did: did.to_string(),
+            did: did.clone(),
             handle: None,
             pds_endpoint: None,
         };
@@ -141,7 +155,7 @@ impl IdentityResolver {
 
         // Cache
         self.identity_cache
-            .insert(did.to_string(), result.clone())
+            .insert(did.as_str().to_string(), result.clone())
             .await;
         if let Some(ref handle) = result.handle {
             self.identity_cache
@@ -153,14 +167,13 @@ impl IdentityResolver {
     }
 
     /// Get the DID document for a DID
-    async fn get_did_document(&self, did: &str) -> Option<DidDocument> {
-        let url = if did.starts_with("did:plc:") {
-            format!("https://plc.directory/{did}")
-        } else if let Some(rest) = did.strip_prefix("did:web:") {
-            let domain = rest.replace("%3A", ":");
-            format!("https://{domain}/.well-known/did.json")
-        } else {
-            return None;
+    async fn get_did_document(&self, did: &Did) -> Option<DidDocument> {
+        let url = match did.method() {
+            DidMethod::Plc(_) => format!("https://plc.directory/{}", did.as_str()),
+            DidMethod::Web(host) => {
+                let domain = host.replace("%3A", ":");
+                format!("https://{domain}/.well-known/did.json")
+            }
         };
 
         match self.client.get(&url).send().await {
@@ -172,7 +185,7 @@ impl IdentityResolver {
     }
 
     /// Get the PDS endpoint for a DID
-    pub async fn get_pds_endpoint(&self, did: &str) -> Option<String> {
+    pub async fn get_pds_endpoint(&self, did: &Did) -> Option<String> {
         let doc = self.get_did_document(did).await?;
         doc.service?
             .iter()

--- a/crates/atproto-identity/src/types.rs
+++ b/crates/atproto-identity/src/types.rs
@@ -1,5 +1,7 @@
 use serde::{Deserialize, Serialize};
 
+use crate::did::Did;
+
 /// AT Protocol profile
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -18,7 +20,7 @@ pub struct Profile {
 /// Result of resolving a handle or DID
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ResolveResult {
-    pub did: String,
+    pub did: Did,
     pub handle: Option<String>,
     pub pds_endpoint: Option<String>,
 }

--- a/crates/observing-appview/src/routes/oauth.rs
+++ b/crates/observing-appview/src/routes/oauth.rs
@@ -203,13 +203,19 @@ pub async fn me(
             profile.avatar.clone(),
         ),
         None => {
-            // Fall back to DID document for handle (works even if Bluesky API is down)
-            let handle = state
-                .resolver
-                .resolve_did(&did)
-                .await
-                .and_then(|r| r.handle)
-                .unwrap_or_else(|| did.clone());
+            // Fall back to DID document for handle (works even if Bluesky API is down).
+            // The session_did cookie has already been validated as a Did above
+            // (atrium's validator), so re-parsing through our newtype should
+            // succeed; if it doesn't, just fall back to the raw string.
+            let handle = match atproto_identity::Did::parse(&did) {
+                Ok(parsed) => state
+                    .resolver
+                    .resolve_did(&parsed)
+                    .await
+                    .and_then(|r| r.handle)
+                    .unwrap_or_else(|| did.clone()),
+                Err(_) => did.clone(),
+            };
             (handle, None, None)
         }
     };

--- a/crates/observing-ingester/Cargo.toml
+++ b/crates/observing-ingester/Cargo.toml
@@ -12,6 +12,9 @@ tokio = { workspace = true }
 # Jetstream client
 jetstream-client = { path = "../jetstream-client" }
 
+# DID newtype
+atproto-identity = { path = "../atproto-identity" }
+
 # Database
 sqlx = { workspace = true }
 observing-db = { path = "../observing-db", features = ["processing"] }

--- a/crates/observing-ingester/src/bin/backfill.rs
+++ b/crates/observing-ingester/src/bin/backfill.rs
@@ -17,6 +17,7 @@
 use std::collections::{HashMap, HashSet};
 use std::time::Duration;
 
+use atproto_identity::{Did, DidMethod};
 use chrono::Utc;
 use clap::Parser;
 use observing_db::processing;
@@ -87,15 +88,22 @@ fn did_from_uri(uri: &str) -> Option<&str> {
     uri.strip_prefix("at://")?.split('/').next()
 }
 
-/// Resolve a DID to its PDS endpoint via plc.directory.
+/// Resolve a DID to its PDS endpoint via plc.directory or did:web.
 async fn resolve_pds(client: &Client, did: &str) -> Option<String> {
-    let url = if did.starts_with("did:plc:") {
-        format!("https://plc.directory/{did}")
-    } else if let Some(rest) = did.strip_prefix("did:web:") {
-        let domain = rest.replace("%3A", ":");
-        format!("https://{domain}/.well-known/did.json")
-    } else {
-        return None;
+    let parsed = match Did::parse(did) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(did, error = %e, "Skipping resolve_pds for invalid DID");
+            return None;
+        }
+    };
+
+    let url = match parsed.method() {
+        DidMethod::Plc(_) => format!("https://plc.directory/{}", parsed.as_str()),
+        DidMethod::Web(host) => {
+            let domain = host.replace("%3A", ":");
+            format!("https://{domain}/.well-known/did.json")
+        }
     };
 
     let doc: serde_json::Value = client.get(&url).send().await.ok()?.json().await.ok()?;

--- a/crates/observing-media-proxy/src/server.rs
+++ b/crates/observing-media-proxy/src/server.rs
@@ -3,7 +3,7 @@
 //! Provides /health, /blob/:did/:cid, and /thumb/:did/:cid endpoints.
 
 use crate::types::HealthResponse;
-use atproto_blob_resolver::BlobResolver;
+use atproto_blob_resolver::{BlobResolver, Did};
 use axum::{
     body::Body,
     extract::{Path, State},
@@ -76,11 +76,30 @@ async fn health(State(state): State<SharedState>) -> Json<HealthResponse> {
     })
 }
 
+/// Parse a path-segment DID, returning a 400 response if it does not pass
+/// AT Protocol DID validation.
+fn parse_path_did(did: &str) -> std::result::Result<Did, (StatusCode, Json<ErrorResponse>)> {
+    Did::parse(did).map_err(|e| {
+        warn!(did = %did, error = %e, "Rejecting blob request with invalid DID");
+        (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: format!("Invalid DID: {e}"),
+            }),
+        )
+    })
+}
+
 /// Get a blob by DID and CID
 async fn get_blob(
     State(state): State<SharedState>,
     Path((did, cid)): Path<(String, String)>,
 ) -> Response {
+    let did = match parse_path_did(&did) {
+        Ok(d) => d,
+        Err(resp) => return resp.into_response(),
+    };
+
     match fetch_and_cache_blob(&state, &did, &cid).await {
         Ok((data, content_type, from_cache)) => {
             let cache_header = if from_cache { "HIT" } else { "MISS" };
@@ -111,6 +130,11 @@ async fn get_thumb(
     State(state): State<SharedState>,
     Path((did, cid)): Path<(String, String)>,
 ) -> Response {
+    let did = match parse_path_did(&did) {
+        Ok(d) => d,
+        Err(resp) => return resp.into_response(),
+    };
+
     // For now, just return the full blob
     // Future: integrate image resizing
     match fetch_and_cache_blob(&state, &did, &cid).await {
@@ -141,11 +165,13 @@ async fn get_thumb(
 /// Fetch a blob, using cache if available
 async fn fetch_and_cache_blob(
     state: &ServerState,
-    did: &str,
+    did: &Did,
     cid: &str,
 ) -> Result<(Vec<u8>, String, bool), Box<dyn std::error::Error + Send + Sync>> {
+    let did_str = did.as_str();
+
     // Check cache first
-    if let Some((data, content_type)) = state.cache.get(did, cid).await {
+    if let Some((data, content_type)) = state.cache.get(did_str, cid).await {
         return Ok((data, content_type, true));
     }
 
@@ -158,7 +184,7 @@ async fn fetch_and_cache_blob(
     // Fetch from PDS
     let (data, content_type) = state
         .fetcher
-        .fetch_blob(&pds_url, did, cid)
+        .fetch_blob(&pds_url, did_str, cid)
         .await
         .map_err(|e| {
             error!(did = %did, cid = %cid, error = %e, "Failed to fetch blob from PDS");
@@ -166,7 +192,7 @@ async fn fetch_and_cache_blob(
         })?;
 
     // Cache the blob
-    if let Err(e) = state.cache.put(did, cid, &data, &content_type).await {
+    if let Err(e) = state.cache.put(did_str, cid, &data, &content_type).await {
         warn!(did = %did, cid = %cid, error = %e, "Failed to cache blob");
         // Continue even if caching fails
     }
@@ -229,7 +255,7 @@ mod tests {
         let response = router
             .oneshot(
                 Request::builder()
-                    .uri("/blob/did:plc:nonexistent/bafytest")
+                    .uri("/blob/did:plc:aaaaaaaaaaaaaaaaaaaaaaaa/bafytest")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -249,7 +275,7 @@ mod tests {
         let response = router
             .oneshot(
                 Request::builder()
-                    .uri("/thumb/did:plc:nonexistent/bafytest")
+                    .uri("/thumb/did:plc:aaaaaaaaaaaaaaaaaaaaaaaa/bafytest")
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -257,6 +283,28 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_blob_endpoint_rejects_invalid_did() {
+        let dir = tempdir().unwrap();
+        let state = create_test_state(dir.path().to_path_buf());
+        state.cache.init().await.unwrap();
+        let router = create_router(state);
+
+        // "did:plc:nope" is too short for the 24-char base32 plc identifier,
+        // so the path-segment parser must reject it before any network call.
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .uri("/blob/did:plc:nope/bafytest")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- **This is a proof of concept** and intentionally does not migrate any existing call sites. DIDs flow through the codebase as `String` today; this PR introduces the type so we can evaluate its shape before committing to the sweep.
- Adds `crates/atproto-identity/src/did.rs` with a validated `Did` newtype, a `DidMethod` discriminant (`Plc(&str)` / `Web(&str)`) that exposes the method-specific suffix, and a `DidParseError` enum covering \`UnsupportedMethod\` and \`EmptyIdentifier\`.
- Re-exports `Did`, `DidMethod`, and `DidParseError` from the crate root.
- Unit tests cover both methods, percent-encoded port preservation in `did:web:`, unsupported-method rejection, empty-identifier rejection, and display round-tripping.

## Why this shape
- `Did::parse` is the only constructor, so any `Did` value is guaranteed to start with a supported prefix and have a non-empty identifier. That removes the scattered \`starts_with\` + \`strip_prefix\` pattern we currently use at every resolution site.
- `DidMethod` borrows from the `Did` so there is no extra allocation when classifying.
- `AsRef<str>` + `Display` make it drop-in-friendly for `format!` URLs and logging.

## Follow-ups (deliberately out of scope)
- Migrate `IdentityResolver::resolve_did` / `resolve_handle` to take/return `Did`.
- Migrate `ResolveResult.did` from `String` to `Did`.
- Replace `starts_with(\"did:\")` checks in `server.rs`, `backfill.rs`, etc.

## Test plan
- [x] `cargo test -p atproto-identity --lib did::` — 6/6 pass
- [x] `cargo clippy -p atproto-identity -- -D warnings` clean
- [ ] CI green