### PR TITLE
feat(frontend): apply Herbarium design direction

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { Provider } from "react-redux";
-import { ThemeProvider, CssBaseline, Box, Alert } from "@mui/material";
+import { ThemeProvider, CssBaseline, Box } from "@mui/material";
 import { getTheme } from "./theme";
 import { store, useAppDispatch, useAppSelector } from "./store";
 import { checkAuth } from "./store/authSlice";
@@ -79,23 +79,34 @@ function AppContent() {
       {!showLanding && (
         <>
           <TopBar onMobileMenuClick={handleDrawerOpen} unreadCount={unreadCount} />
-          <Alert
-            severity="warning"
+          <Box
             sx={{
-              borderRadius: 0,
-              py: 0.5,
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              gap: 1.25,
+              px: 2,
+              py: 1.1,
               flexShrink: 0,
+              bgcolor: "var(--ov-warning-bg)",
+              color: "var(--ov-warning)",
               borderBottom: 1,
-              borderColor: "warning.main",
-              "& .MuiAlert-message": {
-                width: "100%",
-                textAlign: "center",
-              },
+              borderColor: "divider",
+              fontSize: "12.5px",
+              fontFamily: "var(--ov-mono)",
+              letterSpacing: "0.04em",
             }}
           >
-            <strong>Pre-release:</strong> This is an early alpha. The database may be wiped at any
-            time without notice.
-          </Alert>
+            <Box component="span" sx={{ fontWeight: 700, textTransform: "uppercase" }}>
+              Pre-release
+            </Box>
+            <Box component="span" sx={{ opacity: 0.5 }}>
+              ·
+            </Box>
+            <Box component="span">
+              Early alpha. The database may be wiped at any time without notice.
+            </Box>
+          </Box>
           <Sidebar
             mobileOpen={mobileOpen}
             onMobileClose={handleDrawerClose}

--- a/frontend/src/components/common/TaxonLink.tsx
+++ b/frontend/src/components/common/TaxonLink.tsx
@@ -76,12 +76,24 @@ export function TaxonLink({
           label={name}
           size="small"
           variant="outlined"
-          sx={{ fontStyle: shouldItalicize ? "italic" : "normal" }}
+          sx={{
+            fontStyle: shouldItalicize ? "italic" : "normal",
+            fontFamily: shouldItalicize ? "var(--ov-serif)" : undefined,
+          }}
         />
       );
     }
     return (
-      <Typography sx={{ fontStyle: shouldItalicize ? "italic" : "normal" }}>{name}</Typography>
+      <Typography
+        component="span"
+        sx={{
+          fontStyle: shouldItalicize ? "italic" : "normal",
+          fontFamily: shouldItalicize ? "var(--ov-serif)" : undefined,
+          fontWeight: shouldItalicize ? 500 : undefined,
+        }}
+      >
+        {name}
+      </Typography>
     );
   }
 
@@ -96,6 +108,7 @@ export function TaxonLink({
         onClick={handleClick}
         sx={{
           fontStyle: shouldItalicize ? "italic" : "normal",
+          fontFamily: shouldItalicize ? "var(--ov-serif)" : undefined,
           cursor: "pointer",
           "&:hover": {
             bgcolor: "rgba(255, 255, 255, 0.08)",
@@ -112,6 +125,8 @@ export function TaxonLink({
       onClick={handleClick}
       sx={{
         fontStyle: shouldItalicize ? "italic" : "normal",
+        fontFamily: shouldItalicize ? "var(--ov-serif)" : undefined,
+        fontWeight: shouldItalicize ? 500 : undefined,
         color: "primary.main",
         textDecoration: "none",
         "&:hover": {

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -136,54 +136,74 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
   );
 
   const titleEl = (
+    <Typography
+      component={Link}
+      to={`/profile/${encodeURIComponent(owner.did)}`}
+      onClick={(e) => e.stopPropagation()}
+      sx={{
+        fontWeight: 600,
+        fontSize: "14px",
+        color: "text.primary",
+        textDecoration: "none",
+        "&:hover": { textDecoration: "underline" },
+      }}
+    >
+      {displayName}
+    </Typography>
+  );
+
+  const subheaderEl = (
     <Stack
       direction="row"
       spacing={1}
       sx={{
-        alignItems: "baseline",
-        flexWrap: "wrap",
+        alignItems: "center",
+        mt: 0.25,
+        fontFamily: "var(--ov-mono)",
+        fontSize: "12px",
+        color: "text.disabled",
       }}
     >
-      <Typography
-        component={Link}
-        to={`/profile/${encodeURIComponent(owner.did)}`}
-        onClick={(e) => e.stopPropagation()}
-        sx={{
-          fontWeight: 600,
-          color: "text.primary",
-          textDecoration: "none",
-          "&:hover": { textDecoration: "underline" },
-        }}
-      >
-        {displayName}
-      </Typography>
-      {hasCoObservers && (
-        <Tooltip title={`With ${coObserverNames}`}>
-          <Typography
-            variant="body2"
-            sx={{
-              color: "primary.main",
-              cursor: "pointer",
-              "&:hover": { textDecoration: "underline" },
-            }}
-            onClick={(e) => e.stopPropagation()}
-          >
-            +{coObservers.length} other{coObservers.length > 1 ? "s" : ""}
-          </Typography>
-        </Tooltip>
-      )}
+      {handle && <Box component="span">{handle}</Box>}
       {handle && (
-        <Typography
-          variant="body2"
-          sx={{
-            color: "text.disabled",
-          }}
-        >
-          {handle}
-        </Typography>
+        <Box component="span" sx={{ opacity: 0.5 }}>
+          ·
+        </Box>
+      )}
+      <Box component="span">{timeAgo}</Box>
+      {hasCoObservers && (
+        <>
+          <Box component="span" sx={{ opacity: 0.5 }}>
+            ·
+          </Box>
+          <Tooltip title={`With ${coObserverNames}`}>
+            <Box
+              component="span"
+              sx={{ color: "primary.main", cursor: "pointer" }}
+              onClick={(e) => e.stopPropagation()}
+            >
+              +{coObservers.length}
+            </Box>
+          </Tooltip>
+        </>
       )}
     </Stack>
   );
+
+  const taxoStrip = taxonomy
+    ? [taxonomy.kingdom, taxonomy.phylum, taxonomy.class, taxonomy.order, taxonomy.family].filter(
+        Boolean,
+      )
+    : [];
+
+  const eventDate = observation.eventDate ? new Date(observation.eventDate) : null;
+  const dateStr = eventDate
+    ? eventDate.toLocaleDateString("en-US", { year: "numeric", month: "short", day: "2-digit" })
+    : "—";
+  const coordStr = observation.location
+    ? `${observation.location.latitude.toFixed(3)}°, ${observation.location.longitude.toFixed(3)}°`
+    : "—";
+  const idCount = observation.identificationCount ?? 0;
 
   return (
     <Card sx={FEED_CARD_SX}>
@@ -191,8 +211,8 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
         <CardHeader
           avatar={avatarEl}
           title={titleEl}
-          subheader={timeAgo}
-          subheaderTypographyProps={{ variant: "body2", color: "text.disabled" }}
+          subheader={subheaderEl}
+          disableTypography
           action={
             <>
               <IconButton
@@ -232,15 +252,46 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
         />
 
         {imageUrl && (
-          <ImageWithSkeleton
-            src={imageUrl}
-            alt={species || "Observation photo"}
-            sx={{ height: FEED_IMAGE_MAX_HEIGHT }}
-          />
+          <Box sx={{ position: "relative" }}>
+            <ImageWithSkeleton
+              src={imageUrl}
+              alt={species || "Observation photo"}
+              sx={{ height: FEED_IMAGE_MAX_HEIGHT }}
+            />
+            {observation.images.length > 1 && (
+              <Box
+                sx={{
+                  position: "absolute",
+                  right: 10,
+                  bottom: 10,
+                  px: 1,
+                  py: 0.5,
+                  borderRadius: 0.5,
+                  bgcolor: "rgba(0,0,0,0.55)",
+                  color: "#fff",
+                  fontFamily: "var(--ov-mono)",
+                  fontSize: "10.5px",
+                  backdropFilter: "blur(4px)",
+                }}
+              >
+                1 / {observation.images.length}
+              </Box>
+            )}
+          </Box>
         )}
 
-        <CardContent>
-          <Box sx={{ fontSize: "1.1rem" }}>
+        <CardContent sx={{ py: 2 }}>
+          <Box
+            sx={{
+              fontFamily: "var(--ov-serif)",
+              fontStyle: "italic",
+              fontWeight: 500,
+              fontSize: "21px",
+              color: "primary.main",
+              letterSpacing: "-0.01em",
+              lineHeight: 1.2,
+            }}
+          >
             {species ? (
               <TaxonLink
                 name={species}
@@ -249,14 +300,108 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
                 onClick={(e) => e.stopPropagation()}
               />
             ) : (
-              <Typography sx={{ fontStyle: "italic", color: "text.secondary" }}>
+              <Box component="span" sx={{ color: "text.secondary" }}>
                 Unidentified
-              </Typography>
+              </Box>
             )}
+          </Box>
+          {taxonomy?.vernacularName && (
+            <Typography sx={{ color: "text.secondary", fontSize: "14px", mt: 0.4 }}>
+              {taxonomy.vernacularName}
+            </Typography>
+          )}
+          {taxoStrip.length > 0 && (
+            <Box
+              sx={{
+                display: "flex",
+                flexWrap: "wrap",
+                mt: 1.25,
+                fontFamily: "var(--ov-mono)",
+                fontSize: "10px",
+                color: "text.disabled",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+              }}
+            >
+              {taxoStrip.map((t, i) => (
+                <Box component="span" key={i} sx={{ display: "inline-flex" }}>
+                  {i > 0 && (
+                    <Box component="span" sx={{ opacity: 0.4, px: 0.75 }}>
+                      ·
+                    </Box>
+                  )}
+                  <Box component="span" sx={{ color: "text.secondary" }}>
+                    {t}
+                  </Box>
+                </Box>
+              ))}
+            </Box>
+          )}
+          <Box
+            sx={{
+              display: "grid",
+              gridTemplateColumns: "repeat(3, 1fr)",
+              borderTop: 1,
+              borderColor: "divider",
+              mt: 1.75,
+              fontFamily: "var(--ov-mono)",
+              fontSize: "11px",
+              color: "text.disabled",
+              "& > div": { py: 1.25 },
+              "& > div + div": { borderLeft: 1, borderColor: "divider", pl: 1.75 },
+              "& .k": {
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                fontSize: "9.5px",
+                display: "block",
+                mb: 0.4,
+              },
+              "& .v": {
+                color: "text.primary",
+                fontSize: "12px",
+                fontWeight: 500,
+                fontVariantNumeric: "tabular-nums",
+              },
+            }}
+          >
+            <Box>
+              <Box component="span" className="k">
+                Observed
+              </Box>
+              <Box component="span" className="v">
+                {dateStr}
+              </Box>
+            </Box>
+            <Box>
+              <Box component="span" className="k">
+                Location
+              </Box>
+              <Box component="span" className="v">
+                {coordStr}
+              </Box>
+            </Box>
+            <Box>
+              <Box component="span" className="k">
+                IDs
+              </Box>
+              <Box component="span" className="v">
+                {idCount}
+              </Box>
+            </Box>
           </Box>
         </CardContent>
       </CardActionArea>
-      <CardActions disableSpacing sx={{ pt: 0 }}>
+      <CardActions
+        disableSpacing
+        sx={{
+          pt: 1,
+          pb: 1,
+          px: 1.5,
+          borderTop: 1,
+          borderColor: "divider",
+          gap: 0.5,
+        }}
+      >
         <Tooltip title={!currentUser ? "Log in to like" : ""}>
           <span>
             <IconButton
@@ -265,23 +410,29 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
               disabled={!currentUser}
               aria-label={liked ? "Unlike" : "Like"}
               sx={{
-                color: liked ? "error.main" : "text.disabled",
+                color: liked ? "var(--ov-heart)" : "text.disabled",
+                gap: 0.75,
+                fontSize: "12px",
+                borderRadius: 1,
               }}
             >
               {liked ? <FavoriteIcon fontSize="small" /> : <FavoriteBorderIcon fontSize="small" />}
+              {likeCount > 0 && (
+                <Box
+                  component="span"
+                  sx={{
+                    fontFamily: "var(--ov-mono)",
+                    fontVariantNumeric: "tabular-nums",
+                    fontSize: "12px",
+                    ml: 0.5,
+                  }}
+                >
+                  {likeCount}
+                </Box>
+              )}
             </IconButton>
           </span>
         </Tooltip>
-        {likeCount > 0 && (
-          <Typography
-            variant="body2"
-            sx={{
-              color: "text.secondary",
-            }}
-          >
-            {likeCount}
-          </Typography>
-        )}
       </CardActions>
     </Card>
   );

--- a/frontend/src/components/feed/FeedView.tsx
+++ b/frontend/src/components/feed/FeedView.tsx
@@ -131,6 +131,42 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
             </>
           ) : (
             <>
+              <Box
+                sx={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  justifyContent: "space-between",
+                  px: 3,
+                  pt: 3,
+                  pb: 1.75,
+                  borderBottom: 1,
+                  borderColor: "divider",
+                }}
+              >
+                <Typography
+                  component="h1"
+                  sx={{
+                    fontFamily: "var(--ov-display)",
+                    fontWeight: 500,
+                    fontSize: "28px",
+                    letterSpacing: "-0.02em",
+                    m: 0,
+                  }}
+                >
+                  Observations
+                </Typography>
+                <Box
+                  sx={{
+                    fontFamily: "var(--ov-mono)",
+                    fontSize: "10.5px",
+                    textTransform: "uppercase",
+                    letterSpacing: "0.08em",
+                    color: "text.disabled",
+                  }}
+                >
+                  {observations.length > 0 ? `n = ${observations.length}` : ""}
+                </Box>
+              </Box>
               <Box>
                 {observations.map((obs) => (
                   <FeedItem

--- a/frontend/src/components/feed/feedLayout.ts
+++ b/frontend/src/components/feed/feedLayout.ts
@@ -2,8 +2,17 @@ import type { SxProps, Theme } from "@mui/material";
 
 /** Card wrapper styles shared between FeedItem and FeedItemSkeleton */
 export const FEED_CARD_SX: SxProps<Theme> = {
-  mb: 1.5,
+  mb: 3.25,
   mx: { xs: 0.5, sm: 1 },
+  border: 1,
+  borderColor: "divider",
+  borderRadius: 1,
+  bgcolor: "background.paper",
+  boxShadow: "none",
+  transition: "border-color 0.15s",
+  "&:hover": {
+    borderColor: "var(--ov-border-strong)",
+  },
   "&:first-of-type": {
     mt: 1.5,
   },

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Divider,
   Typography,
 } from "@mui/material";
-import { Login, Logout, GitHub, Schema } from "@mui/icons-material";
+import { Login, Logout, GitHub } from "@mui/icons-material";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
@@ -102,19 +102,6 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
       <Box sx={{ p: 1 }}>
         <Divider sx={{ mb: 1 }} />
         <List dense>
-          <ListItem disablePadding>
-            <ListItemButton
-              component={Link}
-              to="/lexicons"
-              onClick={onMobileClose}
-              sx={{ borderRadius: 2 }}
-            >
-              <ListItemIcon sx={{ minWidth: 40 }}>
-                <Schema fontSize="small" />
-              </ListItemIcon>
-              <ListItemText primary="Lexicons" />
-            </ListItemButton>
-          </ListItem>
           <ListItem disablePadding>
             <ListItemButton
               component="a"

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -20,15 +20,7 @@ import {
   Divider,
   alpha,
 } from "@mui/material";
-import {
-  Person,
-  Login,
-  Logout,
-  GitHub,
-  Schema,
-  Settings,
-  Menu as MenuIcon,
-} from "@mui/icons-material";
+import { Person, Login, Logout, GitHub, Settings, Menu as MenuIcon } from "@mui/icons-material";
 import { getDisplayName } from "../../lib/utils";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
@@ -106,18 +98,18 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
                 "&:hover": { opacity: 0.8 },
               }}
             >
-              <img src={logoSvg} alt="" width={32} height={32} />
+              <img src={logoSvg} alt="" width={26} height={26} />
               <Typography
-                variant="h6"
                 component="span"
                 sx={{
-                  fontWeight: 800,
+                  fontWeight: 700,
+                  fontSize: "15px",
                   color: "primary.main",
                   display: { xs: "none", sm: "block" },
-                  letterSpacing: "-0.02em",
+                  letterSpacing: "-0.01em",
                 }}
               >
-                Observ.ing
+                observ.ing
               </Typography>
             </Box>
 
@@ -151,24 +143,17 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
 
           <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 0.5, md: 1.5 } }}>
             {!isMobile && (
-              <>
-                <Tooltip title="Lexicons">
-                  <IconButton component={Link} to="/lexicons" color="inherit">
-                    <Schema />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="Source Code">
-                  <IconButton
-                    component="a"
-                    href="https://github.com/observ-ing/core"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    color="inherit"
-                  >
-                    <GitHub />
-                  </IconButton>
-                </Tooltip>
-              </>
+              <Tooltip title="Source Code">
+                <IconButton
+                  component="a"
+                  href="https://github.com/observ-ing/core"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  color="inherit"
+                >
+                  <GitHub />
+                </IconButton>
+              </Tooltip>
             )}
 
             {notificationItem && (

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -11,9 +11,7 @@ import {
   ButtonBase,
   Menu,
   MenuItem,
-  List,
   ListItem,
-  ListItemIcon,
   ListItemAvatar,
   ListItemText,
   Tooltip,
@@ -22,8 +20,6 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
-import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
-import MyLocationIcon from "@mui/icons-material/MyLocation";
 import { fetchObservation, getImageUrl, deleteIdentification } from "../../services/api";
 import { useAppSelector, useAppDispatch } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
@@ -208,24 +204,38 @@ export function ObservationDetail() {
         {/* Header */}
         <Box
           sx={{
-            p: 1.5,
+            px: 2,
+            py: 1.25,
             borderBottom: 1,
             borderColor: "divider",
             display: "flex",
             alignItems: "center",
+            gap: 1,
           }}
         >
-          <IconButton onClick={handleBack} sx={{ mr: 1 }}>
-            <ArrowBackIcon />
+          <IconButton onClick={handleBack} size="small">
+            <ArrowBackIcon fontSize="small" />
           </IconButton>
-          <Typography
-            variant="subtitle1"
+          <Box
             sx={{
-              fontWeight: 500,
+              fontFamily: "var(--ov-mono)",
+              fontSize: "11.5px",
+              letterSpacing: "0.06em",
+              textTransform: "uppercase",
+              color: "text.disabled",
+              display: "flex",
+              alignItems: "center",
+              gap: 0.75,
             }}
           >
-            Observation
-          </Typography>
+            <Box component="span">Observation</Box>
+            <Box component="span" sx={{ opacity: 0.45 }}>
+              /
+            </Box>
+            <Box component="span" sx={{ color: "text.secondary" }}>
+              {rkey}
+            </Box>
+          </Box>
           <Box sx={{ ml: "auto" }}>
             <IconButton
               size="small"
@@ -260,112 +270,307 @@ export function ObservationDetail() {
           </Box>
         </Box>
 
-        {/* Species Header */}
-        <Box sx={{ px: 3, pt: 2, pb: 1 }}>
-          {species ? (
-            <TaxonLink name={species} kingdom={taxonomy?.kingdom} />
-          ) : (
-            <Typography
-              variant="h5"
-              sx={{ fontWeight: 600, fontStyle: "italic", color: "text.secondary" }}
-            >
-              Unidentified
-            </Typography>
-          )}
-          {taxonomy?.vernacularName && (
-            <Typography
-              variant="body1"
-              sx={{
-                color: "text.secondary",
-              }}
-            >
-              {taxonomy.vernacularName}
-            </Typography>
-          )}
-        </Box>
-
-        {/* Like button */}
-        <Stack
-          direction="row"
+        {/* Specimen Header */}
+        <Box
           sx={{
-            alignItems: "center",
-            px: 3,
-            pb: 1,
+            display: "grid",
+            gridTemplateColumns: { xs: "1fr", md: "1fr 300px" },
+            gap: { xs: 3, md: 6 },
+            px: 3.5,
+            pt: 4.5,
+            pb: 3.5,
+            borderBottom: 1,
+            borderColor: "divider",
           }}
         >
-          <Tooltip title={!user ? "Log in to like" : ""}>
-            <span>
-              <IconButton
-                size="small"
-                onClick={() => observation && handleLikeToggle(observation.uri, observation.cid)}
-                disabled={!user}
-                aria-label={liked ? "Unlike" : "Like"}
-                sx={{
-                  color: liked ? "error.main" : "text.disabled",
-                  ml: -0.5,
-                }}
-              >
-                {liked ? (
-                  <FavoriteIcon fontSize="small" />
-                ) : (
-                  <FavoriteBorderIcon fontSize="small" />
-                )}
-              </IconButton>
-            </span>
-          </Tooltip>
-          {likeCount > 0 && (
-            <Typography
-              variant="body2"
+          <Box>
+            <Box
               sx={{
-                color: "text.secondary",
-                ml: -0.25,
+                fontFamily: "var(--ov-mono)",
+                fontSize: "10.5px",
+                letterSpacing: "0.12em",
+                textTransform: "uppercase",
+                color: "text.disabled",
+                mb: 1.5,
+                display: "flex",
+                gap: 1,
+                alignItems: "center",
               }}
             >
-              {likeCount}
-            </Typography>
-          )}
-        </Stack>
+              <Box component="span">Taxon</Box>
+              {taxonomy?.kingdom && (
+                <Box
+                  component="span"
+                  sx={{
+                    px: 0.75,
+                    py: 0.25,
+                    bgcolor: "primary.light",
+                    color: "primary.dark",
+                    borderRadius: 0.5,
+                    fontSize: "9.5px",
+                  }}
+                >
+                  {taxonomy.kingdom}
+                </Box>
+              )}
+            </Box>
+            <Box
+              sx={{
+                fontFamily: "var(--ov-serif)",
+                fontStyle: "italic",
+                fontWeight: 500,
+                fontSize: { xs: "40px", sm: "56px" },
+                lineHeight: 0.98,
+                color: "primary.main",
+                letterSpacing: "-0.02em",
+              }}
+            >
+              {species ? (
+                <TaxonLink name={species} kingdom={taxonomy?.kingdom} />
+              ) : (
+                <Box component="span" sx={{ color: "text.secondary" }}>
+                  Unidentified
+                </Box>
+              )}
+            </Box>
+            {taxonomy?.vernacularName && (
+              <Typography sx={{ fontSize: "17px", color: "text.secondary", mt: 1 }}>
+                {taxonomy.vernacularName}
+              </Typography>
+            )}
+            {/* Taxonomic ladder */}
+            {taxonomy && (
+              <Box sx={{ mt: 2.75, borderTop: 1, borderColor: "divider" }}>
+                {(
+                  [
+                    ["Kingdom", taxonomy.kingdom],
+                    ["Phylum", taxonomy.phylum],
+                    ["Class", taxonomy.class],
+                    ["Order", taxonomy.order],
+                    ["Family", taxonomy.family],
+                    ["Genus", taxonomy.genus],
+                  ] satisfies [string, string | undefined][]
+                )
+                  .filter(([, v]) => !!v)
+                  .map(([k, v], i, arr) => (
+                    <Box
+                      key={k}
+                      sx={{
+                        display: "grid",
+                        gridTemplateColumns: "90px 1fr",
+                        gap: 2,
+                        alignItems: "baseline",
+                        py: 1,
+                        borderBottom: i === arr.length - 1 ? 1 : 0,
+                        borderBottomStyle: "solid",
+                        borderColor: "divider",
+                        fontFamily: "var(--ov-mono)",
+                        fontSize: "12px",
+                        position: "relative",
+                        "&::after":
+                          i !== arr.length - 1
+                            ? {
+                                content: '""',
+                                position: "absolute",
+                                left: 0,
+                                right: 0,
+                                bottom: 0,
+                                borderBottom: "1px dashed",
+                                borderColor: "divider",
+                              }
+                            : {},
+                      }}
+                    >
+                      <Box
+                        sx={{
+                          color: "text.disabled",
+                          textTransform: "uppercase",
+                          fontSize: "10px",
+                          letterSpacing: "0.08em",
+                        }}
+                      >
+                        {k}
+                      </Box>
+                      <Box
+                        sx={{
+                          color: "text.primary",
+                          fontFamily: k === "Kingdom" ? "var(--ov-mono)" : "var(--ov-serif)",
+                          fontStyle: k === "Kingdom" ? "normal" : "italic",
+                          fontSize: "14px",
+                        }}
+                      >
+                        {v}
+                      </Box>
+                    </Box>
+                  ))}
+              </Box>
+            )}
+            <Box sx={{ mt: 2.5, display: "flex", alignItems: "center", gap: 1 }}>
+              <Tooltip title={!user ? "Log in to like" : ""}>
+                <span>
+                  <IconButton
+                    size="small"
+                    onClick={() =>
+                      observation && handleLikeToggle(observation.uri, observation.cid)
+                    }
+                    disabled={!user}
+                    aria-label={liked ? "Unlike" : "Like"}
+                    sx={{
+                      color: liked ? "var(--ov-heart)" : "text.disabled",
+                      gap: 0.75,
+                      fontSize: "12px",
+                      borderRadius: 1,
+                    }}
+                  >
+                    {liked ? (
+                      <FavoriteIcon fontSize="small" />
+                    ) : (
+                      <FavoriteBorderIcon fontSize="small" />
+                    )}
+                    {likeCount > 0 && (
+                      <Box
+                        component="span"
+                        sx={{
+                          fontFamily: "var(--ov-mono)",
+                          fontVariantNumeric: "tabular-nums",
+                          fontSize: "12px",
+                          ml: 0.5,
+                        }}
+                      >
+                        {likeCount}
+                      </Box>
+                    )}
+                  </IconButton>
+                </span>
+              </Tooltip>
+            </Box>
+          </Box>
+          {/* Record card */}
+          <Box
+            sx={{
+              border: 1,
+              borderColor: "divider",
+              borderRadius: 0.5,
+              fontFamily: "var(--ov-mono)",
+              fontSize: "11px",
+              bgcolor: "background.paper",
+              alignSelf: "start",
+              "& .rc-row": {
+                display: "grid",
+                gridTemplateColumns: "86px 1fr",
+                px: 1.75,
+                py: 1.1,
+                borderBottom: 1,
+                borderColor: "divider",
+                alignItems: "baseline",
+              },
+              "& .rc-row:last-of-type": { borderBottom: 0 },
+              "& .rc-k": {
+                color: "text.disabled",
+                textTransform: "uppercase",
+                letterSpacing: "0.08em",
+                fontSize: "10px",
+              },
+              "& .rc-v": {
+                color: "text.primary",
+                fontVariantNumeric: "tabular-nums",
+                wordBreak: "break-all",
+              },
+            }}
+          >
+            <Box className="rc-row">
+              <Box className="rc-k">Record</Box>
+              <Box className="rc-v">{rkey}</Box>
+            </Box>
+            <Box className="rc-row">
+              <Box className="rc-k">DID</Box>
+              <Box className="rc-v" sx={{ fontSize: "10px" }}>
+                {did}
+              </Box>
+            </Box>
+            <Box className="rc-row">
+              <Box className="rc-k">CID</Box>
+              <Box className="rc-v" sx={{ fontSize: "10px" }}>
+                {observation.cid}
+              </Box>
+            </Box>
+            <Box className="rc-row">
+              <Box className="rc-k">Created</Box>
+              <Box className="rc-v">
+                {new Date(observation.createdAt).toISOString().slice(0, 10)}
+              </Box>
+            </Box>
+          </Box>
+        </Box>
 
         {/* Images */}
         {observation.images.length > 0 && (
-          <Box sx={{ bgcolor: "grey.900", p: { xs: 0, sm: 2 } }}>
-            <ButtonBase
-              onClick={() => setLightboxOpen(true)}
-              aria-label="Enlarge photo"
+          <Box sx={{ px: 3.5, pt: 3.5 }}>
+            <Box
               sx={{
-                display: "block",
-                width: "100%",
-                borderRadius: { xs: 0, sm: 2 },
+                border: 1,
+                borderColor: "divider",
+                borderRadius: 0.5,
                 overflow: "hidden",
-                cursor: "zoom-in",
+                bgcolor: "var(--ov-bg-sunken)",
               }}
             >
-              <Box
-                component="img"
-                src={getImageUrl(observation.images[activeImageIndex] ?? "")}
-                alt={species}
+              <ButtonBase
+                onClick={() => setLightboxOpen(true)}
+                aria-label="Enlarge photo"
                 sx={{
-                  width: "100%",
-                  maxHeight: 400,
-                  objectFit: "contain",
                   display: "block",
-                  boxShadow: { xs: "none", sm: "0 4px 12px rgba(0, 0, 0, 0.15)" },
+                  width: "100%",
+                  cursor: "zoom-in",
                 }}
-              />
-            </ButtonBase>
+              >
+                <Box
+                  component="img"
+                  src={getImageUrl(observation.images[activeImageIndex] ?? "")}
+                  alt={species}
+                  sx={{
+                    width: "100%",
+                    maxHeight: 520,
+                    objectFit: "contain",
+                    display: "block",
+                  }}
+                />
+              </ButtonBase>
+              <Box
+                sx={{
+                  display: "flex",
+                  justifyContent: "space-between",
+                  px: 1.75,
+                  py: 1.25,
+                  borderTop: 1,
+                  borderColor: "divider",
+                  fontFamily: "var(--ov-mono)",
+                  fontSize: "11px",
+                  color: "text.disabled",
+                  fontVariantNumeric: "tabular-nums",
+                }}
+              >
+                <Box component="span">
+                  Plate {activeImageIndex + 1} / {observation.images.length}
+                </Box>
+                <Box component="span">{formatDate(observation.eventDate)}</Box>
+              </Box>
+            </Box>
             {observation.images.length > 1 && (
-              <Stack direction="row" spacing={1} sx={{ p: 1, justifyContent: "center" }}>
+              <Stack direction="row" spacing={1} sx={{ mt: 1.5, flexWrap: "wrap" }}>
                 {observation.images.map((img, idx) => (
                   <ButtonBase
                     key={img}
                     onClick={() => setActiveImageIndex(idx)}
                     sx={{
-                      width: 60,
-                      height: 60,
-                      border: 2,
+                      width: 62,
+                      height: 62,
+                      border: 1,
                       borderColor: idx === activeImageIndex ? "primary.main" : "divider",
-                      borderRadius: 1,
+                      boxShadow: idx === activeImageIndex ? "0 0 0 1px var(--ov-accent)" : "none",
+                      borderRadius: 0.5,
                       overflow: "hidden",
+                      position: "relative",
                     }}
                   >
                     <Box
@@ -374,6 +579,21 @@ export function ObservationDetail() {
                       alt={`Photo ${idx + 1}`}
                       sx={{ width: "100%", height: "100%", objectFit: "cover" }}
                     />
+                    <Box
+                      sx={{
+                        position: "absolute",
+                        left: 3,
+                        top: 2,
+                        fontFamily: "var(--ov-mono)",
+                        fontSize: "9px",
+                        color: "#fff",
+                        bgcolor: "rgba(0,0,0,0.6)",
+                        px: 0.4,
+                        borderRadius: 0.25,
+                      }}
+                    >
+                      {String(idx + 1).padStart(2, "0")}
+                    </Box>
                   </ButtonBase>
                 ))}
               </Stack>
@@ -382,8 +602,20 @@ export function ObservationDetail() {
         )}
 
         {/* Content */}
-        <Box sx={{ p: 3 }}>
+        <Box sx={{ px: 3.5, py: 3.5 }}>
           {/* Observer */}
+          <Box
+            sx={{
+              fontFamily: "var(--ov-mono)",
+              fontSize: "10.5px",
+              letterSpacing: "0.12em",
+              textTransform: "uppercase",
+              color: "text.disabled",
+              mb: 1.25,
+            }}
+          >
+            Observer
+          </Box>
           <ListItem
             component={Link}
             to={`/profile/${encodeURIComponent(observation.observer.did)}`}
@@ -391,7 +623,7 @@ export function ObservationDetail() {
               textDecoration: "none",
               color: "inherit",
               "&:hover": { bgcolor: "action.hover" },
-              mx: -2,
+              mx: -1.5,
               borderRadius: 1,
             }}
           >
@@ -406,69 +638,78 @@ export function ObservationDetail() {
               secondary={handle || undefined}
               slotProps={{
                 primary: { sx: { fontWeight: 600 } },
-                secondary: { sx: { color: "text.disabled" } },
+                secondary: {
+                  sx: { color: "text.disabled", fontFamily: "var(--ov-mono)", fontSize: "12px" },
+                },
               }}
             />
           </ListItem>
 
-          {/* Observation Details */}
-          <List disablePadding sx={{ mt: 1 }}>
-            <ListItem disableGutters alignItems="flex-start">
-              <ListItemIcon sx={{ minWidth: 36, mt: 0.5 }}>
-                <CalendarTodayIcon sx={{ fontSize: 18, color: "text.secondary" }} />
-              </ListItemIcon>
-              <ListItemText
-                primary="Observed"
-                secondary={formatDate(observation.eventDate)}
-                slotProps={{
-                  primary: { variant: "caption", color: "text.secondary" },
-                  secondary: { variant: "body1", color: "text.primary" },
-                }}
-              />
-            </ListItem>
-
-            <ListItem disableGutters alignItems="flex-start">
-              <ListItemIcon sx={{ minWidth: 36, mt: 0.5 }}>
-                <MyLocationIcon sx={{ fontSize: 18, color: "text.secondary" }} />
-              </ListItemIcon>
-              <ListItemText
-                primary="Coordinates"
-                secondary={
-                  <>
-                    {observation.location.latitude.toFixed(5)},{" "}
-                    {observation.location.longitude.toFixed(5)}
-                    {observation.location.uncertaintyMeters && (
-                      <Typography
-                        component="span"
-                        variant="body2"
-                        sx={{
-                          color: "text.disabled",
-                        }}
-                      >
-                        {" "}
-                        (±{observation.location.uncertaintyMeters}m)
-                      </Typography>
-                    )}
-                  </>
-                }
-                slotProps={{
-                  primary: { variant: "caption", color: "text.secondary" },
-                  secondary: {
-                    variant: "body1",
-                    color: "text.primary",
-                    component: "div",
-                  },
-                }}
-              />
-            </ListItem>
-            <Box sx={{ ml: 4.5, mb: 1 }}>
-              <LocationMap
-                latitude={observation.location.latitude}
-                longitude={observation.location.longitude}
-                uncertaintyMeters={observation.location.uncertaintyMeters}
-              />
-            </Box>
-          </List>
+          {/* Observation metadata */}
+          <Box
+            component="table"
+            sx={{
+              width: "100%",
+              borderCollapse: "collapse",
+              mt: 2.5,
+              "& td": {
+                py: 1.4,
+                borderBottom: "1px dashed",
+                borderColor: "divider",
+                verticalAlign: "top",
+                fontSize: "13px",
+              },
+              "& td:first-of-type": {
+                width: 130,
+                color: "text.disabled",
+                fontFamily: "var(--ov-mono)",
+                textTransform: "uppercase",
+                fontSize: "10.5px",
+                letterSpacing: "0.08em",
+                pr: 1.75,
+                pt: 1.6,
+              },
+              "& td:last-of-type": {
+                color: "text.primary",
+                fontFamily: "var(--ov-mono)",
+                fontVariantNumeric: "tabular-nums",
+                fontSize: "12.5px",
+              },
+              "& tr:last-of-type td": { borderBottom: 0 },
+            }}
+          >
+            <tbody>
+              <tr>
+                <td>Observed</td>
+                <td>{formatDate(observation.eventDate)}</td>
+              </tr>
+              <tr>
+                <td>Latitude</td>
+                <td>{observation.location.latitude.toFixed(5)}°</td>
+              </tr>
+              <tr>
+                <td>Longitude</td>
+                <td>{observation.location.longitude.toFixed(5)}°</td>
+              </tr>
+              {observation.location.uncertaintyMeters !== undefined && (
+                <tr>
+                  <td>Uncertainty</td>
+                  <td>±{observation.location.uncertaintyMeters} m</td>
+                </tr>
+              )}
+              <tr>
+                <td>Photos</td>
+                <td>{observation.images.length}</td>
+              </tr>
+            </tbody>
+          </Box>
+          <Box sx={{ mt: 2 }}>
+            <LocationMap
+              latitude={observation.location.latitude}
+              longitude={observation.location.longitude}
+              uncertaintyMeters={observation.location.uncertaintyMeters}
+            />
+          </Box>
 
           <Box sx={{ mt: 3 }}>
             {/* Identification History */}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -30,6 +30,13 @@
     />
 
     <link rel="canonical" href="https://observ.ing" />
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:wght@300;400;500;600&family=Newsreader:ital,opsz,wght@0,6..72,400;0,6..72,500;0,6..72,600;1,6..72,400;1,6..72,500;1,6..72,600&family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,500;0,9..144,600;0,9..144,700;1,9..144,400;1,9..144,500&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/styles/global.css
+++ b/frontend/src/styles/global.css
@@ -39,3 +39,21 @@ button,
     opacity 0.15s ease,
     transform 0.15s ease;
 }
+
+/* Herbarium utility classes */
+.ov-mono {
+  font-family: var(--ov-mono);
+  font-variant-numeric: tabular-nums;
+}
+.ov-sci {
+  font-family: var(--ov-serif);
+  font-style: italic;
+}
+.ov-label {
+  font-family: var(--ov-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--ov-fg-3);
+  font-weight: 600;
+}

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,76 +1,107 @@
 import { createTheme, type Theme, type PaletteMode } from "@mui/material/styles";
 
+export const fontStacks = {
+  sans: '"Helvetica Neue", Helvetica, Arial, sans-serif',
+  mono: '"JetBrains Mono", ui-monospace, Menlo, monospace',
+  serif: '"Newsreader", Georgia, serif',
+  display: '"Fraunces", "Newsreader", Georgia, serif',
+};
+
 const sharedConfig = {
   typography: {
-    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif',
-    h1: { fontSize: "1.5rem", fontWeight: 700, letterSpacing: "-0.02em" },
-    h2: { fontSize: "1.25rem", fontWeight: 700, letterSpacing: "-0.01em" },
-    h3: { fontSize: "1.1rem", fontWeight: 700 },
+    fontFamily: fontStacks.sans,
+    h1: {
+      fontFamily: fontStacks.display,
+      fontSize: "1.75rem",
+      fontWeight: 500,
+      letterSpacing: "-0.02em",
+    },
+    h2: {
+      fontFamily: fontStacks.display,
+      fontSize: "1.375rem",
+      fontWeight: 500,
+      letterSpacing: "-0.01em",
+    },
+    h3: { fontFamily: fontStacks.display, fontSize: "1.125rem", fontWeight: 500 },
     h4: { fontSize: "1rem", fontWeight: 600 },
     h5: { fontSize: "0.95rem", fontWeight: 600 },
     h6: { fontSize: "0.875rem", fontWeight: 600 },
-    body1: { fontSize: "1rem" },
+    body1: { fontSize: "0.95rem" },
     body2: { fontSize: "0.875rem" },
-    caption: { fontSize: "0.75rem" },
+    caption: { fontSize: "0.75rem", fontFamily: fontStacks.mono },
+    overline: {
+      fontFamily: fontStacks.mono,
+      fontSize: "0.66rem",
+      letterSpacing: "0.12em",
+      textTransform: "uppercase" as const,
+      fontWeight: 600,
+    },
   },
   shape: {
-    borderRadius: 8,
+    borderRadius: 4,
   },
 };
 
+// Herbarium tokens — bone paper / warm dark, hunter green accent
 const darkPalette = {
   mode: "dark" as const,
   primary: {
-    main: "#22c55e",
-    dark: "#16a34a",
+    main: "#8ab87a",
+    dark: "#b5d6a4",
+    light: "#2c3a28",
     contrastText: "#0a0a0a",
   },
   background: {
-    default: "#0a0a0a",
-    paper: "#1a1a1a",
+    default: "#1a1814",
+    paper: "#211f1a",
   },
   text: {
-    primary: "#fafafa",
-    secondary: "#999",
-    disabled: "#666",
+    primary: "#efe8d6",
+    secondary: "#a39c86",
+    disabled: "#746c59",
   },
   warning: {
-    main: "#f59e0b",
+    main: "#d9a23c",
   },
   error: {
-    main: "#ef4444",
+    main: "#e06a56",
   },
-  divider: "#333",
+  divider: "#332f27",
 };
 
 const lightPalette = {
   mode: "light" as const,
   primary: {
-    main: "#15803d",
-    dark: "#166534",
+    main: "#355e3b",
+    dark: "#24422a",
+    light: "#d6ddc4",
     contrastText: "#ffffff",
   },
   background: {
-    default: "#f5f5f5",
-    paper: "#ffffff",
+    default: "#f4efe6",
+    paper: "#fbf8f1",
   },
   text: {
-    primary: "#171717",
-    secondary: "#525252",
-    disabled: "#737373",
+    primary: "#1c1a15",
+    secondary: "#5b5445",
+    disabled: "#8c836d",
   },
   warning: {
-    main: "#b45309",
+    main: "#8a5a00",
   },
   error: {
-    main: "#b91c1c",
+    main: "#b33a2a",
   },
-  divider: "#d4d4d4",
+  divider: "#d9d0bb",
 };
 
 const createAppTheme = (mode: PaletteMode): Theme => {
   const isDark = mode === "dark";
   const palette = isDark ? darkPalette : lightPalette;
+  const borderStrong = isDark ? "#4a463c" : "#b9ae93";
+  const sunken = isDark ? "#13110e" : "#ebe4d2";
+  const fg3 = isDark ? "#746c59" : "#8c836d";
+  const warningBg = isDark ? "#2c261a" : "#efe5cf";
 
   return createTheme({
     palette,
@@ -78,15 +109,41 @@ const createAppTheme = (mode: PaletteMode): Theme => {
     components: {
       MuiCssBaseline: {
         styleOverrides: {
+          ":root": {
+            "--ov-bg": palette.background.default,
+            "--ov-bg-elev": palette.background.paper,
+            "--ov-bg-sunken": sunken,
+            "--ov-fg": palette.text.primary,
+            "--ov-fg-2": palette.text.secondary,
+            "--ov-fg-3": fg3,
+            "--ov-border": palette.divider,
+            "--ov-border-strong": borderStrong,
+            "--ov-accent": palette.primary.main,
+            "--ov-accent-strong": palette.primary.dark,
+            "--ov-accent-soft": palette.primary.light,
+            "--ov-warning": palette.warning.main,
+            "--ov-warning-bg": warningBg,
+            "--ov-heart": palette.error.main,
+            "--ov-sans": fontStacks.sans,
+            "--ov-mono": fontStacks.mono,
+            "--ov-serif": fontStacks.serif,
+            "--ov-display": fontStacks.display,
+          },
           body: {
             scrollbarWidth: "none",
             "&::-webkit-scrollbar": { display: "none" },
+            fontFamily: fontStacks.sans,
+            WebkitFontSmoothing: "antialiased",
           },
           "#root": {
             width: "100vw",
             height: "100vh",
             display: "flex",
             flexDirection: "column",
+          },
+          "::selection": {
+            background: palette.primary.light,
+            color: palette.primary.dark,
           },
         },
       },
@@ -112,5 +169,4 @@ export const darkTheme = createAppTheme("dark");
 export const lightTheme = createAppTheme("light");
 export const getTheme = (mode: PaletteMode): Theme => createAppTheme(mode);
 
-// Default export for backwards compatibility
 export default darkTheme;


### PR DESCRIPTION
## Summary
- Ports the Herbarium variant from the Claude Design handoff onto the feed + observation detail pages, layered on the existing MUI theme.
- Palette shifts to bone paper (light) / warm black (dark) with hunter green accent; JetBrains Mono + Newsreader italic + Fraunces display loaded from Google Fonts.
- Scientific names now render in Newsreader italic everywhere via `TaxonLink`.
- Feed card picks up mono metadata, serif-italic species title, taxonomic strip, and a mono 3-cell data row (observed / location / IDs).
- Observation detail gets a specimen header (56px italic sciname + taxonomic ladder + record card for rkey/DID/CID), a dashed-rule mono meta table, and a plate-captioned image frame with indexed thumbnails.
- TopBar brand goes lowercase `observ.ing`; Lexicons removed from both TopBar and Sidebar per design chat.
- Pre-release banner reworked with mono uppercase over the warning-bg token.

## Scope decisions
Per the handoff chat transcript:
- **One variant only** — Herbarium (not Field or Atlas).
- **Adopted on top of MUI** — no wholesale CSS rewrite; theme tokens exposed as both MUI palette values and `--ov-*` CSS vars.
- **Omitted features without data**: AI suggestion chips, related-species grid, right-rail stats/leaderboard.

## Test plan
- [ ] Start backend (`process-compose up -D`), hit `/` and `/observation/:did/:rkey`, verify cards and detail page render populated.
- [ ] Toggle light/dark via settings, confirm Herbarium tokens in both modes.
- [ ] Verify sidebar + topbar no longer link to `/lexicons` (route itself still resolves).
- [ ] Verify scientific names render in Newsreader italic in feed, detail header, taxonomic ladder, and identification history.
- [ ] Check mobile/tablet breakpoints don't regress the specimen header grid.

## Known follow-ups (out of scope)
- Landing page footer still links to Lexicons.
- Identification history / AI suggestions / interaction panel internals were not restyled — they still render but in their pre-existing MUI look.