### PR TITLE
ci: flip appview deploy to appview_reader DB role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,8 +343,8 @@ jobs:
             --region=$REGION \
             --allow-unauthenticated \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,PUBLIC_URL=$PUBLIC_URL,SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b,ADMIN_DIDS=did:plc:vozr2os4b4sxrxr6opde5js5 \
-            --set-secrets=DB_PASSWORD=observing-db-password:latest \
+            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=appview_reader,PUBLIC_URL=$PUBLIC_URL,SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b,ADMIN_DIDS=did:plc:vozr2os4b4sxrxr6opde5js5 \
+            --set-secrets=DB_PASSWORD=observing-db-appview-password:latest \
             --format='value(status.url)')
           echo "url=$URL" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- `DB_USER`: `postgres` → `appview_reader`
- `DB_PASSWORD` secret: `observing-db-password` → `observing-db-appview-password`
- Ingester untouched (still owns writes + migrations via `postgres`)

## Why
Final step of the ingester-only-writes spike. The `appview_reader` role exists (created out-of-band in Cloud SQL) and its grants are defined by #320: SELECT on lexicon tables, UPDATE on `notifications.read`, full CRUD on OAuth + private-location. With the admin bulk-delete surface removed in #321, the appview no longer needs any DELETE privilege on lexicon tables, so this flip is safe.

## Rollback
Revert this commit — the `postgres` credentials and `observing-db-password` secret still exist.

## Test plan
- [ ] Deploy succeeds on merge to `main`
- [ ] `/health` returns 200
- [ ] Create occurrence (full write path exercises ingester)
- [ ] Mark notification read (appview UPDATE path)
- [ ] OAuth login (appview writes `oauth_state` + `oauth_sessions`)
- [ ] Admin page loads at `/admin` (SELECT-only reads)