### PR TITLE
security: bump rustls-webpki to 0.103.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3720,9 +3720,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
 dependencies = [
  "aws-lc-rs",
  "ring",


### PR DESCRIPTION
## Summary
Addresses two \`rustls-webpki\` advisories published 2026-04-15 that began failing \`rust-deny\` on all PRs entering the merge queue:

- **RUSTSEC-2026-0098** / [GHSA-965h-392x-2mh5](https://github.com/rustls/webpki/security/advisories/GHSA-965h-392x-2mh5) — name constraints for URI names were incorrectly accepted
- **RUSTSEC-2026-0099** / [GHSA-xgp8-3hg3-c2mh](https://github.com/rustls/webpki/security/advisories/GHSA-xgp8-3hg3-c2mh) — name constraints were accepted for certificates asserting a wildcard name

Bump is a patch-level \`Cargo.lock\` update only: \`0.103.10 → 0.103.12\`. No \`Cargo.toml\` changes.

## Test plan
- [x] \`cargo deny check advisories\` locally — previously FAILED with both vulnerabilities, now reports \`advisories ok\`
- [ ] CI \`rust-deny\` passes
- [ ] CI \`rust-test\` passes (sanity — TLS stack is load-bearing)