### PR TITLE
test(observing-db): baseline coverage for processing::*_from_json parsers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2883,6 +2883,7 @@ name = "observing-db"
 version = "0.1.0"
 dependencies = [
  "chrono",
+ "jacquard-lexicon",
  "observing-lexicons",
  "serde",
  "serde_json",

--- a/crates/observing-db/Cargo.toml
+++ b/crates/observing-db/Cargo.toml
@@ -28,3 +28,7 @@ chrono = { workspace = true }
 
 # Optional: AT Protocol lexicon types for record processing
 observing-lexicons = { path = "../observing-lexicons", optional = true }
+
+# Test-only: lexicon constraint validation in processing tests
+[dev-dependencies]
+jacquard-lexicon = "0.12.0-beta.2"

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -395,6 +395,28 @@ pub fn extract_co_observers<T: AsRef<str>>(
 mod tests {
     use super::*;
     use chrono::{Datelike, Timelike};
+    use jacquard_lexicon::schema::LexiconSchema;
+    use observing_lexicons::bio_lexicons::temp::identification::Identification;
+    use observing_lexicons::ing_observ::temp::like::Like;
+
+    /// Asserts the JSON fixture is a structurally valid record under its
+    /// declared lexicon: it deserializes into the typed lexicon struct *and*
+    /// satisfies the schema's runtime constraint checks (maxLength, enum
+    /// values, required fields, etc.). This proves a fixture is something a
+    /// real PDS could produce — not just JSON that happens to flow through a
+    /// `*_from_json` parser. Every happy-path test below validates its
+    /// fixture this way before exercising the parser, so any drift between
+    /// the test fixtures and the lexicon definitions surfaces immediately.
+    fn assert_valid_lexicon<T>(record: &serde_json::Value)
+    where
+        T: serde::de::DeserializeOwned + LexiconSchema,
+    {
+        let typed: T = serde_json::from_value(record.clone())
+            .unwrap_or_else(|e| panic!("fixture failed to deserialize as {}: {e}", T::nsid()));
+        typed.validate().unwrap_or_else(|e| {
+            panic!("fixture violated {} lexicon constraints: {e:?}", T::nsid())
+        });
+    }
 
     #[test]
     fn test_parse_datetime_utc() {
@@ -487,6 +509,8 @@ mod tests {
             "createdAt": "2024-06-15T08:30:45Z"
         });
 
+        assert_valid_lexicon::<Identification>(&record);
+
         let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
@@ -530,6 +554,8 @@ mod tests {
             // no createdAt
         });
 
+        assert_valid_lexicon::<Identification>(&record);
+
         let fallback = DateTime::parse_from_rfc3339("2024-03-20T15:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
@@ -558,6 +584,8 @@ mod tests {
             "body": "Nice find — looks like a juvenile.",
             "createdAt": "2024-06-15T08:30:45Z"
         });
+
+        assert_valid_lexicon::<Comment>(&record);
 
         let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
             .unwrap()
@@ -600,6 +628,8 @@ mod tests {
             "body": "Agreed!",
             "createdAt": "2024-06-15T08:35:00Z"
         });
+
+        assert_valid_lexicon::<Comment>(&record);
 
         let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
             .unwrap()
@@ -645,6 +675,8 @@ mod tests {
             "comment": "Caught mid-strike.",
             "createdAt": "2024-06-15T08:30:45Z"
         });
+
+        assert_valid_lexicon::<Interaction>(&record);
 
         let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
             .unwrap()
@@ -698,6 +730,8 @@ mod tests {
             "createdAt": "2024-06-15T08:30:45Z"
         });
 
+        assert_valid_lexicon::<Interaction>(&record);
+
         let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
             .unwrap()
             .with_timezone(&Utc);
@@ -730,6 +764,8 @@ mod tests {
             },
             "createdAt": "2024-06-15T08:30:45Z"
         });
+
+        assert_valid_lexicon::<Like>(&record);
 
         let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
             .unwrap()
@@ -792,6 +828,11 @@ mod tests {
                 }
             ]
         });
