### PR TITLE
feat(admin): add per-collection detail page

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -24,6 +24,7 @@ import { LexiconView } from "./components/lexicon/LexiconView";
 import { NotificationsPage } from "./components/notifications/NotificationsPage";
 import { SettingsPage } from "./components/settings/SettingsPage";
 import { AdminPage } from "./components/admin/AdminPage";
+import { CollectionDetailPage } from "./components/admin/CollectionDetailPage";
 import "./styles/global.css";
 
 function AppContent() {
@@ -122,6 +123,7 @@ function AppContent() {
           <Route path="/lexicons" element={<LexiconView />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/admin" element={<AdminPage />} />
+          <Route path="/admin/collections/:nsid" element={<CollectionDetailPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Box>

--- a/frontend/src/components/admin/AdminPage.tsx
+++ b/frontend/src/components/admin/AdminPage.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
 import {
   Alert,
   Button,
@@ -10,6 +11,7 @@ import {
   DialogContent,
   DialogTitle,
   FormControlLabel,
+  Link,
   Paper,
   Table,
   TableBody,
@@ -103,7 +105,15 @@ export function AdminPage() {
           <TableBody>
             {collections.map((c) => (
               <TableRow key={c.nsid}>
-                <TableCell sx={{ fontFamily: "monospace" }}>{c.nsid}</TableCell>
+                <TableCell sx={{ fontFamily: "monospace" }}>
+                  <Link
+                    component={RouterLink}
+                    to={`/admin/collections/${encodeURIComponent(c.nsid)}`}
+                    underline="hover"
+                  >
+                    {c.nsid}
+                  </Link>
+                </TableCell>
                 <TableCell sx={{ fontFamily: "monospace" }}>{c.table}</TableCell>
                 <TableCell align="right">{c.count.toLocaleString()}</TableCell>
                 <TableCell sx={{ fontSize: "0.8rem", color: "text.secondary" }}>

--- a/frontend/src/components/admin/CollectionDetailPage.tsx
+++ b/frontend/src/components/admin/CollectionDetailPage.tsx
@@ -1,0 +1,217 @@
+import { useEffect, useState } from "react";
+import { Link as RouterLink, useParams } from "react-router-dom";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Link,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  TextField,
+  Typography,
+} from "@mui/material";
+import { usePageTitle } from "../../hooks/usePageTitle";
+import {
+  AdminError,
+  type CollectionDetail,
+  type RecordSummary,
+  getCollection,
+  listRecords,
+} from "../../services/admin";
+
+const PAGE_SIZE = 50;
+
+export function CollectionDetailPage() {
+  const { nsid: rawNsid } = useParams<{ nsid: string }>();
+  const nsid = rawNsid ? decodeURIComponent(rawNsid) : "";
+  usePageTitle(`Admin: ${nsid}`);
+
+  const [detail, setDetail] = useState<CollectionDetail | null>(null);
+  const [records, setRecords] = useState<RecordSummary[]>([]);
+  const [offset, setOffset] = useState(0);
+  const [didFilter, setDidFilter] = useState("");
+  const [appliedDid, setAppliedDid] = useState("");
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!nsid) return;
+    setLoading(true);
+    setError(null);
+    const opts: { limit: number; offset: number; did?: string } = {
+      limit: PAGE_SIZE,
+      offset,
+    };
+    if (appliedDid) opts.did = appliedDid;
+    Promise.all([getCollection(nsid), listRecords(nsid, opts)])
+      .then(([d, r]) => {
+        setDetail(d);
+        setRecords(r.records);
+      })
+      .catch((e: unknown) => {
+        if (e instanceof AdminError) {
+          setStatus(e.status);
+          setError(e.message);
+        } else {
+          setError(e instanceof Error ? e.message : "Unknown error");
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [nsid, offset, appliedDid]);
+
+  if (loading && !detail) {
+    return (
+      <Container sx={{ py: 4, display: "flex", justifyContent: "center" }}>
+        <CircularProgress />
+      </Container>
+    );
+  }
+
+  if (error && !detail) {
+    return (
+      <Container sx={{ py: 4 }}>
+        <Alert severity={status === 403 || status === 401 ? "warning" : "error"}>
+          {status != null ? `[${status}] ` : ""}
+          {error}
+        </Alert>
+      </Container>
+    );
+  }
+
+  return (
+    <Container sx={{ py: 4 }}>
+      <Link component={RouterLink} to="/admin" underline="hover">
+        ← All collections
+      </Link>
+      <Typography variant="h4" sx={{ mt: 1, fontFamily: "monospace" }} gutterBottom>
+        {nsid}
+      </Typography>
+
+      {detail && (
+        <Paper sx={{ p: 2, mb: 3 }}>
+          <Stack direction="row" spacing={4} sx={{ flexWrap: "wrap" }}>
+            <Stat label="Table" value={detail.table} mono />
+            <Stat label="Count" value={detail.count.toLocaleString()} />
+            <Stat label="Unique DIDs" value={detail.unique_dids.toLocaleString()} />
+            <Stat label="Oldest indexed" value={detail.oldest_indexed_at ?? "—"} />
+            <Stat label="Newest indexed" value={detail.newest_indexed_at ?? "—"} />
+            <Stat label="Cascades to" value={detail.cascades_to.join(", ") || "—"} />
+          </Stack>
+        </Paper>
+      )}
+
+      <Stack direction="row" spacing={1} sx={{ mb: 2 }}>
+        <TextField
+          size="small"
+          label="Filter by DID"
+          value={didFilter}
+          onChange={(e) => setDidFilter(e.target.value)}
+          placeholder="did:plc:..."
+          sx={{ minWidth: 320 }}
+        />
+        <Button
+          variant="outlined"
+          onClick={() => {
+            setOffset(0);
+            setAppliedDid(didFilter.trim());
+          }}
+        >
+          Apply
+        </Button>
+        {appliedDid && (
+          <Button
+            onClick={() => {
+              setDidFilter("");
+              setAppliedDid("");
+              setOffset(0);
+            }}
+          >
+            Clear
+          </Button>
+        )}
+      </Stack>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>DID</TableCell>
+              <TableCell>rkey</TableCell>
+              <TableCell>URI</TableCell>
+              <TableCell>CID</TableCell>
+              <TableCell>Indexed at</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {records.map((r) => (
+              <TableRow key={r.uri}>
+                <TableCell sx={{ fontFamily: "monospace", fontSize: "0.8rem" }}>{r.did}</TableCell>
+                <TableCell sx={{ fontFamily: "monospace", fontSize: "0.8rem" }}>{r.rkey}</TableCell>
+                <TableCell sx={{ fontFamily: "monospace", fontSize: "0.75rem" }}>{r.uri}</TableCell>
+                <TableCell sx={{ fontFamily: "monospace", fontSize: "0.75rem" }}>
+                  {r.cid ?? "—"}
+                </TableCell>
+                <TableCell sx={{ fontSize: "0.8rem" }}>{r.indexed_at}</TableCell>
+              </TableRow>
+            ))}
+            {records.length === 0 && !loading && (
+              <TableRow>
+                <TableCell colSpan={5} align="center" sx={{ color: "text.secondary", py: 3 }}>
+                  No records
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </Paper>
+
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mt: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          Showing {records.length === 0 ? 0 : offset + 1}–{offset + records.length}
+          {detail ? ` of ${detail.count.toLocaleString()}` : ""}
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            disabled={offset === 0 || loading}
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+          >
+            Previous
+          </Button>
+          <Button
+            disabled={records.length < PAGE_SIZE || loading}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+          >
+            Next
+          </Button>
+        </Stack>
+      </Box>
+    </Container>
+  );
+}
+
+function Stat({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <Box>
+      <Typography variant="caption" color="text.secondary" sx={{ display: "block" }}>
+        {label}
+      </Typography>
+      <Typography variant="body2" sx={{ fontFamily: mono ? "monospace" : undefined }}>
+        {value}
+      </Typography>
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- New `/admin/collections/:nsid` page with stats header (count, unique DIDs, oldest/newest indexed, cascades), DID filter, and paginated records table (50/page).
- NSID cells on the admin index now link to the detail view.
- Backend endpoints (`GET /admin/collections/:nsid` and `.../records`) already exist; this just surfaces them.

## Test plan
- [ ] Log in as an `ADMIN_DIDS` user, visit `/admin`, click an NSID, confirm stats and records load
- [ ] Paginate with Previous/Next
- [ ] Filter by DID, clear filter
- [ ] Visit as a non-admin user and confirm 403 is surfaced