### PR TITLE
refactor(admin): drop bulk-delete-by-NSID endpoint

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -208,7 +208,7 @@ async fn main() {
         .route("/admin/collections", get(routes::admin::list_collections))
         .route(
             "/admin/collections/{nsid}",
-            get(routes::admin::get_collection).delete(routes::admin::delete_collection),
+            get(routes::admin::get_collection),
         )
         .route(
             "/admin/collections/{nsid}/records",

--- a/crates/observing-appview/src/routes/admin.rs
+++ b/crates/observing-appview/src/routes/admin.rs
@@ -1,4 +1,4 @@
-//! Lexicon-scoped admin endpoints: count/list/delete records by NSID.
+//! Lexicon-scoped admin endpoints: count/list records by NSID.
 //!
 //! Authenticated via the standard session cookie (`AuthUser`), then the
 //! caller's DID must appear in the `ADMIN_DIDS` allowlist env var. When the
@@ -209,65 +209,5 @@ pub async fn list_table_rows(
         rows,
         limit,
         offset,
-    }))
-}
-
-#[derive(Deserialize)]
-pub struct DeleteCollectionQuery {
-    /// Must match the NSID in the path. Prevents accidental deletion.
-    pub confirm: String,
-    #[serde(default)]
-    pub dry_run: bool,
-}
-
-#[derive(Serialize)]
-pub struct DeleteCollectionResponse {
-    pub nsid: String,
-    pub dry_run: bool,
-    pub rows_affected: u64,
-    /// Tables whose rows were deleted by cascade (best-effort — not a count).
-    pub cascades_to: &'static [&'static str],
-}
-
-/// `DELETE /admin/collections/{nsid}` — purge all rows for an NSID.
-///
-/// Requires `?confirm={nsid}` (must match the path). Pass `?dry_run=true` to
-/// return the count that *would* be deleted without executing the DELETE.
-pub async fn delete_collection(
-    _auth: AdminAuth,
-    State(state): State<AppState>,
-    Path(nsid): Path<String>,
-    Query(params): Query<DeleteCollectionQuery>,
-) -> Result<Json<DeleteCollectionResponse>, AppError> {
-    let meta = db_admin::lookup(&nsid)
-        .ok_or_else(|| AppError::NotFound(format!("Unknown NSID: {nsid}")))?;
-    if params.confirm != nsid {
-        return Err(AppError::BadRequest(
-            "confirm parameter must match the NSID in the path".into(),
-        ));
-    }
-
-    if params.dry_run {
-        let count = db_admin::count(&state.pool, &nsid).await?;
-        tracing::warn!(nsid = %nsid, count, "admin delete dry-run");
-        return Ok(Json(DeleteCollectionResponse {
-            nsid,
-            dry_run: true,
-            rows_affected: count as u64,
-            cascades_to: meta.cascades_to,
-        }));
-    }
-
-    let rows_affected = db_admin::delete_by_nsid(&state.pool, &nsid).await?;
-    tracing::warn!(
-        nsid = %nsid,
-        rows_affected,
-        "admin delete executed"
-    );
-    Ok(Json(DeleteCollectionResponse {
-        nsid,
-        dry_run: false,
-        rows_affected,
-        cascades_to: meta.cascades_to,
     }))
 }

--- a/crates/observing-db/src/admin.rs
+++ b/crates/observing-db/src/admin.rs
@@ -338,17 +338,3 @@ pub async fn list_table_rows(
         .await?;
     Ok(rows.into_iter().map(|(v,)| v).collect())
 }
-
-/// Delete all rows belonging to an NSID. Returns the number of rows affected.
-/// Callers are responsible for guarding this with a confirmation token.
-pub async fn delete_by_nsid(pool: &PgPool, nsid: &str) -> Result<u64, sqlx::Error> {
-    let Some(meta) = lookup(nsid) else {
-        return Ok(0);
-    };
-    let sql = format!("DELETE FROM {} WHERE uri LIKE $1", meta.table);
-    let result = sqlx::query(&sql)
-        .bind(format!("at://%/{}/%", nsid))
-        .execute(pool)
-        .await?;
-    Ok(result.rows_affected())
-}

