### PR TITLE
refactor(autocomplete): extract shared renderInput helper

### DIFF
--- a/frontend/src/components/common/ActorAutocomplete.tsx
+++ b/frontend/src/components/common/ActorAutocomplete.tsx
@@ -1,16 +1,9 @@
 import { useState, useCallback } from "react";
-import {
-  Autocomplete,
-  Avatar,
-  Box,
-  CircularProgress,
-  Stack,
-  TextField,
-  Typography,
-} from "@mui/material";
+import { Autocomplete, Avatar, Box, Stack, Typography } from "@mui/material";
 import { searchActors } from "../../services/api";
 import type { ActorSearchResult } from "../../services/api";
 import { useAutocomplete } from "../../hooks/useAutocomplete";
+import { renderAutocompleteInput } from "./autocompleteInput";
 
 interface ActorAutocompleteProps {
   onSelect: (actor: ActorSearchResult) => void;
@@ -56,29 +49,7 @@ export function ActorAutocomplete({
       }}
       filterOptions={(x) => x}
       size="small"
-      renderInput={(params) => {
-        const { slotProps: paramsSlotProps, ...rest } = params;
-        return (
-          <TextField
-            {...rest}
-            fullWidth
-            label={label}
-            placeholder={placeholder}
-            slotProps={{
-              ...paramsSlotProps,
-              input: {
-                ...paramsSlotProps.input,
-                endAdornment: (
-                  <>
-                    {loading && <CircularProgress color="inherit" size={20} />}
-                    {paramsSlotProps.input?.endAdornment}
-                  </>
-                ),
-              },
-            }}
-          />
-        );
-      }}
+      renderInput={(params) => renderAutocompleteInput({ params, loading, label, placeholder })}
       renderOption={(props, option) => {
         const { key, ...otherProps } = props;
         return (

--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -1,10 +1,11 @@
 import { useCallback, type ReactNode } from "react";
-import { Autocomplete, Box, CircularProgress, Stack, TextField, Typography } from "@mui/material";
+import { Autocomplete, Box, Stack, Typography } from "@mui/material";
 import { searchTaxa } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ConservationStatus } from "./ConservationStatus";
 import { useAutocomplete } from "../../hooks/useAutocomplete";
 import { MAX_AUTOCOMPLETE_RESULTS } from "../../lib/utils";
+import { renderAutocompleteInput } from "./autocompleteInput";
 
 interface TaxaAutocompleteProps {
   value: string;
@@ -64,30 +65,9 @@ export function TaxaAutocomplete({
         }}
         filterOptions={(x) => x}
         {...(size ? { size } : {})}
-        renderInput={(params) => {
-          const { slotProps: paramsSlotProps, ...rest } = params;
-          return (
-            <TextField
-              {...rest}
-              fullWidth
-              label={label}
-              placeholder={placeholder}
-              margin={margin}
-              slotProps={{
-                ...paramsSlotProps,
-                input: {
-                  ...paramsSlotProps.input,
-                  endAdornment: (
-                    <>
-                      {loading && <CircularProgress color="inherit" size={20} />}
-                      {paramsSlotProps.input?.endAdornment}
-                    </>
-                  ),
-                },
-              }}
-            />
-          );
-        }}
+        renderInput={(params) =>
+          renderAutocompleteInput({ params, loading, label, placeholder, margin })
+        }
         renderOption={(props, option) => {
           const { key, ...otherProps } = props;
           return (

--- a/frontend/src/components/common/autocompleteInput.tsx
+++ b/frontend/src/components/common/autocompleteInput.tsx
@@ -1,0 +1,45 @@
+import { CircularProgress, TextField } from "@mui/material";
+import type { AutocompleteRenderInputParams } from "@mui/material";
+
+interface RenderAutocompleteInputOptions {
+  params: AutocompleteRenderInputParams;
+  loading: boolean;
+  label: string;
+  placeholder: string;
+  margin?: "normal" | "dense" | "none";
+}
+
+/**
+ * Shared `renderInput` for MUI Autocomplete components: threads through MUI's
+ * slot props while adding a loading spinner as an endAdornment.
+ */
+export function renderAutocompleteInput({
+  params,
+  loading,
+  label,
+  placeholder,
+  margin,
+}: RenderAutocompleteInputOptions) {
+  const { slotProps: paramsSlotProps, ...rest } = params;
+  return (
+    <TextField
+      {...rest}
+      fullWidth
+      label={label}
+      placeholder={placeholder}
+      {...(margin ? { margin } : {})}
+      slotProps={{
+        ...paramsSlotProps,
+        input: {
+          ...paramsSlotProps.input,
+          endAdornment: (
+            <>
+              {loading && <CircularProgress color="inherit" size={20} />}
+              {paramsSlotProps.input?.endAdornment}
+            </>
+          ),
+        },
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- `ActorAutocomplete` and `TaxaAutocomplete` both inlined the same `renderInput`: destructure `slotProps`, merge a loading `CircularProgress` into `endAdornment`, forward to `TextField`.
- Extract that ~20-line block into a shared `renderAutocompleteInput()` in `common/autocompleteInput.tsx`. Both components shed the duplicated JSX plus the now-unused `TextField` / `CircularProgress` imports.

No visual or behavioral change — the helper produces the same JSX tree with the same slot-prop merging.

## Test plan
- [x] `npm run fmt`
- [x] `npm run lint`
- [x] `npm run build`
- [ ] Manual: open the actor-search field (e.g. add co-observer), confirm loading spinner appears on the right while searching, and selection/clear still work.
- [ ] Manual: open the taxa-search field (observation upload / edit), same check including free-solo typing.