### PR TITLE
perf(observing-db): avoid cloning bind values in feed queries

### DIFF
--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -28,19 +28,19 @@ pub async fn get_explore_feed(
         qb.push_bind(format!("{taxon}%"));
     }
 
-    if let Some(ref kingdom) = options.kingdom {
+    if let Some(kingdom) = options.kingdom.as_deref() {
         qb.push(" AND kingdom = ");
-        qb.push_bind(kingdom.clone());
+        qb.push_bind(kingdom);
     }
 
-    if let Some(ref start_date) = options.start_date {
+    if let Some(start_date) = options.start_date.as_deref() {
         qb.push(" AND event_date >= ");
-        qb.push_bind(start_date.clone());
+        qb.push_bind(start_date);
     }
 
-    if let Some(ref end_date) = options.end_date {
+    if let Some(end_date) = options.end_date.as_deref() {
         qb.push(" AND event_date <= ");
-        qb.push_bind(end_date.clone());
+        qb.push_bind(end_date);
     }
 
     if let (Some(lat), Some(lng)) = (options.lat, options.lng) {
@@ -54,9 +54,9 @@ pub async fn get_explore_feed(
         qb.push(")");
     }
 
-    if let Some(ref cursor) = options.cursor {
+    if let Some(cursor) = options.cursor.as_deref() {
         qb.push(" AND created_at < ");
-        qb.push_bind(cursor.clone());
+        qb.push_bind(cursor);
         qb.push("::timestamptz");
     }
 
@@ -238,9 +238,9 @@ pub async fn get_home_feed(
         qb.push(")");
     }
 
-    if let Some(ref cursor) = options.cursor {
+    if let Some(cursor) = options.cursor.as_deref() {
         qb.push(" AND created_at < ");
-        qb.push_bind(cursor.clone());
+        qb.push_bind(cursor);
         qb.push("::timestamptz");
     }
 
@@ -278,16 +278,16 @@ pub async fn get_occurrences_by_taxon(
         qb.push(")");
     }
 
-    if let Some(ref kingdom) = options.kingdom {
+    if let Some(kingdom) = options.kingdom.as_deref() {
         if rank_lower != "kingdom" {
             qb.push(" AND kingdom = ");
-            qb.push_bind(kingdom.clone());
+            qb.push_bind(kingdom);
         }
     }
 
-    if let Some(ref cursor) = options.cursor {
+    if let Some(cursor) = options.cursor.as_deref() {
         qb.push(" AND created_at < ");
-        qb.push_bind(cursor.clone());
+        qb.push_bind(cursor);
         qb.push("::timestamptz");
     }
 


### PR DESCRIPTION
## Summary
- `get_explore_feed` and `get_occurrences_by_taxon` were cloning `String` values out of `&ExploreFeedOptions` / `&TaxonOccurrenceOptions` just to pass them to `QueryBuilder::push_bind`.
- `push_bind` accepts `&str` directly, so we can switch `if let Some(ref x) = options.x` to `if let Some(x) = options.x.as_deref()` and avoid the clone entirely.
- Removes 7 unnecessary heap allocations per feed query on a hot path.

## Test plan
- [ ] `cargo check -p observing-db`
- [ ] `cargo test -p observing-db` (no behavioral change)