### PR TITLE
feat(db): ingester_writer least-privilege role

### DIFF
--- a/crates/observing-db/migrations/20260421000000_ingester_writer_role.sql
+++ b/crates/observing-db/migrations/20260421000000_ingester_writer_role.sql
@@ -1,0 +1,62 @@
+-- Give the ingester runtime its own least-privilege DB role.
+--
+-- Before this, the ingester connected as `postgres` (superuser). After the
+-- schema split and the notification_reads split, the ingester actually only
+-- needs:
+--   - CRUD on the `ingester` schema
+--   - SELECT on `appview.oauth_sessions` (for the backfill --all binary)
+--   - SELECT on `public.sensitive_species`
+--
+-- So we mirror the pattern we set up for `appview_reader`: define the runtime
+-- grants here (idempotent no-op when the role is absent, as on CI/local),
+-- create the role separately in Cloud SQL, and flip the Cloud Run env in a
+-- follow-up PR.
+--
+-- Migrations themselves still run as `postgres` — the ingester process will
+-- connect twice on startup: once with `DATABASE_ADMIN_URL` to migrate, then
+-- with `DATABASE_URL` (ingester_writer) for runtime writes.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_writer') THEN
+        RAISE NOTICE 'ingester_writer role not found; skipping grants (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    -- Clean slate. No prior grants to this role on any schema, but guard
+    -- against reruns / partial state.
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA ingester FROM ingester_writer';
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA appview FROM ingester_writer';
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA public FROM ingester_writer';
+    EXECUTE 'REVOKE ALL ON ALL SEQUENCES IN SCHEMA ingester FROM ingester_writer';
+
+    -- Schema usage.
+    EXECUTE 'GRANT USAGE ON SCHEMA ingester, appview, public TO ingester_writer';
+
+    -- ingester: full CRUD on all current and future tables.
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ingester
+             TO ingester_writer';
+    -- BIGSERIAL columns need sequence access for nextval().
+    EXECUTE 'GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA ingester
+             TO ingester_writer';
+
+    -- appview: the backfill --all binary reads oauth_sessions to discover
+    -- known DIDs. Nothing else in the ingester touches the appview schema.
+    EXECUTE 'GRANT SELECT ON TABLE appview.oauth_sessions TO ingester_writer';
+
+    -- public: sensitive_species reference data, read-only.
+    EXECUTE 'GRANT SELECT ON TABLE public.sensitive_species TO ingester_writer';
+
+    -- REFRESH MATERIALIZED VIEW CONCURRENTLY requires ownership (or MAINTAIN
+    -- privilege, added in PG17). Transfer ownership so the runtime role can
+    -- refresh community_ids after each identification upsert/delete.
+    EXECUTE 'ALTER MATERIALIZED VIEW ingester.community_ids OWNER TO ingester_writer';
+
+    -- Default privileges so future tables/sequences created by the postgres
+    -- migrator are immediately usable by the runtime role.
+    EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ingester
+             GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ingester_writer';
+    EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ingester
+             GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO ingester_writer';
+END
+$$;

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -93,6 +93,22 @@ impl Database {
         })
     }
 
+    /// Connect with a single-connection pool, intended for short-lived tasks
+    /// like running migrations under an admin role. Dropping this `Database`
+    /// closes the pool.
+    pub async fn connect_single(database_url: &str) -> Result<Self> {
+        info!("Connecting to database (single-connection admin pool)...");
+        let pool = PgPoolOptions::new()
+            .max_connections(1)
+            .acquire_timeout(std::time::Duration::from_secs(10))
+            .connect(database_url)
+            .await?;
+        Ok(Self {
+            pool,
+            media_resolver: MediaResolver::new(),
+        })
+    }
+
     /// Run database migrations using the shared migration
     pub async fn migrate(&self) -> Result<()> {
         observing_db::migrate::migrate(&self.pool).await?;

--- a/crates/observing-ingester/src/main.rs
+++ b/crates/observing-ingester/src/main.rs
@@ -71,9 +71,21 @@ async fn main() -> Result<()> {
         }
     });
 
-    // Connect to database
+    // Run migrations using the admin URL when configured, then connect with
+    // the (potentially narrower) runtime URL. If no admin URL is set, both
+    // paths use the same URL — same behavior as before the role split.
+    if let Some(admin_url) = config.database_admin_url.as_deref() {
+        info!("Running migrations with dedicated admin connection");
+        let admin_db = Database::connect_single(admin_url).await?;
+        admin_db.migrate().await?;
+    } else {
+        info!("Running migrations with runtime DB connection");
+    }
+
     let db = Database::connect(&config.database_url).await?;
-    db.migrate().await?;
+    if config.database_admin_url.is_none() {
+        db.migrate().await?;
+    }
 
     // Load saved cursor
     let saved_cursor = db.get_cursor().await?;
