### PR TITLE
docs: drop Cloud SQL Proxy from the local dev loop

### DIFF
--- a/crates/observing-ingester/README.md
+++ b/crates/observing-ingester/README.md
@@ -10,6 +10,8 @@ cargo build --release
 
 ## Running Locally
 
+Point at a local PostgreSQL (with PostGIS) — see `docs/development.md` for setup.
+
 ```bash
 DATABASE_URL="postgresql://postgres:mysecretpassword@localhost:5432/observing" \
 cargo run --release
@@ -24,15 +26,15 @@ cargo run --release
 | `PORT` | No | `8080` | HTTP server port |
 | `RUST_LOG` | No | `observing_ingester=info` | Log level |
 
-*Either `DATABASE_URL` or Cloud SQL environment variables are required:
+*If `DATABASE_URL` is unset, the ingester builds one from the env vars below. This fallback exists for Cloud Run's Cloud SQL Unix-socket integration in production (`DB_HOST=/cloudsql/project:region:instance`); local development should prefer `DATABASE_URL`.
 
 | Variable | Required | Default | Description |
 |----------|----------|---------|-------------|
-| `DB_HOST` | Yes* | - | Database host or Cloud SQL socket path (e.g., `/cloudsql/project:region:instance`) |
+| `DB_HOST` | Yes* | - | Database host or Unix-socket path |
 | `DB_NAME` | No | `observing` | Database name |
 | `DB_USER` | No | `postgres` | Database user |
 | `DB_PASSWORD` | No | - | Database password |
-| `DB_PORT` | No | `5432` | Database port (ignored for Cloud SQL sockets) |
+| `DB_PORT` | No | `5432` | Database port (ignored when `DB_HOST` is a Unix socket) |
 
 ## Endpoints
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -14,16 +14,25 @@ npm install
 
 ## Database Setup
 
+Run PostgreSQL with PostGIS locally. All app services connect to it over `localhost:5432` — there is no Cloud SQL Proxy step in local dev; production Cloud SQL is a separate concern handled by CI (see `docs/deployment.md`).
+
+Docker is the path of least resistance:
+
 ```bash
-# Using Docker with PostGIS
+# One-time: create the container
 docker run --name observing-postgres \
   -e POSTGRES_PASSWORD=mysecretpassword \
   -p 5432:5432 \
   -d postgis/postgis
 
-# Create database
+# Create the database
 docker exec -it observing-postgres createdb -U postgres observing
+
+# After reboot / on subsequent sessions
+docker start observing-postgres
 ```
+
+Native installs (Postgres.app, Homebrew `postgresql` + `postgis`, etc.) work too — anything that exposes PostgreSQL with PostGIS on `localhost:5432` is fine.
 
 ## Configuration
 
@@ -91,7 +100,7 @@ npm run generate-rust-types
 
 ### Using process-compose (recommended)
 
-All services can be managed with `process-compose`. Config in `process-compose.yaml`.
+All services can be managed with `process-compose`. Config in `process-compose.yaml`. Make sure your local PostgreSQL is running first (see [Database Setup](#database-setup)) — process-compose only manages the app processes.
 
 ```bash
 # Start all services (detached)
@@ -114,7 +123,7 @@ process-compose process logs <name>
 process-compose down
 ```
 
-Service names: `cloud-sql-proxy`, `appview`, `frontend`, `ingester`, `species-id`
+Service names: `appview`, `frontend`, `ingester`, `species-id`
 
 ### Individual Services
 

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -1,12 +1,9 @@
 version: "0.5"
 
-processes:
-  cloud-sql-proxy:
-    command: cloud-sql-proxy --port 5432 observ-ing:us-central1:observing-db
-    readiness_probe:
-      exec:
-        command: pg_isready -h localhost -p 5432
+# Requires a local PostgreSQL (with PostGIS) reachable on localhost:5432
+# before starting. See docs/development.md for setup.
 
+processes:
   appview:
     command: cargo run -p observing-appview
     environment:
@@ -21,9 +18,6 @@ processes:
         path: /health
       initial_delay_seconds: 120
       period_seconds: 5
-    depends_on:
-      cloud-sql-proxy:
-        condition: process_healthy
 
   frontend:
     command: npm run dev
@@ -36,9 +30,6 @@ processes:
     working_dir: crates/observing-ingester
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:${DB_PASSWORD}@localhost:5432/observing}
-    depends_on:
-      cloud-sql-proxy:
-        condition: process_healthy
 
   species-id:
     command: cargo run -p observing-species-id


### PR DESCRIPTION
## Summary

- Drop the `cloud-sql-proxy` process and its `depends_on` blocks from `process-compose.yaml`; add a header comment pointing at the dev docs for local Postgres setup.
- Rewrite `docs/development.md`'s *Database Setup* to lead with a local PostgreSQL (with PostGIS) and call out that there is no proxy step locally; add a reminder under *Running Services* that Postgres must be up before `process-compose up`.
- Reframe `crates/observing-ingester/README.md`'s `DB_*` env-var block as a production-only fallback for Cloud Run's Cloud SQL Unix-socket integration, so `DATABASE_URL` is the obvious local path.

Goal: encourage contributors to spin up PostgreSQL locally instead of tunneling through a shared production instance via the proxy.

Production deploys are intentionally untouched — `docs/deployment.md`, `.github/workflows/ci.yml`, and the `/cloudsql/` branch in `crates/observing-{appview,ingester}/src/*.rs` continue to target Cloud Run's native Cloud SQL integration (which uses a `/cloudsql/<instance>` Unix socket mount, not the `cloud-sql-proxy` binary).

## Test plan

- [ ] `docker start observing-postgres` + `process-compose up -D` brings up `appview`, `frontend`, `ingester`, `species-id` against the local DB
- [ ] `docs/development.md` end-to-end is enough to get a fresh contributor from zero to a running stack
- [ ] Production deploy still succeeds (`--add-cloudsql-instances` + `DB_HOST=/cloudsql/...` path unchanged)