### PR TITLE
Make taxa tree sidebar scroll independently

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -72,7 +72,7 @@ function AppContent() {
   const showLanding = !user && !isAuthLoading && location.pathname === "/";
 
   return (
-    <Box sx={{ display: "flex", flex: 1, flexDirection: "column" }}>
+    <Box sx={{ display: "flex", flex: 1, flexDirection: "column", minHeight: 0 }}>
       {!showLanding && (
         <>
           <TopBar onMobileMenuClick={handleDrawerOpen} unreadCount={unreadCount} />
@@ -107,6 +107,7 @@ function AppContent() {
           display: "flex",
           flexDirection: "column",
           overflow: "auto",
+          minHeight: 0,
         }}
       >
         <Routes>


### PR DESCRIPTION
## Summary
- On the taxa page (`TaxonExplorer`), a large classification tree was pushing the entire document down instead of scrolling inside its sidebar.
- Root cause: `main` had `flex: 1, overflow: auto` but was missing `min-height: 0`. Flex items default to `min-height: auto` (= content size), so `flex: 1` couldn't shrink `main` below content height, and `overflow: auto` was never triggered — the whole body scrolled.
- Fix: add `minHeight: 0` to the `AppContent` outer Box and `main` so they honor their flex allocation, letting the tree sidebar's existing `overflow: auto` clip and scroll.

## Test plan
- [ ] Visit `/taxon/Animalia/Canis lupus` (or any taxon with a deep classification). The tree sidebar should scroll independently; the detail panel on the right should stay in place.
- [ ] Scroll a long feed (`/explore`, `/`) and confirm nothing regresses — pages that were already using their own internal overflow (e.g. `FeedView`) still work.
- [ ] Open an observation detail page and confirm the page still scrolls as expected.