### PR TITLE
perf(file-blob-cache): move cache key into HashMap instead of cloning

### DIFF
--- a/crates/file-blob-cache/src/cache.rs
+++ b/crates/file-blob-cache/src/cache.rs
@@ -121,13 +121,13 @@ impl BlobCache {
             created_at: Utc::now(),
         };
 
-        {
-            let mut entries = self.entries.write().await;
-            entries.insert(key.clone(), entry);
-        }
-
         self.current_size.fetch_add(size, Ordering::Relaxed);
         debug!(key = %key, size, "Cached blob");
+
+        {
+            let mut entries = self.entries.write().await;
+            entries.insert(key, entry);
+        }
 
         Ok(())
     }


### PR DESCRIPTION
## Summary
- \`put\` cloned the cache key to log it after the insert. Reorder: emit the debug log first, then move the key into the HashMap.
- Removes the key clone and also shrinks the critical section since the debug log is now outside the write lock.

## Test plan
- [ ] \`cargo check -p file-blob-cache\`
- [ ] \`cargo test -p file-blob-cache\`