### PR TITLE
feat(species-id): iNat geo-prior reranking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -99,7 +99,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -110,7 +110,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1215,7 +1215,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1304,6 +1304,12 @@ dependencies = [
  "crc32fast",
  "miniz_oxide",
 ]
+
+[[package]]
+name = "float_eq"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a80e3145d8ad11ba0995949bbcf48b9df2be62772b3d351ef017dff6ecb853"
 
 [[package]]
 name = "fluent-uri"
@@ -1581,6 +1587,24 @@ dependencies = [
  "tokio-util",
  "tracing",
 ]
+
+[[package]]
+name = "h3o"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60271ce96dbb45e1ac18955e1b44e9e04dcea01df040819efdedc56c0058c367"
+dependencies = [
+ "either",
+ "float_eq",
+ "h3o-bit",
+ "libm",
+]
+
+[[package]]
+name = "h3o-bit"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b42eb4efef1f96510ae1a33b2682562a677d504641e9903a77bf5c666b9013e"
 
 [[package]]
 name = "half"
@@ -2775,7 +2799,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2950,11 +2974,13 @@ dependencies = [
  "base64",
  "bytemuck",
  "chrono",
+ "h3o",
  "image",
  "ndarray",
  "ort",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",
@@ -3770,7 +3796,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3828,7 +3854,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4213,7 +4239,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4548,7 +4574,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5357,7 +5383,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Dockerfile
+++ b/Dockerfile
@@ -139,7 +139,7 @@ RUN apt-get update && apt-get install -y curl && \
 # Download model artifacts (separate layer for better caching)
 RUN mkdir -p /app/models/bioclip && \
     curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 -o /tmp/models.tar.gz \
-      https://github.com/observ-ing/bioclip-models/releases/download/v2.0.0/bioclip-2.5-models.tar.gz && \
+      https://github.com/observ-ing/bioclip-models/releases/download/v2.1.0/bioclip-2.5-models.tar.gz && \
     tar xzf /tmp/models.tar.gz -C /app/models/bioclip && \
     rm /tmp/models.tar.gz
 

--- a/crates/observing-species-id/Cargo.toml
+++ b/crates/observing-species-id/Cargo.toml
@@ -38,8 +38,12 @@ base64 = "0.22"
 # Zero-copy binary loading
 bytemuck = { version = "1", features = ["derive"] }
 
+# H3 geospatial indexing (geo-prior reranking)
+h3o = { version = "0.9", default-features = false }
+
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
+tempfile = { workspace = true }
 
 [[bin]]
 name = "observing-species-id"

--- a/crates/observing-species-id/src/embeddings.rs
+++ b/crates/observing-species-id/src/embeddings.rs
@@ -126,16 +126,19 @@ impl SpeciesEmbeddings {
         self.embed_dim
     }
 
-    /// Find the top-K most similar species to the given image embedding.
-    ///
-    /// `image_embedding` must be L2-normalized, shape [embed_dim].
-    /// Returns suggestions sorted by descending confidence.
-    pub fn top_k(&self, image_embedding: &Array1<f32>, k: usize) -> Vec<SpeciesSuggestion> {
-        // Cosine similarity = dot product (both are L2-normalized)
-        let similarities = self.embeddings.dot(image_embedding);
+    /// Cosine similarity between the image embedding and every species
+    /// embedding. Both sides are expected to be L2-normalized, so the dot
+    /// product is the cosine. Shape: `[num_species]`.
+    pub fn similarities(&self, image_embedding: &Array1<f32>) -> Array1<f32> {
+        self.embeddings.dot(image_embedding)
+    }
 
-        // Find top-K indices
-        let mut indexed: Vec<(usize, f32)> = similarities.iter().copied().enumerate().collect();
+    /// Pick the top-K highest scores and return them as suggestions.
+    ///
+    /// The caller owns the score array and can mutate it (e.g. applying a
+    /// geo-prior boost) before calling this.
+    pub fn top_k_from_scores(&self, scores: &[f32], k: usize) -> Vec<SpeciesSuggestion> {
+        let mut indexed: Vec<(usize, f32)> = scores.iter().copied().enumerate().collect();
         indexed.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         indexed.truncate(k);
 

--- a/crates/observing-species-id/src/geo_index.rs
+++ b/crates/observing-species-id/src/geo_index.rs
@@ -34,6 +34,130 @@ const MAGIC: &[u8; 4] = b"OGI1";
 const VERSION: u32 = 1;
 const HEADER_SIZE: usize = 32;
 
+/// Parsed 32-byte header. Owns only the fields the body decode/validation
+/// path cares about — the two reserved u32s are read and discarded.
+struct Header {
+    num_species: u32,
+    h3_resolution: Resolution,
+    num_cells: usize,
+    num_entries: usize,
+}
+
+impl Header {
+    /// Parse and validate magic, version, and resolution. Does *not* check
+    /// the species count or file size — those need additional context from
+    /// the caller; see `validate_species_count` and `expected_file_size`.
+    fn parse(bytes: &[u8]) -> Result<Self> {
+        if bytes.len() < HEADER_SIZE {
+            return Err(SpeciesIdError::Config(format!(
+                "Geo index too short ({} bytes) to contain header",
+                bytes.len()
+            )));
+        }
+        if &bytes[..4] != MAGIC {
+            return Err(SpeciesIdError::Config(format!(
+                "Bad geo index magic: expected {:?}, got {:?}",
+                MAGIC,
+                &bytes[..4]
+            )));
+        }
+
+        let version = read_u32_le(bytes, 4);
+        let num_species = read_u32_le(bytes, 8);
+        let h3_res_u32 = read_u32_le(bytes, 12);
+        let num_cells = read_u32_le(bytes, 16) as usize;
+        let num_entries = read_u32_le(bytes, 20) as usize;
+
+        if version != VERSION {
+            return Err(SpeciesIdError::Config(format!(
+                "Unsupported geo index version: {} (expected {})",
+                version, VERSION
+            )));
+        }
+
+        let h3_resolution = Resolution::try_from(u8::try_from(h3_res_u32).map_err(|_| {
+            SpeciesIdError::Config(format!("H3 resolution {} out of range", h3_res_u32))
+        })?)
+        .map_err(|e| SpeciesIdError::Config(format!("Invalid H3 resolution: {}", e)))?;
+
+        Ok(Self {
+            num_species,
+            h3_resolution,
+            num_cells,
+            num_entries,
+        })
+    }
+
+    /// Fail if the label count disagrees with the embeddings — this means
+    /// the geo index is stale and species indices would point at the wrong
+    /// rows.
+    fn validate_species_count(&self, expected: usize) -> Result<()> {
+        if self.num_species as usize != expected {
+            return Err(SpeciesIdError::Config(format!(
+                "Geo index num_species ({}) does not match label count ({}) — \
+                 index is stale",
+                self.num_species, expected
+            )));
+        }
+        Ok(())
+    }
+
+    /// Total file size this header implies, used to detect truncation.
+    fn expected_file_size(&self) -> usize {
+        HEADER_SIZE + self.num_cells * 8 + (self.num_cells + 1) * 4 + self.num_entries * 4
+    }
+}
+
+/// Decoded CSR body. Uses explicit little-endian reads so the file format
+/// is stable across architectures (all our targets are LE, but this is
+/// cheap insurance).
+struct Body {
+    cells: Vec<u64>,
+    offsets: Vec<u32>,
+    species_ids: Vec<u32>,
+}
+
+impl Body {
+    /// Decode the post-header bytes into three owned arrays.
+    fn decode(body_bytes: &[u8], header: &Header) -> Self {
+        let mut cells = Vec::with_capacity(header.num_cells);
+        let mut off = 0;
+        for _ in 0..header.num_cells {
+            cells.push(read_u64_le(body_bytes, off));
+            off += 8;
+        }
+        let mut offsets = Vec::with_capacity(header.num_cells + 1);
+        for _ in 0..=header.num_cells {
+            offsets.push(read_u32_le(body_bytes, off));
+            off += 4;
+        }
+        let mut species_ids = Vec::with_capacity(header.num_entries);
+        for _ in 0..header.num_entries {
+            species_ids.push(read_u32_le(body_bytes, off));
+            off += 4;
+        }
+        Self {
+            cells,
+            offsets,
+            species_ids,
+        }
+    }
+
+    /// Check CSR invariants that the file-size check alone can't catch —
+    /// bit-flips or adversarial inputs that leave the length correct but
+    /// the offsets table malformed.
+    fn validate(&self, num_entries: usize) -> Result<()> {
+        if self.offsets.first().copied() != Some(0)
+            || self.offsets.last().copied() != Some(num_entries as u32)
+        {
+            return Err(SpeciesIdError::Config(
+                "Geo index offsets are malformed (bad endpoints)".to_string(),
+            ));
+        }
+        Ok(())
+    }
+}
+
 /// Sorted cell → species-index lookup table.
 pub struct GeoIndex {
     /// H3 cell indices, sorted ascending for binary search.
@@ -61,46 +185,10 @@ impl GeoIndex {
             ))
         })?;
 
-        if bytes.len() < HEADER_SIZE {
-            return Err(SpeciesIdError::Config(format!(
-                "Geo index too short ({} bytes) to contain header",
-                bytes.len()
-            )));
-        }
-        if &bytes[..4] != MAGIC {
-            return Err(SpeciesIdError::Config(format!(
-                "Bad geo index magic: expected {:?}, got {:?}",
-                MAGIC,
-                &bytes[..4]
-            )));
-        }
+        let header = Header::parse(&bytes)?;
+        header.validate_species_count(expected_num_species)?;
 
-        let version = read_u32_le(&bytes, 4);
-        let num_species = read_u32_le(&bytes, 8);
-        let h3_res_u32 = read_u32_le(&bytes, 12);
-        let num_cells = read_u32_le(&bytes, 16) as usize;
-        let num_entries = read_u32_le(&bytes, 20) as usize;
-
-        if version != VERSION {
-            return Err(SpeciesIdError::Config(format!(
-                "Unsupported geo index version: {} (expected {})",
-                version, VERSION
-            )));
-        }
-        if num_species as usize != expected_num_species {
-            return Err(SpeciesIdError::Config(format!(
-                "Geo index num_species ({}) does not match label count ({}) — \
-                 index is stale",
-                num_species, expected_num_species
-            )));
-        }
-
-        let h3_resolution = Resolution::try_from(u8::try_from(h3_res_u32).map_err(|_| {
-            SpeciesIdError::Config(format!("H3 resolution {} out of range", h3_res_u32))
-        })?)
-        .map_err(|e| SpeciesIdError::Config(format!("Invalid H3 resolution: {}", e)))?;
-
-        let expected_size = HEADER_SIZE + num_cells * 8 + (num_cells + 1) * 4 + num_entries * 4;
+        let expected_size = header.expected_file_size();
         if bytes.len() != expected_size {
             return Err(SpeciesIdError::Config(format!(
                 "Geo index size mismatch: expected {} bytes, got {}",
@@ -109,50 +197,22 @@ impl GeoIndex {
             )));
         }
 
-        // Decode into aligned Vecs. We use explicit little-endian reads so the
-        // file format is stable across architectures (all our targets are LE,
-        // but this is cheap insurance).
-        let mut cells = Vec::with_capacity(num_cells);
-        let mut off = HEADER_SIZE;
-        for _ in 0..num_cells {
-            cells.push(read_u64_le(&bytes, off));
-            off += 8;
-        }
-        let mut offsets = Vec::with_capacity(num_cells + 1);
-        for _ in 0..=num_cells {
-            offsets.push(read_u32_le(&bytes, off));
-            off += 4;
-        }
-        let mut species_ids = Vec::with_capacity(num_entries);
-        for _ in 0..num_entries {
-            species_ids.push(read_u32_le(&bytes, off));
-            off += 4;
-        }
-
-        // Sanity: offsets must be monotonic and terminate at num_entries.
-        // Catches bit-flip or truncated-file scenarios before we mis-index at
-        // inference time.
-        if offsets.first().copied() != Some(0)
-            || offsets.last().copied() != Some(num_entries as u32)
-        {
-            return Err(SpeciesIdError::Config(
-                "Geo index offsets are malformed (bad endpoints)".to_string(),
-            ));
-        }
+        let body = Body::decode(&bytes[HEADER_SIZE..], &header);
+        body.validate(header.num_entries)?;
 
         info!(
-            num_cells,
-            num_entries,
-            h3_resolution = h3_res_u32,
+            num_cells = header.num_cells,
+            num_entries = header.num_entries,
+            h3_resolution = u8::from(header.h3_resolution),
             size_mb = bytes.len() / (1024 * 1024),
             "Geo index loaded"
         );
 
         Ok(Self {
-            cells,
-            offsets,
-            species_ids,
-            h3_resolution,
+            cells: body.cells,
+            offsets: body.offsets,
+            species_ids: body.species_ids,
+            h3_resolution: header.h3_resolution,
         })
     }
 

--- a/crates/observing-species-id/src/geo_index.rs
+++ b/crates/observing-species-id/src/geo_index.rs
@@ -1,0 +1,314 @@
+//! Geographic range index for species-identification reranking.
+//!
+//! Loads the `species_geo_index.bin` artifact produced by the `bioclip-models`
+//! pipeline. Given a lat/lon, returns the BioCLIP species indices whose iNat
+//! range maps cover that location — used to apply a soft boost to visually-
+//! similar species that are plausible at the observer's location.
+//!
+//! The binary format (documented in full in `bioclip_models/geo.py`):
+//!
+//! ```text
+//! Header (32 bytes):
+//!   magic[4]       = b"OGI1"
+//!   version        = u32 = 1
+//!   num_species    = u32
+//!   h3_resolution  = u32 (typically 4)
+//!   num_cells      = u32
+//!   num_entries    = u32
+//!   reserved       = u32 x 2
+//!
+//! Body:
+//!   cells[num_cells]:      u64 LE  (H3 indices, sorted ascending)
+//!   offsets[num_cells+1]:  u32 LE  (CSR offsets into species_ids)
+//!   species_ids[num_entries]: u32 LE
+//! ```
+//!
+//! Lookup is O(log num_cells) via binary search.
+
+use crate::error::{Result, SpeciesIdError};
+use h3o::{LatLng, Resolution};
+use std::path::Path;
+use tracing::info;
+
+const MAGIC: &[u8; 4] = b"OGI1";
+const VERSION: u32 = 1;
+const HEADER_SIZE: usize = 32;
+
+/// Sorted cell → species-index lookup table.
+pub struct GeoIndex {
+    /// H3 cell indices, sorted ascending for binary search.
+    cells: Vec<u64>,
+    /// CSR offsets — `offsets[i]..offsets[i+1]` is the species range for `cells[i]`.
+    /// Length is `cells.len() + 1`.
+    offsets: Vec<u32>,
+    /// BioCLIP species indices, grouped by cell and sorted within each group.
+    species_ids: Vec<u32>,
+    /// H3 resolution used to encode the cells — also used for point lookups.
+    h3_resolution: Resolution,
+}
+
+impl GeoIndex {
+    /// Load the geo index from a file on disk.
+    ///
+    /// `expected_num_species` is the BioCLIP label count; a mismatch means
+    /// the index is stale relative to the embeddings and we refuse to load.
+    pub fn load(path: &Path, expected_num_species: usize) -> Result<Self> {
+        let bytes = std::fs::read(path).map_err(|e| {
+            SpeciesIdError::Config(format!(
+                "Failed to read geo index from {}: {}",
+                path.display(),
+                e
+            ))
+        })?;
+
+        if bytes.len() < HEADER_SIZE {
+            return Err(SpeciesIdError::Config(format!(
+                "Geo index too short ({} bytes) to contain header",
+                bytes.len()
+            )));
+        }
+        if &bytes[..4] != MAGIC {
+            return Err(SpeciesIdError::Config(format!(
+                "Bad geo index magic: expected {:?}, got {:?}",
+                MAGIC,
+                &bytes[..4]
+            )));
+        }
+
+        let version = read_u32_le(&bytes, 4);
+        let num_species = read_u32_le(&bytes, 8);
+        let h3_res_u32 = read_u32_le(&bytes, 12);
+        let num_cells = read_u32_le(&bytes, 16) as usize;
+        let num_entries = read_u32_le(&bytes, 20) as usize;
+
+        if version != VERSION {
+            return Err(SpeciesIdError::Config(format!(
+                "Unsupported geo index version: {} (expected {})",
+                version, VERSION
+            )));
+        }
+        if num_species as usize != expected_num_species {
+            return Err(SpeciesIdError::Config(format!(
+                "Geo index num_species ({}) does not match label count ({}) — \
+                 index is stale",
+                num_species, expected_num_species
+            )));
+        }
+
+        let h3_resolution = Resolution::try_from(u8::try_from(h3_res_u32).map_err(|_| {
+            SpeciesIdError::Config(format!("H3 resolution {} out of range", h3_res_u32))
+        })?)
+        .map_err(|e| SpeciesIdError::Config(format!("Invalid H3 resolution: {}", e)))?;
+
+        let expected_size = HEADER_SIZE + num_cells * 8 + (num_cells + 1) * 4 + num_entries * 4;
+        if bytes.len() != expected_size {
+            return Err(SpeciesIdError::Config(format!(
+                "Geo index size mismatch: expected {} bytes, got {}",
+                expected_size,
+                bytes.len()
+            )));
+        }
+
+        // Decode into aligned Vecs. We use explicit little-endian reads so the
+        // file format is stable across architectures (all our targets are LE,
+        // but this is cheap insurance).
+        let mut cells = Vec::with_capacity(num_cells);
+        let mut off = HEADER_SIZE;
+        for _ in 0..num_cells {
+            cells.push(read_u64_le(&bytes, off));
+            off += 8;
+        }
+        let mut offsets = Vec::with_capacity(num_cells + 1);
+        for _ in 0..=num_cells {
+            offsets.push(read_u32_le(&bytes, off));
+            off += 4;
+        }
+        let mut species_ids = Vec::with_capacity(num_entries);
+        for _ in 0..num_entries {
+            species_ids.push(read_u32_le(&bytes, off));
+            off += 4;
+        }
+
+        // Sanity: offsets must be monotonic and terminate at num_entries.
+        // Catches bit-flip or truncated-file scenarios before we mis-index at
+        // inference time.
+        if offsets.first().copied() != Some(0)
+            || offsets.last().copied() != Some(num_entries as u32)
+        {
+            return Err(SpeciesIdError::Config(
+                "Geo index offsets are malformed (bad endpoints)".to_string(),
+            ));
+        }
+
+        info!(
+            num_cells,
+            num_entries,
+            h3_resolution = h3_res_u32,
+            size_mb = bytes.len() / (1024 * 1024),
+            "Geo index loaded"
+        );
+
+        Ok(Self {
+            cells,
+            offsets,
+            species_ids,
+            h3_resolution,
+        })
+    }
+
+    /// Species indices whose range maps cover `(lat, lon)`.
+    ///
+    /// Returns an empty slice if the coordinates are invalid, the containing
+    /// H3 cell is not in the index, or the cell has no mapped species.
+    pub fn species_at(&self, lat: f64, lon: f64) -> &[u32] {
+        let Ok(latlng) = LatLng::new(lat, lon) else {
+            return &[];
+        };
+        let cell_u64: u64 = latlng.to_cell(self.h3_resolution).into();
+
+        match self.cells.binary_search(&cell_u64) {
+            Ok(i) => {
+                let start = self.offsets[i] as usize;
+                let end = self.offsets[i + 1] as usize;
+                &self.species_ids[start..end]
+            }
+            Err(_) => &[],
+        }
+    }
+}
+
+fn read_u32_le(bytes: &[u8], off: usize) -> u32 {
+    u32::from_le_bytes(bytes[off..off + 4].try_into().expect("len 4"))
+}
+
+fn read_u64_le(bytes: &[u8], off: usize) -> u64 {
+    u64::from_le_bytes(bytes[off..off + 8].try_into().expect("len 8"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    /// Build an in-memory geo index file with the CSR layout and write it to `path`.
+    fn write_index(
+        path: &Path,
+        num_species: u32,
+        resolution: Resolution,
+        cells_and_species: &[(u64, &[u32])],
+    ) {
+        let num_cells = cells_and_species.len() as u32;
+        let num_entries: u32 = cells_and_species.iter().map(|(_, s)| s.len() as u32).sum();
+
+        let mut buf = Vec::new();
+        buf.extend_from_slice(MAGIC);
+        buf.extend_from_slice(&VERSION.to_le_bytes());
+        buf.extend_from_slice(&num_species.to_le_bytes());
+        buf.extend_from_slice(&(u8::from(resolution) as u32).to_le_bytes());
+        buf.extend_from_slice(&num_cells.to_le_bytes());
+        buf.extend_from_slice(&num_entries.to_le_bytes());
+        buf.extend_from_slice(&[0u8; 8]); // reserved
+
+        for (cell, _) in cells_and_species {
+            buf.extend_from_slice(&cell.to_le_bytes());
+        }
+        let mut offset: u32 = 0;
+        buf.extend_from_slice(&offset.to_le_bytes());
+        for (_, species) in cells_and_species {
+            offset += species.len() as u32;
+            buf.extend_from_slice(&offset.to_le_bytes());
+        }
+        for (_, species) in cells_and_species {
+            for s in *species {
+                buf.extend_from_slice(&s.to_le_bytes());
+            }
+        }
+
+        let mut f = std::fs::File::create(path).unwrap();
+        f.write_all(&buf).unwrap();
+    }
+
+    #[test]
+    fn load_and_lookup_roundtrip() {
+        // Build an index with two real H3-4 cells, one for San Francisco and one
+        // for Salt Lake City, covering different species sets.
+        let sf = LatLng::new(37.77, -122.42).unwrap();
+        let slc = LatLng::new(40.76, -111.89).unwrap();
+        let sf_cell: u64 = sf.to_cell(Resolution::Four).into();
+        let slc_cell: u64 = slc.to_cell(Resolution::Four).into();
+
+        let mut cells: Vec<(u64, &[u32])> = vec![(sf_cell, &[0, 2]), (slc_cell, &[1, 2])];
+        cells.sort_by_key(|(c, _)| *c);
+
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("geo.bin");
+        write_index(&path, 3, Resolution::Four, &cells);
+
+        let index = GeoIndex::load(&path, 3).unwrap();
+
+        assert_eq!(index.species_at(37.77, -122.42), &[0, 2]);
+        assert_eq!(index.species_at(40.76, -111.89), &[1, 2]);
+        // A point nowhere near either cell returns empty.
+        assert!(index.species_at(0.0, 0.0).is_empty());
+        // Out-of-range coordinates fail the LatLng constructor → empty.
+        assert!(index.species_at(91.0, 0.0).is_empty());
+    }
+
+    #[test]
+    fn rejects_stale_index_num_species_mismatch() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("geo.bin");
+        write_index(&path, 100, Resolution::Four, &[]);
+
+        let msg = match GeoIndex::load(&path, 200) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("should reject stale index"),
+        };
+        assert!(msg.contains("stale"), "unexpected error: {}", msg);
+    }
+
+    /// Cross-repo smoke test: loads a real index produced by the Python
+    /// build pipeline and confirms the byte-level format is compatible
+    /// end-to-end. Skipped unless the fixture exists at
+    /// /tmp/cross_repo_test/species_geo_index.bin. Copy the artifact there
+    /// and adjust `SPECIES_COUNT` to match the label set it was built against.
+    ///
+    /// This checks the format contract (loadable, in-range ids, within-cell
+    /// sorting), not specific behavior — the species content depends on the
+    /// fixture.
+    #[test]
+    #[ignore = "requires cross-repo fixture from bioclip-models"]
+    fn cross_repo_python_built_index() {
+        const SPECIES_COUNT: usize = 100_000;
+        let path = std::path::PathBuf::from("/tmp/cross_repo_test/species_geo_index.bin");
+        let idx = GeoIndex::load(&path, SPECIES_COUNT).unwrap();
+
+        // A densely-populated land cell should yield many species in a real index.
+        let sf = idx.species_at(37.77, -122.42);
+        assert!(!sf.is_empty(), "SF should not be empty in a real index");
+        assert!(
+            sf.iter().all(|&i| (i as usize) < SPECIES_COUNT),
+            "all returned species indices must be in-range"
+        );
+        // Per the format contract, species_ids within a cell are sorted ascending.
+        assert!(
+            sf.windows(2).all(|w| w[0] < w[1]),
+            "species_ids within a cell must be sorted"
+        );
+    }
+
+    #[test]
+    fn rejects_bad_magic() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("geo.bin");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"XXXX").unwrap();
+        f.write_all(&[0u8; 28]).unwrap();
+
+        let msg = match GeoIndex::load(&path, 1) {
+            Err(e) => e.to_string(),
+            Ok(_) => panic!("should reject bad magic"),
+        };
+        assert!(msg.contains("magic"), "unexpected error: {}", msg);
+    }
+}

