### PR TITLE
ci: fix Cloud Run Jobs flag for migrate deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -361,7 +361,7 @@ jobs:
             --cpu=1 \
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=RUST_LOG=observing_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_writer,JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe \
+            --set-env-vars=RUST_LOG=observing_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe \
             --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
             --min-instances=1 \
             --max-instances=1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,7 +344,7 @@ jobs:
           gcloud run jobs deploy observing-migrate \
             --image=$REGISTRY/observing-migrate:latest \
             --region=$REGION \
-            --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
+            --set-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
             --set-secrets=DATABASE_URL=observing-db-admin-url:latest \
             --max-retries=0 \
             --task-timeout=600

--- a/crates/observing-db/migrations/20260423000000_ingester_runtime_rename.sql
+++ b/crates/observing-db/migrations/20260423000000_ingester_runtime_rename.sql
@@ -1,0 +1,29 @@
+-- Rename `ingester_writer` to `ingester_runtime`.
+--
+-- Matches the naming convention already used for `appview_runtime`. The role
+-- isn't strictly a "writer" either — it also needs SELECT on
+-- `appview.oauth_sessions` (backfill --all) and `public.sensitive_species` —
+-- so "runtime" describes it more honestly.
+--
+-- `ALTER ROLE ... RENAME TO ...` preserves the password, all grants, and
+-- ownership (including the `ingester.community_ids` matview), so no grant
+-- migrations need to be re-run.
+--
+-- Idempotent: no-op if the role was already renamed, and no-op on local/CI
+-- where the role doesn't exist.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_runtime') THEN
+        RAISE NOTICE 'ingester_runtime role already exists; skipping rename';
+        RETURN;
+    END IF;
+
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_writer') THEN
+        RAISE NOTICE 'ingester_writer role not found; skipping rename (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    EXECUTE 'ALTER ROLE ingester_writer RENAME TO ingester_runtime';
+END
+$$;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -8,7 +8,7 @@ flowchart TB
     PDS[Bluesky PDS]
     JS[Jetstream firehose]
     AV[observing-appview<br/>DB_USER=appview_runtime]
-    IG[observing-ingester<br/>DB_USER=ingester_writer]
+    IG[observing-ingester<br/>DB_USER=ingester_runtime]
     MIG[observing-migrate<br/>Cloud Run Job<br/>DB_USER=postgres]
     SID[species-id]
 
@@ -42,7 +42,7 @@ flowchart TB
     MIG -. "DDL (one-shot, pre-deploy)" .-> DB
 ```
 
-Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. Migrations run as a one-shot `observing-migrate` Cloud Run Job executed by CI *before* services are deployed; that job is the only thing that ever connects as the `postgres` superuser. No long-running service holds admin credentials — the ingester runs as `ingester_writer` (CRUD on `ingester` schema, `SELECT` on `appview.oauth_sessions` for the backfill `--all` binary, and `SELECT` on `public.sensitive_species`), and the appview runs as `appview_runtime`.
+Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. Migrations run as a one-shot `observing-migrate` Cloud Run Job executed by CI *before* services are deployed; that job is the only thing that ever connects as the `postgres` superuser. No long-running service holds admin credentials — the ingester runs as `ingester_runtime` (CRUD on `ingester` schema, `SELECT` on `appview.oauth_sessions` for the backfill `--all` binary, and `SELECT` on `public.sensitive_species`), and the appview runs as `appview_runtime`.
 
 ## Project Structure
 


### PR DESCRIPTION
## Summary
`gcloud run jobs deploy` uses `--set-cloudsql-instances`, not `--add-cloudsql-instances`. The latter is valid for `gcloud run deploy` (services) but not for Jobs, so #330's "Run migrations" step failed with:

```
ERROR: (gcloud.run.jobs.deploy) unrecognized arguments:
  --add-cloudsql-instances=... (did you mean '--set-cloudsql-instances'?)
```

As a result the `observing-migrate` Job never deployed in either #330 or #331. The subsequent "Deploy ingester" step was skipped in both runs, so prod is still on the pre-#330 ingester revision running as `ingester_writer` — nothing is broken, but the `ingester_runtime` rename migration has not yet been applied.

## What this unblocks
- Migrate Job deploys and executes against Cloud SQL
- Pending migration `20260423000000_ingester_runtime_rename.sql` renames `ingester_writer` → `ingester_runtime`
- "Deploy ingester" runs, new revision comes up with `DB_USER=ingester_runtime`

## Test plan
- [x] Verified locally: #330's CI log shows the exact flag error on `gcloud run jobs deploy`
- [ ] After merge: confirm the migrate Job deploys, the execution succeeds, and the ingester revision connects as `ingester_runtime`