### PR TITLE
feat(db): enforce runtime role boundary via cloudsqlsuperuser revoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,6 +352,21 @@ jobs:
             --region=$REGION \
             --wait
 
+      # Strip the auto-granted `cloudsqlsuperuser` membership from the runtime
+      # users. Their direct per-table grants (from `appview_reader_grants` and
+      # schema-split migrations) remain; cross-boundary writes that currently
+      # succeed via `cloudsqlsuperuser` inheritance stop working. Idempotent —
+      # if cloudsqlsuperuser is already gone, this is a no-op.
+      - name: Enforce runtime role boundary
+        run: |
+          for USER in appview_runtime ingester_runtime; do
+            gcloud sql users assign-roles $USER \
+              --instance=observing-db \
+              --database-roles=runtime_base \
+              --revoke-existing-roles \
+              --type=BUILT_IN
+          done
+
       - name: Deploy ingester
         run: |
           gcloud run deploy observing-ingester \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -352,21 +352,6 @@ jobs:
             --region=$REGION \
             --wait
 
-      # Strip the auto-granted `cloudsqlsuperuser` membership from the runtime
-      # users. Their direct per-table grants (from `appview_reader_grants` and
-      # schema-split migrations) remain; cross-boundary writes that currently
-      # succeed via `cloudsqlsuperuser` inheritance stop working. Idempotent —
-      # if cloudsqlsuperuser is already gone, this is a no-op.
-      - name: Enforce runtime role boundary
-        run: |
-          for USER in appview_runtime ingester_runtime; do
-            gcloud sql users assign-roles $USER \
-              --instance=observing-db \
-              --database-roles=runtime_base \
-              --revoke-existing-roles \
-              --type=BUILT_IN
-          done
-
       - name: Deploy ingester
         run: |
           gcloud run deploy observing-ingester \

--- a/crates/observing-db/migrations/20260424000000_create_runtime_base_role.sql
+++ b/crates/observing-db/migrations/20260424000000_create_runtime_base_role.sql
@@ -1,0 +1,29 @@
+-- Create an empty placeholder role so CI can call `gcloud sql users
+-- assign-roles --revoke-existing-roles --database-roles=runtime_base`
+-- on both runtime users.
+--
+-- Why: Cloud SQL auto-grants `cloudsqlsuperuser` to every built-in user.
+-- That membership confers `arwdDxt` on every table via role inheritance,
+-- which nullifies the per-schema least-privilege grants in the
+-- `appview_reader_grants` migration (appview_runtime can write ingester
+-- tables; ingester_runtime can write appview tables). Verified against
+-- prod with `has_table_privilege`.
+--
+-- The documented way to drop `cloudsqlsuperuser` from a built-in user is
+-- `gcloud sql users assign-roles --revoke-existing-roles`, which requires
+-- `--database-roles=` with at least one value. `runtime_base` is that
+-- placeholder — it carries no privileges of its own. The direct GRANTs
+-- on each user stay intact through the swap.
+--
+-- Idempotent: no-op if the role already exists.
+
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'runtime_base') THEN
+        RAISE NOTICE 'runtime_base role already exists; skipping';
+        RETURN;
+    END IF;
+
+    EXECUTE 'CREATE ROLE runtime_base';
+END
+$$;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,8 +25,11 @@ All services and the migrate Job are Rust binaries built from the shared multi-s
 CI runs the deploy steps in this order to ensure DDL lands before any service starts on the new schema:
 
 1. `Run migrations` → deploys + executes the `observing-migrate` Cloud Run Job.
-2. `Deploy ingester` → single-writer for lexicon-derived tables.
-3. `Deploy appview` → last, so it sees the fully-migrated schema and up-to-date ingester grants.
+2. `Enforce runtime role boundary` → `gcloud sql users assign-roles --revoke-existing-roles --database-roles=runtime_base` for `appview_runtime` and `ingester_runtime`. Strips the auto-granted `cloudsqlsuperuser` membership so the per-schema grants from `appview_reader_grants` actually bind. Idempotent.
+3. `Deploy ingester` → single-writer for lexicon-derived tables.
+4. `Deploy appview` → last, so it sees the fully-migrated schema and up-to-date ingester grants.
+
+Without step 2, Cloud SQL's default `cloudsqlsuperuser` membership gives every built-in user `arwdDxt` on every table via role inheritance, nullifying the least-privilege grants. `runtime_base` is an empty placeholder created by the migrate Job, required only because `--database-roles=` needs a non-empty value.
 
 ## Environment Variables
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -25,11 +25,24 @@ All services and the migrate Job are Rust binaries built from the shared multi-s
 CI runs the deploy steps in this order to ensure DDL lands before any service starts on the new schema:
 
 1. `Run migrations` → deploys + executes the `observing-migrate` Cloud Run Job.
