### PR TITLE
cleanup(upload-modal): use .filter() in handleRemoveImage

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -263,11 +263,9 @@ export function UploadModal() {
 
   const handleRemoveImage = (index: number) => {
     setImages((prev) => {
-      const newImages = [...prev];
-      const removed = newImages[index];
+      const removed = prev[index];
       if (removed) URL.revokeObjectURL(removed.preview);
-      newImages.splice(index, 1);
-      return newImages;
+      return prev.filter((_, i) => i !== index);
     });
   };
 


### PR DESCRIPTION
## Summary
- \`handleRemoveImage\` built a copy with spread, spliced, and returned — while the sibling \`handleRemoveExistingImage\` directly used \`prev.filter((_, i) => i !== index)\`.
- Align both handlers on \`.filter()\` for consistency and readability. Behavior unchanged; the \`revokeObjectURL\` side effect still fires before the filter.

## Test plan
- [ ] Remove an uploaded image in the upload modal; other images remain in order
- [ ] Check that object URL is still revoked (no memory leak in devtools)