### PR TITLE
feat(db): extract migrations into Cloud Run Job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
       REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/observing
     strategy:
       matrix:
-        service: [appview, ingester, species-id]
+        service: [appview, ingester, species-id, migrate]
     steps:
       - uses: actions/checkout@v4
 
@@ -335,9 +335,23 @@ jobs:
         run: |
           echo "species_id=$(gcloud run services describe observing-species-id --region=$REGION --format='value(status.url)')" >> $GITHUB_OUTPUT
 
-      # Deploy ingester first so any pending migrations (which run during
-      # its startup) are applied before the appview revision comes up and
-      # tries to connect with its runtime role.
+      # Apply pending DB migrations as a one-shot Cloud Run Job *before* any
+      # runtime service comes up with the new schema. The job connects as
+      # postgres (superuser) via `observing-db-admin-url`; no long-running
+      # service holds that credential.
+      - name: Run migrations
+        run: |
+          gcloud run jobs deploy observing-migrate \
+            --image=$REGISTRY/observing-migrate:latest \
+            --region=$REGION \
+            --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
+            --set-secrets=DATABASE_URL=observing-db-admin-url:latest \
+            --max-retries=0 \
+            --task-timeout=600
+          gcloud run jobs execute observing-migrate \
+            --region=$REGION \
+            --wait
+
       - name: Deploy ingester
         run: |
           gcloud run deploy observing-ingester \
@@ -348,7 +362,7 @@ jobs:
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
             --set-env-vars=RUST_LOG=observing_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_writer,JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe \
-            --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest,DATABASE_ADMIN_URL=observing-db-admin-url:latest \
+            --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
             --min-instances=1 \
             --max-instances=1 \
             --timeout=3600

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2931,6 +2931,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "observing-migrate"
+version = "0.1.0"
+dependencies = [
+ "observing-db",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-stackdriver",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "observing-species-id"
 version = "0.1.0"
 dependencies = [

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@
 # when SERVICE=observing-appview.
 #
 # Supported SERVICE values:
-#   observing-appview, observing-ingester, observing-species-id
+#   observing-appview, observing-ingester, observing-species-id, observing-migrate
 
 ARG SERVICE=observing-appview
 
@@ -112,6 +112,16 @@ ENV RUST_LOG=observing_ingester=info
 ENV PORT=8080
 EXPOSE 8080
 CMD ["/app/observing-ingester"]
+
+# ---------------------------------------------------------------------------
+# Stage: runtime for migrate (one-shot Cloud Run Job)
+# ---------------------------------------------------------------------------
+FROM runtime-base AS runtime-observing-migrate
+
+COPY --from=builder /app/target/release/observing-migrate /app/observing-migrate
+
+ENV RUST_LOG=observing_migrate=info,sqlx::migrate=info
+CMD ["/app/observing-migrate"]
 
 # ---------------------------------------------------------------------------
 # Stage: runtime for species-id

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -93,28 +93,6 @@ impl Database {
         })
     }
 
-    /// Connect with a single-connection pool, intended for short-lived tasks
-    /// like running migrations under an admin role. Dropping this `Database`
-    /// closes the pool.
-    pub async fn connect_single(database_url: &str) -> Result<Self> {
-        info!("Connecting to database (single-connection admin pool)...");
-        let pool = PgPoolOptions::new()
-            .max_connections(1)
-            .acquire_timeout(std::time::Duration::from_secs(10))
-            .connect(database_url)
-            .await?;
-        Ok(Self {
-            pool,
-            media_resolver: MediaResolver::new(),
-        })
-    }
-
-    /// Run database migrations using the shared migration
-    pub async fn migrate(&self) -> Result<()> {
-        observing_db::migrate::migrate(&self.pool).await?;
-        Ok(())
-    }
-
     /// Upsert an occurrence record
     pub async fn upsert_occurrence(&self, commit: &CommitInfo) -> Result<()> {
         debug!("Upserting occurrence: {}", commit.uri);

--- a/crates/observing-ingester/src/main.rs
+++ b/crates/observing-ingester/src/main.rs
@@ -71,21 +71,10 @@ async fn main() -> Result<()> {
         }
     });
 
