### PR TITLE
perf(profiles): concurrent feed enrichment with tokio::join!

### DIFF
--- a/crates/observing-appview/src/routes/profiles.rs
+++ b/crates/observing-appview/src/routes/profiles.rs
@@ -44,20 +44,17 @@ pub async fn get_profile_feed(
     let result = observing_db::feeds::get_profile_feed(&state.pool, &did, &options).await?;
 
     let viewer = session_did(&cookies);
-    let occurrences = enrichment::enrich_occurrences(
-        &state.pool,
-        &state.resolver,
-        &state.taxonomy,
-        &result.occurrences,
-        viewer.as_deref(),
-    )
-    .await;
-
-    let identifications =
-        enrichment::enrich_identifications(&state.resolver, &result.identifications).await;
-
-    // Resolve profile for the DID
-    let profile = state.resolver.get_profile(&did).await;
+    let (occurrences, identifications, profile) = tokio::join!(
+        enrichment::enrich_occurrences(
+            &state.pool,
+            &state.resolver,
+            &state.taxonomy,
+            &result.occurrences,
+            viewer.as_deref(),
+        ),
+        enrichment::enrich_identifications(&state.resolver, &result.identifications),
+        state.resolver.get_profile(&did),
+    );
 
     let next_cursor = occurrences
         .last()


### PR DESCRIPTION
## Summary

- `get_profile_feed` currently chains three independent awaits (`enrich_occurrences`, `enrich_identifications`, `resolver.get_profile`) sequentially.
- Wrapping them in `tokio::join!` lets them run concurrently. All three take immutable borrows of `state.resolver`, so no ownership issues.
- Expected latency improvement on cold profile pages ≈ the slowest of the three rather than the sum.

Part of a perf sweep; opening as draft.

## Test plan

- [ ] `cargo check -p observing-appview` passes (done locally)
- [ ] Profile feed endpoint smoke test: `/api/profiles/{did}/feed` returns identical shape
- [ ] Compare p50/p95 latency against current main on a staging profile with many observations