### PR TITLE
feat(db): privilege split migration for appview_reader role

### DIFF
--- a/crates/observing-db/migrations/20260418000000_appview_reader_grants.sql
+++ b/crates/observing-db/migrations/20260418000000_appview_reader_grants.sql
@@ -1,0 +1,58 @@
+-- Privilege split for the appview_reader role.
+--
+-- The ingester is the single writer for occurrence-derived tables; the appview
+-- owns OAuth + private-location data and UPDATEs notifications.read. This
+-- migration makes that invariant enforceable at the DB layer.
+--
+-- The role is created out-of-band via Cloud SQL user management before the
+-- migration lands in prod. On fresh local/CI DBs where the role does not
+-- exist, this migration is a no-op.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'appview_reader') THEN
+        RAISE NOTICE 'appview_reader role not found; skipping grants (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    -- Clean slate: any previous manual grants are superseded by this migration.
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA public FROM appview_reader';
+    EXECUTE 'REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM appview_reader';
+
+    -- Schema access.
+    EXECUTE 'GRANT USAGE ON SCHEMA public TO appview_reader';
+
+    -- Ingester-owned tables: SELECT only.
+    EXECUTE 'GRANT SELECT ON TABLE
+        occurrences,
+        occurrence_observers,
+        identifications,
+        comments,
+        interactions,
+        likes
+        TO appview_reader';
+
+    -- notifications: ingester INSERTs from firehose events, appview UPDATEs
+    -- the read flag via mark_read / mark_all_read.
+    EXECUTE 'GRANT SELECT, UPDATE ON TABLE notifications TO appview_reader';
+
+    -- Appview-owned tables: full CRUD.
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE
+        occurrence_private_data,
+        oauth_sessions,
+        oauth_state
+        TO appview_reader';
+
+    -- Read access to diagnostic / reference tables.
+    EXECUTE 'GRANT SELECT ON TABLE
+        sensitive_species,
+        ingester_state
+        TO appview_reader';
+
+    -- Future tables created by the (postgres) migrator default to SELECT-only
+    -- for the appview; tables that need appview writes get explicit GRANTs
+    -- alongside their CREATE TABLE migration.
+    EXECUTE 'ALTER DEFAULT PRIVILEGES IN SCHEMA public
+             GRANT SELECT ON TABLES TO appview_reader';
+END
+$$;


### PR DESCRIPTION
## Summary
Part of #311, Step 2 of the role split.

After #309 / #310 / #312 / #318 / #319 migrated every appview write off ingester-owned tables, this migration adds the DB-layer enforcement:

- **SELECT only** on `occurrences`, `occurrence_observers`, `identifications`, `comments`, `interactions`, `likes`
- **SELECT + UPDATE** on `notifications` (ingester INSERTs from the firehose; appview UPDATEs the `read` flag via `mark_read` / `mark_all_read`)
- **Full CRUD** on `occurrence_private_data`, `oauth_sessions`, `oauth_state`
- **SELECT** on `sensitive_species` and `ingester_state`
- **Default SELECT** on future tables created by the migrator (so new shared tables are safe by default; appview-writable tables get explicit GRANTs alongside their CREATE TABLE migration)

## Step 1 (done, out-of-band)
- `appview_reader` Cloud SQL user created
- Password stored in Secret Manager as `observing-db-appview-password`
- Default compute SA already has project-scoped `secretmanager.secretAccessor`, so no IAM change needed

## Step 3 (follow-up, not in this PR)
Flip the appview Cloud Run deploy from `DB_USER=postgres` to `DB_USER=appview_reader` with the new secret. That step also needs to address `admin::delete_by_nsid` — it bulk-deletes from ingester-owned tables and will fail under the restricted role. Options: move to a separate admin role, delete the endpoint, or route via PDS `deleteRecord` per URI.

## Idempotency / safety
- The migration is wrapped in a `DO $$ IF NOT EXISTS (role) RETURN $$;` block, so on fresh local/CI DBs where `appview_reader` doesn't exist it's a clean no-op.
- Starts with `REVOKE ALL` so re-runs or manual grants are normalized.
- Landing this PR doesn't change any live behavior — appview is still connecting as `postgres`. The new grants only take effect once Step 3 flips the deploy.

## Test plan
- [ ] CI passes (fresh Postgres, no role → no-op path exercised)
- [ ] After deploy, connect to prod as `appview_reader` and verify: `SELECT * FROM occurrences LIMIT 1` works, `DELETE FROM occurrences WHERE ...` is denied, `UPDATE notifications SET read = true WHERE ...` works, `INSERT INTO oauth_sessions ...` works.