@@ -270,6 +282,10 @@ fn load_config(cli: &Cli) -> Result<IngesterConfig> {
         }
     };
 
+    // Optional: separate URL used only for running migrations. When present,
+    // DATABASE_URL can point to the least-privilege ingester_writer role.
+    let database_admin_url = std::env::var("DATABASE_ADMIN_URL").ok();
+
     let relay_url = std::env::var("JETSTREAM_URL")
         .unwrap_or_else(|_| "wss://jetstream2.us-east.bsky.network/subscribe".to_string());
 
@@ -293,6 +309,7 @@ fn load_config(cli: &Cli) -> Result<IngesterConfig> {
     Ok(IngesterConfig {
         relay_url,
         database_url,
+        database_admin_url,
         cursor,
         port,
         collections,

--- a/crates/observing-ingester/src/types.rs
+++ b/crates/observing-ingester/src/types.rs
@@ -28,6 +28,11 @@ pub struct RecentEvent {
 pub struct IngesterConfig {
     pub relay_url: String,
     pub database_url: String,
+    /// Optional admin DB URL for running migrations. When set, the ingester
+    /// connects here with DDL privileges at startup, runs migrations, and
+    /// closes the pool — `database_url` can then be a least-privilege role
+    /// (e.g. `ingester_writer`) that only has CRUD on its own schema.
+    pub database_admin_url: Option<String>,
     pub cursor: Option<i64>,
     pub port: u16,
     /// Full NSIDs of collections to subscribe to
@@ -39,6 +44,7 @@ impl Default for IngesterConfig {
         Self {
             relay_url: "wss://jetstream2.us-east.bsky.network/subscribe".to_string(),
             database_url: String::new(),
+            database_admin_url: None,
             cursor: None,
             port: 8080,
             collections: ALL_COLLECTIONS

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ flowchart TB
     PDS[Bluesky PDS]
     JS[Jetstream firehose]
     AV[observing-appview<br/>DB_USER=appview_reader]
-    IG[observing-ingester<br/>DB_USER=postgres]
+    IG[observing-ingester<br/>DB_USER=ingester_writer<br/>DATABASE_ADMIN_URL=postgres]
     SID[species-id]
 
     subgraph DB["Postgres + PostGIS"]
@@ -39,7 +39,7 @@ flowchart TB
     AV -- "READ-ONLY" --> PUB
 ```
 
-Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. The ingester runs as the `postgres` role — it owns migrations, so it has full access to every schema at the grant level, but in practice only writes its own schema (plus `public.sensitive_species` during seeding, and read access to `appview.oauth_sessions` during backfill).
+Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. The ingester connects twice at startup: once with `DATABASE_ADMIN_URL` (the `postgres` superuser) to run migrations, then drops that pool and opens its runtime pool as `ingester_writer` — a least-privilege role with CRUD only on the `ingester` schema, `SELECT` on `appview.oauth_sessions` (for the backfill `--all` binary), and `SELECT` on `public.sensitive_species`. No service runs as a superuser at steady state.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary

Mirrors the `appview_reader` split (#322) for the ingester. Before this, the ingester connected as `postgres` (superuser). After it:

- **Connects twice at startup** — once with `DATABASE_ADMIN_URL` (postgres) to run migrations, then drops that pool and opens the runtime pool as `ingester_writer`.
- **Runtime role grants** — CRUD on `ingester` schema, `SELECT` on `appview.oauth_sessions` (needed by the backfill `--all` binary), `SELECT` on `public.sensitive_species`.
- **Matview ownership** — `ingester.community_ids` owner transferred to `ingester_writer` so the runtime role can `REFRESH MATERIALIZED VIEW CONCURRENTLY` (required post-identification).
- **Backwards compatible** — when `DATABASE_ADMIN_URL` is unset, the ingester behaves exactly as before (migrate + run on the same URL). No behavior change until the Cloud Run env is flipped.

The migration itself is idempotent and a no-op when `ingester_writer` doesn't exist (local/CI).

## Follow-up (separate PR, matches #322 pattern)

1. Create `ingester_writer` role + password secret in Cloud SQL / Secret Manager.
2. Flip the Cloud Run ingester deploy to set `DATABASE_URL` → `ingester_writer` and `DATABASE_ADMIN_URL` → `postgres`.

After that, no service in steady-state operation runs as a superuser.

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] Migrations apply clean on a fresh Postgres
- [x] Verified as `ingester_writer` via psql: `REFRESH MATERIALIZED VIEW CONCURRENTLY community_ids` ✓, `INSERT INTO ingester.notifications` ✓, `SELECT FROM appview.oauth_sessions` ✓, `INSERT INTO appview.notification_reads` denied ✓
- [x] Backfill `--dry-run` works as `ingester_writer`
- [ ] CI green