### PR TITLE
Add justfile for common dev commands

### DIFF
--- a/justfile
+++ b/justfile
@@ -1,0 +1,78 @@
+_default:
+    @just --list
+
+# --- process-compose ---
+
+# Start all services (detached)
+up:
+    process-compose up -D
+
+# Stop all services
+down:
+    process-compose down
+
+# List running processes
+ps:
+    process-compose process list
+
+# Tail logs for a service (cloud-sql-proxy, appview, frontend, ingester, species-id)
+logs service:
+    process-compose process logs {{service}}
+
+# Restart a service
+restart service:
+    process-compose process restart {{service}}
+
+# Rebuild static frontend and restart appview to serve it
+rebuild-appview:
+    npm run build
+    process-compose process restart appview
+
+# --- build / codegen ---
+
+# Build Rust workspace
+build-rust:
+    cargo build
+
+# Build static frontend
+build-frontend:
+    npm run build
+
+# Generate lexicon types (Rust + TypeScript)
+gen:
+    npm run generate-rust-types
+    npm run generate-types
+
+# --- format / lint ---
+
+# Format Rust + TypeScript
+fmt:
+    cargo fmt
+    npm run fmt
+
+# Check formatting + lint without modifying files (CI-equivalent)
+check:
+    cargo fmt --check
+    cargo clippy --workspace --all-targets -- -D warnings
+    npm run fmt:check
+    npm run lint
+
+# --- tests ---
+
+# Rust workspace tests
+test:
+    cargo test --workspace
+
+# Frontend integration tests (requires stack running)
+test-integration:
+    npm run test:integration
+
+# Frontend e2e tests (requires stack running + .env creds)
+test-e2e:
+    npm run test:e2e
+
+# --- scripts ---
+
+# Download BioCLIP models for species-id
+download-models:
+    ./scripts/download-models.sh


### PR DESCRIPTION
## Summary
- Adds a `justfile` that wraps the commands already documented in `docs/development.md` and `package.json`: process-compose lifecycle, codegen, fmt/lint/check, tests, and the model download script.
- `just check` runs the full CI-equivalent gate locally (`cargo fmt --check`, `clippy -D warnings`, `npm run fmt:check`, `npm run lint`) so contributors can verify before pushing.
- Does not touch `process-compose.yaml` — this is purely additive. A future PR can revisit process-compose itself.

## Test plan
- [ ] `just` (no args) lists recipes
- [ ] `just up` / `just down` / `just logs appview` behave as before
- [ ] `just check` passes on a clean main
- [ ] `just rebuild-appview` rebuilds frontend and restarts appview