### PR TITLE
typesafe(explore-filter): drop 'as object' cast on Autocomplete params

### DIFF
--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -157,13 +157,9 @@ export function ExploreFilterPanel() {
               }
             }}
             filterOptions={(x) => x}
-            renderInput={(params) => {
-              // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-              const p = params as object;
-              return (
-                <TextField {...p} size="small" label="Taxon" placeholder="Search species..." />
-              );
-            }}
+            renderInput={(params) => (
+              <TextField {...params} size="small" label="Taxon" placeholder="Search species..." />
+            )}
             renderOption={(props, option) => {
               const { key, ...otherProps } = props;
               return (


### PR DESCRIPTION
## Summary
- Spread MUI Autocomplete \`renderInput\` params directly into TextField
- Removes the \`as object\` cast and its \`eslint-disable\` comment. No InputProps override here, so no destructuring needed.

## Test plan
- [x] \`tsc --noEmit\` clean
- [ ] Explore page taxon filter still renders and searches correctly