-    // Run migrations using the admin URL when configured, then connect with
-    // the (potentially narrower) runtime URL. If no admin URL is set, both
-    // paths use the same URL — same behavior as before the role split.
-    if let Some(admin_url) = config.database_admin_url.as_deref() {
-        info!("Running migrations with dedicated admin connection");
-        let admin_db = Database::connect_single(admin_url).await?;
-        admin_db.migrate().await?;
-    } else {
-        info!("Running migrations with runtime DB connection");
-    }
-
+    // Migrations run out-of-band in a dedicated Cloud Run Job; see
+    // crates/observing-migrate. The runtime role used here has no DDL
+    // privileges and should never attempt to migrate.
     let db = Database::connect(&config.database_url).await?;
-    if config.database_admin_url.is_none() {
-        db.migrate().await?;
-    }
 
     // Load saved cursor
     let saved_cursor = db.get_cursor().await?;
@@ -282,10 +271,6 @@ fn load_config(cli: &Cli) -> Result<IngesterConfig> {
         }
     };
 
-    // Optional: separate URL used only for running migrations. When present,
-    // DATABASE_URL can point to the least-privilege ingester_writer role.
-    let database_admin_url = std::env::var("DATABASE_ADMIN_URL").ok();
-
     let relay_url = std::env::var("JETSTREAM_URL")
         .unwrap_or_else(|_| "wss://jetstream2.us-east.bsky.network/subscribe".to_string());
 
