### PR TITLE
fix(ingester): resolve associatedMedia strong refs to blob entries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,8 @@ dependencies = [
 name = "observing-ingester"
 version = "0.1.0"
 dependencies = [
+ "at-uri-parser",
+ "atproto-blob-resolver",
  "atproto-identity",
  "axum",
  "chrono",
@@ -2914,6 +2916,7 @@ dependencies = [
  "tracing-stackdriver",
  "tracing-subscriber",
  "url",
+ "urlencoding",
 ]
 
 [[package]]

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -47,12 +47,26 @@ pub fn parse_naive_datetime(s: &str) -> Option<NaiveDateTime> {
         .ok()
 }
 
+/// A strong reference to a `bio.lexicons.temp.media` record, as it appears
+/// in an occurrence's `associatedMedia` array. Callers (the ingester) resolve
+/// these by fetching the referenced record from the author's PDS to build
+/// `BlobEntry` values for `associated_media`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AssociatedMediaRef {
+    pub uri: String,
+    pub cid: String,
+}
+
 /// Result of parsing an occurrence record, containing both the database
 /// params and the typed `recorded_by` field for co-observer processing.
 pub struct ParsedOccurrence {
     pub params: UpsertOccurrenceParams,
     /// The `recordedBy` DIDs from the lexicon record (if present).
     pub recorded_by: Option<Vec<String>>,
+    /// Strong refs to `bio.lexicons.temp.media` records. The ingester resolves
+    /// these asynchronously to populate `params.associated_media`; the appview
+    /// write path ignores this field because it already has the blobs in-memory.
+    pub associated_media_refs: Vec<AssociatedMediaRef>,
 }
 
 /// Convert an occurrence record JSON to database params.
@@ -132,6 +146,20 @@ pub fn occurrence_from_json(
                 .collect()
         });
 
+    let associated_media_refs: Vec<AssociatedMediaRef> = record_json
+        .get("associatedMedia")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| {
+                    let uri = v.get("uri").and_then(|u| u.as_str())?.to_string();
+                    let cid = v.get("cid").and_then(|c| c.as_str())?.to_string();
+                    Some(AssociatedMediaRef { uri, cid })
+                })
+                .collect()
+        })
+        .unwrap_or_default();
+
     Ok(ParsedOccurrence {
         params: UpsertOccurrenceParams {
             uri,
@@ -173,6 +201,7 @@ pub fn occurrence_from_json(
             created_at,
         },
         recorded_by,
+        associated_media_refs,
     })
 }
 
