### PR TITLE
feat(admin): browse non-lexicon tables

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -215,6 +215,11 @@ async fn main() {
             "/admin/collections/{nsid}/records",
             get(routes::admin::list_records),
         )
+        .route("/admin/tables", get(routes::admin::list_tables))
+        .route(
+            "/admin/tables/{name}/rows",
+            get(routes::admin::list_table_rows),
+        )
         // Media (blob/thumb cache, formerly observing-media-proxy)
         .route("/media/health", get(routes::media::health))
         .route("/media/blob/{did}/{cid}", get(routes::media::get_blob))

--- a/crates/observing-appview/src/routes/admin.rs
+++ b/crates/observing-appview/src/routes/admin.rs
@@ -148,7 +148,7 @@ pub async fn list_records(
 #[derive(Serialize)]
 pub struct TableSummary {
     pub name: &'static str,
-    pub columns: &'static [&'static str],
+    pub columns: Vec<&'static str>,
     pub count: i64,
 }
 
@@ -167,7 +167,7 @@ pub async fn list_tables(
         let count = db_admin::table_count(&state.pool, meta.name).await?;
         out.push(TableSummary {
             name: meta.name,
-            columns: meta.columns,
+            columns: meta.column_names(),
             count,
         });
     }
@@ -185,7 +185,7 @@ pub struct ListTableRowsQuery {
 #[derive(Serialize)]
 pub struct ListTableRowsResponse {
     pub name: &'static str,
-    pub columns: &'static [&'static str],
+    pub columns: Vec<&'static str>,
     pub rows: Vec<serde_json::Value>,
     pub limit: i64,
     pub offset: i64,
@@ -205,7 +205,7 @@ pub async fn list_table_rows(
     let rows = db_admin::list_table_rows(&state.pool, &name, limit, offset).await?;
     Ok(Json(ListTableRowsResponse {
         name: meta.name,
-        columns: meta.columns,
+        columns: meta.column_names(),
         rows,
         limit,
         offset,

--- a/crates/observing-appview/src/routes/admin.rs
+++ b/crates/observing-appview/src/routes/admin.rs
@@ -145,6 +145,73 @@ pub async fn list_records(
     }))
 }
 
+#[derive(Serialize)]
+pub struct TableSummary {
+    pub name: &'static str,
+    pub columns: &'static [&'static str],
+    pub count: i64,
+}
+
+#[derive(Serialize)]
+pub struct TablesListResponse {
+    pub tables: Vec<TableSummary>,
+}
+
+/// `GET /admin/tables` — list all browsable non-lexicon tables with counts.
+pub async fn list_tables(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+) -> Result<Json<TablesListResponse>, AppError> {
+    let mut out = Vec::with_capacity(db_admin::KNOWN_TABLES.len());
+    for meta in db_admin::KNOWN_TABLES {
+        let count = db_admin::table_count(&state.pool, meta.name).await?;
+        out.push(TableSummary {
+            name: meta.name,
+            columns: meta.columns,
+            count,
+        });
+    }
+    Ok(Json(TablesListResponse { tables: out }))
+}
+
+#[derive(Deserialize)]
+pub struct ListTableRowsQuery {
+    #[serde(default = "default_limit")]
+    pub limit: i64,
+    #[serde(default)]
+    pub offset: i64,
+}
+
+#[derive(Serialize)]
+pub struct ListTableRowsResponse {
+    pub name: &'static str,
+    pub columns: &'static [&'static str],
+    pub rows: Vec<serde_json::Value>,
+    pub limit: i64,
+    pub offset: i64,
+}
+
+/// `GET /admin/tables/{name}/rows` — paginated rows for an allowlisted table.
+pub async fn list_table_rows(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+    Query(params): Query<ListTableRowsQuery>,
+) -> Result<Json<ListTableRowsResponse>, AppError> {
+    let meta = db_admin::lookup_table(&name)
+        .ok_or_else(|| AppError::NotFound(format!("Unknown table: {name}")))?;
+    let limit = params.limit.clamp(1, 500);
+    let offset = params.offset.max(0);
+    let rows = db_admin::list_table_rows(&state.pool, &name, limit, offset).await?;
+    Ok(Json(ListTableRowsResponse {
+        name: meta.name,
+        columns: meta.columns,
+        rows,
+        limit,
+        offset,
+    }))
+}
+
 #[derive(Deserialize)]
 pub struct DeleteCollectionQuery {
     /// Must match the NSID in the path. Prevents accidental deletion.

--- a/crates/observing-db/src/admin.rs
+++ b/crates/observing-db/src/admin.rs
@@ -205,77 +205,94 @@ pub async fn list_records(
 /// Metadata for a non-lexicon table the admin interface can browse read-only.
 ///
 /// Unlike `KnownCollection` (lexicon-scoped records keyed by NSID), these are
-/// internal tables: OAuth/session stores are intentionally excluded, and
-/// `occurrence_private_data.exact_location` is excluded from `columns` because
-/// surfacing exact coords would defeat the whole point of that table.
+/// internal tables. OAuth/session stores are intentionally excluded.
 pub struct KnownTable {
     pub name: &'static str,
-    /// Explicit allowlist of columns to return. Never `SELECT *` — some columns
-    /// are privacy-sensitive (e.g. `exact_location`) and must not leak.
-    pub columns: &'static [&'static str],
+    /// Explicit allowlist of columns. Never `SELECT *`. Each entry is a
+    /// `(select_expr, display_name)` pair — the expression is used in the
+    /// SELECT clause (aliased to `display_name`) and the name is used as the
+    /// JSON key and column header. Expressions are constants from this source
+    /// file, never user input.
+    pub columns: &'static [(&'static str, &'static str)],
     pub order_by: &'static str,
 }
 
 pub const KNOWN_TABLES: &[KnownTable] = &[
     KnownTable {
         name: "ingester_state",
-        columns: &["key", "value", "updated_at"],
+        columns: &[
+            ("key", "key"),
+            ("value", "value"),
+            ("updated_at", "updated_at"),
+        ],
         order_by: "updated_at DESC NULLS LAST",
     },
     KnownTable {
         name: "occurrence_observers",
-        columns: &["occurrence_uri", "observer_did", "role", "added_at"],
+        columns: &[
+            ("occurrence_uri", "occurrence_uri"),
+            ("observer_did", "observer_did"),
+            ("role", "role"),
+            ("added_at", "added_at"),
+        ],
         order_by: "added_at DESC NULLS LAST",
     },
     KnownTable {
         name: "occurrence_private_data",
         columns: &[
-            "uri",
-            "geoprivacy",
-            "effective_geoprivacy",
-            "created_at",
-            "updated_at",
+            ("uri", "uri"),
+            ("ST_AsText(exact_location)", "exact_location"),
+            ("geoprivacy", "geoprivacy"),
+            ("effective_geoprivacy", "effective_geoprivacy"),
+            ("created_at", "created_at"),
+            ("updated_at", "updated_at"),
         ],
         order_by: "updated_at DESC NULLS LAST",
     },
     KnownTable {
         name: "sensitive_species",
         columns: &[
-            "scientific_name",
-            "kingdom",
-            "geoprivacy",
-            "reason",
-            "source",
+            ("scientific_name", "scientific_name"),
+            ("kingdom", "kingdom"),
+            ("geoprivacy", "geoprivacy"),
+            ("reason", "reason"),
+            ("source", "source"),
         ],
         order_by: "scientific_name",
     },
     KnownTable {
         name: "notifications",
         columns: &[
-            "id",
-            "recipient_did",
-            "actor_did",
-            "kind",
-            "subject_uri",
-            "reference_uri",
-            "read",
-            "created_at",
+            ("id", "id"),
+            ("recipient_did", "recipient_did"),
+            ("actor_did", "actor_did"),
+            ("kind", "kind"),
+            ("subject_uri", "subject_uri"),
+            ("reference_uri", "reference_uri"),
+            ("read", "read"),
+            ("created_at", "created_at"),
         ],
         order_by: "created_at DESC",
     },
     KnownTable {
         name: "community_ids",
         columns: &[
-            "occurrence_uri",
-            "subject_index",
-            "scientific_name",
-            "kingdom",
-            "id_count",
-            "agreement_count",
+            ("occurrence_uri", "occurrence_uri"),
+            ("subject_index", "subject_index"),
+            ("scientific_name", "scientific_name"),
+            ("kingdom", "kingdom"),
+            ("id_count", "id_count"),
+            ("agreement_count", "agreement_count"),
         ],
         order_by: "occurrence_uri",
     },
 ];
+
+impl KnownTable {
+    pub fn column_names(&self) -> Vec<&'static str> {
+        self.columns.iter().map(|(_, name)| *name).collect()
+    }
+}
 
 pub fn lookup_table(name: &str) -> Option<&'static KnownTable> {
     KNOWN_TABLES.iter().find(|t| t.name == name)
