### PR TITLE
Require kingdom when species name has no GBIF match in upload modal

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -9,6 +9,12 @@ import { MAX_AUTOCOMPLETE_RESULTS } from "../../lib/utils";
 interface TaxaAutocompleteProps {
   value: string;
   onChange: (name: string) => void;
+  /**
+   * Fires whenever the user picks a suggestion (with the full TaxaResult)
+   * or types free text that no longer corresponds to a pick (with null).
+   * Lets callers know whether they have authoritative taxonomy data.
+   */
+  onMatchChange?: (match: TaxaResult | null) => void;
   label?: string;
   placeholder?: string;
   size?: "small" | "medium";
@@ -20,6 +26,7 @@ interface TaxaAutocompleteProps {
 export function TaxaAutocomplete({
   value,
   onChange,
+  onMatchChange,
   label = "Species Name",
   placeholder = "Search by common or scientific name...",
   size,
@@ -40,15 +47,19 @@ export function TaxaAutocomplete({
         loading={loading}
         getOptionLabel={(option) => (typeof option === "string" ? option : option.scientificName)}
         inputValue={value}
-        onInputChange={(_, v) => {
+        onInputChange={(_, v, reason) => {
           onChange(v);
+          if (reason === "input") onMatchChange?.(null);
           handleSearch(v);
         }}
         onChange={(_, v) => {
-          if (v) {
-            const name = typeof v === "string" ? v : v.scientificName;
-            onChange(name);
+          if (v && typeof v !== "string") {
+            onChange(v.scientificName);
+            onMatchChange?.(v);
             clearOptions();
+          } else if (typeof v === "string") {
+            onChange(v);
+            onMatchChange?.(null);
           }
         }}
         filterOptions={(x) => x}

--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -28,17 +28,9 @@ import { setFilters, loadInitialFeed } from "../../store/feedSlice";
 import type { FeedFilters } from "../../services/types";
 import { useDebouncedTaxaSearch } from "../../hooks/useDebouncedTaxaSearch";
 import { LocationPicker } from "../map/LocationPicker";
+import { KINGDOMS as KINGDOM_OPTIONS } from "../../lib/kingdoms";
 
-const KINGDOMS = [
-  { value: "", label: "All Kingdoms" },
-  { value: "Animalia", label: "Animals" },
-  { value: "Plantae", label: "Plants" },
-  { value: "Fungi", label: "Fungi" },
-  { value: "Bacteria", label: "Bacteria" },
-  { value: "Archaea", label: "Archaea" },
-  { value: "Protozoa", label: "Protozoa" },
-  { value: "Chromista", label: "Chromista" },
-];
+const KINGDOMS = [{ value: "", label: "All Kingdoms" }, ...KINGDOM_OPTIONS];
 
 const DEFAULT_RADIUS = 10000; // 10km
 

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -22,12 +22,14 @@ import { useAppDispatch, useAppSelector } from "../../store";
 import { closeUploadModal, addToast, consumePendingUploadFiles } from "../../store/uiSlice";
 import { submitObservation, updateObservation, fetchObservation } from "../../services/api";
 import type { ActorSearchResult } from "../../services/api";
+import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { ActorAutocomplete } from "../common/ActorAutocomplete";
 import { AiSuggestions } from "../identification/AiSuggestions";
 import { LocationPicker } from "../map/LocationPicker";
 import { getObservationUrl, getErrorMessage } from "../../lib/utils";
+import { KINGDOMS } from "../../lib/kingdoms";
 
 interface ImagePreview {
   file: File;
@@ -60,6 +62,8 @@ export function UploadModal() {
   const isEditMode = !!editingObservation;
 
   const [species, setSpecies] = useState("");
+  const [matchedTaxon, setMatchedTaxon] = useState<TaxaResult | null>(null);
+  const [kingdom, setKingdom] = useState("");
   const [license, setLicense] = useState("CC-BY-4.0");
   const [lat, setLat] = useState("");
   const [lng, setLng] = useState("");
@@ -80,6 +84,8 @@ export function UploadModal() {
     if (isOpen) {
       if (editingObservation) {
         setSpecies(editingObservation.effectiveTaxonomy?.scientificName || "");
+        setKingdom(editingObservation.effectiveTaxonomy?.kingdom || "");
+        setMatchedTaxon(null);
         if (editingObservation.eventDate) {
           setObservationDate(toDatetimeLocal(new Date(editingObservation.eventDate)));
         }
@@ -120,6 +126,8 @@ export function UploadModal() {
   const handleClose = () => {
     dispatch(closeUploadModal());
     setSpecies("");
+    setMatchedTaxon(null);
+    setKingdom("");
     setLicense("CC-BY-4.0");
     images.forEach((img) => URL.revokeObjectURL(img.preview));
     setImages([]);
@@ -294,6 +302,17 @@ export function UploadModal() {
       return;
     }
 
+    const trimmedSpecies = species.trim();
+    if (trimmedSpecies && !matchedTaxon && !kingdom) {
+      dispatch(
+        addToast({
+          message: "Please select a kingdom for the species name you entered",
+          type: "error",
+        }),
+      );
+      return;
+    }
+
     setIsSubmitting(true);
 
     try {
@@ -312,10 +331,10 @@ export function UploadModal() {
           return url.split("/").at(-1) ?? "";
         });
 
-        const trimmedSpecies = species.trim();
         const result = await updateObservation({
           uri: editingObservation.uri,
           ...(trimmedSpecies ? { scientificName: trimmedSpecies } : {}),
+          ...(trimmedSpecies && kingdom ? { kingdom } : {}),
           latitude: parseFloat(lat),
           longitude: parseFloat(lng),
           coordinateUncertaintyInMeters: uncertaintyMeters,
@@ -339,9 +358,9 @@ export function UploadModal() {
       } else {
         const eventDate = new Date(observationDate).toISOString();
 
-        const trimmedSpecies = species.trim();
         const result = await submitObservation({
           ...(trimmedSpecies ? { scientificName: trimmedSpecies } : {}),
+          ...(trimmedSpecies && kingdom ? { kingdom } : {}),
           latitude: parseFloat(lat),
           longitude: parseFloat(lng),
           coordinateUncertaintyInMeters: uncertaintyMeters,
@@ -536,7 +555,19 @@ export function UploadModal() {
 
         <TaxaAutocomplete
           value={species}
-          onChange={setSpecies}
+          onChange={(name) => {
+            setSpecies(name);
+            if (name === "") {
+              setMatchedTaxon(null);
+              setKingdom("");
+            }
+          }}
+          onMatchChange={(match) => {
+            setMatchedTaxon(match);
+            if (match?.kingdom) {
+              setKingdom(match.kingdom);
+            }
+          }}
           label="Species (optional)"
           placeholder="e.g. Eschscholzia californica - leave blank if unknown"
           bottomContent={
@@ -551,6 +582,30 @@ export function UploadModal() {
             ) : undefined
           }
         />
+
+        <FormControl
+          fullWidth
+          margin="normal"
+          required={!!species.trim() && !matchedTaxon}
+          disabled={!!matchedTaxon}
+        >
+          <InputLabel id="kingdom-label">Kingdom</InputLabel>
+          <Select
+            labelId="kingdom-label"
+            value={kingdom}
+            label="Kingdom"
+            onChange={(e) => setKingdom(e.target.value)}
+          >
+            <MenuItem value="">
+              <em>None</em>
+            </MenuItem>
+            {KINGDOMS.map((k) => (
+              <MenuItem key={k.value} value={k.value}>
+                {k.label}
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
 
         <FormControl fullWidth margin="normal">
           <InputLabel id="license-label">License</InputLabel>

--- a/frontend/src/lib/kingdoms.ts
+++ b/frontend/src/lib/kingdoms.ts
@@ -1,0 +1,9 @@
+export const KINGDOMS: ReadonlyArray<{ value: string; label: string }> = [
+  { value: "Animalia", label: "Animals" },
+  { value: "Plantae", label: "Plants" },
+  { value: "Fungi", label: "Fungi" },
+  { value: "Bacteria", label: "Bacteria" },
+  { value: "Archaea", label: "Archaea" },
+  { value: "Protozoa", label: "Protozoa" },
+  { value: "Chromista", label: "Chromista" },
+];

--- a/tests/species-input.spec.ts
+++ b/tests/species-input.spec.ts
@@ -73,4 +73,27 @@ authTest.describe("Species Input", () => {
       await authExpect(page.locator(".MuiAutocomplete-popper")).not.toBeVisible();
     },
   );
+
+  authTest(
+    "selecting an autocomplete suggestion auto-fills and disables the kingdom select",
+    async ({ authenticatedPage: page }) => {
+      await searchSpecies(page, "quercus");
+      await page.locator(".MuiAutocomplete-option").first().click();
+      const kingdomCombo = page.getByRole("combobox", { name: "Kingdom" });
+      await authExpect(kingdomCombo).toHaveText("Plants");
+      await authExpect(kingdomCombo).toHaveAttribute("aria-disabled", "true");
+    },
+  );
+
+  authTest(
+    "free-text species enables the kingdom select and clears any prior match",
+    async ({ authenticatedPage: page }) => {
+      await searchSpecies(page, "quercus");
+      await page.locator(".MuiAutocomplete-option").first().click();
+      const speciesInput = page.getByLabel(/Species/i);
+      await speciesInput.fill("My Custom Species");
+      const kingdomCombo = page.getByRole("combobox", { name: "Kingdom" });
+      await authExpect(kingdomCombo).not.toHaveAttribute("aria-disabled", "true");
+    },
+  );
 });


### PR DESCRIPTION
## Summary
- Adds an always-visible Kingdom select to the upload modal, placed directly below the species field.
- When the observer picks a GBIF suggestion, the kingdom auto-fills from the match and the select is disabled.
- When the observer keeps free-text (no GBIF match), the select is enabled and required — submit is blocked with a toast if it's empty.
- On edit, the select pre-populates from `editingObservation.effectiveTaxonomy.kingdom`.
- Factors the kingdom list into `frontend/src/lib/kingdoms.ts` so `ExploreFilterPanel` and `UploadModal` share one source of truth.
- Wires a new optional `onMatchChange(match | null)` callback into `TaxaAutocomplete`, driven by MUI Autocomplete's `reason === "input"` vs selection events, so callers can know whether they currently hold authoritative taxonomy data.

## Why
Before this change, if a user typed a free-text species name that wasn't in GBIF, the observation landed with no kingdom at all, so it couldn't be routed into the right tree branch. Now we get a kingdom either from the GBIF match or from an explicit user choice.

## Test plan
- [x] `npx tsc` clean
- [x] `npm run build` clean
- [x] `tests/species-input.spec.ts` integration — 6/6 pass (2 new tests cover disabled-when-matched and enabled-when-free-text).
- [x] `tests/upload.spec.ts` integration — 11/11 pass (no regressions).
- [x] `tests/observation-edit.spec.ts`, `tests/identification.spec.ts`, `tests/explore-filters.spec.ts` — 18/18 pass.
- [ ] Manual: submit a free-text species without picking a kingdom → blocked with toast.
- [ ] Manual: pick a GBIF suggestion → kingdom auto-fills and greys out; clearing the species re-enables it.
- [ ] Manual: edit an existing observation → kingdom pre-populates from the stored taxonomy.