### PR TITLE
ci: flip ingester deploy to ingester_writer role

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -347,8 +347,8 @@ jobs:
             --cpu=1 \
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=RUST_LOG=observing_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=postgres,JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe \
-            --set-secrets=DB_PASSWORD=observing-db-password:latest \
+            --set-env-vars=RUST_LOG=observing_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_writer,JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe \
+            --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest,DATABASE_ADMIN_URL=observing-db-admin-url:latest \
             --min-instances=1 \
             --max-instances=1 \
             --timeout=3600


### PR DESCRIPTION
## Summary

Follow-up to #327. With the `ingester_writer` role and the new Secret Manager entries (`observing-db-ingester-password`, `observing-db-admin-url`) provisioned in Cloud SQL, this PR flips the ingester Cloud Run deploy to use the least-privilege role.

- `DB_USER`: `postgres` → `ingester_writer`
- `DB_PASSWORD`: `observing-db-password` → `observing-db-ingester-password`
- `DATABASE_ADMIN_URL`: new secret holding the postgres (superuser) connection URL. Used only to run migrations at startup, then the pool is dropped.

After this lands, no service runs as a Postgres superuser at steady state — matching the invariant described in `docs/architecture.md`.

## Manual ops steps already completed

- [x] `gcloud sql users create ingester_writer` with generated password
- [x] Secret Manager: `observing-db-ingester-password` created
- [x] Secret Manager: `observing-db-admin-url` created with `postgresql://postgres:…@localhost/observing?host=/cloudsql/observ-ing:us-central1:observing-db`
- [x] Grants from `20260421000000_ingester_writer_role.sql` re-applied against prod as postgres (the migration itself no-op'd during the #327 deploy since the role didn't exist yet)
- [x] Verified as `ingester_writer` via psql: matview ownership ✓, `SELECT appview.oauth_sessions` ✓, `SELECT public.sensitive_species` ✓, CRUD on `ingester` schema ✓, `INSERT appview.notification_reads` correctly denied ✓

## Test plan

- [ ] CI green
- [ ] After merge: confirm new ingester revision starts cleanly (migrations run as postgres, runtime pool connects as `ingester_writer`)
- [ ] Spot-check ingester logs for "Running migrations with dedicated admin connection"