### PR TITLE
refactor(api): extract deleteResource helper

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -41,6 +41,24 @@ async function fetchApi<T>(url: string, errorMessage: string, init?: RequestInit
   return response.json();
 }
 
+/**
+ * DELETE a resource and return the JSON body. Surfaces 401s as a
+ * session-expired error so callers can prompt for re-login.
+ */
+async function deleteResource<T>(url: string, errorMessage: string): Promise<T> {
+  const response = await fetch(url, {
+    method: "DELETE",
+    credentials: "include",
+  });
+  if (!response.ok) {
+    if (response.status === 401) {
+      throw new Error("Session expired, please log in again");
+    }
+    throw new Error(await extractErrorMessage(response, errorMessage));
+  }
+  return response.json();
+}
+
 export async function checkAuth(): Promise<User | null> {
   try {
     const response = await fetch(`${API_BASE}/oauth/me`, {
@@ -249,35 +267,17 @@ export async function updateObservation(data: {
 }
 
 export async function deleteObservation(uri: string): Promise<{ success: boolean }> {
-  const response = await fetch(`${API_BASE}/api/occurrences/${encodeURIComponent(uri)}`, {
-    method: "DELETE",
-    credentials: "include",
-  });
-
-  if (!response.ok) {
-    if (response.status === 401) {
-      throw new Error("Session expired, please log in again");
-    }
-    throw new Error(await extractErrorMessage(response, "Failed to delete observation"));
-  }
-
-  return response.json();
+  return deleteResource(
+    `${API_BASE}/api/occurrences/${encodeURIComponent(uri)}`,
+    "Failed to delete observation",
+  );
 }
 
 export async function deleteIdentification(uri: string): Promise<{ success: boolean }> {
-  const response = await fetch(`${API_BASE}/api/identifications/${encodeURIComponent(uri)}`, {
-    method: "DELETE",
-    credentials: "include",
-  });
-
-  if (!response.ok) {
-    if (response.status === 401) {
-      throw new Error("Session expired, please log in again");
-    }
-    throw new Error(await extractErrorMessage(response, "Failed to delete identification"));
-  }
-
-  return response.json();
+  return deleteResource(
+    `${API_BASE}/api/identifications/${encodeURIComponent(uri)}`,
+    "Failed to delete identification",
+  );
 }
 
 export function getImageUrl(path: string): string {


### PR DESCRIPTION
## Summary
- `deleteObservation` and `deleteIdentification` duplicated the full DELETE + `response.status === 401` + `extractErrorMessage` sequence.
- Fold into a shared `deleteResource<T>(url, errorMessage)` helper so the session-expired error string and auth handling live in one place.

No behavior change — same user-facing error messages, same credentials mode.

## Test plan
- [x] `npm run fmt`
- [x] `npm run lint`
- [x] `npm run build` (typecheck)
- [ ] Manual: delete an observation while logged in (success), while logged out / 401 (see "Session expired, please log in again").
- [ ] Manual: delete an identification — same two cases.