### PR TITLE
refactor(occurrences): ingester becomes single writer on update

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -312,17 +312,13 @@ pub async fn update_occurrence(
     let retained_cids = body.retained_blob_cids.clone().unwrap_or_default();
 
     let mut media_refs: Vec<StrongRef> = Vec::new();
-    let mut blob_entries: Vec<BlobEntry> = Vec::new();
 
     if existing_media_refs.len() == existing_blobs.len() {
         for (i, blob) in existing_blobs.iter().enumerate() {
             let blob_cid = blob.image.ref_.cid();
             if retained_cids.iter().any(|cid| cid == blob_cid) {
                 match serde_json::from_value::<StrongRef>(existing_media_refs[i].clone()) {
-                    Ok(strong_ref) => {
-                        media_refs.push(strong_ref);
-                        blob_entries.push(blob.clone());
-                    }
+                    Ok(strong_ref) => media_refs.push(strong_ref),
                     Err(e) => {
                         warn!(error = %e, "Failed to parse existing strong ref; dropping");
                     }
@@ -338,18 +334,10 @@ pub async fn update_occurrence(
         );
     }
 
-    // Upload new images and append their strong refs + blob entries to what was retained
-    let (new_blob_entries, new_media_refs) =
+    // Upload new images and append their strong refs to what was retained
+    let (_new_blob_entries, new_media_refs) =
         upload_media_records(&agent, &user.did, body.images.as_deref().unwrap_or(&[])).await?;
-    blob_entries.extend(new_blob_entries);
     media_refs.extend(new_media_refs);
-
-    // Serialize the blob entries now for the DB upsert below. We can't use
-    // `UpsertOccurrenceParams::set_blobs`, which clears the column on empty
-    // input — the upsert's COALESCE would then keep the stale existing value,
-    // so we must write an explicit (possibly empty) array to replace it.
-    let blob_entries_json = serde_json::to_value(&blob_entries)
-        .map_err(|e| AppError::Internal(format!("Failed to serialize blob entries: {e}")))?;
 
     let record_value = build_occurrence_record_json(
         body.latitude,
@@ -360,9 +348,9 @@ pub async fn update_occurrence(
         body.recorded_by.as_deref(),
     )?;
 
-    let record_value_for_db = record_value.clone();
-
-    // putRecord on the PDS
+    // putRecord on the PDS. The firehose commit that follows triggers the
+    // ingester to refresh the occurrence row and observer links — the appview
+    // no longer writes directly to those tables, mirroring the create flow.
     let resp = agent
         .api
         .com
@@ -394,38 +382,15 @@ pub async fn update_occurrence(
     let uri = resp.uri.clone();
     let cid = resp.cid.as_ref().to_string();
 
-    info!(uri = %uri, "Updated occurrence");
+    info!(uri = %uri, "Updated occurrence (PDS); awaiting ingester for DB refresh");
 
-    // Refresh local DB row
-    if let Ok(mut parsed) = observing_db::processing::occurrence_from_json(
-        &record_value_for_db,
-        uri.clone(),
-        cid.clone(),
-        user.did.clone(),
-    ) {
-        // Always set associated_media to the new list — the upsert uses
-        // COALESCE, so passing an explicit value (even an empty array) is
-        // required to actually replace the existing column.
-        parsed.params.associated_media = Some(blob_entries_json);
-        parsed.params.created_at = existing_db_row.created_at;
-        if let Err(e) = observing_db::occurrences::upsert(&state.pool, &parsed.params).await {
-            warn!(error = %e, "Failed to upsert occurrence into local DB");
-        }
-    }
-
-    // Refresh private location data
+    // Private location data is intentionally never written to the PDS, so the
+    // ingester has no path to populate it. This is still the appview's job.
     if let Err(e) =
         observing_db::private_data::save(&state.pool, &uri, body.latitude, body.longitude, "open")
             .await
     {
         warn!(error = %e, "Failed to save private location data");
-    }
-
-    // Sync observers
-    let co_observers = body.recorded_by.unwrap_or_default();
-    if let Err(e) = observing_db::observers::sync(&state.pool, &uri, &user.did, &co_observers).await
-    {
-        warn!(error = %e, "Failed to sync observers");
     }
 
     // If a scientific name was provided and no existing identification from this

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -277,13 +277,20 @@ export function UploadModal() {
     fileInputRef.current?.click();
   };
 
-  // Poll for observation to appear in database after AT Protocol submission
-  const waitForObservation = async (uri: string, maxAttempts = 30): Promise<boolean> => {
+  // Poll for observation to appear in database after AT Protocol submission.
+  // When targetCid is provided, wait until the stored occurrence CID matches —
+  // required for updates where the URI is stable but the row is stale until
+  // the ingester processes the firehose commit.
+  const waitForObservation = async (
+    uri: string,
+    targetCid?: string,
+    maxAttempts = 30,
+  ): Promise<boolean> => {
     // Sequential polling by design
     for (let attempt = 0; attempt < maxAttempts; attempt++) {
       // eslint-disable-next-line no-await-in-loop
       const result = await fetchObservation(uri);
-      if (result?.occurrence) {
+      if (result?.occurrence && (targetCid === undefined || result.occurrence.cid === targetCid)) {
         return true;
       }
       // eslint-disable-next-line no-await-in-loop
@@ -343,8 +350,8 @@ export function UploadModal() {
           retainedBlobCids,
         });
 
-        // Wait for the update to be processed
-        await waitForObservation(result.uri);
+        // Wait for the ingester to refresh the row to the new CID
+        await waitForObservation(result.uri, result.cid);
         observationUri = result.uri;
 
         dispatch(
@@ -369,7 +376,7 @@ export function UploadModal() {
         });
 
         // Wait for the observation to be processed by the ingester
-        const processed = await waitForObservation(result.uri);
+        const processed = await waitForObservation(result.uri, result.cid);
         observationUri = result.uri;
 
         dispatch(


### PR DESCRIPTION
## Summary

Finishes the ingester-only DB writes spike for occurrences, picking up where #309 (create path) left off.

- `update_occurrence` no longer calls `observing_db::occurrences::upsert` or `observing_db::observers::sync` — the firehose commit from `putRecord` lands in the ingester, which owns `occurrences` and `occurrence_observers` for both create and update now.
- `private_data::save` stays in the appview (never on PDS) and the auto-identification path is unchanged.
- Frontend `waitForObservation` gains an optional `targetCid` and polls until `occurrence.cid === targetCid`. Without this, updates returned immediately on the stale row since `putRecord` preserves the URI — the user would see pre-update data.

## Test plan

- [ ] Local: update an existing occurrence (location + species + observers + image add/remove) and verify the detail view reflects the edit after the toast
- [ ] CI e2e job exercises the create + edit flow with the real ingester (wired in #309)
- [ ] `cargo build --workspace` clean
- [ ] `npm run build` + `oxfmt --check` clean