### PR TITLE
feat(db): rename appview_reader to appview_runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,19 +335,9 @@ jobs:
         run: |
           echo "species_id=$(gcloud run services describe observing-species-id --region=$REGION --format='value(status.url)')" >> $GITHUB_OUTPUT
 
-      - name: Deploy appview
-        id: deploy-appview
-        run: |
-          URL=$(gcloud run deploy observing-appview \
-            --image=$REGISTRY/observing-appview:latest \
-            --region=$REGION \
-            --allow-unauthenticated \
-            --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=appview_reader,PUBLIC_URL=$PUBLIC_URL,SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b,ADMIN_DIDS=did:plc:vozr2os4b4sxrxr6opde5js5 \
-            --set-secrets=DB_PASSWORD=observing-db-appview-password:latest \
-            --format='value(status.url)')
-          echo "url=$URL" >> $GITHUB_OUTPUT
-
+      # Deploy ingester first so any pending migrations (which run during
+      # its startup) are applied before the appview revision comes up and
+      # tries to connect with its runtime role.
       - name: Deploy ingester
         run: |
           gcloud run deploy observing-ingester \
@@ -362,3 +352,16 @@ jobs:
             --min-instances=1 \
             --max-instances=1 \
             --timeout=3600
+
+      - name: Deploy appview
+        id: deploy-appview
+        run: |
+          URL=$(gcloud run deploy observing-appview \
+            --image=$REGISTRY/observing-appview:latest \
+            --region=$REGION \
+            --allow-unauthenticated \
+            --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
+            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=appview_runtime,PUBLIC_URL=$PUBLIC_URL,SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b,ADMIN_DIDS=did:plc:vozr2os4b4sxrxr6opde5js5 \
+            --set-secrets=DB_PASSWORD=observing-db-appview-password:latest \
+            --format='value(status.url)')
+          echo "url=$URL" >> $GITHUB_OUTPUT

--- a/crates/observing-db/migrations/20260422000000_appview_runtime_rename.sql
+++ b/crates/observing-db/migrations/20260422000000_appview_runtime_rename.sql
@@ -1,0 +1,28 @@
+-- Rename `appview_reader` to `appview_runtime`.
+--
+-- The name `appview_reader` predates the notification_reads split (#326),
+-- which added appview writes to `appview.notification_reads`. The role is
+-- no longer read-only on the appview schema — it's the appview's general
+-- runtime role — so rename it to match the pattern used by `ingester_writer`.
+--
+-- `ALTER ROLE ... RENAME TO ...` preserves the password, all grants, and
+-- ownership — so no grant migrations need to be re-run.
+--
+-- Idempotent: no-op if the role was already renamed, and no-op on local/CI
+-- where the role doesn't exist.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'appview_runtime') THEN
+        RAISE NOTICE 'appview_runtime role already exists; skipping rename';
+        RETURN;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'appview_reader') THEN
+        RAISE NOTICE 'appview_reader role not found; skipping rename (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    EXECUTE 'ALTER ROLE appview_reader RENAME TO appview_runtime';
+END
+$$;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -7,7 +7,7 @@ flowchart TB
     User([Browser])
     PDS[Bluesky PDS]
     JS[Jetstream firehose]
-    AV[observing-appview<br/>DB_USER=appview_reader]
+    AV[observing-appview<br/>DB_USER=appview_runtime]
     IG[observing-ingester<br/>DB_USER=ingester_writer<br/>DATABASE_ADMIN_URL=postgres]
     SID[species-id]
 


### PR DESCRIPTION
## Summary

Renames the appview's runtime DB role from `appview_reader` to `appview_runtime`. The old name was accurate when #322 landed (role was read-only on the ingester schema), but after the notification-reads split in #326 the role also writes to `appview.notification_reads` — so it's no longer a "reader." The new name matches the pattern used by `ingester_writer`.

- **Migration** — idempotent `ALTER ROLE appview_reader RENAME TO appview_runtime`. Preserves the password and all existing grants/ownership, so no other grant migrations need to re-run. No-ops on local/CI where the role doesn't exist, and no-ops if the rename has already been applied.
- **CI deploy order** — swapped ingester deploy to run before appview. That way the rename migration (which runs during ingester startup) completes before the appview revision tries to connect as `appview_runtime`. This ordering is also the safer default going forward — migrations land before their consumers.
- **Env flip** — `DB_USER=appview_reader` → `DB_USER=appview_runtime` in the appview deploy step.
- **Docs** — `docs/architecture.md` mermaid diagram updated.

## Test plan

- [x] Migrations apply clean on a fresh Postgres (no role present → rename is a no-op)
- [x] With `appview_reader` created up front: migration renames it; `psql -U appview_runtime` with the old password still connects and still has `SELECT` on `ingester.notifications`
- [ ] CI green
- [ ] After merge: verify appview Cloud Run revision comes up healthy with the new `DB_USER`