### PR TITLE
refactor(occurrences): ingester becomes single writer on delete + like create

### DIFF
--- a/crates/observing-appview/src/routes/identifications.rs
+++ b/crates/observing-appview/src/routes/identifications.rs
@@ -5,7 +5,7 @@ use observing_lexicons::bio_lexicons::temp::identification::{
     Identification, IdentificationRecord, IdentificationTaxonRank,
 };
 use serde::Deserialize;
-use tracing::{info, warn};
+use tracing::info;
 use ts_rs::TS;
 
 use crate::auth::{self, AuthUser};
@@ -157,10 +157,7 @@ pub async fn delete_identification(
             }
         })?;
 
-    // Delete from local DB (refreshes community IDs)
-    if let Err(e) = observing_db::identifications::delete(&state.pool, &uri).await {
-        warn!(error = %e, "Failed to delete identification from local DB");
-    }
-
+    // The firehose delete commit will trigger the ingester to remove the row
+    // and refresh community IDs for the occurrence.
     Ok(Json(SuccessResponse { success: true }))
 }

--- a/crates/observing-appview/src/routes/likes.rs
+++ b/crates/observing-appview/src/routes/likes.rs
@@ -3,10 +3,9 @@ use axum::Json;
 use chrono::Utc;
 use jacquard_common::types::collection::Collection;
 use jacquard_common::types::string::Datetime;
-use observing_db::types::CreateLikeParams;
 use observing_lexicons::ing_observ::temp::like::{Like, LikeRecord};
 use serde::Deserialize;
-use tracing::{info, warn};
+use tracing::info;
 use ts_rs::TS;
 
 use crate::auth::{self, AuthUser};
