### PR TITLE
Fix waitForURL predicate in Bluesky OAuth e2e setup

### DIFF
--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -32,13 +32,20 @@ setup("authenticate via Bluesky OAuth", async ({ page }) => {
   await page.getByRole("button", { name: "Continue" }).click();
 
   // 4. The app redirects to Bluesky's OAuth authorization page.
-  //    Wait for navigation away from our app.
-  await page.waitForURL(/(?!.*127\.0\.0\.1).*/, { timeout: 15000 });
+  //    Wait for navigation away from our app. We must use a predicate function
+  //    here — a negative-lookahead regex like /(?!.*127\.0\.0\.1).*/ matches
+  //    any URL (the engine retries at each position and finds a suffix where
+  //    the lookahead succeeds), so waitForURL would return immediately without
+  //    actually waiting for the redirect.
+  await page.waitForURL((url) => url.hostname !== "127.0.0.1" && url.hostname !== "localhost", {
+    timeout: 15000,
+  });
+  await page.waitForLoadState("domcontentloaded");
 
   // 5. Handle the Bluesky sign-in page.
   //    The identifier is pre-filled and disabled. Just fill the password.
   const passwordField = page.locator('input[name="password"]');
-  await expect(passwordField).toBeVisible({ timeout: 10000 });
+  await expect(passwordField).toBeVisible({ timeout: 15000 });
   await passwordField.fill(password);
 
   // 6. Click "Sign in"


### PR DESCRIPTION
## Summary

Fixes #265. Replaces a broken negative-lookahead regex in `tests/auth.setup.ts` that was causing intermittent e2e setup failures.

## Root cause

`page.waitForURL(/(?!.*127\.0\.0\.1).*/, ...)` is supposed to wait until the page navigates away from our app to Bluesky's OAuth host. But the regex is broken: negative-lookahead regexes are retried at each position, so for a URL like `http://127.0.0.1:3000/`, the engine eventually finds a suffix (e.g., the trailing `/`) where `.*127.0.0.1` can't match and `.*` matches empty. The pattern matches immediately on every URL, so `waitForURL` returns without actually waiting.

The test then races past to look for the Bluesky password field while sometimes still sitting on our own login modal in its "Connecting..." state. That's exactly what the failure screenshot from [run 24318455385](https://github.com/observ-ing/core/actions/runs/24318455385) shows — our app's login dialog, handle field disabled, submit button labelled "Connecting...", no Bluesky page in sight.

## Fix

- Replace the regex with a predicate function that actually checks `url.hostname !== "127.0.0.1" && url.hostname !== "localhost"`.
- Add a `waitForLoadState("domcontentloaded")` after the redirect so the password field has a chance to render before we assert on it.
- Bump the password-field timeout from 10s → 15s for good measure.

## Test plan

- [ ] CI e2e job passes on this PR (previously flaked on the same step).
- [ ] No change to any integration tests — they don't go through this setup.