### PR TITLE
perf(vite): split vendor code into cacheable chunks

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,6 +18,25 @@ export default defineConfig({
   build: {
     outDir: path.resolve(__dirname, "../dist/public"),
     emptyOutDir: true,
+    target: "es2022",
+    rollupOptions: {
+      output: {
+        manualChunks: (id) => {
+          if (!id.includes("node_modules")) return;
+          if (id.includes("maplibre-gl")) return "maplibre";
+          if (id.includes("/@mui/") || id.includes("/@emotion/")) return "mui";
+          if (
+            id.includes("/react/") ||
+            id.includes("/react-dom/") ||
+            id.includes("/react-router") ||
+            id.includes("/scheduler/")
+          )
+            return "react";
+          if (id.includes("/@reduxjs/") || id.includes("/react-redux/")) return "redux";
+          if (id.includes("/exifreader/")) return "exif";
+        },
+      },
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
## Summary

Production build shipped everything as a single bundle — a one-line app change busted the entire JS cache on every deploy.

Split by vendor group via \`rollupOptions.output.manualChunks\`:

| chunk | size | gzip |
| ----- | ---: | ---: |
| maplibre | 1 025 kB | 272 kB |
| mui | 682 kB | 199 kB |
| react | 219 kB | 70 kB |
| exif | 102 kB | 32 kB |
| redux | 25 kB | 9 kB |
| index (app) | 167 kB | 48 kB |

App-only deploys now only invalidate the 48 kB \`index\` chunk instead of the full bundle. Also sets an explicit \`build.target: \"es2022\"\` so rolldown isn't relying on an implicit default.

Part of a perf sweep; opening as draft.

## Test plan

- [ ] \`npm run build\` completes cleanly (done locally)
- [ ] Frontend boots and renders map, feed, upload flow
- [ ] Check Network tab: vendor chunks load in parallel, app chunk is small
- [ ] Confirm SSR/prerender (if any) still works — we only produce a static SPA today, so should be fine