@@ -42,23 +41,10 @@ pub async fn create_like(
     let (agent, did_parsed) = auth::require_agent(&state.oauth_client, &user.did).await?;
     let output = auth::create_at_record(&agent, did_parsed, LikeRecord::NSID, record_value).await?;
 
-    let uri = output.uri.clone();
+    let uri = output.uri.to_string();
     let cid = output.cid.as_ref().to_string();
 
-    info!(uri = %uri, "Created like");
-
-    // Immediate local DB insert
-    let params = CreateLikeParams {
-        uri: uri.clone(),
-        cid: cid.clone(),
-        did: user.did,
-        subject_uri: body.occurrence_uri,
-        subject_cid: body.occurrence_cid,
-        created_at: now.naive_utc(),
-    };
-    if let Err(e) = observing_db::likes::create(&state.pool, &params).await {
-        warn!(error = %e, "Failed to insert like into local DB");
-    }
+    info!(uri = %uri, "Created like (PDS); awaiting ingester for DB row");
 
     Ok(Json(RecordCreatedResponse {
         success: true,

--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -225,10 +225,8 @@ pub async fn delete_occurrence_catch_all(
             }
         })?;
 
-    if let Err(e) = observing_db::occurrences::delete(&state.pool, uri).await {
-        warn!(error = %e, "Failed to delete occurrence from local DB");
-    }
-
+    // The firehose delete commit will trigger the ingester to remove the row
+    // (and cascade to identifications/comments/likes/interactions via FK).
     Ok(Json(SuccessResponse { success: true }))
 }
 

--- a/frontend/src/components/modals/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/modals/DeleteConfirmDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeDeleteConfirm, addToast } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
-import { deleteObservation, fetchObservation } from "../../services/api";
+import { deleteObservation, pollObservation } from "../../services/api";
 import { getErrorMessage } from "../../lib/utils";
 
 export function DeleteConfirmDialog() {
@@ -39,14 +39,7 @@ export function DeleteConfirmDialog() {
 
       // Wait for the ingester to remove the row; the navigate/reload below
       // would otherwise briefly show the deleted observation in the feed.
-      // Sequential polling by design
-      for (let attempt = 0; attempt < 30; attempt++) {
-        // eslint-disable-next-line no-await-in-loop
-        const result = await fetchObservation(observation.uri);
-        if (!result?.occurrence) break;
-        // eslint-disable-next-line no-await-in-loop
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-      }
+      await pollObservation(observation.uri, (r) => !r?.occurrence);
 
       dispatch(
         addToast({

--- a/frontend/src/components/modals/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/modals/DeleteConfirmDialog.tsx
@@ -12,7 +12,7 @@ import {
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeDeleteConfirm, addToast } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
-import { deleteObservation } from "../../services/api";
+import { deleteObservation, fetchObservation } from "../../services/api";
 import { getErrorMessage } from "../../lib/utils";
 
 export function DeleteConfirmDialog() {
@@ -36,6 +36,17 @@ export function DeleteConfirmDialog() {
     setIsDeleting(true);
     try {
       await deleteObservation(observation.uri);
+
+      // Wait for the ingester to remove the row; the navigate/reload below
+      // would otherwise briefly show the deleted observation in the feed.
+      // Sequential polling by design
+      for (let attempt = 0; attempt < 30; attempt++) {
+        // eslint-disable-next-line no-await-in-loop
+        const result = await fetchObservation(observation.uri);
+        if (!result?.occurrence) break;
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
 
       dispatch(
         addToast({

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -20,7 +20,7 @@ import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
 import ExifReader from "exifreader";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeUploadModal, addToast, consumePendingUploadFiles } from "../../store/uiSlice";
-import { submitObservation, updateObservation, fetchObservation } from "../../services/api";
+import { submitObservation, updateObservation, pollObservation } from "../../services/api";
 import type { ActorSearchResult } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
@@ -277,27 +277,10 @@ export function UploadModal() {
     fileInputRef.current?.click();
   };
 
-  // Poll for observation to appear in database after AT Protocol submission.
-  // When targetCid is provided, wait until the stored occurrence CID matches —
-  // required for updates where the URI is stable but the row is stale until
-  // the ingester processes the firehose commit.
-  const waitForObservation = async (
-    uri: string,
-    targetCid?: string,
-    maxAttempts = 30,
-  ): Promise<boolean> => {
-    // Sequential polling by design
-    for (let attempt = 0; attempt < maxAttempts; attempt++) {
-      // eslint-disable-next-line no-await-in-loop
-      const result = await fetchObservation(uri);
-      if (result?.occurrence && (targetCid === undefined || result.occurrence.cid === targetCid)) {
-        return true;
-      }
-      // eslint-disable-next-line no-await-in-loop
-      await new Promise((resolve) => setTimeout(resolve, 1000));
-    }
-    return false;
-  };
+  // On update the URI is stable, so matching on CID is required to
+  // distinguish the ingester's new row from the pre-update one.
+  const waitForObservation = (uri: string, targetCid: string) =>
+    pollObservation(uri, (r) => r?.occurrence?.cid === targetCid);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -480,6 +480,20 @@ export function ObservationDetail() {
                 onDeleteIdentification={async (uri) => {
                   try {
                     await deleteIdentification(uri);
+                    // Wait for the ingester to remove the identification;
+                    // refetching immediately would show the stale row and
+                    // make the delete look like it failed.
+                    if (atUri) {
+                      // Sequential polling by design
+                      for (let attempt = 0; attempt < 30; attempt++) {
+                        // eslint-disable-next-line no-await-in-loop
+                        const result = await fetchObservation(atUri);
+                        const stillPresent = result?.identifications?.some((id) => id.uri === uri);
+                        if (!stillPresent) break;
+                        // eslint-disable-next-line no-await-in-loop
+                        await new Promise((resolve) => setTimeout(resolve, 1000));
+                      }
+                    }
                     dispatch(addToast({ message: "Identification deleted", type: "success" }));
                     await handleIdentificationSuccess();
                   } catch (error) {

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -24,7 +24,12 @@ import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
-import { fetchObservation, getImageUrl, deleteIdentification } from "../../services/api";
+import {
+  fetchObservation,
+  getImageUrl,
+  deleteIdentification,
+  pollObservation,
+} from "../../services/api";
 import { useAppSelector, useAppDispatch } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useLikeToggle } from "../../hooks/useLikeToggle";
@@ -484,15 +489,10 @@ export function ObservationDetail() {
                     // refetching immediately would show the stale row and
                     // make the delete look like it failed.
                     if (atUri) {
-                      // Sequential polling by design
-                      for (let attempt = 0; attempt < 30; attempt++) {
-                        // eslint-disable-next-line no-await-in-loop
-                        const result = await fetchObservation(atUri);
-                        const stillPresent = result?.identifications?.some((id) => id.uri === uri);
-                        if (!stillPresent) break;
-                        // eslint-disable-next-line no-await-in-loop
-                        await new Promise((resolve) => setTimeout(resolve, 1000));
-                      }
+                      await pollObservation(
+                        atUri,
+                        (r) => !r?.identifications?.some((id) => id.uri === uri),
+                      );
                     }
                     dispatch(addToast({ message: "Identification deleted", type: "success" }));
                     await handleIdentificationSuccess();

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -159,6 +159,26 @@ export async function fetchObservation(uri: string): Promise<OccurrenceDetailRes
   }
 }
 
+// Poll fetchObservation until the predicate is satisfied. Used to wait for the
+// ingester to catch up after a PDS write before the UI refetches or navigates
+// — without this, callers would see stale data (pre-update row, ghost of a
+// deleted record, missing new identification).
+export async function pollObservation(
+  uri: string,
+  predicate: (result: OccurrenceDetailResponse | null) => boolean,
+  { maxAttempts = 30, intervalMs = 1000 }: { maxAttempts?: number; intervalMs?: number } = {},
+): Promise<boolean> {
+  // Sequential polling by design
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    // eslint-disable-next-line no-await-in-loop
+    const result = await fetchObservation(uri);
+    if (predicate(result)) return true;
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  return false;
+}
+
 export async function fetchObservationsGeoJSON(bounds: {
   minLat: number;
   minLng: number;


### PR DESCRIPTION
## Summary

Continues #311 — drops three more direct DB writes from the appview so we can move toward restricting the appview's DB role to SELECT on ingester-owned tables.

- `delete_occurrence_catch_all` (`write.rs:228`) no longer calls \`observing_db::occurrences::delete\`. FK cascades on the ingester-owned delete clean up identifications, comments, likes, and interactions.
- Identification delete (`identifications.rs:161`) no longer calls \`observing_db::identifications::delete\`. The ingester's delete handler refreshes community IDs on the occurrence.
- Like create (`likes.rs:59`) no longer calls \`observing_db::likes::create\`. The optimistic like UI (\`useLikeToggle\`) already masks the brief gap before the ingester lands the row.

On the frontend, two delete flows now poll until the record is gone before proceeding:
- \`DeleteConfirmDialog\` polls \`fetchObservation\` until it returns null before navigating / reloading the feed.
- \`ObservationDetail.onDeleteIdentification\` polls until the deleted identification is absent from the fetched list before the refetch. Without this, the refetch would display the stale row and make the action look like it failed.

## Still outstanding in #311

- Like-delete (DB-first by design — needs PDS-first restructuring + an alternate URI lookup).
- Observer \`POST /observers\` + \`DELETE /observers/{did}\` endpoints (need a design decision: kill them, or rebuild them as \`putRecord\` calls that rewrite \`recordedBy\`).
- Admin \`delete_by_nsid\` stays (admin-only tooling).

## Test plan

- [ ] Local: delete an observation from the feed and from the detail page; both should disappear without a brief stale render.
- [ ] Local: delete an identification from an observation; the identification list should update cleanly (not briefly reappear).
- [ ] Local: like/unlike an occurrence; optimistic UI should behave unchanged.
- [ ] \`cargo build --workspace\` clean.
- [ ] \`npm run build\` + \`oxfmt --check\` clean.