@@ -796,21 +825,13 @@ mod tests {
     /// `associatedMedia` strong refs to separate `bio.lexicons.temp.media`
     /// records — there is no inline `blobs` field on the occurrence itself.
     ///
-    /// Today this conversion only reads the legacy inline `blobs` field and
-    /// silently drops `associatedMedia`, so any record produced by the
-    /// current write path ends up with `associated_media = None`. This works
-    /// only because the appview also writes the DB row directly with the
-    /// in-memory blob entries — if anything other than that direct write
-    /// becomes the populating path (ingester-only writes, backfill, etc.),
-    /// new observations land with no images.
-    ///
-    /// Marked `#[ignore]` because the bug is not yet fixed; running with
-    /// `cargo test -- --ignored` reproduces the failure. Remove the attribute
-    /// once the ingester learns to resolve `associatedMedia` → media records
-    /// → blob entries.
+    /// Resolving those strong refs requires HTTP calls to the author's PDS,
+    /// which the synchronous `observing-db` layer intentionally does not do;
+    /// the ingester fetches and converts them in a follow-up step. This test
+    /// covers the first half of that pipeline: the parser must surface the
+    /// strong refs so the ingester has something to resolve.
     #[test]
-    #[ignore = "ingester does not yet resolve associatedMedia strong refs; see test docs"]
-    fn test_occurrence_from_json_resolves_associated_media() {
+    fn test_occurrence_from_json_extracts_associated_media_refs() {
         let record = serde_json::json!({
             "$type": "bio.lexicons.temp.occurrence",
             "decimalLatitude": "37.7749",
@@ -842,11 +863,26 @@ mod tests {
         )
         .expect("record should parse");
 
+        assert_eq!(
+            parsed.associated_media_refs,
+            vec![
+                AssociatedMediaRef {
+                    uri: "at://did:plc:author/bio.lexicons.temp.media/abc123".into(),
+                    cid: "bafyreiabc123".into(),
+                },
+                AssociatedMediaRef {
+                    uri: "at://did:plc:author/bio.lexicons.temp.media/def456".into(),
+                    cid: "bafyreidef456".into(),
+                },
+            ],
+            "occurrence_from_json must surface associatedMedia strong refs so the \
+             ingester can resolve them; without this, ingester-only writes lose \
+             every photo on new observations"
+        );
         assert!(
-            parsed.params.associated_media.is_some(),
-            "occurrence_from_json must populate associated_media when the \
-             record carries associatedMedia strong refs; without this, \
-             ingester-only writes lose every photo on new observations"
+            parsed.params.associated_media.is_none(),
+            "synchronous parser should not populate associated_media from strong \
+             refs — that is the ingester's async job"
         );
     }
 }

--- a/crates/observing-ingester/Cargo.toml
+++ b/crates/observing-ingester/Cargo.toml
@@ -15,6 +15,12 @@ jetstream-client = { path = "../jetstream-client" }
 # DID newtype
 atproto-identity = { path = "../atproto-identity" }
 
+# AT URI parsing (for resolving associatedMedia strong refs)
+at-uri-parser = { path = "../at-uri-parser" }
+
+# DID → PDS resolution (for fetching media records)
+atproto-blob-resolver = { path = "../atproto-blob-resolver" }
+
 # Database
 sqlx = { workspace = true }
 observing-db = { path = "../observing-db", features = ["processing"] }
@@ -44,6 +50,7 @@ reqwest = { workspace = true }
 
 # URL parsing
 url = { workspace = true }
+urlencoding = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -4,6 +4,7 @@
 //! and uses `observing-db` for SQL execution.
 
 use crate::error::Result;
+use crate::media_resolver::MediaResolver;
 use jetstream_client::CommitInfo;
 use observing_db::processing;
 use sqlx::postgres::{PgPool, PgPoolOptions};
@@ -72,6 +73,7 @@ macro_rules! process_or_warn {
 /// Database connection and operations
 pub struct Database {
     pool: PgPool,
+    media_resolver: MediaResolver,
 }
 
 impl Database {
@@ -85,7 +87,10 @@ impl Database {
             .connect(database_url)
             .await?;
         info!("Database connection established");
-        Ok(Self { pool })
+        Ok(Self {
+            pool,
+            media_resolver: MediaResolver::new(),
+        })
     }
 
     /// Run database migrations using the shared migration
@@ -100,7 +105,7 @@ impl Database {
 
         let record_json = require_record!(commit, "occurrence");
 
-        let parsed = process_or_warn!(
+        let mut parsed = process_or_warn!(
             commit,
             occurrence_from_json,
             "occurrence",
@@ -109,6 +114,23 @@ impl Database {
             commit.cid.clone(),
             commit.did.clone(),
         );
+
+        // Resolve associatedMedia strong refs → media records → blob entries.
+        // The appview write path populates associated_media directly from
+        // in-memory blobs, but firehose-only ingestion has only strong refs
+        // and must fetch the referenced media records from the author's PDS.
+        if !parsed.associated_media_refs.is_empty() {
+            let entries = self
+                .media_resolver
+                .resolve(&parsed.associated_media_refs)
+                .await;
+            if !entries.is_empty() {
+                match serde_json::to_value(&entries) {
+                    Ok(v) => parsed.params.associated_media = Some(v),
+                    Err(e) => warn!(error = %e, "Failed to serialize resolved associated_media"),
+                }
+            }
+        }
 
         observing_db::occurrences::upsert(&self.pool, &parsed.params).await?;
 

--- a/crates/observing-ingester/src/lib.rs
+++ b/crates/observing-ingester/src/lib.rs
@@ -4,6 +4,7 @@
 
 pub mod database;
 pub mod error;
+pub mod media_resolver;
 pub mod server;
 pub mod types;
 

--- a/crates/observing-ingester/src/main.rs
+++ b/crates/observing-ingester/src/main.rs
@@ -5,6 +5,7 @@
 
 mod database;
 mod error;
+mod media_resolver;
 mod server;
 mod types;
 

--- a/crates/observing-ingester/src/media_resolver.rs
+++ b/crates/observing-ingester/src/media_resolver.rs
@@ -1,0 +1,184 @@
+//! Resolve `associatedMedia` strong refs to blob entries by fetching the
+//! referenced `bio.lexicons.temp.media` records from their author's PDS.
+//!
+//! The appview write path already has blob metadata in memory when it writes
+//! the occurrence row, so it bypasses this resolution. The firehose path has
+//! only the strong refs, so the ingester performs the network round trip to
+//! materialize the blobs into the `associated_media` JSONB column.
+//!
+//! Best-effort: if a media record cannot be fetched (e.g. firehose
+//! out-of-order delivery, PDS error), that ref is skipped with a warning
+//! rather than failing the whole occurrence upsert. Most of the time media
+//! records arrive on the firehose before the occurrence that references them
+//! — the appview uploads them first — so this typically succeeds.
+
+use at_uri_parser::AtUri;
+use atproto_blob_resolver::BlobResolver;
+use atproto_identity::Did;
+use observing_db::processing::AssociatedMediaRef;
+use observing_db::types::{BlobEntry, BlobImage, BlobRef};
+use reqwest::Client;
+use serde_json::Value;
+use std::time::Duration;
+use tracing::warn;
+
+/// Fetches `bio.lexicons.temp.media` records from PDSes and converts them to
+/// the `BlobEntry` shape stored in `occurrences.associated_media`.
+pub struct MediaResolver {
+    client: Client,
+    blob_resolver: BlobResolver,
+}
+
+impl MediaResolver {
+    pub fn new() -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(Duration::from_secs(10))
+                .build()
+                .expect("reqwest client build should not fail with defaults"),
+            blob_resolver: BlobResolver::new(),
+        }
+    }
+
+    /// Resolve a slice of strong refs to blob entries. Refs that fail to
+    /// resolve (invalid URI, DID resolution failure, PDS error, malformed
+    /// media record) are dropped with a warning.
+    pub async fn resolve(&self, refs: &[AssociatedMediaRef]) -> Vec<BlobEntry> {
+        let mut entries = Vec::with_capacity(refs.len());
+        for r in refs {
+            match self.resolve_one(r).await {
+                Some(entry) => entries.push(entry),
+                None => warn!(uri = %r.uri, "Failed to resolve associatedMedia ref"),
+            }
+        }
+        entries
+    }
+
+    async fn resolve_one(&self, r: &AssociatedMediaRef) -> Option<BlobEntry> {
+        let at_uri = AtUri::parse(&r.uri)?;
+        let did = Did::parse(&at_uri.did).ok()?;
+        let pds_url = self.blob_resolver.resolve_pds_url(&did).await.ok()?;
+        let record = self
+            .fetch_record(&pds_url, &at_uri.did, &at_uri.collection, &at_uri.rkey)
+            .await?;
+        media_record_to_blob_entry(&record)
+    }
+
+    async fn fetch_record(
+        &self,
+        pds_url: &str,
+        did: &str,
+        collection: &str,
+        rkey: &str,
+    ) -> Option<Value> {
+        let url = format!(
+            "{}/xrpc/com.atproto.repo.getRecord?repo={}&collection={}&rkey={}",
+            pds_url.trim_end_matches('/'),
+            urlencoding::encode(did),
+            urlencoding::encode(collection),
+            urlencoding::encode(rkey),
+        );
+        let resp = self.client.get(&url).send().await.ok()?;
+        if !resp.status().is_success() {
+            return None;
+        }
+        let body: Value = resp.json().await.ok()?;
+        // getRecord wraps the record in `{ uri, cid, value }`.
+        body.get("value").cloned()
+    }
+}
+
+impl Default for MediaResolver {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Pull the blob ref, mime type, and alt text out of a `bio.lexicons.temp.media`
+/// record JSON to build a `BlobEntry`. Returns `None` if the record is missing
+/// the required blob fields.
+fn media_record_to_blob_entry(record: &Value) -> Option<BlobEntry> {
+    let image = record.get("image")?;
+    let cid = image
+        .get("ref")
+        .and_then(|r| r.get("$link"))
+        .and_then(|l| l.as_str())?
+        .to_string();
+    let mime_type = image.get("mimeType").and_then(|m| m.as_str())?.to_string();
+    let alt = record
+        .get("alt")
+        .and_then(|a| a.as_str())
+        .map(|s| s.to_string());
+    Some(BlobEntry {
+        image: BlobImage {
+            ref_: BlobRef::Link { link: cid },
+            mime_type,
+        },
+        alt,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_blob_entry_from_canonical_media_record() {
+        let record = json!({
+            "$type": "bio.lexicons.temp.media",
+            "image": {
+                "$type": "blob",
+                "ref": { "$link": "bafyreiabc123" },
+                "mimeType": "image/jpeg",
+                "size": 12345,
+            },
+            "alt": "A ruby-throated hummingbird at a feeder.",
+        });
+
+        let entry = media_record_to_blob_entry(&record).expect("should parse");
+        match &entry.image.ref_ {
+            BlobRef::Link { link } => assert_eq!(link, "bafyreiabc123"),
+            _ => panic!("expected Link variant"),
+        }
+        assert_eq!(entry.image.mime_type, "image/jpeg");
+        assert_eq!(
+            entry.alt.as_deref(),
+            Some("A ruby-throated hummingbird at a feeder.")
+        );
+    }
+
+    #[test]
+    fn alt_is_optional() {
+        let record = json!({
+            "image": {
+                "ref": { "$link": "bafyreiabc" },
+                "mimeType": "image/png",
+            }
+        });
+        let entry = media_record_to_blob_entry(&record).expect("should parse");
+        assert!(entry.alt.is_none());
+    }
+
+    #[test]
+    fn returns_none_without_image() {
+        let record = json!({ "alt": "no image here" });
+        assert!(media_record_to_blob_entry(&record).is_none());
+    }
+
+    #[test]
+    fn returns_none_without_cid() {
+        let record = json!({
+            "image": { "mimeType": "image/png" }
+        });
+        assert!(media_record_to_blob_entry(&record).is_none());
+    }
+
+    #[test]
+    fn returns_none_without_mime_type() {
+        let record = json!({
+            "image": { "ref": { "$link": "bafyreiabc" } }
+        });
+        assert!(media_record_to_blob_entry(&record).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- Firehose-path occurrences used to land with `associated_media = NULL` because `occurrence_from_json` only read the legacy inline `blobs` field and silently dropped `associatedMedia` strong refs. The appview's create path hid the gap by writing the DB row directly from in-memory blob entries — anything else (backfill, third-party PDSes, future ingester-only writes) lost every photo.
- Split the work: the sync parser now extracts strong refs into `ParsedOccurrence::associated_media_refs`, and a new `MediaResolver` in the ingester fetches each referenced `bio.lexicons.temp.media` record via `com.atproto.repo.getRecord` and materializes blob entries before upsert.
- Best-effort: an unresolvable ref (out-of-order firehose delivery, PDS error, malformed record) logs a warning and the occurrence still upserts, so firehose processing keeps up even when media isn't there yet.

## Test plan

- [x] `cargo test -p observing-db --features processing` — regression test `test_occurrence_from_json_extracts_associated_media_refs` now passes (was `#[ignore]`'d on main).
- [x] `cargo test -p observing-ingester --lib` — 5 new unit tests cover `media_record_to_blob_entry` (happy path, optional alt, missing image/cid/mime).
- [x] `cargo build -p observing-appview` — appview continues to build; it still writes `associated_media` directly and ignores the new `associated_media_refs` field.
- [ ] Manual verification against a real firehose once deployed (the HTTP round trip is not covered by unit tests — only the JSON → `BlobEntry` conversion is).