### PR TITLE
Fix spurious "Taxon not found" from racing StrictMode effect fires

### DIFF
--- a/crates/gbif-api/src/client.rs
+++ b/crates/gbif-api/src/client.rs
@@ -1,7 +1,8 @@
 //! GBIF API HTTP client
 
-use crate::error::Result;
+use crate::error::{GbifError, Result};
 use crate::types::*;
+use reqwest::StatusCode;
 use std::time::Duration;
 
 /// Client for interacting with the GBIF (Global Biodiversity Information Facility) API
@@ -117,14 +118,22 @@ impl GbifClient {
 
     /// Get detailed species information by GBIF key
     ///
+    /// Returns `Ok(None)` only on a genuine 404 (species key does not exist).
+    /// Other non-success statuses (rate limits, 5xx) become `Err(UpstreamStatus)`
+    /// so callers don't mistake transient upstream issues for "not found".
+    ///
     /// # Arguments
     /// * `key` - The GBIF species key (numeric ID)
     pub async fn get_species(&self, key: u64) -> Result<Option<SpeciesDetail>> {
         let url = format!("{}/species/{}", Self::V1_BASE_URL, key);
         let response = self.http.get(&url).send().await?;
 
-        if !response.status().is_success() {
+        let status = response.status();
+        if status == StatusCode::NOT_FOUND {
             return Ok(None);
+        }
+        if !status.is_success() {
+            return Err(GbifError::UpstreamStatus(status));
         }
 
         Ok(Some(response.json().await?))
@@ -134,6 +143,11 @@ impl GbifClient {
     ///
     /// This is the preferred method for name matching as it includes
     /// IUCN conservation status and classification hierarchy.
+    ///
+    /// `Ok(None)` is reserved for genuine "no match" responses: a 404, or a
+    /// 2xx body with no `usage` field. Transient upstream failures (429, 5xx,
+    /// timeouts) become `Err(UpstreamStatus)` so callers don't silently
+    /// cache/return "not found" when GBIF is flaky.
     ///
     /// # Arguments
     /// * `name` - Scientific name to match
@@ -154,8 +168,12 @@ impl GbifClient {
 
         let response = self.http.get(url).send().await?;
 
-        if !response.status().is_success() {
+        let status = response.status();
+        if status == StatusCode::NOT_FOUND {
             return Ok(None);
+        }
+        if !status.is_success() {
+            return Err(GbifError::UpstreamStatus(status));
         }
 
         let data: V2MatchResult = response.json().await?;

--- a/crates/gbif-api/src/error.rs
+++ b/crates/gbif-api/src/error.rs
@@ -9,6 +9,11 @@ pub enum GbifError {
     Http(reqwest::Error),
     /// Failed to parse JSON response
     Json(serde_json::Error),
+    /// GBIF returned a non-success status that is not a genuine 404.
+    /// Callers must NOT treat this as "not found" — it indicates a transient
+    /// upstream problem (rate limiting, 5xx, etc.) and should be surfaced
+    /// so the caller can retry or return an appropriate error.
+    UpstreamStatus(reqwest::StatusCode),
 }
 
 impl fmt::Display for GbifError {
@@ -16,6 +21,7 @@ impl fmt::Display for GbifError {
         match self {
             Self::Http(e) => write!(f, "GBIF HTTP error: {}", e),
             Self::Json(e) => write!(f, "GBIF JSON parse error: {}", e),
+            Self::UpstreamStatus(s) => write!(f, "GBIF upstream status: {}", s),
         }
     }
 }
@@ -25,6 +31,7 @@ impl std::error::Error for GbifError {
         match self {
             Self::Http(e) => Some(e),
             Self::Json(e) => Some(e),
+            Self::UpstreamStatus(_) => None,
         }
     }
 }

--- a/crates/observing-taxonomy/src/error.rs
+++ b/crates/observing-taxonomy/src/error.rs
@@ -8,6 +8,10 @@ pub enum TaxonomyError {
     Gbif(gbif_api::GbifError),
     /// Configuration error
     Config(String),
+    /// Upstream error surfaced via request coalescing. The original error
+    /// type (reqwest / serde_json) isn't Clone, so coalesced callers receive
+    /// a stringified copy of the failure.
+    Upstream(String),
 }
 
 impl fmt::Display for TaxonomyError {
@@ -15,6 +19,7 @@ impl fmt::Display for TaxonomyError {
         match self {
             Self::Gbif(e) => write!(f, "{}", e),
             Self::Config(msg) => write!(f, "Configuration error: {}", msg),
+            Self::Upstream(msg) => write!(f, "Upstream error: {}", msg),
         }
     }
 }
@@ -23,7 +28,7 @@ impl std::error::Error for TaxonomyError {
     fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
         match self {
             Self::Gbif(e) => Some(e),
-            Self::Config(_) => None,
+            Self::Config(_) | Self::Upstream(_) => None,
         }
     }
 }

--- a/crates/observing-taxonomy/src/gbif.rs
+++ b/crates/observing-taxonomy/src/gbif.rs
@@ -1,6 +1,6 @@
 //! GBIF-based taxonomy client with caching
 
-use crate::error::Result;
+use crate::error::{Result, TaxonomyError};
 use crate::types::*;
 use crate::wikidata::WikidataClient;
 use gbif_api::{
@@ -8,6 +8,7 @@ use gbif_api::{
 };
 use moka::future::Cache;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use std::time::Duration;
 use tracing::warn;
 
@@ -37,6 +38,10 @@ pub struct GbifClient {
 enum CachedValue {
     SearchResults(Vec<TaxonResult>),
     TaxonDetail(Box<TaxonDetail>),
+    /// Result of a by-name lookup. `None` means the name resolved to no
+    /// accepted taxon (a genuine miss), distinct from an upstream failure
+    /// which is surfaced via `Err` instead of being cached.
+    NameLookup(Option<Box<TaxonDetail>>),
     Children(Vec<TaxonResult>),
 }
 
@@ -299,8 +304,49 @@ impl GbifClient {
         Ok(Some(taxon_detail))
     }
 
-    /// Get detailed taxon information by scientific name
+    /// Get detailed taxon information by scientific name.
+    ///
+    /// Concurrent callers for the same `(kingdom, name)` pair share a single
+    /// in-flight lookup via `try_get_with`. Before this, two simultaneous
+    /// requests (e.g. React StrictMode's double-fire of an effect) each
+    /// issued their own `match_name` call, and a flaky GBIF response on one
+    /// of them surfaced as a spurious "taxon not found" — see #269.
+    ///
+    /// Successful resolutions (including genuine misses) are cached; errors
+    /// propagate to all waiters as `TaxonomyError::Upstream` and are NOT
+    /// cached, so a later retry can succeed.
     pub async fn get_by_name(
+        &self,
+        scientific_name: &str,
+        kingdom: Option<&str>,
+    ) -> Result<Option<TaxonDetail>> {
+        let cache_key = format!(
+            "by_name:{}:{}",
+            kingdom.unwrap_or(""),
+            scientific_name.to_lowercase()
+        );
+
+        let attempt: std::result::Result<CachedValue, Arc<String>> = self
+            .cache
+            .try_get_with(cache_key, async {
+                match self.get_by_name_uncached(scientific_name, kingdom).await {
+                    Ok(opt) => Ok(CachedValue::NameLookup(opt.map(Box::new))),
+                    Err(e) => Err(e.to_string()),
+                }
+            })
+            .await;
+
+        match attempt {
+            Ok(CachedValue::NameLookup(opt)) => Ok(opt.map(|b| *b)),
+            Ok(_) => unreachable!("by_name cache key always holds NameLookup"),
+            Err(arc_msg) => Err(TaxonomyError::Upstream((*arc_msg).clone())),
+        }
+    }
+
+    /// Uncached name lookup. Callers should go through `get_by_name` which
+    /// wraps this in request coalescing — this is only separated out so the
+    /// coalescing layer has a clean future to pass into `try_get_with`.
+    async fn get_by_name_uncached(
         &self,
         scientific_name: &str,
         kingdom: Option<&str>,

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -245,6 +245,12 @@ export function TaxonExplorer() {
       return;
     }
 
+    // StrictMode double-fires this effect in dev, and route changes can also
+    // re-fire it mid-load. A late response from a superseded run must not
+    // overwrite state from the current one — guard every setState behind this
+    // flag and flip it in the cleanup.
+    let cancelled = false;
+
     async function loadTaxon() {
       setLoading(true);
       setError(null);
@@ -270,10 +276,13 @@ export function TaxonExplorer() {
       try {
         result = await taxonPromise;
       } catch (e) {
+        if (cancelled) return;
         setError(e instanceof Error ? e.message : "Failed to load taxon");
         setLoading(false);
         return;
       }
+
+      if (cancelled) return;
 
       if (!result) {
         setError("Taxon not found");
@@ -282,6 +291,7 @@ export function TaxonExplorer() {
       }
 
       const obsResult = await obsPromise;
+      if (cancelled) return;
 
       setTaxon(result);
       mergeIntoTree(result);
@@ -310,6 +320,7 @@ export function TaxonExplorer() {
             }
           }),
         ).then((settled) => {
+          if (cancelled) return;
           for (const entry of settled) {
             if (entry) addChildrenToNodes(entry.ancestorId, entry.children);
           }
@@ -319,6 +330,9 @@ export function TaxonExplorer() {
     }
 
     loadTaxon();
+    return () => {
+      cancelled = true;
+    };
   }, [lookupKingdom, lookupName, lookupId, mergeIntoTree, addChildrenToNodes, rebuildTreeFromRoot]);
 
   const handleBack = () => {


### PR DESCRIPTION
## Summary

Fixes #269. When React StrictMode double-fires the `TaxonExplorer` effect (or the user navigates quickly between taxa), two identical `/api/taxa/:kingdom/:name` requests reach the appview within milliseconds. Each independently called `match_name` against GBIF, and if GBIF rate-limited or briefly failed one of them, the two requests returned inconsistent results — the user saw "Taxon not found" for a taxon that exists.

Three independent commits that each address one layer of the problem:

- **`gbif-api`** — `match_name` and `get_species` used to collapse every non-success response (429, 5xx, timeouts) into `Ok(None)`, indistinguishable from a real 404. A new `GbifError::UpstreamStatus(StatusCode)` variant is returned for non-2xx, non-404 responses so callers don't cache transient failures as "not found".
- **`observing-taxonomy`** — `get_by_name` is now wrapped in moka's `try_get_with`, keyed on `(kingdom, name)`. Concurrent callers share a single in-flight lookup and a single GBIF call. Successful resolutions (including genuine misses) are cached for the usual 30-minute TTL; errors propagate to all waiters as `TaxonomyError::Upstream` and are NOT cached so a later retry can succeed.
- **`TaxonExplorer`** — `useEffect` now captures a `cancelled` flag and checks it before every `setState` that follows an `await`, so a late response from a superseded run (rapid navigation, StrictMode) can't clobber current state. Independent from the backend coalescing fix but uncovered during the same investigation.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test -p gbif-api -p observing-taxonomy`
- [x] `cargo clippy -p gbif-api -p observing-taxonomy -- -D warnings`
- [x] `npm run fmt:check`
- [x] `npm run lint` (no new warnings)
- [x] `npx tsc --noEmit`
- [ ] Manual: navigate to `/taxon/Plantae/Quercus-agrifolia` in dev mode (StrictMode on) and confirm the detail panel renders without flashing "Taxon not found"
- [ ] Manual: rapidly click between two taxa in the tree and confirm the final display matches the last clicked taxon