### PR TITLE
perf(build): enable thin LTO and single codegen unit for release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,3 +47,5 @@ tempfile = "3"
 
 [profile.release]
 debug = true
+lto = "thin"
+codegen-units = 1


### PR DESCRIPTION
## Summary

- Add `lto = \"thin\"` and `codegen-units = 1` to `[profile.release]` so LLVM can inline and DCE across crates.
- Chose `\"thin\"` over `true` (fat) to keep CI/Docker build times manageable — most of the runtime benefit without the 2–4× compile-time blow-up.
- Kept `debug = true` unchanged so Cloud Run still gets useful stack traces.

Part of a perf sweep; opening as draft so we can measure before merging.

## Test plan

- [ ] `cargo build --release` locally succeeds
- [ ] Docker build in CI still finishes within budget
- [ ] Measure release binary size before/after
- [ ] Spot-check appview p50/p95 latency (feed, profile) after a canary deploy