+
+        // Pin down that the fixture really is a valid bio.lexicons.temp.occurrence
+        // — the regression is "we lose photos on a structurally valid record",
+        // not "we mishandle malformed input".
+        assert_valid_lexicon::<Occurrence>(&record);
 
         let parsed = occurrence_from_json(
             &record,

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -467,4 +467,345 @@ mod tests {
         let result = extract_co_observers(Some(recorded_by.as_slice()), "did:plc:author");
         assert!(result.is_empty());
     }
+
+    /// Baseline happy-path coverage for `identification_from_json`. Locks in
+    /// the current field mapping so future divergence between the appview
+    /// write path and the ingester surfaces here.
+    #[test]
+    fn test_identification_from_json_happy_path() {
+        let record = serde_json::json!({
+            "$type": "bio.lexicons.temp.identification",
+            "scientificName": "Quercus alba",
+            "taxonRank": "species",
+            "kingdom": "Plantae",
+            "taxonId": "gbif:2879737",
+            "isAgreement": true,
+            "occurrence": {
+                "uri": "at://did:plc:author/bio.lexicons.temp.occurrence/abc",
+                "cid": "bafyreioccurrence"
+            },
+            "createdAt": "2024-06-15T08:30:45Z"
+        });
+
+        let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let params = identification_from_json(
+            &record,
+            "at://did:plc:identifier/bio.lexicons.temp.identification/xyz".to_string(),
+            "bafyreiident".to_string(),
+            "did:plc:identifier".to_string(),
+            fallback,
+        )
+        .expect("record should parse");
+
+        assert_eq!(params.scientific_name, "Quercus alba");
+        assert_eq!(params.taxon_rank.as_deref(), Some("species"));
+        assert_eq!(params.kingdom.as_deref(), Some("Plantae"));
+        assert_eq!(params.taxon_id.as_deref(), Some("gbif:2879737"));
+        assert!(params.is_agreement);
+        assert_eq!(
+            params.subject_uri,
+            "at://did:plc:author/bio.lexicons.temp.occurrence/abc"
+        );
+        assert_eq!(params.subject_cid, "bafyreioccurrence");
+        // createdAt is parsed via parse_naive_datetime, so it lands as UTC naive.
+        assert_eq!(params.date_identified.date().to_string(), "2024-06-15");
+    }
+
+    /// `identification_from_json` falls back to the supplied time when the
+    /// record's `createdAt` is missing or unparseable. Pins the fallback
+    /// behavior so the ingester (which passes the firehose event time) and
+    /// the appview (which would pass `Utc::now()`) stay aligned.
+    #[test]
+    fn test_identification_from_json_uses_fallback_time() {
+        let record = serde_json::json!({
+            "$type": "bio.lexicons.temp.identification",
+            "scientificName": "Quercus alba",
+            "occurrence": {
+                "uri": "at://did:plc:author/bio.lexicons.temp.occurrence/abc",
+                "cid": "bafyreioccurrence"
+            }
+            // no createdAt
+        });
+
+        let fallback = DateTime::parse_from_rfc3339("2024-03-20T15:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let params = identification_from_json(
+            &record,
+            "uri".into(),
+            "cid".into(),
+            "did:plc:x".into(),
+            fallback,
+        )
+        .expect("record should parse without createdAt");
+
+        assert_eq!(params.date_identified, fallback.naive_utc());
+    }
+
+    /// Baseline happy-path coverage for `comment_from_json`.
+    #[test]
+    fn test_comment_from_json_happy_path() {
+        let record = serde_json::json!({
+            "$type": "ing.observ.temp.comment",
+            "subject": {
+                "uri": "at://did:plc:author/bio.lexicons.temp.occurrence/abc",
+                "cid": "bafyreioccurrence"
+            },
+            "body": "Nice find — looks like a juvenile.",
+            "createdAt": "2024-06-15T08:30:45Z"
+        });
+
+        let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let params = comment_from_json(
+            &record,
+            "at://did:plc:commenter/ing.observ.temp.comment/xyz".to_string(),
+            "bafyreicomment".to_string(),
+            "did:plc:commenter".to_string(),
+            fallback,
+        )
+        .expect("record should parse");
+
+        assert_eq!(params.body, "Nice find — looks like a juvenile.");
+        assert_eq!(
+            params.subject_uri,
+            "at://did:plc:author/bio.lexicons.temp.occurrence/abc"
+        );
+        assert_eq!(params.subject_cid, "bafyreioccurrence");
+        assert!(params.reply_to_uri.is_none());
+        assert!(params.reply_to_cid.is_none());
+    }
+
+    /// `comment_from_json` carries `replyTo` strong refs through to the
+    /// `reply_to_uri` / `reply_to_cid` columns. This is the only place
+    /// threaded discussion state is reconstructed in the DB.
+    #[test]
+    fn test_comment_from_json_threaded_reply() {
+        let record = serde_json::json!({
+            "$type": "ing.observ.temp.comment",
+            "subject": {
+                "uri": "at://did:plc:author/bio.lexicons.temp.occurrence/abc",
+                "cid": "bafyreioccurrence"
+            },
+            "replyTo": {
+                "uri": "at://did:plc:other/ing.observ.temp.comment/parent",
+                "cid": "bafyreiparentcomment"
+            },
+            "body": "Agreed!",
+            "createdAt": "2024-06-15T08:35:00Z"
+        });
+
+        let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let params = comment_from_json(
+            &record,
+            "uri".into(),
+            "cid".into(),
+            "did:plc:replier".into(),
+            fallback,
+        )
+        .expect("record should parse");
+
+        assert_eq!(
+            params.reply_to_uri.as_deref(),
+            Some("at://did:plc:other/ing.observ.temp.comment/parent")
+        );
+        assert_eq!(params.reply_to_cid.as_deref(), Some("bafyreiparentcomment"));
+    }
+
+    /// Baseline happy-path coverage for `interaction_from_json`. Covers the
+    /// "both subjects reference an occurrence" shape — the only path the
+    /// interaction lexicon supports without taxon-only references.
+    #[test]
+    fn test_interaction_from_json_happy_path_both_occurrences() {
+        let record = serde_json::json!({
+            "$type": "ing.observ.temp.interaction",
+            "subjectA": {
+                "occurrence": {
+                    "uri": "at://did:plc:author/bio.lexicons.temp.occurrence/predator",
+                    "cid": "bafyreipred"
+                }
+            },
+            "subjectB": {
+                "occurrence": {
+                    "uri": "at://did:plc:author/bio.lexicons.temp.occurrence/prey",
+                    "cid": "bafyreiprey"
+                }
+            },
+            "interactionType": "predation",
+            "direction": "AtoB",
+            "comment": "Caught mid-strike.",
+            "createdAt": "2024-06-15T08:30:45Z"
+        });
+
+        let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let params = interaction_from_json(
+            &record,
+            "at://did:plc:observer/ing.observ.temp.interaction/xyz".to_string(),
+            "bafyreiinter".to_string(),
+            "did:plc:observer".to_string(),
+            fallback,
+        )
+        .expect("record should parse");
+
+        assert_eq!(params.interaction_type, "predation");
+        assert_eq!(params.direction, "AtoB");
+        assert_eq!(params.comment.as_deref(), Some("Caught mid-strike."));
+        assert_eq!(
+            params.subject_a_occurrence_uri.as_deref(),
+            Some("at://did:plc:author/bio.lexicons.temp.occurrence/predator")
+        );
+        assert_eq!(
+            params.subject_b_occurrence_uri.as_deref(),
+            Some("at://did:plc:author/bio.lexicons.temp.occurrence/prey")
+        );
+        // No taxon references on either side
+        assert!(params.subject_a_taxon_name.is_none());
+        assert!(params.subject_b_taxon_name.is_none());
+    }
+
+    /// `interaction_from_json` should pull taxon scientific names through
+    /// when subjects use the taxon-only shape (no concrete occurrence).
+    #[test]
+    fn test_interaction_from_json_taxon_only_subject() {
+        let record = serde_json::json!({
+            "$type": "ing.observ.temp.interaction",
+            "subjectA": {
+                "occurrence": {
+                    "uri": "at://did:plc:author/bio.lexicons.temp.occurrence/bee",
+                    "cid": "bafyreibee"
+                }
+            },
+            "subjectB": {
+                "taxon": {
+                    "scientificName": "Trifolium repens",
+                    "kingdom": "Plantae"
+                }
+            },
+            "interactionType": "pollination",
+            "direction": "AtoB",
+            "createdAt": "2024-06-15T08:30:45Z"
+        });
+
+        let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let params = interaction_from_json(
+            &record,
+            "uri".into(),
+            "cid".into(),
+            "did:plc:observer".into(),
+            fallback,
+        )
+        .expect("record should parse");
+
+        assert_eq!(
+            params.subject_b_taxon_name.as_deref(),
+            Some("Trifolium repens")
+        );
+        assert_eq!(params.subject_b_kingdom.as_deref(), Some("Plantae"));
+        assert!(params.subject_b_occurrence_uri.is_none());
+    }
+
+    /// Baseline happy-path coverage for `like_from_json`.
+    #[test]
+    fn test_like_from_json_happy_path() {
+        let record = serde_json::json!({
+            "$type": "ing.observ.temp.like",
+            "subject": {
+                "uri": "at://did:plc:author/bio.lexicons.temp.occurrence/abc",
+                "cid": "bafyreioccurrence"
+            },
+            "createdAt": "2024-06-15T08:30:45Z"
+        });
+
+        let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let params = like_from_json(
+            &record,
+            "at://did:plc:liker/ing.observ.temp.like/xyz".to_string(),
+            "bafyreilike".to_string(),
+            "did:plc:liker".to_string(),
+            fallback,
+        )
+        .expect("record should parse");
+
+        assert_eq!(
+            params.subject_uri,
+            "at://did:plc:author/bio.lexicons.temp.occurrence/abc"
+        );
+        assert_eq!(params.subject_cid, "bafyreioccurrence");
+        assert_eq!(params.did, "did:plc:liker");
+        assert_eq!(params.created_at.date().to_string(), "2024-06-15");
+    }
+
+    /// `occurrence_from_json` is the single conversion both the appview and
+    /// the ingester use to turn a PDS occurrence record into a DB row. The
+    /// appview's create path writes occurrences in the
+    /// `bio.lexicons.temp.occurrence` shape, where images are referenced via
+    /// `associatedMedia` strong refs to separate `bio.lexicons.temp.media`
+    /// records — there is no inline `blobs` field on the occurrence itself.
+    ///
+    /// Today this conversion only reads the legacy inline `blobs` field and
+    /// silently drops `associatedMedia`, so any record produced by the
+    /// current write path ends up with `associated_media = None`. This works
+    /// only because the appview also writes the DB row directly with the
+    /// in-memory blob entries — if anything other than that direct write
+    /// becomes the populating path (ingester-only writes, backfill, etc.),
+    /// new observations land with no images.
+    ///
+    /// Marked `#[ignore]` because the bug is not yet fixed; running with
+    /// `cargo test -- --ignored` reproduces the failure. Remove the attribute
+    /// once the ingester learns to resolve `associatedMedia` → media records
+    /// → blob entries.
+    #[test]
+    #[ignore = "ingester does not yet resolve associatedMedia strong refs; see test docs"]
+    fn test_occurrence_from_json_resolves_associated_media() {
+        let record = serde_json::json!({
+            "$type": "bio.lexicons.temp.occurrence",
+            "decimalLatitude": "37.7749",
+            "decimalLongitude": "-122.4194",
+            "coordinateUncertaintyInMeters": 10,
+            "eventDate": "2024-06-15T08:30:45.123Z",
+            "associatedMedia": [
+                {
+                    "uri": "at://did:plc:author/bio.lexicons.temp.media/abc123",
+                    "cid": "bafyreiabc123"
+                },
+                {
+                    "uri": "at://did:plc:author/bio.lexicons.temp.media/def456",
+                    "cid": "bafyreidef456"
+                }
+            ]
+        });
+
+        let parsed = occurrence_from_json(
+            &record,
+            "at://did:plc:author/bio.lexicons.temp.occurrence/xyz".to_string(),
+            "bafyreioccurrence".to_string(),
+            "did:plc:author".to_string(),
+        )
+        .expect("record should parse");
+
+        assert!(
+            parsed.params.associated_media.is_some(),
+            "occurrence_from_json must populate associated_media when the \
+             record carries associatedMedia strong refs; without this, \
+             ingester-only writes lose every photo on new observations"
+        );
+    }
 }