-2. `Enforce runtime role boundary` → `gcloud sql users assign-roles --revoke-existing-roles --database-roles=runtime_base` for `appview_runtime` and `ingester_runtime`. Strips the auto-granted `cloudsqlsuperuser` membership so the per-schema grants from `appview_reader_grants` actually bind. Idempotent.
-3. `Deploy ingester` → single-writer for lexicon-derived tables.
-4. `Deploy appview` → last, so it sees the fully-migrated schema and up-to-date ingester grants.
+2. `Deploy ingester` → single-writer for lexicon-derived tables.
+3. `Deploy appview` → last, so it sees the fully-migrated schema and up-to-date ingester grants.
 
-Without step 2, Cloud SQL's default `cloudsqlsuperuser` membership gives every built-in user `arwdDxt` on every table via role inheritance, nullifying the least-privilege grants. `runtime_base` is an empty placeholder created by the migrate Job, required only because `--database-roles=` needs a non-empty value.
+## Runtime role boundary (one-shot)
+
+Cloud SQL auto-grants `cloudsqlsuperuser` to every built-in user, and that membership confers `arwdDxt` on every table via role inheritance — which nullifies the per-schema grants in the `appview_reader_grants` migration. To actually enforce the boundary, `cloudsqlsuperuser` must be stripped from `appview_runtime` and `ingester_runtime`. This is a one-shot operation tied to user creation, not deploy state, so it lives here as a runbook step rather than a CI step:
+
+```bash
+for USER in appview_runtime ingester_runtime; do
+  gcloud sql users assign-roles $USER \
+    --instance=observing-db \
+    --database-roles=runtime_base \
+    --revoke-existing-roles \
+    --type=BUILT_IN
+done
+```
+
+`runtime_base` is an empty placeholder role created by the migrate Job, required only because `--database-roles=` needs a non-empty value. Direct per-table grants on each user stay intact through the swap. Re-run this command any time a runtime user is recreated.
 
 ## Environment Variables
 


### PR DESCRIPTION
## Summary
- Adds migration `20260424000000_create_runtime_base_role.sql` — empty placeholder role required by `gcloud sql users assign-roles`.
- Documents the one-shot runbook step in `docs/deployment.md` under "Runtime role boundary (one-shot)". **No CI change.**

## Why
Verified against prod with `has_table_privilege()`:
- `appview_runtime` → `INSERT` on `ingester.occurrences`: `true`
- `ingester_runtime` → `INSERT` on `appview.oauth_state`: `true`

Cloud SQL auto-grants `cloudsqlsuperuser` to every built-in user. That role has `arwdDxt` on every table, and role inheritance confers those privileges to members — nullifying the per-schema grants from the `appview_reader_grants` migration. The architecture docs claimed DB-level isolation was enforced; it wasn't.

## Why runbook, not CI
This is a one-shot tied to user creation, not deploy state. Users are created out-of-band; the revoke belongs with them, not in the deploy loop.

## Why gcloud, not SQL
`postgres` has `admin_option = f` on `cloudsqlsuperuser`, so it cannot `REVOKE` the membership. `gcloud sql users assign-roles --revoke-existing-roles` runs as `cloudsqladmin` under the hood and is Google's documented path.

## Why `runtime_base` placeholder
`--database-roles=` is required and must have at least one value. `runtime_base` has no grants of its own; the direct per-table/schema grants on each user (already landed in prior migrations) stay intact through the role swap.

## Rollout after merge
1. Merge PR → migrate Job creates `runtime_base` role in prod.
2. Run the one-shot command from `docs/deployment.md` once against prod.
3. Verify via `has_table_privilege()`:
   - [ ] `appview_runtime` can still `SELECT` ingester tables
   - [ ] `appview_runtime` can still CRUD `appview.oauth_*` and `appview.notification_reads`
   - [ ] `appview_runtime` can **no longer** INSERT into `ingester.occurrences`
   - [ ] `ingester_runtime` can still CRUD ingester tables
   - [ ] `ingester_runtime` can still SELECT `appview.oauth_sessions`
   - [ ] `ingester_runtime` can **no longer** INSERT into `appview.oauth_state`
4. Smoke test app: post an occurrence via frontend, confirm the firehose→ingester→DB→appview flow.