--- a/frontend/src/components/admin/AdminPage.tsx
+++ b/frontend/src/components/admin/AdminPage.tsx
@@ -2,15 +2,8 @@ import { useEffect, useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
 import {
   Alert,
-  Button,
-  Checkbox,
   CircularProgress,
   Container,
-  Dialog,
-  DialogActions,
-  DialogContent,
-  DialogTitle,
-  FormControlLabel,
   Link,
   Paper,
   Table,
@@ -18,16 +11,13 @@ import {
   TableCell,
   TableHead,
   TableRow,
-  TextField,
   Typography,
 } from "@mui/material";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import {
   AdminError,
   type CollectionSummary,
-  type DeleteResponse,
   type TableSummary,
-  deleteCollection,
   listCollections,
   listTables,
 } from "../../services/admin";
@@ -41,9 +31,8 @@ export function AdminPage() {
   const [collections, setCollections] = useState<CollectionSummary[]>([]);
   const [tables, setTables] = useState<TableSummary[]>([]);
   const [total, setTotal] = useState(0);
-  const [target, setTarget] = useState<CollectionSummary | null>(null);
 
-  const refresh = () => {
+  useEffect(() => {
     setLoading(true);
     setError(null);
     Promise.all([listCollections(), listTables()])
@@ -61,10 +50,6 @@ export function AdminPage() {
         }
       })
       .finally(() => setLoading(false));
-  };
-
-  useEffect(() => {
-    refresh();
   }, []);
 
   if (loading) {
@@ -103,7 +88,6 @@ export function AdminPage() {
               <TableCell>Table</TableCell>
               <TableCell align="right">Count</TableCell>
               <TableCell>Cascades to</TableCell>
-              <TableCell align="right">Actions</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -122,16 +106,6 @@ export function AdminPage() {
                 <TableCell align="right">{c.count.toLocaleString()}</TableCell>
                 <TableCell sx={{ fontSize: "0.8rem", color: "text.secondary" }}>
                   {c.cascades_to.join(", ") || "—"}
-                </TableCell>
-                <TableCell align="right">
-                  <Button
-                    size="small"
-                    color="error"
-                    disabled={c.count === 0}
-                    onClick={() => setTarget(c)}
-                  >
-                    Purge
-                  </Button>
                 </TableCell>
               </TableRow>
             ))}
@@ -176,104 +150,6 @@ export function AdminPage() {
           </TableBody>
         </Table>
       </Paper>
-
-      {target && (
-        <PurgeDialog
-          collection={target}
-          onClose={() => setTarget(null)}
-          onPurged={() => {
-            setTarget(null);
-            refresh();
-          }}
-        />
-      )}
     </Container>
-  );
-}
-
-function PurgeDialog({
-  collection,
-  onClose,
-  onPurged,
-}: {
-  collection: CollectionSummary;
-  onClose: () => void;
-  onPurged: () => void;
-}) {
-  const [typed, setTyped] = useState("");
-  const [dryRun, setDryRun] = useState(true);
-  const [pending, setPending] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [result, setResult] = useState<DeleteResponse | null>(null);
-
-  const confirmed = typed === collection.nsid;
-
-  const submit = async () => {
-    setPending(true);
-    setError(null);
-    try {
-      const res = await deleteCollection(collection.nsid, { dryRun });
-      setResult(res);
-      if (!res.dry_run) {
-        // Trigger refresh shortly so the user can read the result.
-        setTimeout(onPurged, 1200);
-      }
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Request failed");
-    } finally {
-      setPending(false);
-    }
-  };
-
-  return (
-    <Dialog open onClose={onClose} maxWidth="sm" fullWidth>
-      <DialogTitle>Purge {collection.nsid}</DialogTitle>
-      <DialogContent>
-        <Alert severity="warning" sx={{ mb: 2 }}>
-          This will delete <strong>{collection.count.toLocaleString()}</strong> rows from{" "}
-          <code>{collection.table}</code>.
-          {collection.cascades_to.length > 0 && (
-            <> Cascades to: {collection.cascades_to.join(", ")}.</>
-          )}
-        </Alert>
-        <Typography variant="body2" sx={{ mb: 1 }}>
-          Type the NSID to confirm:
-        </Typography>
-        <TextField
-          fullWidth
-          size="small"
-          value={typed}
-          onChange={(e) => setTyped(e.target.value)}
-          placeholder={collection.nsid}
-          disabled={pending}
-          autoFocus
-        />
-        <FormControlLabel
-          sx={{ mt: 1 }}
-          control={<Checkbox checked={dryRun} onChange={(e) => setDryRun(e.target.checked)} />}
-          label="Dry run (count only, don't delete)"
-        />
-        {error && (
-          <Alert severity="error" sx={{ mt: 2 }}>
-            {error}
-          </Alert>
-        )}
-        {result && (
-          <Alert severity={result.dry_run ? "info" : "success"} sx={{ mt: 2 }}>
-            {result.dry_run
-              ? `Dry run: would delete ${result.rows_affected.toLocaleString()} rows.`
-              : `Deleted ${result.rows_affected.toLocaleString()} rows.`}
-          </Alert>
-        )}
-      </DialogContent>
-      <DialogActions>
-        <Button onClick={onClose} disabled={pending}>
-          Close
-        </Button>
-        <Button color="error" variant="contained" onClick={submit} disabled={!confirmed || pending}>
-          {dryRun ? "Dry run" : "Purge"}
-        </Button>
-      </DialogActions>
-    </Dialog>
   );
 }

--- a/frontend/src/services/admin.ts
+++ b/frontend/src/services/admin.ts
@@ -39,13 +39,6 @@ export interface ListRecordsResponse {
   offset: number;
 }
 
-export interface DeleteResponse {
-  nsid: string;
-  dry_run: boolean;
-  rows_affected: number;
-  cascades_to: string[];
-}
-
 export class AdminError extends Error {
   constructor(
     public status: number,
@@ -124,14 +117,4 @@ export function listTableRows(
   if (opts.offset != null) params.set("offset", String(opts.offset));
   const qs = params.toString();
   return adminFetch(`/admin/tables/${encodeURIComponent(name)}/rows${qs ? `?${qs}` : ""}`);
-}
-
-export function deleteCollection(nsid: string, opts: { dryRun: boolean }): Promise<DeleteResponse> {
-  const params = new URLSearchParams({
-    confirm: nsid,
-    dry_run: String(opts.dryRun),
-  });
-  return adminFetch(`/admin/collections/${encodeURIComponent(nsid)}?${params.toString()}`, {
-    method: "DELETE",
-  });
 }


### PR DESCRIPTION
## Summary
- Removes `DELETE /admin/collections/{nsid}` plus `delete_by_nsid` in `observing-db::admin`
- Removes the frontend Purge dialog and `deleteCollection` service call
- Admin surface is now read-only (list collections/tables, detail, records, rows)

## Why
Final piece before flipping the appview Cloud Run deploy to the `appview_reader` DB role (#320). That role has no DELETE privilege on the lexicon tables, so this handler would start 500ing on deploy. Rather than wire up a second admin-only DB pool, we drop the functionality — lexicon cleanup can be done via a one-off psql runbook.

## Test plan
- [x] `cargo build --workspace` passes
- [x] `npx tsc --noEmit` passes
- [x] `cargo fmt` / `npm run fmt` clean