### PR TITLE
refactor(observing-appview): deduplicate enrich_observers via enrich_rows

### DIFF
--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -425,21 +425,19 @@ pub async fn enrich_observers(
     resolver: &IdentityResolver,
     rows: &[ObserverRow],
 ) -> Vec<ObserverInfo> {
-    let dids: Vec<String> = rows.iter().map(|r| r.did.clone()).collect();
-    let profiles = resolver.get_profiles(&dids).await;
-
-    rows.iter()
-        .map(|o| {
-            let p = profile_summary(&o.did, &profiles);
-            ObserverInfo {
-                did: o.did.clone(),
-                role: o.role.clone(),
-                handle: p.handle,
-                display_name: p.display_name,
-                avatar: p.avatar,
-            }
-        })
-        .collect()
+    enrich_rows(
+        resolver,
+        rows,
+        |r| &r.did,
+        |row, profile| ObserverInfo {
+            did: row.did.clone(),
+            role: row.role.clone(),
+            handle: profile.handle,
+            display_name: profile.display_name,
+            avatar: profile.avatar,
+        },
+    )
+    .await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- \`enrich_observers\` was the only one of the four \`enrich_*\` functions that didn't use the generic \`enrich_rows\` helper.
- Pass a builder closure to match \`enrich_identifications\`, \`enrich_comments\`, and \`enrich_interactions\`.
- Net -5 lines and removes a duplicate profile-resolution loop.

## Test plan
- [ ] \`cargo check -p observing-appview\`
- [ ] \`cargo test -p observing-appview\`