### PR TITLE
docs(architecture): show per-schema r/o vs r/w in system diagram

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 ## System Overview
 
 ```mermaid
-flowchart LR
+flowchart TB
     User([Browser])
     PDS[Bluesky PDS]
     JS[Jetstream firehose]
@@ -12,7 +12,7 @@ flowchart LR
     SID[species-id]
 
     subgraph DB["Postgres + PostGIS"]
-      direction TB
+      direction LR
       subgraph ING["schema: ingester"]
         ING_TBL["occurrences, occurrence_observers,<br/>identifications, comments,<br/>interactions, likes, notifications,<br/>ingester_state, community_ids"]
       end

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,10 +13,15 @@ flowchart LR
 
     subgraph DB["Postgres + PostGIS"]
       direction TB
-      T1["occurrences, occurrence_observers,<br/>identifications, comments,<br/>interactions, likes"]
-      T2[notifications]
-      T3["occurrence_private_data,<br/>oauth_sessions, oauth_state"]
-      T4["sensitive_species,<br/>ingester_state"]
+      subgraph ING["schema: ingester"]
+        ING_TBL["occurrences, occurrence_observers,<br/>identifications, comments,<br/>interactions, likes, notifications,<br/>ingester_state, community_ids"]
+      end
+      subgraph APPV["schema: appview"]
+        APPV_TBL["occurrence_private_data,<br/>oauth_sessions, oauth_state"]
+      end
+      subgraph PUB["schema: public"]
+        PUB_TBL["sensitive_species,<br/>spatial_ref_sys"]
+      end
     end
 
     User -- HTTP --> AV
@@ -25,17 +30,16 @@ flowchart LR
     JS -- "WSS subscribe" --> IG
     AV -- species-id --> SID
 
-    IG == "READ+WRITE" ==> T1
-    IG == "INSERT" ==> T2
-    IG -- "read (cursor)" --> T4
+    IG == "READ+WRITE" ==> ING
+    IG -- "READ-ONLY<br/>(backfill reads oauth_sessions)" --> APPV
+    IG -- "READ-ONLY" --> PUB
 
-    AV -- "READ-ONLY (SELECT)" --> T1
-    AV -- "SELECT + UPDATE read flag" --> T2
-    AV == "READ+WRITE" ==> T3
-    AV -- "READ-ONLY" --> T4
+    AV -- "READ-ONLY<br/>(+ UPDATE notifications.read)" --> ING
+    AV == "READ+WRITE" ==> APPV
+    AV -- "READ-ONLY" --> PUB
 ```
 
-Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes those tables directly. Only OAuth state, private location, and the `notifications.read` flag are written by the appview itself — enforced at the DB layer by the `appview_reader` grants.
+Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema directly (except to flip `notifications.read`). OAuth state and private location live in the `appview` schema, where the appview has full CRUD. The ingester runs as the `postgres` role — it owns migrations, so it has full access to every schema at the grant level, but in practice only writes its own schema (plus `public.sensitive_species` during seeding, and read access to `appview.oauth_sessions` during backfill).
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Follow-up to #324 (schema split). Updates `docs/architecture.md` so the system diagram reflects the new `ingester` / `appview` / `public` schemas.
- Each service-to-schema arrow is labeled with its actual access level (R/O, R/W, or the special `UPDATE notifications.read` case).
- Tweaks the explanatory paragraph to match (ingester runs as `postgres` so grants are wide, but actual writes are scoped to its own schema).

## Test plan
- [ ] Mermaid renders on GitHub (visual check in PR Files tab)