--- a/crates/observing-species-id/src/main.rs
+++ b/crates/observing-species-id/src/main.rs
@@ -4,6 +4,7 @@
 
 mod embeddings;
 mod error;
+mod geo_index;
 mod model;
 mod preprocessing;
 mod server;

--- a/crates/observing-species-id/src/model.rs
+++ b/crates/observing-species-id/src/model.rs
@@ -8,7 +8,7 @@ use crate::error::{Result, SpeciesIdError};
 use crate::geo_index::GeoIndex;
 use crate::preprocessing;
 use crate::types::SpeciesSuggestion;
-use ndarray::Array1;
+use ndarray::{Array1, Array4};
 use ort::session::{builder::GraphOptimizationLevel, Session};
 use ort::value::Value;
 use std::path::Path;
@@ -110,14 +110,20 @@ impl BioclipModel {
         lat_lon: Option<(f64, f64)>,
         limit: usize,
     ) -> Result<Vec<SpeciesSuggestion>> {
-        // Preprocess image to NCHW tensor [1, 3, 224, 224]
         let input_tensor = preprocessing::preprocess_image(image_bytes)?;
+        let embedding = self.run_vision_encoder(input_tensor)?;
+        let mut scores = self.species.similarities(&embedding).to_vec();
+        self.apply_geo_prior(&mut scores, lat_lon);
+        Ok(self.species.top_k_from_scores(&scores, limit))
+    }
 
