### PR TITLE
chore(deps): address RUSTSEC-2026-0104/0105 + npm audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3839,9 +3839,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",

--- a/deny.toml
+++ b/deny.toml
@@ -2,6 +2,9 @@
 ignore = [
 # jacquard-common -> postcard -> heapless 0.7 -> atomic-polyfill (no postcard release with heapless 0.8 yet)
     { id = "RUSTSEC-2023-0089", reason = "unmaintained, transitive dep via postcard" },
+# observing-appview -> jacquard-common -> cid -> ipld-core -> atrium-api -> core2
+# (atrium/cid stack hasn't yet migrated off core2; we don't call into it directly)
+    { id = "RUSTSEC-2026-0105", reason = "core2 unmaintained, transitive dep via atrium-api/cid" },
 ]
 
 [licenses]

--- a/package-lock.json
+++ b/package-lock.json
@@ -2619,9 +2619,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.9.9",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.9.tgz",
-      "integrity": "sha512-qycIHAucxy/LXAYIjmLmtQ8q9GPnMbnjG1KXhWm9o5sCr6pOYDATkMPiTNa6/v8eELyqOQ2FsEqeoFYmgv/gJg==",
+      "version": "0.9.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.10.tgz",
+      "integrity": "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.6"
@@ -3612,9 +3612,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {
@@ -3664,9 +3664,9 @@
       "license": "MIT"
     },
     "node_modules/protocol-buffers-schema": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
+      "version": "3.6.1",
+      "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.1.tgz",
+      "integrity": "sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==",
       "license": "MIT"
     },
     "node_modules/quickselect": {


### PR DESCRIPTION
## Summary

CI started failing today against advisory updates that landed since main last built green. This PR clears them so other PRs (e.g. #337) can run on a green base.

- `rustls-webpki` **0.103.12 → 0.103.13** — patched release for [RUSTSEC-2026-0104](https://rustsec.org/advisories/RUSTSEC-2026-0104) (reachable panic in CRL parsing). Pulled in transitively by reqwest/sqlx via rustls.
- `core2` 0.4.0 ([RUSTSEC-2026-0105](https://rustsec.org/advisories/RUSTSEC-2026-0105), unmaintained + yanked) added to `[advisories.ignore]` in `deny.toml`. Reaches us only via `atrium-api → ipld-core → cid → core2`; we don't call into it directly. Upstream `cid` hasn't migrated off yet.
- `npm audit fix` cleared three frontend advisories (patch-level bumps):
  - `@xmldom/xmldom` DoS / XML injection (high)
  - `postcss` XSS via unescaped `</style>` (moderate)
  - `protocol-buffers-schema` prototype pollution (moderate)

## Test plan

- [x] `cargo deny check` — `advisories ok, bans ok, licenses ok, sources ok`
- [x] `npm audit` — `found 0 vulnerabilities`
- [x] `cargo build` / `cargo test` still pass (no source changes; only Cargo.lock + package-lock.json + deny.toml)