### PR TITLE
refactor(gbif-api): parse endpoint URLs once via LazyLock

### DIFF
--- a/crates/gbif-api/src/client.rs
+++ b/crates/gbif-api/src/client.rs
@@ -2,7 +2,25 @@
 
 use crate::error::Result;
 use crate::types::*;
+use std::sync::LazyLock;
 use std::time::Duration;
+
+// Endpoint URLs parsed once at first use. Using LazyLock<Url> keeps the
+// `Url::parse` failure mode out of every request path — if the literal is
+// malformed the process panics the first time the endpoint is touched,
+// which is caught by any test that exercises the client.
+static V1_SPECIES_SUGGEST_URL: LazyLock<reqwest::Url> = LazyLock::new(|| {
+    reqwest::Url::parse(&format!("{}/species/suggest", GbifClient::V1_BASE_URL))
+        .expect("V1_BASE_URL + /species/suggest must be a valid URL")
+});
+static V1_SPECIES_SEARCH_URL: LazyLock<reqwest::Url> = LazyLock::new(|| {
+    reqwest::Url::parse(&format!("{}/species/search", GbifClient::V1_BASE_URL))
+        .expect("V1_BASE_URL + /species/search must be a valid URL")
+});
+static V2_SPECIES_MATCH_URL: LazyLock<reqwest::Url> = LazyLock::new(|| {
+    reqwest::Url::parse(&format!("{}/species/match", GbifClient::V2_BASE_URL))
+        .expect("V2_BASE_URL + /species/match must be a valid URL")
+});
 
 /// Client for interacting with the GBIF (Global Biodiversity Information Facility) API
 ///
@@ -48,8 +66,7 @@ impl GbifClient {
         limit: u32,
         status: Option<&str>,
     ) -> Result<Vec<SuggestResult>> {
-        let mut url =
-            reqwest::Url::parse(&format!("{}/species/suggest", Self::V1_BASE_URL)).unwrap();
+        let mut url = V1_SPECIES_SUGGEST_URL.clone();
         {
             let mut params = url.query_pairs_mut();
             params.append_pair("q", query);
@@ -91,8 +108,7 @@ impl GbifClient {
         status: Option<&str>,
         backbone_only: bool,
     ) -> Result<Vec<SearchResult>> {
-        let mut url =
-            reqwest::Url::parse(&format!("{}/species/search", Self::V1_BASE_URL)).unwrap();
+        let mut url = V1_SPECIES_SEARCH_URL.clone();
         {
             let mut params = url.query_pairs_mut();
             params.append_pair("q", query);
@@ -143,7 +159,7 @@ impl GbifClient {
         name: &str,
         kingdom: Option<&str>,
     ) -> Result<Option<V2MatchResult>> {
-        let mut url = reqwest::Url::parse(&format!("{}/species/match", Self::V2_BASE_URL)).unwrap();
+        let mut url = V2_SPECIES_MATCH_URL.clone();
         {
             let mut params = url.query_pairs_mut();
             params.append_pair("scientificName", name);


### PR DESCRIPTION
## Summary
`suggest`, `search`, and `match_name` each built a `reqwest::Url` with
`Url::parse(&format!("{}/species/...", V_BASE_URL)).unwrap()` on every call.
The base URLs are compile-time constants and the path suffix is a literal,
so the parse is infallible — but that infallibility was expressed as three
runtime unwraps in the hot path.

Move the parses into three `LazyLock<Url>` statics:
- `V1_SPECIES_SUGGEST_URL`
- `V1_SPECIES_SEARCH_URL`
- `V2_SPECIES_MATCH_URL`

Call sites clone the static and push query params onto the clone, which
matches the prior flow exactly.

## Why
- Removes three panic sites from the request path.
- Avoids re-parsing a constant URL on every request.
- Centralizes the "this literal is a valid URL" assertion to a single
  `expect()` per endpoint, which fires the first time the endpoint is
  touched (covered by any test that hits the client).

## Test plan
- [x] `cargo test -p gbif-api` (8/8 pass)
- [x] `cargo clippy -p gbif-api` (clean)
- [x] `cargo fmt -p gbif-api`
- [ ] Manual smoke: taxa search in the UI still returns GBIF matches.

## Not in scope (follow-ups)
Other runtime-reachable unwraps I considered but left alone:
- `nominatim-client/src/client.rs:76` — `rate_limiter.acquire().await.unwrap()`. Semaphore is owned by the client and never closed, so this is infallible-by-construction. Could be an `expect("rate limiter not closed")` for documentation; didn't feel worth a PR on its own.
- `observing-ingester/src/bin/backfill.rs:431,485,615` — `pool.unwrap()` under a `!dry_run` invariant. Restructuring to pass `Option<&PgPool>` through the call tree would enforce it in the type system, but the change is larger than this PR's scope.
- The remaining `expect()` calls (main.rs, state.rs, resolver.rs, species_id_client.rs, gbif-api client builder) are all startup-time and intentionally panic with informative messages — left as-is.
- Generated code in `observing-lexicons` (builder `.unwrap()`s) is produced by jacquard-derive and not worth hand-editing.