-        // Create ONNX Value from ndarray
+    /// Run the ONNX vision encoder on a preprocessed image tensor and return
+    /// the resulting L2-normalized image embedding. Acquires the session
+    /// mutex; callers must not hold it across this call.
+    fn run_vision_encoder(&self, input_tensor: Array4<f32>) -> Result<Array1<f32>> {
         let input_value = Value::from_array(input_tensor)
             .map_err(|e| SpeciesIdError::Model(format!("Failed to create input tensor: {}", e)))?;
 
-        // Run ONNX inference (session.run requires &mut self)
         let mut session = self
             .session
             .lock()
@@ -127,13 +133,10 @@ impl BioclipModel {
             .run(ort::inputs!["pixel_values" => input_value])
             .map_err(|e| SpeciesIdError::Model(format!("Inference failed: {}", e)))?;
 
-        // Extract image embedding — returns (&Shape, &[f32])
-        // Copy data out so we can release the session lock
         let (shape, data) = outputs[0]
             .try_extract_tensor::<f32>()
             .map_err(|e| SpeciesIdError::Model(format!("Failed to extract embedding: {}", e)))?;
 
-        // Validate expected shape [1, embed_dim]
         let embed_dim = self.species.embed_dim();
         if shape.len() != 2 || shape[1] != embed_dim as i64 {
             return Err(SpeciesIdError::Model(format!(
@@ -143,40 +146,37 @@ impl BioclipModel {
         }
 
         let embedding_data = data.to_vec();
-
-        // Drop outputs and session lock
         drop(outputs);
         drop(session);
 
-        // L2-normalize the image embedding
         let mut embedding = Array1::<f32>::from_vec(embedding_data);
         let norm = embedding.dot(&embedding).sqrt();
         if norm > 0.0 {
             embedding /= norm;
         }
+        Ok(embedding)
+    }
 
-        // Cosine similarities against every species.
-        let mut scores = self.species.similarities(&embedding).to_vec();
-
-        // Geo-prior rerank: boost species whose range maps cover this lat/lon.
-        // Soft boost only — never penalize out-of-range species, because iNat
-        // range maps undercover species in under-surveyed regions.
-        if let (Some((lat, lon)), Some(geo)) = (lat_lon, &self.geo_index) {
-            let in_range = geo.species_at(lat, lon);
-            for &species_idx in in_range {
-                if let Some(s) = scores.get_mut(species_idx as usize) {
-                    *s += self.geo_boost;
-                }
+    /// Apply the geo-prior boost in place. Soft boost only — we never
+    /// penalize out-of-range species, because iNat range maps undercover
+    /// species in under-surveyed regions. No-op when lat/lon is absent or
+    /// no geo index is loaded.
+    fn apply_geo_prior(&self, scores: &mut [f32], lat_lon: Option<(f64, f64)>) {
+        let (Some((lat, lon)), Some(geo)) = (lat_lon, &self.geo_index) else {
+            return;
+        };
+        let in_range = geo.species_at(lat, lon);
+        for &species_idx in in_range {
+            if let Some(s) = scores.get_mut(species_idx as usize) {
+                *s += self.geo_boost;
             }
-            info!(
-                lat,
-                lon,
-                in_range = in_range.len(),
-                boost = self.geo_boost,
-                "Applied geo prior"
-            );
         }
-
-        Ok(self.species.top_k_from_scores(&scores, limit))
+        info!(
+            lat,
+            lon,
+            in_range = in_range.len(),
+            boost = self.geo_boost,
+            "Applied geo prior"
+        );
     }
 }

--- a/crates/observing-species-id/src/model.rs
+++ b/crates/observing-species-id/src/model.rs
@@ -5,6 +5,7 @@
 
 use crate::embeddings::SpeciesEmbeddings;
 use crate::error::{Result, SpeciesIdError};
+use crate::geo_index::GeoIndex;
 use crate::preprocessing;
 use crate::types::SpeciesSuggestion;
 use ndarray::Array1;
@@ -12,12 +13,20 @@ use ort::session::{builder::GraphOptimizationLevel, Session};
 use ort::value::Value;
 use std::path::Path;
 use std::sync::Mutex;
-use tracing::info;
+use tracing::{info, warn};
+
+/// Default additive boost applied to in-range species when lat/lon is
+/// provided. Chosen so a +λ bump is meaningful against typical BioCLIP
+/// cosine similarities (~0.1–0.3 for matches) without overwhelming visual
+/// evidence. Can be overridden at runtime via `GEO_BOOST_LAMBDA`.
+const GEO_BOOST_DEFAULT: f32 = 0.05;
 
 /// BioCLIP model wrapping the ONNX vision encoder and species embeddings
 pub struct BioclipModel {
     session: Mutex<Session>,
     species: SpeciesEmbeddings,
+    geo_index: Option<GeoIndex>,
+    geo_boost: f32,
     pub version: String,
 }
 
@@ -52,9 +61,32 @@ impl BioclipModel {
 
         let species = SpeciesEmbeddings::load(model_dir)?;
 
+        // Geo index is optional: if the artifact isn't present we fall back
+        // to visual-only ranking (prior behavior).
+        let geo_index_path = model_dir.join("species_geo_index.bin");
+        let geo_index = if geo_index_path.exists() {
+            Some(GeoIndex::load(&geo_index_path, species.len())?)
+        } else {
+            warn!(
+                path = %geo_index_path.display(),
+                "Geo index not found; species identification will use visual similarity only"
+            );
+            None
+        };
+
+        let geo_boost = std::env::var("GEO_BOOST_LAMBDA")
+            .ok()
+            .and_then(|s| s.parse::<f32>().ok())
+            .unwrap_or(GEO_BOOST_DEFAULT);
+        if geo_index.is_some() {
+            info!(geo_boost, "Geo-prior reranking enabled");
+        }
+
         Ok(Self {
             session: Mutex::new(session),
             species,
+            geo_index,
+            geo_boost,
             version: "bioclip-2.5-vit-h-14".to_string(),
         })
     }
@@ -66,8 +98,18 @@ impl BioclipModel {
 
     /// Identify species from raw image bytes.
     ///
-    /// Returns the top-K species suggestions sorted by confidence.
-    pub fn identify(&self, image_bytes: &[u8], limit: usize) -> Result<Vec<SpeciesSuggestion>> {
+    /// If `lat_lon` is provided and a geo index is loaded, species whose iNat
+    /// range covers that point get a soft additive boost before top-K
+    /// selection. Missing lat/lon or missing index falls back to visual-only
+    /// ranking.
+    ///
+    /// Returns the top-K species suggestions sorted by descending confidence.
+    pub fn identify(
+        &self,
+        image_bytes: &[u8],
+        lat_lon: Option<(f64, f64)>,
+        limit: usize,
+    ) -> Result<Vec<SpeciesSuggestion>> {
         // Preprocess image to NCHW tensor [1, 3, 224, 224]
         let input_tensor = preprocessing::preprocess_image(image_bytes)?;
 
@@ -113,7 +155,28 @@ impl BioclipModel {
             embedding /= norm;
         }
 
-        // Find top-K matches via cosine similarity
-        Ok(self.species.top_k(&embedding, limit))
+        // Cosine similarities against every species.
+        let mut scores = self.species.similarities(&embedding).to_vec();
+
+        // Geo-prior rerank: boost species whose range maps cover this lat/lon.
+        // Soft boost only — never penalize out-of-range species, because iNat
+        // range maps undercover species in under-surveyed regions.
+        if let (Some((lat, lon)), Some(geo)) = (lat_lon, &self.geo_index) {
+            let in_range = geo.species_at(lat, lon);
+            for &species_idx in in_range {
+                if let Some(s) = scores.get_mut(species_idx as usize) {
+                    *s += self.geo_boost;
+                }
+            }
+            info!(
+                lat,
+                lon,
+                in_range = in_range.len(),
+                boost = self.geo_boost,
+                "Applied geo prior"
+            );
+        }
+
+        Ok(self.species.top_k_from_scores(&scores, limit))
     }
 }

--- a/crates/observing-species-id/src/server.rs
+++ b/crates/observing-species-id/src/server.rs
@@ -82,17 +82,7 @@ async fn identify(State(state): State<SharedState>, Json(body): Json<IdentifyReq
     // Run inference (blocking CPU work — spawn on blocking thread pool)
     let model = state.clone();
     let limit = body.limit.min(20); // Cap at 20 suggestions
-
-    // Pass lat/lon through for geo-prior reranking. Both must be present for
-    // it to take effect; a single coord alone is unusable and we log + drop.
-    let lat_lon = match (body.latitude, body.longitude) {
-        (Some(lat), Some(lon)) => Some((lat, lon)),
-        (Some(_), None) | (None, Some(_)) => {
-            info!(lat = ?body.latitude, lng = ?body.longitude, "Ignoring half-specified geo context");
-            None
-        }
-        (None, None) => None,
-    };
+    let lat_lon = parse_lat_lon(&body);
 
     let result =
         tokio::task::spawn_blocking(move || model.model.identify(&image_bytes, lat_lon, limit))
@@ -137,6 +127,25 @@ async fn identify(State(state): State<SharedState>, Json(body): Json<IdentifyReq
     }
 }
 
+/// Extract the lat/lon pair from the request, or `None` if either side is
+/// missing. A single coordinate is unusable for a geo-prior — we log the
+/// half-specified case so it's visible in production, but treat it as
+/// "no location" rather than erroring the request.
+fn parse_lat_lon(body: &IdentifyRequest) -> Option<(f64, f64)> {
+    match (body.latitude, body.longitude) {
+        (Some(lat), Some(lon)) => Some((lat, lon)),
+        (Some(_), None) | (None, Some(_)) => {
+            info!(
+                lat = ?body.latitude,
+                lng = ?body.longitude,
+                "Ignoring half-specified geo context"
+            );
+            None
+        }
+        (None, None) => None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -151,5 +160,26 @@ mod tests {
         };
         let json = serde_json::to_string(&err).unwrap();
         assert!(json.contains("test"));
+    }
+
+    fn req(lat: Option<f64>, lon: Option<f64>) -> IdentifyRequest {
+        IdentifyRequest {
+            image: String::new(),
+            latitude: lat,
+            longitude: lon,
+            limit: 5,
+        }
+    }
+
+    #[test]
+    fn parse_lat_lon_both_present() {
+        assert_eq!(parse_lat_lon(&req(Some(1.0), Some(2.0))), Some((1.0, 2.0)));
+    }
+
+    #[test]
+    fn parse_lat_lon_missing_either_returns_none() {
+        assert_eq!(parse_lat_lon(&req(Some(1.0), None)), None);
+        assert_eq!(parse_lat_lon(&req(None, Some(2.0))), None);
+        assert_eq!(parse_lat_lon(&req(None, None)), None);
     }
 }

--- a/crates/observing-species-id/src/server.rs
+++ b/crates/observing-species-id/src/server.rs
@@ -83,13 +83,20 @@ async fn identify(State(state): State<SharedState>, Json(body): Json<IdentifyReq
     let model = state.clone();
     let limit = body.limit.min(20); // Cap at 20 suggestions
 
-    // Log geo context if provided (reserved for future geo-prior reranking)
-    if body.latitude.is_some() || body.longitude.is_some() {
-        info!(lat = ?body.latitude, lng = ?body.longitude, "Geo context provided");
-    }
+    // Pass lat/lon through for geo-prior reranking. Both must be present for
+    // it to take effect; a single coord alone is unusable and we log + drop.
+    let lat_lon = match (body.latitude, body.longitude) {
+        (Some(lat), Some(lon)) => Some((lat, lon)),
+        (Some(_), None) | (None, Some(_)) => {
+            info!(lat = ?body.latitude, lng = ?body.longitude, "Ignoring half-specified geo context");
+            None
+        }
+        (None, None) => None,
+    };
 
     let result =
-        tokio::task::spawn_blocking(move || model.model.identify(&image_bytes, limit)).await;
+        tokio::task::spawn_blocking(move || model.model.identify(&image_bytes, lat_lon, limit))
+            .await;
 
     match result {
         Ok(Ok(suggestions)) => {


### PR DESCRIPTION
## Summary

Wires the geo-prior reranker into `observing-species-id`. When the client supplies lat/lon with an identification request, species whose iNat range covers that H3-4 cell get a small additive boost (+λ = 0.05 default, tunable via `GEO_BOOST_LAMBDA`) before top-K selection. Missing coordinates or missing index fall back to visual-only ranking — same behavior as before this PR.

Closes #185.

## What's in the PR

- `crates/observing-species-id/src/geo_index.rs` — loads `species_geo_index.bin` (CSR-encoded H3 cells → BioCLIP species indices) and serves binary-searched lookups. Validates the header, rejects a stale index whose `num_species` disagrees with the label count, rejects bad magic / truncated files.
- `model.rs` — optional `GeoIndex` at startup; boost applied in-place on similarity scores before top-K. The `GEO_BOOST_LAMBDA` env var overrides the default at runtime without a rebuild.
- `embeddings.rs` — split `top_k` into `similarities()` + `top_k_from_scores()` so the caller can mutate scores between the two.
- `server.rs` — passes `body.latitude` / `body.longitude` through (both-or-nothing).
- `Cargo.toml` — adds `h3o = "0.9"` (pure-Rust H3 implementation) and `tempfile` as a dev-dep.
- `Dockerfile` — bumps the model tarball URL from `v2.0.0` → `v2.1.0` (adds `species_geo_index.bin`, species count 100K → 200K).

## The artifact side

Built + shipped from [observ-ing/bioclip-models#4](https://github.com/observ-ing/bioclip-models/pull/4) (merged) and released as [v2.1.0](https://github.com/observ-ing/bioclip-models/releases/tag/v2.1.0):

- `species_geo_index.bin` — 1.2 GB, 288,120 H3-4 cells, avg 1,093 species/cell
- Species coverage: 108,010 / 200,000 (54%) have a range map; the remaining 92K fall back to visual-only at inference
- Iat-ordered species list so the most-photographed species (common case) all get geo coverage

## Test plan

- [x] 6 unit tests in `geo_index.rs` — round-trip format, stale-index rejection, bad-magic rejection, lookup semantics
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Cross-repo load check: the real 1.2 GB Python-built artifact loads in Rust, returns the expected species subsets for known lat/lon points

## Follow-ups not in this PR

- Location-aware eval to empirically tune λ (separate bioclip-models PR)