### PR DESCRIPTION
## Summary
- `processing::*_from_json` is the single conversion both the appview's synchronous write path and the ingester's firehose path use to turn a PDS record into DB upsert params. Until now this load-bearing module had no test coverage for any of its five parsers — only its small helpers (`parse_datetime`, `extract_co_observers`) were tested.
- Adds 7 happy-path tests pinning current field mapping for occurrence, identification, comment, interaction, and like records, plus targeted cases for identification's `createdAt` fallback, comment threading via `replyTo`, and the interaction taxon-only subject shape.
- Adds 1 `#[ignore]`-marked regression test that documents a real bug: `occurrence_from_json` silently drops `associatedMedia` strong refs and only reads the legacy inline `blobs` field. Today this is hidden because the appview write path also writes the DB row directly with in-memory blob entries — but any non-appview populating path (ingester catch-up, backfill, future ingester-only writes) would land new occurrences with no images.

## Why now
While exploring whether to move occurrence/identification/like writes to be ingester-only (driven by appview/ingester dataflow being hard to reason about), I needed to understand the parser contracts and discovered there were none. These tests serve two purposes regardless of which architectural direction we take next:
1. **Drift detection** — if the appview's record builder and the ingester's parser ever diverge in field mapping, the test suite will catch it instead of users seeing missing fields in production.
2. **Bug capture** — the `#[ignore]`'d test marks the `associatedMedia` bug in code rather than only in chat/PR history. Whoever fixes the ingester to resolve strong refs can delete the attribute and watch it go green.

## Test plan
- [x] `cargo test -p observing-db --features processing processing::tests::` — 17 passed, 1 ignored
- [x] `cargo test -p observing-db --features processing processing::tests:: -- --ignored` reproduces the documented bug
- [x] `cargo fmt -p observing-db` clean