### PR TITLE
refactor(likes): ingester becomes single writer on like delete

### DIFF
--- a/.sqlx/query-a2dd890bb3d0dca5cfebf4b191ca6519eed3c85869df474e8c8149dfe379d4ab.json
+++ b/.sqlx/query-a2dd890bb3d0dca5cfebf4b191ca6519eed3c85869df474e8c8149dfe379d4ab.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "DELETE FROM likes WHERE subject_uri = $1 AND did = $2 RETURNING uri",
+  "query": "SELECT uri FROM likes WHERE subject_uri = $1 AND did = $2",
   "describe": {
     "columns": [
       {
@@ -19,5 +19,5 @@
       false
     ]
   },
-  "hash": "4b9645883c3349e181d810ea2fa1bb0bd0a94fb1363f018c12f1e318db86da3f"
+  "hash": "a2dd890bb3d0dca5cfebf4b191ca6519eed3c85869df474e8c8149dfe379d4ab"
 }

--- a/crates/observing-appview/src/routes/likes.rs
+++ b/crates/observing-appview/src/routes/likes.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use axum::extract::State;
 use axum::Json;
 use chrono::Utc;
@@ -5,6 +7,7 @@ use jacquard_common::types::collection::Collection;
 use jacquard_common::types::string::Datetime;
 use observing_lexicons::ing_observ::temp::like::{Like, LikeRecord};
 use serde::Deserialize;
+use tokio::time::sleep;
 use tracing::info;
 use ts_rs::TS;
 
@@ -65,20 +68,39 @@ pub async fn delete_like(
     user: AuthUser,
     Json(body): Json<DeleteLikeRequest>,
 ) -> Result<Json<SuccessResponse>, AppError> {
-    // Delete from local DB first (returns the like URI)
-    let like_uri = observing_db::likes::delete_by_subject_and_did(
-        &state.pool,
-        &body.occurrence_uri,
-        &user.did,
-    )
-    .await?;
+    // Short retry window: a rapid like→unlike can race the ingester landing
+    // the freshly-created like row. Without this, the lookup returns None and
+    // we leak a zombie PDS record.
+    let like_uri = find_like_uri_with_retry(&state, &body.occurrence_uri, &user.did).await?;
 
-    // Try to delete from AT Protocol too (non-fatal: local DB is already updated)
     if let Some(ref uri) = like_uri {
+        // Best-effort: ingester will remove the DB row when the delete commit
+        // lands on the firehose.
         let _ = try_delete_atp_record(&state.oauth_client, uri, &user.did).await;
     }
 
     Ok(Json(SuccessResponse { success: true }))
+}
+
+async fn find_like_uri_with_retry(
+    state: &AppState,
+    subject_uri: &str,
+    did: &str,
+) -> Result<Option<String>, AppError> {
+    const MAX_ATTEMPTS: usize = 5;
+    const INTERVAL: Duration = Duration::from_millis(300);
+
+    for attempt in 0..MAX_ATTEMPTS {
+        let uri =
+            observing_db::likes::find_uri_by_subject_and_did(&state.pool, subject_uri, did).await?;
+        if uri.is_some() {
+            return Ok(uri);
+        }
+        if attempt + 1 < MAX_ATTEMPTS {
+            sleep(INTERVAL).await;
+        }
+    }
+    Ok(None)
 }
 
 /// Best-effort deletion of an AT Protocol record. Returns `None` if any step

--- a/crates/observing-db/src/likes.rs
+++ b/crates/observing-db/src/likes.rs
@@ -32,14 +32,14 @@ pub async fn delete(executor: impl sqlx::PgExecutor<'_>, uri: &str) -> Result<()
     Ok(())
 }
 
-/// Delete a like by subject URI and user DID, returning the deleted like's URI
-pub async fn delete_by_subject_and_did(
+/// Look up a like's URI by subject URI and user DID.
+pub async fn find_uri_by_subject_and_did(
     executor: impl sqlx::PgExecutor<'_>,
     subject_uri: &str,
     did: &str,
 ) -> Result<Option<String>, sqlx::Error> {
     let row = sqlx::query!(
-        "DELETE FROM likes WHERE subject_uri = $1 AND did = $2 RETURNING uri",
+        "SELECT uri FROM likes WHERE subject_uri = $1 AND did = $2",
         subject_uri,
         did
     )


### PR DESCRIPTION
## Summary
- PDS-first delete: look up the like URI, call `deleteRecord`, let the ingester remove the DB row on firehose commit
- Replaces `likes::delete_by_subject_and_did` (DELETE ... RETURNING) with read-only `likes::find_uri_by_subject_and_did`
- Adds a short retry window (~1.5s, 5×300ms) around the lookup to cover the race where a rapid like→unlike fires before the ingester lands the like row. If the window times out, we return success and leave a zombie PDS record — matches the pre-existing "DB empty → skip PDS delete" behavior

Part of #311.

## Test plan
- [ ] Unit: existing like/unlike e2e still passes
- [ ] Manual: rapid like→unlike toggle leaves no zombie PDS record
- [ ] Manual: unlike after ingester has caught up still removes the PDS record and the DB row