### PR TITLE
feat(admin): click-through row detail with full JSON

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -215,6 +215,10 @@ async fn main() {
             "/admin/collections/{nsid}/records",
             get(routes::admin::list_records),
         )
+        .route(
+            "/admin/collections/{nsid}/record",
+            get(routes::admin::get_record),
+        )
         .route("/admin/tables", get(routes::admin::list_tables))
         .route(
             "/admin/tables/{name}/rows",

--- a/crates/observing-appview/src/routes/admin.rs
+++ b/crates/observing-appview/src/routes/admin.rs
@@ -213,6 +213,27 @@ pub async fn list_table_rows(
 }
 
 #[derive(Deserialize)]
+pub struct GetRecordQuery {
+    pub uri: String,
+}
+
+/// `GET /admin/collections/{nsid}/record?uri=...` — full row JSON for one record.
+pub async fn get_record(
+    _auth: AdminAuth,
+    State(state): State<AppState>,
+    Path(nsid): Path<String>,
+    Query(params): Query<GetRecordQuery>,
+) -> Result<Json<serde_json::Value>, AppError> {
+    if db_admin::lookup(&nsid).is_none() {
+        return Err(AppError::NotFound(format!("Unknown NSID: {nsid}")));
+    }
+    let row = db_admin::get_record(&state.pool, &nsid, &params.uri)
+        .await?
+        .ok_or_else(|| AppError::NotFound(format!("Record not found: {}", params.uri)))?;
+    Ok(Json(row))
+}
+
+#[derive(Deserialize)]
 pub struct DeleteCollectionQuery {
     /// Must match the NSID in the path. Prevents accidental deletion.
     pub confirm: String,

--- a/crates/observing-db/src/admin.rs
+++ b/crates/observing-db/src/admin.rs
@@ -202,6 +202,68 @@ pub async fn list_records(
     Ok(summaries)
 }
 
+/// Full-detail SELECT column list for a lexicon table, with PostGIS geometry
+/// columns cast to WKT so `row_to_json` can serialize them.
+fn record_detail_columns(table: &str) -> &'static str {
+    match table {
+        "occurrences" => {
+            "uri, cid, did, scientific_name, event_date, \
+             ST_AsText(location) AS location, coordinate_uncertainty_meters, \
+             continent, country, country_code, state_province, county, \
+             municipality, locality, water_body, verbatim_locality, \
+             occurrence_remarks, associated_media, recorded_by, taxon_id, \
+             taxon_rank, vernacular_name, kingdom, phylum, class, \"order\", \
+             family, genus, created_at, indexed_at"
+        }
+        "identifications" => {
+            "uri, cid, did, subject_uri, subject_cid, subject_index, \
+             scientific_name, taxon_rank, identification_qualifier, taxon_id, \
+             identification_verification_status, type_status, is_agreement, \
+             date_identified, indexed_at, vernacular_name, kingdom, phylum, \
+             class, \"order\", family, genus"
+        }
+        "comments" => {
+            "uri, cid, did, subject_uri, subject_cid, body, reply_to_uri, \
+             reply_to_cid, created_at, indexed_at"
+        }
+        "likes" => "uri, cid, did, subject_uri, subject_cid, created_at, indexed_at",
+        "interactions" => {
+            "uri, cid, did, subject_a_occurrence_uri, subject_a_occurrence_cid, \
+             subject_a_subject_index, subject_a_taxon_name, subject_a_kingdom, \
+             subject_b_occurrence_uri, subject_b_occurrence_cid, \
+             subject_b_subject_index, subject_b_taxon_name, subject_b_kingdom, \
+             interaction_type, direction, comment, created_at, indexed_at"
+        }
+        _ => "*",
+    }
+}
+
+/// Fetch the full row for a single lexicon record, returned as a JSON object.
+///
+/// The URI must match the NSID's `at://<did>/<nsid>/<rkey>` pattern to prevent
+/// reading rows of a different collection through an adjacent NSID's detail
+/// endpoint.
+pub async fn get_record(
+    pool: &PgPool,
+    nsid: &str,
+    uri: &str,
+) -> Result<Option<serde_json::Value>, sqlx::Error> {
+    let Some(meta) = lookup(nsid) else {
+        return Ok(None);
+    };
+    if !uri.starts_with("at://") || !uri.contains(&format!("/{}/", nsid)) {
+        return Ok(None);
+    }
+    let cols = record_detail_columns(meta.table);
+    let sql = format!(
+        "SELECT row_to_json(t) FROM (SELECT {cols} FROM {table} WHERE uri = $1) t",
+        table = meta.table,
+    );
+    let row: Option<(serde_json::Value,)> =
+        sqlx::query_as(&sql).bind(uri).fetch_optional(pool).await?;
+    Ok(row.map(|(v,)| v))
+}
+
 /// Metadata for a non-lexicon table the admin interface can browse read-only.
 ///
 /// Unlike `KnownCollection` (lexicon-scoped records keyed by NSID), these are

--- a/frontend/src/components/admin/CollectionDetailPage.tsx
+++ b/frontend/src/components/admin/CollectionDetailPage.tsx
@@ -23,8 +23,10 @@ import {
   type CollectionDetail,
   type RecordSummary,
   getCollection,
+  getRecord,
   listRecords,
 } from "../../services/admin";
+import { RowDetailDialog } from "./RowDetailDialog";
 
 const PAGE_SIZE = 50;
 
@@ -41,6 +43,23 @@ export function CollectionDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<number | null>(null);
+  const [detailUri, setDetailUri] = useState<string | null>(null);
+  const [detailData, setDetailData] = useState<unknown>(null);
+  const [detailLoading, setDetailLoading] = useState(false);
+  const [detailError, setDetailError] = useState<string | null>(null);
+
+  const openDetail = (uri: string) => {
+    setDetailUri(uri);
+    setDetailData(null);
+    setDetailError(null);
+    setDetailLoading(true);
+    getRecord(nsid, uri)
+      .then(setDetailData)
+      .catch((e: unknown) => {
+        setDetailError(e instanceof Error ? e.message : "Failed to load record");
+      })
+      .finally(() => setDetailLoading(false));
+  };
 
   useEffect(() => {
     if (!nsid) return;
@@ -158,7 +177,12 @@ export function CollectionDetailPage() {
           </TableHead>
           <TableBody>
             {records.map((r) => (
-              <TableRow key={r.uri}>
+              <TableRow
+                key={r.uri}
+                hover
+                sx={{ cursor: "pointer" }}
+                onClick={() => openDetail(r.uri)}
+              >
                 <TableCell sx={{ fontFamily: "monospace", fontSize: "0.8rem" }}>{r.did}</TableCell>
                 <TableCell sx={{ fontFamily: "monospace", fontSize: "0.8rem" }}>{r.rkey}</TableCell>
                 <TableCell sx={{ fontFamily: "monospace", fontSize: "0.75rem" }}>{r.uri}</TableCell>
@@ -199,6 +223,16 @@ export function CollectionDetailPage() {
           </Button>
         </Stack>
       </Box>
+
+      {detailUri && (
+        <RowDetailDialog
+          title={detailUri}
+          data={detailData}
+          loading={detailLoading}
+          error={detailError}
+          onClose={() => setDetailUri(null)}
+        />
+      )}
     </Container>
   );
 }

--- a/frontend/src/components/admin/RowDetailDialog.tsx
+++ b/frontend/src/components/admin/RowDetailDialog.tsx
@@ -1,0 +1,60 @@
+import {
+  Alert,
+  Box,
+  Button,
+  CircularProgress,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+} from "@mui/material";
+
+export function RowDetailDialog({
+  title,
+  data,
+  loading,
+  error,
+  onClose,
+}: {
+  title: string;
+  data: unknown;
+  loading?: boolean;
+  error?: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <Dialog open onClose={onClose} maxWidth="md" fullWidth>
+      <DialogTitle sx={{ fontFamily: "monospace", wordBreak: "break-all" }}>{title}</DialogTitle>
+      <DialogContent>
+        {loading && (
+          <Box sx={{ display: "flex", justifyContent: "center", py: 4 }}>
+            <CircularProgress />
+          </Box>
+        )}
+        {error && <Alert severity="error">{error}</Alert>}
+        {!loading && !error && (
+          <Box
+            component="pre"
+            sx={{
+              fontSize: "0.8rem",
+              fontFamily: "monospace",
+              whiteSpace: "pre-wrap",
+              wordBreak: "break-word",
+              m: 0,
+              p: 2,
+              bgcolor: "action.hover",
+              borderRadius: 1,
+              maxHeight: "70vh",
+              overflow: "auto",
+            }}
+          >
+            {JSON.stringify(data, null, 2)}
+          </Box>
+        )}
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose}>Close</Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/admin/TableDetailPage.tsx
+++ b/frontend/src/components/admin/TableDetailPage.tsx
@@ -18,6 +18,7 @@ import {
 } from "@mui/material";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { AdminError, type ListTableRowsResponse, listTableRows } from "../../services/admin";
+import { RowDetailDialog } from "./RowDetailDialog";
 
 const PAGE_SIZE = 50;
 
@@ -31,6 +32,7 @@ export function TableDetailPage() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [status, setStatus] = useState<number | null>(null);
+  const [detailRow, setDetailRow] = useState<Record<string, unknown> | null>(null);
 
   useEffect(() => {
     if (!name) return;
@@ -96,7 +98,7 @@ export function TableDetailPage() {
           </TableHead>
           <TableBody>
             {data.rows.map((row, i) => (
-              <TableRow key={i}>
+              <TableRow key={i} hover sx={{ cursor: "pointer" }} onClick={() => setDetailRow(row)}>
                 {data.columns.map((col) => (
                   <TableCell
                     key={col}
@@ -141,6 +143,14 @@ export function TableDetailPage() {
           </Button>
         </Stack>
       </Box>
+
+      {detailRow && (
+        <RowDetailDialog
+          title={String(detailRow[data.columns[0] ?? ""] ?? "Row detail")}
+          data={detailRow}
+          onClose={() => setDetailRow(null)}
+        />
+      )}
     </Container>
   );
 }

--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -126,6 +126,11 @@ export function listTableRows(
   return adminFetch(`/admin/tables/${encodeURIComponent(name)}/rows${qs ? `?${qs}` : ""}`);
 }
 
+export function getRecord(nsid: string, uri: string): Promise<Record<string, unknown>> {
+  const params = new URLSearchParams({ uri });
+  return adminFetch(`/admin/collections/${encodeURIComponent(nsid)}/record?${params.toString()}`);
+}
+
 export function deleteCollection(nsid: string, opts: { dryRun: boolean }): Promise<DeleteResponse> {
   const params = new URLSearchParams({
     confirm: nsid,


### PR DESCRIPTION
## Summary
- Click any row on `/admin/collections/:nsid` or `/admin/tables/:name` to see the full row as pretty-printed JSON.
- New backend endpoint `GET /admin/collections/:nsid/record?uri=...` returns the full lexicon record with PostGIS geometry cast to WKT via `ST_AsText`. URI is validated against the NSID prefix.
- Non-lexicon rows are already fully fetched, so that dialog opens with local data — no extra request.
- New shared `RowDetailDialog` component.

## Test plan
- [ ] Click a row in a lexicon collection, confirm JSON modal shows all columns (scientific_name, location WKT, etc. for occurrences)
- [ ] Click a row in `occurrence_private_data` — shows `exact_location` as `POINT(...)`
- [ ] Visiting `/admin/collections/<nsid>/record?uri=<mismatched-nsid-uri>` returns 404