@@ -309,7 +294,6 @@ fn load_config(cli: &Cli) -> Result<IngesterConfig> {
     Ok(IngesterConfig {
         relay_url,
         database_url,
-        database_admin_url,
         cursor,
         port,
         collections,

--- a/crates/observing-ingester/src/types.rs
+++ b/crates/observing-ingester/src/types.rs
@@ -28,11 +28,6 @@ pub struct RecentEvent {
 pub struct IngesterConfig {
     pub relay_url: String,
     pub database_url: String,
-    /// Optional admin DB URL for running migrations. When set, the ingester
-    /// connects here with DDL privileges at startup, runs migrations, and
-    /// closes the pool — `database_url` can then be a least-privilege role
-    /// (e.g. `ingester_writer`) that only has CRUD on its own schema.
-    pub database_admin_url: Option<String>,
     pub cursor: Option<i64>,
     pub port: u16,
     /// Full NSIDs of collections to subscribe to
@@ -44,7 +39,6 @@ impl Default for IngesterConfig {
         Self {
             relay_url: "wss://jetstream2.us-east.bsky.network/subscribe".to_string(),
             database_url: String::new(),
-            database_admin_url: None,
             cursor: None,
             port: 8080,
             collections: ALL_COLLECTIONS

--- a/crates/observing-migrate/Cargo.toml
+++ b/crates/observing-migrate/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "observing-migrate"
+version = "0.1.0"
+edition = "2021"
+description = "One-shot binary that runs Observ.ing database migrations and exits"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+observing-db = { path = "../observing-db" }
+sqlx = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-stackdriver = { workspace = true }

--- a/crates/observing-migrate/src/main.rs
+++ b/crates/observing-migrate/src/main.rs
@@ -1,0 +1,53 @@
+//! One-shot migration runner.
+//!
+//! Connects to the database using `DATABASE_URL` (must point at a role with
+//! DDL privileges), runs all pending sqlx migrations, and exits. Packaged as
+//! its own Cloud Run Job so that migrations happen as an explicit deploy step
+//! instead of a side effect of a service container's startup.
+
+use sqlx::postgres::PgPoolOptions;
+use std::process::ExitCode;
+use std::time::Duration;
+use tracing::{error, info};
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("observing_migrate=info,sqlx::migrate=info"));
+
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_stackdriver::layer())
+        .init();
+
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => {
+            error!("DATABASE_URL is required");
+            return ExitCode::from(2);
+        }
+    };
+
+    info!("Connecting with admin credentials to run migrations");
+    let pool = match PgPoolOptions::new()
+        .max_connections(1)
+        .acquire_timeout(Duration::from_secs(30))
+        .connect(&database_url)
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            error!(error = %e, "Failed to connect to database");
+            return ExitCode::from(1);
+        }
+    };
+
+    if let Err(e) = observing_db::migrate::migrate(&pool).await {
+        error!(error = %e, "Migration failed");
+        return ExitCode::from(1);
+    }
+
+    info!("Migrations applied successfully");
+    ExitCode::SUCCESS
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,8 @@ flowchart TB
     PDS[Bluesky PDS]
     JS[Jetstream firehose]
     AV[observing-appview<br/>DB_USER=appview_runtime]
-    IG[observing-ingester<br/>DB_USER=ingester_writer<br/>DATABASE_ADMIN_URL=postgres]
+    IG[observing-ingester<br/>DB_USER=ingester_writer]
+    MIG[observing-migrate<br/>Cloud Run Job<br/>DB_USER=postgres]
     SID[species-id]
 
     subgraph DB["Postgres + PostGIS"]
@@ -37,9 +38,11 @@ flowchart TB
     AV -- "READ-ONLY" --> ING
     AV == "READ+WRITE" ==> APPV
     AV -- "READ-ONLY" --> PUB
+
+    MIG -. "DDL (one-shot, pre-deploy)" .-> DB
 ```
 
-Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. The ingester connects twice at startup: once with `DATABASE_ADMIN_URL` (the `postgres` superuser) to run migrations, then drops that pool and opens its runtime pool as `ingester_writer` — a least-privilege role with CRUD only on the `ingester` schema, `SELECT` on `appview.oauth_sessions` (for the backfill `--all` binary), and `SELECT` on `public.sensitive_species`. No service runs as a superuser at steady state.
+Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. Migrations run as a one-shot `observing-migrate` Cloud Run Job executed by CI *before* services are deployed; that job is the only thing that ever connects as the `postgres` superuser. No long-running service holds admin credentials — the ingester runs as `ingester_writer` (CRUD on `ingester` schema, `SELECT` on `appview.oauth_sessions` for the backfill `--all` binary, and `SELECT` on `public.sensitive_species`), and the appview runs as `appview_runtime`.
 
 ## Project Structure
 
@@ -51,6 +54,7 @@ crates/
 ├── observing-identity/    # DID/handle resolution + profile caching (Rust)
 ├── observing-ingester/    # AT Protocol firehose consumer (Rust)
 ├── observing-lexicons/    # Generated AT Protocol record types (Rust)
+├── observing-migrate/     # One-shot DB migration runner (Cloud Run Job)
 └── gbif-api/              # GBIF API client (Rust)
 
 frontend/                  # Web UI (Vite + React + MapLibre GL)


### PR DESCRIPTION
## Summary

Moves schema migrations out of the ingester's startup path and into a dedicated one-shot **Cloud Run Job** (`observing-migrate`) that CI executes before any runtime service is deployed.

After this lands, the `postgres` superuser credential exists only inside `observing-db-admin-url`, which is only mounted on the migrate Job — no long-running service ever holds admin creds.

## Changes

- **New crate `crates/observing-migrate`** — ~50 lines. Reads `DATABASE_URL`, opens a 1-connection pool, calls `observing_db::migrate::migrate`, exits. Structured logging via `tracing-stackdriver`.
- **Dockerfile** — new `runtime-observing-migrate` stage (just copies the release binary onto the shared runtime-base).
- **CI**
  - `build-images` matrix grows to include `migrate`.
  - New deploy step `Run migrations`: `gcloud run jobs deploy observing-migrate` (create-or-update) + `gcloud run jobs execute --wait`. Runs before the ingester and appview deploys.
  - The ingester deploy drops `DATABASE_ADMIN_URL` from its `--set-secrets`.
- **Ingester cleanup**
  - `Database::connect_single` and `Database::migrate` deleted.
  - `IngesterConfig::database_admin_url` field deleted.
  - The two-path startup branch in `main.rs` collapses back to a single `Database::connect` call.
- **docs/architecture.md** — diagram adds a `observing-migrate` node with a dotted "DDL (one-shot, pre-deploy)" edge to the DB; explanatory paragraph rewritten.

## Trade-offs considered

- One more image to build + one more CI step. Worth it: failed migrations abort the deploy as a visible step instead of surfacing as a Cloud Run revision rollback, and the ingester stops holding any admin credential.
- sqlx advisory locks already handle concurrent migrators, so this isn't urgent today (ingester is pinned `min=1 max=1`), but it makes multi-replica safe as a bonus.

## Test plan

- [x] `cargo check --workspace`, `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test -p observing-ingester` (31 tests pass)
- [x] `cargo run -p observing-migrate` against a fresh postgres applies all migrations cleanly and is idempotent on re-run
- [ ] CI green
- [ ] First post-merge deploy: confirm `Run migrations` step completes; confirm ingester revision comes up with only `DB_PASSWORD` secret (no admin URL); tail migrate Job logs

## Rollout note

The job is created on first deploy via `gcloud run jobs deploy` (create-or-update), so no manual Cloud SQL ops are needed — all credentials are already in Secret Manager from prior PRs.