### PR TITLE
perf(frontend): hoist ConservationStatus category list to Set

### DIFF
--- a/frontend/src/components/common/ConservationStatus.tsx
+++ b/frontend/src/components/common/ConservationStatus.tsx
@@ -24,6 +24,8 @@ const CATEGORY_INFO: Record<string, { label: string; color: string }> = {
   NE: { label: "Not Evaluated", color: "#ffffff" },
 };
 
+const DARK_TEXT_CATEGORIES: ReadonlySet<string> = new Set(["VU", "NT", "LC", "DD", "NE"]);
+
 /**
  * Displays IUCN Red List conservation status as a colored badge
  */
@@ -35,7 +37,7 @@ export function ConservationStatus({
   const info = CATEGORY_INFO[status.category];
   if (!info) return null;
 
-  const needsDarkText = ["VU", "NT", "LC", "DD", "NE"].includes(status.category);
+  const needsDarkText = DARK_TEXT_CATEGORIES.has(status.category);
 
   return (
     <Chip


### PR DESCRIPTION
## Summary
- The dark-text category check was an inline array literal passed to \`.includes()\`: allocates an array of 5 strings plus an O(n) lookup on every render of every species chip.
- Hoist to a module-level \`ReadonlySet<string>\`: allocated once, O(1) \`.has()\` lookup, zero per-render cost.

## Test plan
- [ ] Species chips render with matching text color (VU/NT/LC/DD/NE get dark, EX/EW/CR/EN get light)
- [ ] \`npm run check\`