### PR TITLE
feat(db): rename ingester_writer to ingester_runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
             --cpu=1 \
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=RUST_LOG=observing_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_writer,JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe \
+            --set-env-vars=RUST_LOG=observing_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe \
             --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
             --min-instances=1 \
             --max-instances=1 \

--- a/crates/observing-db/migrations/20260423000000_ingester_runtime_rename.sql
+++ b/crates/observing-db/migrations/20260423000000_ingester_runtime_rename.sql
@@ -1,0 +1,29 @@
+-- Rename `ingester_writer` to `ingester_runtime`.
+--
+-- Matches the naming convention already used for `appview_runtime`. The role
+-- isn't strictly a "writer" either — it also needs SELECT on
+-- `appview.oauth_sessions` (backfill --all) and `public.sensitive_species` —
+-- so "runtime" describes it more honestly.
+--
+-- `ALTER ROLE ... RENAME TO ...` preserves the password, all grants, and
+-- ownership (including the `ingester.community_ids` matview), so no grant
+-- migrations need to be re-run.
+--
+-- Idempotent: no-op if the role was already renamed, and no-op on local/CI
+-- where the role doesn't exist.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_runtime') THEN
+        RAISE NOTICE 'ingester_runtime role already exists; skipping rename';
+        RETURN;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_writer') THEN
+        RAISE NOTICE 'ingester_writer role not found; skipping rename (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    EXECUTE 'ALTER ROLE ingester_writer RENAME TO ingester_runtime';
+END
+$$;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ flowchart TB
     PDS[Bluesky PDS]
     JS[Jetstream firehose]
     AV[observing-appview<br/>DB_USER=appview_runtime]
-    IG[observing-ingester<br/>DB_USER=ingester_writer]
+    IG[observing-ingester<br/>DB_USER=ingester_runtime]
     MIG[observing-migrate<br/>Cloud Run Job<br/>DB_USER=postgres]
     SID[species-id]
 
@@ -42,7 +42,7 @@ flowchart TB
     MIG -. "DDL (one-shot, pre-deploy)" .-> DB
 ```
 
-Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. Migrations run as a one-shot `observing-migrate` Cloud Run Job executed by CI *before* services are deployed; that job is the only thing that ever connects as the `postgres` superuser. No long-running service holds admin credentials — the ingester runs as `ingester_writer` (CRUD on `ingester` schema, `SELECT` on `appview.oauth_sessions` for the backfill `--all` binary, and `SELECT` on `public.sensitive_species`), and the appview runs as `appview_runtime`.
+Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. Migrations run as a one-shot `observing-migrate` Cloud Run Job executed by CI *before* services are deployed; that job is the only thing that ever connects as the `postgres` superuser. No long-running service holds admin credentials — the ingester runs as `ingester_runtime` (CRUD on `ingester` schema, `SELECT` on `appview.oauth_sessions` for the backfill `--all` binary, and `SELECT` on `public.sensitive_species`), and the appview runs as `appview_runtime`.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
- Rename the ingester runtime Postgres role from `ingester_writer` to `ingester_runtime` for consistency with `appview_runtime` (#328).
- "Writer" was misleading — the role also holds `SELECT` on `appview.oauth_sessions` (backfill `--all`) and `public.sensitive_species`. "Runtime" describes it more honestly.
- Flip `DB_USER` on the ingester Cloud Run deploy step accordingly.

## Why it's safe
- `ALTER ROLE ... RENAME TO ...` preserves the password, all grants, and ownership (including the `ingester.community_ids` matview). No grant migrations need to be re-run.
- Migration is idempotent: no-ops if the target role already exists, and no-ops on local/CI where the source role doesn't exist.
- No deploy race: migrations run via the `observing-migrate` Cloud Run Job (#330) before any service deploys, so by the time the new ingester revision starts with `DB_USER=ingester_runtime` the rename has already landed.

## Test plan
- [x] Verified locally against a Postgres container: applied all migrations (including the new one), confirmed role was renamed, password preserved, and `ingester.community_ids` matview ownership preserved.
- [ ] After merge: verify the new ingester revision connects as `ingester_runtime` via Cloud Run logs.