### PR TITLE
Auto-fill kingdom when user presses Enter or blurs species input

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -43,6 +43,7 @@ export function TaxaAutocomplete({
     <Box>
       <Autocomplete
         freeSolo
+        autoHighlight
         options={options}
         loading={loading}
         getOptionLabel={(option) => (typeof option === "string" ? option : option.scientificName)}
@@ -58,8 +59,16 @@ export function TaxaAutocomplete({
             onMatchChange?.(v);
             clearOptions();
           } else if (typeof v === "string") {
+            // freeSolo commits typed text as a string. If it matches a loaded
+            // option (user typed the full name then blurred), surface that
+            // option so the caller can pre-fill fields like kingdom.
+            const match =
+              options.find((o) => o.scientificName === v) ??
+              options.find((o) => o.commonName === v) ??
+              null;
             onChange(v);
-            onMatchChange?.(null);
+            onMatchChange?.(match);
+            if (match) clearOptions();
           }
         }}
         filterOptions={(x) => x}

--- a/tests/helpers/mock-taxa.ts
+++ b/tests/helpers/mock-taxa.ts
@@ -3,6 +3,22 @@ import type { TaxaResult } from "../../frontend/src/bindings/TaxaResult";
 
 /** Canned taxa results keyed by query substring (lowercase). */
 const TAXA_FIXTURES: Record<string, TaxaResult[]> = {
+  cat: [
+    {
+      id: "2435035",
+      scientificName: "Felis catus",
+      commonName: "Feral Cat",
+      rank: "SPECIES",
+      kingdom: "Animalia",
+      phylum: "Chordata",
+      class: "Mammalia",
+      order: "Carnivora",
+      family: "Felidae",
+      genus: "Felis",
+      species: "Felis catus",
+      source: "gbif",
+    },
+  ],
   "california poppy": [
     {
       id: "3189396",

--- a/tests/species-input.spec.ts
+++ b/tests/species-input.spec.ts
@@ -86,6 +86,36 @@ authTest.describe("Species Input", () => {
   );
 
   authTest(
+    "searching by common name 'cat' and selecting Felis catus auto-fills Animals",
+    async ({ authenticatedPage: page }) => {
+      await searchSpecies(page, "cat");
+      await page.locator(".MuiAutocomplete-option").first().click();
+      const kingdomCombo = page.getByRole("combobox", { name: "Kingdom" });
+      await authExpect(kingdomCombo).toHaveText("Animals");
+      await authExpect(kingdomCombo).toHaveAttribute("aria-disabled", "true");
+    },
+  );
+
+  // Simulates user typing a species, seeing suggestions, then pressing Enter
+  // instead of clicking a suggestion. freeSolo mode should still auto-fill
+  // kingdom if the typed text exactly matches a loaded option.
+  authTest(
+    "typing 'Felis catus' and pressing Enter auto-fills kingdom",
+    async ({ authenticatedPage: page }) => {
+      const speciesInput = page.getByRole("combobox", { name: /Species/i });
+      await speciesInput.click();
+      await Promise.all([
+        page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
+        speciesInput.pressSequentially("cat", { delay: 50 }),
+      ]);
+      await authExpect(page.locator(".MuiAutocomplete-option").first()).toBeVisible();
+      await speciesInput.press("Enter");
+      const kingdomCombo = page.getByRole("combobox", { name: "Kingdom" });
+      await authExpect(kingdomCombo).toHaveText("Animals");
+    },
+  );
+
+  authTest(
     "free-text species enables the kingdom select and clears any prior match",
     async ({ authenticatedPage: page }) => {
       await searchSpecies(page, "quercus");


### PR DESCRIPTION
## Summary
Fixes a regression where selecting a species by typing then pressing Enter (or clicking outside the field) left the Kingdom field empty, even though the typed text matched a loaded autocomplete suggestion. Reported after #274 landed — e.g. typing \"cat\", seeing \"Felis catus\", pressing Enter → Kingdom stayed blank.

## Root cause
MUI Autocomplete in \`freeSolo\` mode treats Enter-with-no-highlighted-option (and blur) as committing the typed text as a **string**, not the highlighted option. \`TaxaAutocomplete\`'s \`onChange\` fell into the \`typeof v === \"string\"\` branch and emitted \`onMatchChange(null)\`, clearing any previously set match.

## Fix
Two changes in \`frontend/src/components/common/TaxaAutocomplete.tsx\`:

1. **\`autoHighlight\`** on the Autocomplete — the first option is highlighted as soon as suggestions arrive, so pressing Enter with the dropdown open selects that option as an object, not as a typed string.
2. **String-to-match lookup fallback** — when \`onChange\` still receives a string (e.g. blur), we look the text up against the current \`options\` (matching on \`scientificName\` then \`commonName\`) and emit the matching \`TaxaResult\` if found, so the caller still gets authoritative taxonomy data.

## Test plan
- [x] New integration test in \`tests/species-input.spec.ts\`: types \"cat\", waits for suggestions, presses Enter, asserts Kingdom reads \"Animals\". Fails without the fix, passes with it.
- [x] Added a Felis catus fixture to \`tests/helpers/mock-taxa.ts\` (kingdom Animalia).
- [x] Existing species-input, upload, observation-edit, identification, explore-filters integration tests still pass (29/29).
- [x] \`npx tsc\` clean.
- [ ] Manual smoke test on localhost.