### PR TITLE
chore(observing-db): drop dead locality columns from occurrences

### DIFF
--- a/crates/observing-db/migrations/20260416000000_drop_dead_locality_columns.sql
+++ b/crates/observing-db/migrations/20260416000000_drop_dead_locality_columns.sql
@@ -1,0 +1,15 @@
+-- Drop locality / remarks columns on `occurrences` that were defined in the
+-- initial migration but are not referenced by any SELECT, INSERT, or UPDATE
+-- in the workspace, nor by the `bio.lexicons.temp.occurrence` lexicon that
+-- the ingester deserializes.
+
+ALTER TABLE occurrences DROP COLUMN IF EXISTS occurrence_remarks;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS continent;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS country;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS country_code;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS state_province;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS county;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS municipality;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS locality;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS water_body;
+ALTER TABLE occurrences DROP COLUMN IF EXISTS verbatim_locality;


### PR DESCRIPTION
## Summary
- Drops 10 columns defined in the initial migration that are never written, never read, and have no corresponding lexicon field: `occurrence_remarks`, `continent`, `country`, `country_code`, `state_province`, `county`, `municipality`, `locality`, `water_body`, `verbatim_locality`.

## Why
Verified per-column via grep across `crates/`, `lexicons/`, `frontend/src/`, and the `.sqlx` cache:
- No `INSERT`/`UPDATE`/`SELECT` references in any Rust source.
- The `bio.lexicons.temp.occurrence` lexicon does not declare any of these fields, so `processing.rs` never maps to them.
- The locality columns mirror `GeocodedLocation` in `nominatim-client`, but no other crate uses that client today — its dep on `observing-appview` is also dead (worth a follow-up cleanup).

## Test plan
- [ ] `cargo build --workspace` (passed locally)
- [ ] CI green
- [ ] Run `sqlx migrate run` against staging DB to confirm the drops apply cleanly