### PR TITLE
typesafe(taxa-autocomplete): drop 'as object' cast, destructure InputProps

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -65,22 +65,21 @@ export function TaxaAutocomplete({
         filterOptions={(x) => x}
         {...(size ? { size } : {})}
         renderInput={(params) => {
-          // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-          const p = params as object;
+          const { InputProps, ...rest } = params;
           return (
             <TextField
-              {...p}
+              {...rest}
               fullWidth
               label={label}
               placeholder={placeholder}
               margin={margin}
               slotProps={{
                 input: {
-                  ...(params.InputProps || {}),
+                  ...(InputProps || {}),
                   endAdornment: (
                     <>
                       {loading && <CircularProgress color="inherit" size={20} />}
-                      {params.InputProps?.endAdornment}
+                      {InputProps?.endAdornment}
                     </>
                   ),
                 },


### PR DESCRIPTION
## Summary
- Destructure \`InputProps\` out of MUI Autocomplete \`renderInput\` params and spread the rest directly
- Removes the \`as object\` cast and its \`eslint-disable\` comment, preserving TextField prop typing

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Taxa search in upload modal + explore filter still shows loading spinner and dropdown correctly