### PR TITLE
fix(process-compose): specify ingester bin

### DIFF
--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -32,7 +32,7 @@ processes:
         condition: process_healthy
 
   ingester:
-    command: cargo run
+    command: cargo run --bin observing-ingester
     working_dir: crates/observing-ingester
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:${DB_PASSWORD}@localhost:5432/observing}


### PR DESCRIPTION
## Summary
- `cargo run` in the ingester process failed because the `observing-ingester` crate has two binaries (`backfill` and `observing-ingester`). Pass `--bin observing-ingester` explicitly.

## Test plan
- [ ] `process-compose up` — ingester process starts cleanly