### PR TITLE
ci: set ADMIN_DIDS on appview deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -327,7 +327,7 @@ jobs:
             --region=$REGION \
             --allow-unauthenticated \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b \
+            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b,ADMIN_DIDS=did:plc:vozr2os4b4sxrxr6opde5js5 \
             --set-secrets=DB_PASSWORD=observing-db-password:latest \
             --format='value(status.url)')
           echo "url=$URL" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
- Adds `ADMIN_DIDS=did:plc:vozr2os4b4sxrxr6opde5js5` (rwell.org) to the `--set-env-vars` list for the `observing-appview` Cloud Run deploy, so the admin allowlist survives subsequent deploys.
- Matches the existing `HIDDEN_DIDS` pattern — DIDs are public identifiers, not secrets.
- Previously set as a one-off via `gcloud run services update`; without this, the next merge to `main` would wipe it (since `--set-env-vars` replaces all vars).

## Notes
- The `ADMIN_DIDS` consumer lives on `feat/admin-lexicon-api` (commit 7642750) and isn't yet merged to `main`. Setting the env var on a service that doesn't read it is a no-op, so this PR is safe to merge first, last, or never.

## Test plan
- [ ] Merge this, then trigger/observe a deploy and confirm `ADMIN_DIDS` shows up in `gcloud run services describe observing-appview --region=us-central1`
- [ ] After `feat/admin-lexicon-api` merges, hit an admin endpoint as `rwell.org` and confirm it's no longer 503