### PR TITLE
Propagate errors from SpeciesIdClient::identify

### DIFF
--- a/crates/observing-appview/src/routes/species_id.rs
+++ b/crates/observing-appview/src/routes/species_id.rs
@@ -1,6 +1,6 @@
 use axum::{extract::State, http::StatusCode, response::IntoResponse, Json};
 use serde::{Deserialize, Serialize};
-use tracing::debug;
+use tracing::{debug, error};
 
 use crate::auth::AuthUser;
 use crate::species_id_client::IdentifyResponse;
@@ -50,17 +50,20 @@ pub async fn identify(
         .identify(&body.image, body.latitude, body.longitude, body.limit)
         .await
     {
-        Some(mut response) => {
+        Ok(mut response) => {
             enrich_common_names(&state, &mut response).await;
             Json(response).into_response()
         }
-        None => (
-            StatusCode::BAD_GATEWAY,
-            Json(ErrorResponse {
-                error: "Species identification failed".into(),
-            }),
-        )
-            .into_response(),
+        Err(e) => {
+            error!(error = %e, "Species identification failed");
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse {
+                    error: "Species identification failed".into(),
+                }),
+            )
+                .into_response()
+        }
     }
 }
 

--- a/crates/observing-appview/src/species_id_client.rs
+++ b/crates/observing-appview/src/species_id_client.rs
@@ -1,7 +1,6 @@
 use reqwest::Client;
 use serde::{Deserialize, Serialize};
 use std::time::Duration;
-use tracing::error;
 use ts_rs::TS;
 
 /// HTTP client for the species identification service
@@ -62,14 +61,19 @@ impl SpeciesIdClient {
         }
     }
 
-    /// Identify species from a base64-encoded image
+    /// Identify species from a base64-encoded image.
+    ///
+    /// Errors are propagated to the caller (network failure, non-2xx status
+    /// from the upstream service, or JSON decode failure) so the route can
+    /// log them with full context instead of collapsing everything into a
+    /// generic `None`.
     pub async fn identify(
         &self,
         image_base64: &str,
         latitude: Option<f64>,
         longitude: Option<f64>,
         limit: Option<usize>,
-    ) -> Option<IdentifyResponse> {
+    ) -> Result<IdentifyResponse, reqwest::Error> {
         let url = format!("{}/identify", self.base_url);
 
         let body = IdentifyRequestBody {
@@ -79,16 +83,13 @@ impl SpeciesIdClient {
             limit: limit.unwrap_or(5),
         };
 
-        match self.client.post(&url).json(&body).send().await {
-            Ok(resp) if resp.status().is_success() => resp.json().await.ok(),
-            Ok(resp) => {
-                error!(status = %resp.status(), "Species identification request failed");
-                None
-            }
-            Err(e) => {
-                error!(error = %e, "Species identification request failed");
-                None
-            }
-        }
+        self.client
+            .post(&url)
+            .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
     }
 }


### PR DESCRIPTION
## Summary
`SpeciesIdClient::identify` previously returned `Option<IdentifyResponse>`, collapsing three distinct failure modes into one `None`:
1. Network / request errors (logged)
2. Non-2xx status from the upstream species ID service (logged)
3. **JSON decode failures on a 2xx response (silently dropped via `.ok()` with no log)**

The third case was the real problem: a malformed upstream response produced a generic 502 with zero diagnostic trail.

## Change
- Return `Result<IdentifyResponse, reqwest::Error>` from `identify`.
- Use `.error_for_status()?` to surface non-2xx as errors.
- Move logging to the route handler so it sees the real error (and we stop double-logging on network failures).
- HTTP response to the client is unchanged: still 502 Bad Gateway with the same generic message, so upstream error details do not leak to end users.

## Test plan
- [x] `cargo check -p observing-appview` passes
- [x] `cargo clippy -p observing-appview -- -D warnings` clean
- [ ] CI green