@@ -304,7 +321,12 @@ pub async fn list_table_rows(
     let Some(meta) = lookup_table(name) else {
         return Ok(Vec::new());
     };
-    let cols = meta.columns.join(", ");
+    let cols = meta
+        .columns
+        .iter()
+        .map(|(expr, name)| format!("{expr} AS {name}"))
+        .collect::<Vec<_>>()
+        .join(", ");
     let sql = format!(
         "SELECT row_to_json(t) AS row FROM (SELECT {} FROM {} ORDER BY {} LIMIT $1 OFFSET $2) t",
         cols, meta.name, meta.order_by,

--- a/crates/observing-db/src/admin.rs
+++ b/crates/observing-db/src/admin.rs
@@ -202,6 +202,121 @@ pub async fn list_records(
     Ok(summaries)
 }
 
+/// Metadata for a non-lexicon table the admin interface can browse read-only.
+///
+/// Unlike `KnownCollection` (lexicon-scoped records keyed by NSID), these are
+/// internal tables: OAuth/session stores are intentionally excluded, and
+/// `occurrence_private_data.exact_location` is excluded from `columns` because
+/// surfacing exact coords would defeat the whole point of that table.
+pub struct KnownTable {
+    pub name: &'static str,
+    /// Explicit allowlist of columns to return. Never `SELECT *` — some columns
+    /// are privacy-sensitive (e.g. `exact_location`) and must not leak.
+    pub columns: &'static [&'static str],
+    pub order_by: &'static str,
+}
+
+pub const KNOWN_TABLES: &[KnownTable] = &[
+    KnownTable {
+        name: "ingester_state",
+        columns: &["key", "value", "updated_at"],
+        order_by: "updated_at DESC NULLS LAST",
+    },
+    KnownTable {
+        name: "occurrence_observers",
+        columns: &["occurrence_uri", "observer_did", "role", "added_at"],
+        order_by: "added_at DESC NULLS LAST",
+    },
+    KnownTable {
+        name: "occurrence_private_data",
+        columns: &[
+            "uri",
+            "geoprivacy",
+            "effective_geoprivacy",
+            "created_at",
+            "updated_at",
+        ],
+        order_by: "updated_at DESC NULLS LAST",
+    },
+    KnownTable {
+        name: "sensitive_species",
+        columns: &[
+            "scientific_name",
+            "kingdom",
+            "geoprivacy",
+            "reason",
+            "source",
+        ],
+        order_by: "scientific_name",
+    },
+    KnownTable {
+        name: "notifications",
+        columns: &[
+            "id",
+            "recipient_did",
+            "actor_did",
+            "kind",
+            "subject_uri",
+            "reference_uri",
+            "read",
+            "created_at",
+        ],
+        order_by: "created_at DESC",
+    },
+    KnownTable {
+        name: "community_ids",
+        columns: &[
+            "occurrence_uri",
+            "subject_index",
+            "scientific_name",
+            "kingdom",
+            "id_count",
+            "agreement_count",
+        ],
+        order_by: "occurrence_uri",
+    },
+];
+
+pub fn lookup_table(name: &str) -> Option<&'static KnownTable> {
+    KNOWN_TABLES.iter().find(|t| t.name == name)
+}
+
+pub async fn table_count(pool: &PgPool, name: &str) -> Result<i64, sqlx::Error> {
+    let Some(meta) = lookup_table(name) else {
+        return Ok(0);
+    };
+    let sql = format!("SELECT COUNT(*) FROM {}", meta.name);
+    sqlx::query_scalar(&sql).fetch_one(pool).await
+}
+
+/// List rows from an allowlisted non-lexicon table, returned as JSON objects.
+///
+/// Uses Postgres `row_to_json` so column-type handling (timestamps, booleans,
+/// bigints, nullables) is done server-side — no per-type Rust decoding. The
+/// table name and column list come from the `KNOWN_TABLES` allowlist, never
+/// user input, so no injection risk.
+pub async fn list_table_rows(
+    pool: &PgPool,
+    name: &str,
+    limit: i64,
+    offset: i64,
+) -> Result<Vec<serde_json::Value>, sqlx::Error> {
+    let Some(meta) = lookup_table(name) else {
+        return Ok(Vec::new());
+    };
+    let cols = meta.columns.join(", ");
+    let sql = format!(
+        "SELECT row_to_json(t) AS row FROM (SELECT {} FROM {} ORDER BY {} LIMIT $1 OFFSET $2) t",
+        cols, meta.name, meta.order_by,
+    );
+    let rows: Vec<(serde_json::Value,)> = sqlx::query_as(&sql)
+        .bind(limit)
+        .bind(offset)
+        .fetch_all(pool)
+        .await?;
+    Ok(rows.into_iter().map(|(v,)| v).collect())
+}
+
 /// Delete all rows belonging to an NSID. Returns the number of rows affected.
 /// Callers are responsible for guarding this with a confirmation token.
 pub async fn delete_by_nsid(pool: &PgPool, nsid: &str) -> Result<u64, sqlx::Error> {

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -25,6 +25,7 @@ import { NotificationsPage } from "./components/notifications/NotificationsPage"
 import { SettingsPage } from "./components/settings/SettingsPage";
 import { AdminPage } from "./components/admin/AdminPage";
 import { CollectionDetailPage } from "./components/admin/CollectionDetailPage";
+import { TableDetailPage } from "./components/admin/TableDetailPage";
 import "./styles/global.css";
 
 function AppContent() {
@@ -124,6 +125,7 @@ function AppContent() {
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/admin" element={<AdminPage />} />
           <Route path="/admin/collections/:nsid" element={<CollectionDetailPage />} />
+          <Route path="/admin/tables/:name" element={<TableDetailPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Box>

--- a/frontend/src/components/admin/AdminPage.tsx
+++ b/frontend/src/components/admin/AdminPage.tsx
@@ -26,8 +26,10 @@ import {
   AdminError,
   type CollectionSummary,
   type DeleteResponse,
+  type TableSummary,
   deleteCollection,
   listCollections,
+  listTables,
 } from "../../services/admin";
 
 export function AdminPage() {
@@ -37,16 +39,18 @@ export function AdminPage() {
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<number | null>(null);
   const [collections, setCollections] = useState<CollectionSummary[]>([]);
+  const [tables, setTables] = useState<TableSummary[]>([]);
   const [total, setTotal] = useState(0);
   const [target, setTarget] = useState<CollectionSummary | null>(null);
 
   const refresh = () => {
     setLoading(true);
     setError(null);
-    listCollections()
-      .then((res) => {
-        setCollections(res.collections);
-        setTotal(res.total);
+    Promise.all([listCollections(), listTables()])
+      .then(([cRes, tRes]) => {
+        setCollections(cRes.collections);
+        setTotal(cRes.total);
+        setTables(tRes.tables);
       })
       .catch((e: unknown) => {
         if (e instanceof AdminError) {
@@ -129,6 +133,44 @@ export function AdminPage() {
                     Purge
                   </Button>
                 </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </Paper>
+
+      <Typography variant="h5" sx={{ mt: 5, mb: 2 }}>
+        Other tables
+      </Typography>
+      <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+        Internal tables (not lexicon records). Read-only. OAuth state and sessions are intentionally
+        excluded.
+      </Typography>
+      <Paper>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              <TableCell>Table</TableCell>
+              <TableCell>Columns</TableCell>
+              <TableCell align="right">Count</TableCell>
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {tables.map((t) => (
+              <TableRow key={t.name}>
+                <TableCell sx={{ fontFamily: "monospace" }}>
+                  <Link
+                    component={RouterLink}
+                    to={`/admin/tables/${encodeURIComponent(t.name)}`}
+                    underline="hover"
+                  >
+                    {t.name}
+                  </Link>
+                </TableCell>
+                <TableCell sx={{ fontSize: "0.75rem", color: "text.secondary" }}>
+                  {t.columns.join(", ")}
+                </TableCell>
+                <TableCell align="right">{t.count.toLocaleString()}</TableCell>
               </TableRow>
             ))}
           </TableBody>

--- a/frontend/src/components/admin/TableDetailPage.tsx
+++ b/frontend/src/components/admin/TableDetailPage.tsx
@@ -1,0 +1,153 @@
+import { useEffect, useState } from "react";
+import { Link as RouterLink, useParams } from "react-router-dom";
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Container,
+  Link,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { usePageTitle } from "../../hooks/usePageTitle";
+import { AdminError, type ListTableRowsResponse, listTableRows } from "../../services/admin";
+
+const PAGE_SIZE = 50;
+
+export function TableDetailPage() {
+  const { name: rawName } = useParams<{ name: string }>();
+  const name = rawName ? decodeURIComponent(rawName) : "";
+  usePageTitle(`Admin: ${name}`);
+
+  const [data, setData] = useState<ListTableRowsResponse | null>(null);
+  const [offset, setOffset] = useState(0);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<number | null>(null);
+
+  useEffect(() => {
+    if (!name) return;
+    setLoading(true);
+    setError(null);
+    listTableRows(name, { limit: PAGE_SIZE, offset })
+      .then(setData)
+      .catch((e: unknown) => {
+        if (e instanceof AdminError) {
+          setStatus(e.status);
+          setError(e.message);
+        } else {
+          setError(e instanceof Error ? e.message : "Unknown error");
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [name, offset]);
+
+  if (loading && !data) {
+    return (
+      <Container sx={{ py: 4, display: "flex", justifyContent: "center" }}>
+        <CircularProgress />
+      </Container>
+    );
+  }
+
+  if (error && !data) {
+    return (
+      <Container sx={{ py: 4 }}>
+        <Alert severity={status === 403 || status === 401 ? "warning" : "error"}>
+          {status != null ? `[${status}] ` : ""}
+          {error}
+        </Alert>
+      </Container>
+    );
+  }
+
+  if (!data) return null;
+
+  return (
+    <Container sx={{ py: 4 }}>
+      <Link component={RouterLink} to="/admin" underline="hover">
+        ← Admin
+      </Link>
+      <Typography variant="h4" sx={{ mt: 1, fontFamily: "monospace" }} gutterBottom>
+        {name}
+      </Typography>
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Paper sx={{ overflowX: "auto" }}>
+        <Table size="small">
+          <TableHead>
+            <TableRow>
+              {data.columns.map((col) => (
+                <TableCell key={col}>{col}</TableCell>
+              ))}
+            </TableRow>
+          </TableHead>
+          <TableBody>
+            {data.rows.map((row, i) => (
+              <TableRow key={i}>
+                {data.columns.map((col) => (
+                  <TableCell
+                    key={col}
+                    sx={{ fontFamily: "monospace", fontSize: "0.75rem", whiteSpace: "nowrap" }}
+                  >
+                    {formatCell(row[col])}
+                  </TableCell>
+                ))}
+              </TableRow>
+            ))}
+            {data.rows.length === 0 && (
+              <TableRow>
+                <TableCell
+                  colSpan={data.columns.length}
+                  align="center"
+                  sx={{ color: "text.secondary", py: 3 }}
+                >
+                  No rows
+                </TableCell>
+              </TableRow>
+            )}
+          </TableBody>
+        </Table>
+      </Paper>
+
+      <Box sx={{ display: "flex", justifyContent: "space-between", alignItems: "center", mt: 2 }}>
+        <Typography variant="body2" color="text.secondary">
+          Showing {data.rows.length === 0 ? 0 : offset + 1}–{offset + data.rows.length}
+        </Typography>
+        <Stack direction="row" spacing={1}>
+          <Button
+            disabled={offset === 0 || loading}
+            onClick={() => setOffset(Math.max(0, offset - PAGE_SIZE))}
+          >
+            Previous
+          </Button>
+          <Button
+            disabled={data.rows.length < PAGE_SIZE || loading}
+            onClick={() => setOffset(offset + PAGE_SIZE)}
+          >
+            Next
+          </Button>
+        </Stack>
+      </Box>
+    </Container>
+  );
+}
+
+function formatCell(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "boolean") return String(value);
+  return JSON.stringify(value);
+}

--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -93,6 +93,39 @@ export function listRecords(
   return adminFetch(`/admin/collections/${encodeURIComponent(nsid)}/records${qs ? `?${qs}` : ""}`);
 }
 
+export interface TableSummary {
+  name: string;
+  columns: string[];
+  count: number;
+}
+
+export interface TablesListResponse {
+  tables: TableSummary[];
+}
+
+export interface ListTableRowsResponse {
+  name: string;
+  columns: string[];
+  rows: Record<string, unknown>[];
+  limit: number;
+  offset: number;
+}
+
+export function listTables(): Promise<TablesListResponse> {
+  return adminFetch("/admin/tables");
+}
+
+export function listTableRows(
+  name: string,
+  opts: { limit?: number; offset?: number } = {},
+): Promise<ListTableRowsResponse> {
+  const params = new URLSearchParams();
+  if (opts.limit != null) params.set("limit", String(opts.limit));
+  if (opts.offset != null) params.set("offset", String(opts.offset));
+  const qs = params.toString();
+  return adminFetch(`/admin/tables/${encodeURIComponent(name)}/rows${qs ? `?${qs}` : ""}`);
+}
+
 export function deleteCollection(nsid: string, opts: { dryRun: boolean }): Promise<DeleteResponse> {
   const params = new URLSearchParams({
     confirm: nsid,


### PR DESCRIPTION
## Summary
- New `GET /admin/tables` and `/admin/tables/:name/rows` endpoints for read-only access to internal tables.
- Allowlisted: `ingester_state`, `occurrence_observers`, `occurrence_private_data` (incl. `exact_location` as WKT via `ST_AsText`), `sensitive_species`, `notifications`, `community_ids`.
- Excluded: `oauth_state`, `oauth_sessions` (contain secrets).
- Column entries are `(select_expr, display_name)` pairs — expressions are constants, never user input.
- Frontend: second section on `/admin` and a new `/admin/tables/:name` page with dynamic columns.

## Test plan
- [ ] Visit `/admin` as an `ADMIN_DIDS` user, confirm "Other tables" section loads with counts
- [ ] Click each table, confirm rows render with correct columns
- [ ] `occurrence_private_data` shows `exact_location` as `POINT(...)`
- [ ] Paginate Previous/Next
- [ ] Non-admin user gets 403