### PR TITLE
perf(frontend): memoize IdentificationHistory, lazy-load upload thumbs

### DIFF
--- a/frontend/src/components/identification/IdentificationHistory.tsx
+++ b/frontend/src/components/identification/IdentificationHistory.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import {
   Box,
@@ -50,31 +50,39 @@ export function IdentificationHistory({
   const handleMenuClose = (uri: string) => {
     setMenuAnchorEl((prev) => ({ ...prev, [uri]: null }));
   };
-  // Sort oldest first
-  const sortedIds = [...identifications].sort(
-    (a, b) => new Date(a.date_identified).getTime() - new Date(b.date_identified).getTime(),
-  );
+  const { sortedIds, supersededUris, observerFirstIdUri } = useMemo(() => {
+    // Sort oldest first
+    const sorted = [...identifications].sort(
+      (a, b) => new Date(a.date_identified).getTime() - new Date(b.date_identified).getTime(),
+    );
 
-  // Build set of superseded identification URIs (user has a newer ID)
-  const supersededUris = new Set<string>();
-  const latestByUser = new Map<string, Identification>();
-  for (const id of sortedIds) {
-    const existing = latestByUser.get(id.did);
-    if (
-      !existing ||
-      new Date(id.date_identified).getTime() > new Date(existing.date_identified).getTime()
-    ) {
-      if (existing) supersededUris.add(existing.uri);
-      latestByUser.set(id.did, id);
-    } else {
-      supersededUris.add(id.uri);
+    // Build set of superseded identification URIs (user has a newer ID)
+    const superseded = new Set<string>();
+    const latestByUser = new Map<string, Identification>();
+    for (const id of sorted) {
+      const existing = latestByUser.get(id.did);
+      if (
+        !existing ||
+        new Date(id.date_identified).getTime() > new Date(existing.date_identified).getTime()
+      ) {
+        if (existing) superseded.add(existing.uri);
+        latestByUser.set(id.did, id);
+      } else {
+        superseded.add(id.uri);
+      }
     }
-  }
 
-  // Find the observer's earliest (first) identification for the "Observer's ID" badge
-  const observerFirstIdUri = observerDid
-    ? sortedIds.find((id) => id.did === observerDid)?.uri
-    : undefined;
+    // Find the observer's earliest (first) identification for the "Observer's ID" badge
+    const firstObserverIdUri = observerDid
+      ? sorted.find((id) => id.did === observerDid)?.uri
+      : undefined;
+
+    return {
+      sortedIds: sorted,
+      supersededUris: superseded,
+      observerFirstIdUri: firstObserverIdUri,
+    };
+  }, [identifications, observerDid]);
 
   if (sortedIds.length === 0) {
     return (

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -470,6 +470,10 @@ export function UploadModal() {
                   component="img"
                   src={url}
                   alt={`Existing ${index + 1}`}
+                  loading="lazy"
+                  decoding="async"
+                  width={80}
+                  height={80}
                   sx={{ width: "100%", height: "100%", objectFit: "cover" }}
                 />
                 <IconButton
@@ -508,6 +512,10 @@ export function UploadModal() {
                   component="img"
                   src={img.preview}
                   alt={`Preview ${index + 1}`}
+                  loading="lazy"
+                  decoding="async"
+                  width={80}
+                  height={80}
                   sx={{ width: "100%", height: "100%", objectFit: "cover" }}
                 />
                 <IconButton


### PR DESCRIPTION
## Summary

Two small React hygiene wins:

**IdentificationHistory** — \`sortedIds\`, \`supersededUris\`, and \`observerFirstIdUri\` were recomputed on every render, including a \`[...identifications].sort(...)\` and a loop with repeated \`new Date().getTime()\` calls. Wrapped in \`useMemo\` keyed on \`(identifications, observerDid)\`. Noticeable on observations with many identifications, and on re-renders triggered by unrelated state (menu open/close, delete in flight).

**UploadModal** thumbnails — the 80×80 preview \`<img>\`s for both existing images and newly-picked previews had no \`loading=\"lazy\"\`, \`decoding=\"async\"\`, or intrinsic \`width\`/\`height\`. Added all three: saves decode work for thumbs offscreen, and eliminates CLS when the form grows.

Part of a perf sweep; opening as draft.

## Test plan

- [ ] \`npm run build\` passes (done locally)
- [ ] Open an observation detail page, verify Identification History renders identically (ordering, superseded styling, \"Observer's ID\" badge)
- [ ] Open the upload modal, add several images, confirm thumbs render at correct size and can be removed