### PR TITLE
Include species in ancestor chain for infraspecific taxa

### DIFF
--- a/crates/observing-taxonomy/src/gbif.rs
+++ b/crates/observing-taxonomy/src/gbif.rs
@@ -446,6 +446,7 @@ impl GbifClient {
             ("order", data.order_key, data.order.as_deref()),
             ("family", data.family_key, data.family.as_deref()),
             ("genus", data.genus_key, data.genus.as_deref()),
+            ("species", data.species_key, data.species.as_deref()),
         ];
 
         for (rank, key, name) in rank_fields {


### PR DESCRIPTION
## Summary
- `build_ancestors` stopped at `genus`, so variety/subspecies detail responses skipped the parent species.
- In the taxa explorer this crashed the page whenever a trinomial repeated the species epithet (e.g. *Castilleja densiflora* var. *densiflora*): `SimpleTreeView` saw two items with id `Plantae/Castilleja densiflora densiflora` and threw, blanking the whole `main` region.
- Added `species` to `rank_fields`. The existing `k != numeric_id` guard still excludes a species from its own ancestor list, so species-level responses are unchanged.

Fixes #271

## Test plan
- [x] `cargo build -p observing-taxonomy`
- [x] Local taxonomy service returns `species: Castilleja densiflora` in ancestors for the variety, and is unchanged for the species itself
- [x] Browser repro: https://localhost:5173/taxon/Plantae/Castilleja-densiflora → click first subspecies → variety page renders fully, zero console errors (previously white-screened with a duplicate-id error)