### PR TITLE
Show ancestor siblings in taxa tree

### DIFF
--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -188,8 +188,8 @@ export function TaxonExplorer() {
     [lookupKingdom],
   );
 
-  /** Merge lazily-loaded children into the tree */
-  const mergeChildren = useCallback((parentId: string, children: TaxaResult[]) => {
+  /** Add children to a parent node without rebuilding the tree (mutates nodesRef) */
+  const addChildrenToNodes = useCallback((parentId: string, children: TaxaResult[]) => {
     const nodes = nodesRef.current;
     const parent = nodes.get(parentId);
     if (!parent) return;
@@ -211,22 +211,31 @@ export function TaxonExplorer() {
         });
       }
     }
+  }, []);
 
-    // Find the root and rebuild
-    let rootId = parentId;
-    // Walk up to find the root (simple: find node with no parent)
+  /** Find the root (a node with no parent) and rebuild treeItems from it */
+  const rebuildTreeFromRoot = useCallback(() => {
+    const nodes = nodesRef.current;
     const allChildIds = new Set<string>();
     for (const n of nodes.values()) {
       for (const cid of n.childIds) allChildIds.add(cid);
     }
     for (const n of nodes.values()) {
       if (!allChildIds.has(n.id)) {
-        rootId = n.id;
-        break;
+        setTreeItems(buildItems(n.id, nodes));
+        return;
       }
     }
-    setTreeItems(buildItems(rootId, nodes));
   }, []);
