### PR TITLE
refactor(occurrences): use rsplit_once for observer path parsing

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -195,11 +195,8 @@ pub async fn delete_occurrence_catch_all(
     user: AuthUser,
     Path(full_path): Path<String>,
 ) -> Result<Json<SuccessResponse>, AppError> {
-    // Try observer removal: path contains /observers/{did}
-    if full_path.contains("/observers/") {
-        let idx = full_path.rfind("/observers/").unwrap();
-        let uri = &full_path[..idx];
-        let observer_did = &full_path[idx + "/observers/".len()..];
+    // Try observer removal: path is `{uri}/observers/{did}`
+    if let Some((uri, observer_did)) = full_path.rsplit_once("/observers/") {
         if let Err(e) = observing_db::observers::remove(&state.pool, uri, observer_did).await {
             warn!(error = %e, "Failed to remove observer");
         }


### PR DESCRIPTION
## Summary
- Replace `full_path.contains("/observers/")` + `rfind(...).unwrap()` + manual index arithmetic with a single `rsplit_once("/observers/")` match.
- Removes the (safe-but-redundant) `unwrap()` and the hard-coded substring length math.

## Test plan
- [x] `cargo build -p observing-appview`
- [x] `cargo clippy -p observing-appview`
- [ ] Manual: DELETE `/api/occurrences/{uri}/observers/{did}` still removes an observer; DELETE `/api/occurrences/{uri}` still falls through to occurrence delete.