### PR TITLE
typesafe(actor-autocomplete): drop 'as object' cast, destructure InputProps

### DIFF
--- a/frontend/src/components/common/ActorAutocomplete.tsx
+++ b/frontend/src/components/common/ActorAutocomplete.tsx
@@ -57,21 +57,20 @@ export function ActorAutocomplete({
       filterOptions={(x) => x}
       size="small"
       renderInput={(params) => {
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        const p = params as object;
+        const { InputProps, ...rest } = params;
         return (
           <TextField
-            {...p}
+            {...rest}
             fullWidth
             label={label}
             placeholder={placeholder}
             slotProps={{
               input: {
-                ...(params.InputProps || {}),
+                ...(InputProps || {}),
                 endAdornment: (
                   <>
                     {loading && <CircularProgress color="inherit" size={20} />}
-                    {params.InputProps?.endAdornment}
+                    {InputProps?.endAdornment}
                   </>
                 ),
               },


### PR DESCRIPTION
## Summary
- Destructure \`InputProps\` out of MUI Autocomplete \`renderInput\` params and spread the rest directly
- Removes the \`as object\` cast and its \`eslint-disable\` comment, preserving TextField prop typing

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Actor search in observer picker still shows loading spinner and dropdown correctly