+
+  /** Merge lazily-loaded children into the tree (single-parent convenience) */
+  const mergeChildren = useCallback(
+    (parentId: string, children: TaxaResult[]) => {
+      addChildrenToNodes(parentId, children);
+      rebuildTreeFromRoot();
+    },
+    [addChildrenToNodes, rebuildTreeFromRoot],
+  );
 
   // Fetch taxon data when URL changes
   useEffect(() => {
@@ -257,6 +266,33 @@ export function TaxonExplorer() {
         setTaxon(result);
         mergeIntoTree(result);
 
+        // Fetch siblings of each ancestor in parallel so the tree shows
+        // aunts/uncles (and direct siblings of the current taxon) without
+        // waiting for user interaction. Runs in the background — don't await.
+        const k = result.kingdom || lookupKingdom || "";
+        const ancestors = result.ancestors ?? [];
+        if (ancestors.length > 0) {
+          Promise.all(
+            ancestors.map(async (a) => {
+              const isKingdom = a.rank === "kingdom";
+              const ancestorId = isKingdom ? a.name : nodeId(k, a.name);
+              // Kingdom-rank ancestors are looked up with their own name as the kingdom param
+              const lookupK = isKingdom ? a.name : k;
+              try {
+                const children = await fetchTaxonChildren(lookupK, a.name);
+                return { ancestorId, children };
+              } catch {
+                return null;
+              }
+            }),
+          ).then((settled) => {
+            for (const entry of settled) {
+              if (entry) addChildrenToNodes(entry.ancestorId, entry.children);
+            }
+            rebuildTreeFromRoot();
+          });
+        }
+
         try {
           let obsResult;
           if (lookupKingdom && lookupName) {
@@ -278,7 +314,7 @@ export function TaxonExplorer() {
     }
 
     loadTaxon();
-  }, [lookupKingdom, lookupName, lookupId, mergeIntoTree]);
+  }, [lookupKingdom, lookupName, lookupId, mergeIntoTree, addChildrenToNodes, rebuildTreeFromRoot]);
 
   const handleBack = () => {
     if (window.history.length > 1) {

--- a/tests/taxon-explorer.spec.ts
+++ b/tests/taxon-explorer.spec.ts
@@ -1,0 +1,181 @@
+import { test, expect, type Page, type Route } from "@playwright/test";
+import type { TaxonAncestor } from "../frontend/src/bindings/TaxonAncestor";
+import type { TaxaResult } from "../frontend/src/bindings/TaxaResult";
+
+/**
+ * Integration test for TaxonExplorer: verifies the classification tree builds
+ * correctly for an example taxon, including aunts/uncles (siblings of each
+ * ancestor). Guards the fix for #246.
+ *
+ * The test mocks /api/taxa/** so no backend (or GBIF) is involved — it drives
+ * the real React component against fixture data that matches the ts-rs types.
+ */
+
+// ---- Fixture: Quercus agrifolia (Coast Live Oak) and its classification ----
+
+const QUERCUS_AGRIFOLIA_ANCESTORS: TaxonAncestor[] = [
+  { id: "6", name: "Plantae", rank: "kingdom" },
+  { id: "7707728", name: "Tracheophyta", rank: "phylum" },
+  { id: "220", name: "Magnoliopsida", rank: "class" },
+  { id: "1354", name: "Fagales", rank: "order" },
+  { id: "4689", name: "Fagaceae", rank: "family" },
+  { id: "2877951", name: "Quercus", rank: "genus" },
+];
+
+const QUERCUS_AGRIFOLIA_DETAIL = {
+  id: "2878289",
+  scientificName: "Quercus agrifolia",
+  commonName: "Coast Live Oak",
+  rank: "species",
+  kingdom: "Plantae",
+  phylum: "Tracheophyta",
+  class: "Magnoliopsida",
+  order: "Fagales",
+  family: "Fagaceae",
+  genus: "Quercus",
+  species: "Quercus agrifolia",
+  source: "gbif",
+  ancestors: QUERCUS_AGRIFOLIA_ANCESTORS,
+  children: [] as TaxaResult[],
+  observationCount: 0,
+  numDescendants: 0,
+};
+
+/** A named sibling at each ancestor's child rank, used to assert aunts/uncles appear. */
+const SIBLING_FIXTURES: Record<string, TaxaResult[]> = {
+  // Siblings of Tracheophyta (other phyla under Plantae)
+  Plantae: [
+    mkTaxon("7707728", "Tracheophyta", "phylum"),
+    mkTaxon("35", "Bryophyta", "phylum"),
+    mkTaxon("36", "Marchantiophyta", "phylum"),
+  ],
+  // Siblings of Magnoliopsida (other classes under Tracheophyta)
+  Tracheophyta: [
+    mkTaxon("220", "Magnoliopsida", "class"),
+    mkTaxon("196", "Liliopsida", "class"),
+    mkTaxon("194", "Pinopsida", "class"),
+  ],
+  // Siblings of Fagales (other orders under Magnoliopsida)
+  Magnoliopsida: [
+    mkTaxon("1354", "Fagales", "order"),
+    mkTaxon("1355", "Rosales", "order"),
+    mkTaxon("1356", "Asterales", "order"),
+  ],
+  // Siblings of Fagaceae (other families under Fagales)
+  Fagales: [
+    mkTaxon("4689", "Fagaceae", "family"),
+    mkTaxon("4690", "Betulaceae", "family"),
+    mkTaxon("4691", "Juglandaceae", "family"),
+  ],
+  // Siblings of Quercus (other genera under Fagaceae)
+  Fagaceae: [
+    mkTaxon("2877951", "Quercus", "genus"),
+    mkTaxon("2877952", "Fagus", "genus"),
+    mkTaxon("2877953", "Castanea", "genus"),
+  ],
+  // Siblings of Quercus agrifolia (other species under Quercus) — these are
+  // the taxon's direct siblings, which surface for free via the same fetch.
+  Quercus: [
+    mkTaxon("2878289", "Quercus agrifolia", "species"),
+    mkTaxon("2878290", "Quercus alba", "species"),
+    mkTaxon("2878291", "Quercus robur", "species"),
+  ],
+};
+
+function mkTaxon(id: string, scientificName: string, rank: string): TaxaResult {
+  return {
+    id,
+    scientificName,
+    rank,
+    kingdom: "Plantae",
+    source: "gbif",
+  };
+}
+
+// ---- Route handler ---------------------------------------------------------
+
+async function mockTaxonomyRoutes(page: Page) {
+  await page.route("**/api/taxa/**", (route: Route) => {
+    const url = new URL(route.request().url());
+    const path = url.pathname;
+
+    // /api/taxa/:kingdom/:name/children
+    const childrenMatch = path.match(/^\/api\/taxa\/[^/]+\/([^/]+)\/children$/);
+    if (childrenMatch) {
+      const name = decodeURIComponent(childrenMatch[1]!);
+      const siblings = SIBLING_FIXTURES[name] ?? [];
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(siblings),
+      });
+    }
+
+    // /api/taxa/:kingdom/:name/occurrences (with optional query string)
+    if (/^\/api\/taxa\/[^/]+\/[^/]+\/occurrences$/.test(path)) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ occurrences: [], cursor: null }),
+      });
+    }
+
+    // /api/taxa/:kingdom/:name (taxon detail)
+    if (/^\/api\/taxa\/[^/]+\/[^/]+$/.test(path)) {
+      return route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify(QUERCUS_AGRIFOLIA_DETAIL),
+      });
+    }
+
+    return route.continue();
+  });
+}
+
+// ---- Tests -----------------------------------------------------------------
+
+test.describe("Taxon Explorer - Classification tree", () => {
+  test("builds the classification tree for Quercus agrifolia with aunts/uncles", async ({
+    page,
+  }) => {
+    await mockTaxonomyRoutes(page);
+    await page.goto("/taxon/Plantae/Quercus-agrifolia");
+
+    // Wait for the detail panel to render, which signals TaxonExplorer has
+    // processed the initial fetchTaxon response and kicked off sibling fetches.
+    await expect(page.getByRole("heading", { name: "Quercus agrifolia", level: 5 })).toBeVisible();
+
+    const tree = page.getByRole("tree");
+    await expect(tree).toBeVisible();
+
+    // Tree items are named "<scientificName> <rank>" (e.g. "Quercus genus").
+    // Anchoring on the rank suffix makes assertions unambiguous when a name
+    // is a prefix of another (e.g. "Quercus" vs "Quercus agrifolia").
+    const treeitem = (name: string, rank: string) =>
+      tree.getByRole("treeitem", { name: `${name} ${rank}`, exact: true });
+
+    // The full ancestor chain must be present as tree items.
+    for (const ancestor of QUERCUS_AGRIFOLIA_ANCESTORS) {
+      await expect(treeitem(ancestor.name, ancestor.rank)).toBeVisible();
+    }
+
+    // The current taxon itself.
+    await expect(treeitem("Quercus agrifolia", "species")).toBeVisible();
+
+    // Aunts/uncles: at least one sibling must appear at each ancestor level.
+    // These names are distinct from anything on the ancestor path, so their
+    // presence uniquely proves the sibling merge worked.
+    const expectedSiblings: Array<[string, string]> = [
+      ["Bryophyta", "phylum"], // sibling of Tracheophyta
+      ["Liliopsida", "class"], // sibling of Magnoliopsida
+      ["Rosales", "order"], // sibling of Fagales
+      ["Betulaceae", "family"], // sibling of Fagaceae
+      ["Fagus", "genus"], // sibling of Quercus
+      ["Quercus alba", "species"], // direct sibling of the current taxon
+    ];
+    for (const [name, rank] of expectedSiblings) {
+      await expect(treeitem(name, rank)).toBeVisible();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fetches children of each ancestor in parallel after the taxon detail loads and merges them into the classification tree, so aunts/uncles (and direct siblings) of the current taxon are visible without manual expansion.
- Splits `mergeChildren` into `addChildrenToNodes` (mutate-only) + `rebuildTreeFromRoot`, so the parallel sibling merge can update N ancestors with a single tree rebuild.
- Runs the sibling fetches in the background after `mergeIntoTree()` — doesn't block the detail panel or observations load.

Fixes #246

## Notes & caveats (not addressed here)

- The taxonomy service hardcodes `limit=20` for children (`crates/observing-taxonomy/src/server.rs:186`). For well-populated clades this may hide some aunts/uncles. Raising this is a separate change.
- Pre-existing backend quirk: `/api/taxa/animalia/Panthera/children` returns `[]`, probably tripping `is_mismatched_higher_rank` in `crates/observing-taxonomy/src/gbif.rs`. `Felis`, `Felidae`, `Quercus`, etc. all return correctly. The lazy-load code path had the same behavior before this PR.
- If the user navigates rapidly between taxa, late-arriving sibling fetches from the previous taxon will still merge into the persistent node map and trigger a rebuild. This is additive (nodes accumulate across navigations by design) and shouldn't cause visible bugs; can add a request-ID guard if flicker shows up in practice.

## Test plan

- [x] `npx tsc` clean
- [x] Manually verified on `http://localhost:5173/taxon/animalia/panthera-tigris`: tree now shows sibling phyla under Animalia, sibling classes under Chordata, sibling orders under Mammalia, sibling families under Carnivora, and sibling genera under Felidae
- [ ] Manually verify clicking a sibling in the tree still navigates correctly
- [ ] Manually verify a deep species in a large clade (e.g. an insect) to confirm no UI jank from ~7 parallel fetches
- [ ] Consider raising the `limit=20` server-side cap in a follow-up