### PR TITLE
feat(species-id): surface in-range flag on each suggestion

### DIFF
--- a/crates/observing-appview/src/species_id_client.rs
+++ b/crates/observing-appview/src/species_id_client.rs
@@ -29,6 +29,11 @@ pub struct SpeciesSuggestion {
     pub family: Option<String>,
     #[ts(optional)]
     pub genus: Option<String>,
+    /// Whether this species' iNat range covers the request lat/lon.
+    /// Absent when no opinion was formed (no coordinates, no geo index,
+    /// or the H3 cell at the request point is unknown to the index).
+    #[ts(optional)]
+    pub in_range: Option<bool>,
 }
 
 #[derive(Debug, Serialize)]

--- a/crates/observing-species-id/src/embeddings.rs
+++ b/crates/observing-species-id/src/embeddings.rs
@@ -137,7 +137,18 @@ impl SpeciesEmbeddings {
     ///
     /// The caller owns the score array and can mutate it (e.g. applying a
     /// geo-prior boost) before calling this.
-    pub fn top_k_from_scores(&self, scores: &[f32], k: usize) -> Vec<SpeciesSuggestion> {
+    ///
+    /// `in_range`, if provided, is a sorted-ascending slice of species
+    /// indices we consider "expected at the request location". Each
+    /// returned suggestion gets `in_range = Some(true|false)`. Pass `None`
+    /// when no geo lookup was performed; suggestions then carry
+    /// `in_range = None` and the field is omitted from the wire response.
+    pub fn top_k_from_scores(
+        &self,
+        scores: &[f32],
+        k: usize,
+        in_range: Option<&[u32]>,
+    ) -> Vec<SpeciesSuggestion> {
         let mut indexed: Vec<(usize, f32)> = scores.iter().copied().enumerate().collect();
         indexed.sort_unstable_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
         indexed.truncate(k);
@@ -146,6 +157,7 @@ impl SpeciesEmbeddings {
             .into_iter()
             .map(|(idx, score)| {
                 let label = &self.labels[idx];
+                let in_range = in_range.map(|set| set.binary_search(&(idx as u32)).is_ok());
                 SpeciesSuggestion {
                     scientific_name: label.scientific_name.clone(),
                     confidence: score,
@@ -156,8 +168,76 @@ impl SpeciesEmbeddings {
                     order: label.order.clone(),
                     family: label.family.clone(),
                     genus: label.genus.clone(),
+                    in_range,
                 }
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_embeddings(rows: usize, embed_dim: usize) -> SpeciesEmbeddings {
+        // Identity-ish: row i has a 1 at column (i % embed_dim), normalized.
+        let mut data = vec![0.0f32; rows * embed_dim];
+        for i in 0..rows {
+            data[i * embed_dim + (i % embed_dim)] = 1.0;
+        }
+        let embeddings = Array2::from_shape_vec((rows, embed_dim), data).unwrap();
+        let labels = (0..rows)
+            .map(|i| SpeciesLabel {
+                scientific_name: format!("Species {}", i),
+                common_name: None,
+                kingdom: None,
+                phylum: None,
+                class: None,
+                order: None,
+                family: None,
+                genus: None,
+            })
+            .collect();
+        SpeciesEmbeddings {
+            embeddings,
+            labels,
+            embed_dim,
+        }
+    }
+
+    #[test]
+    fn top_k_decorates_in_range_when_set_provided() {
+        let species = make_embeddings(5, 4);
+        let scores = vec![0.1, 0.5, 0.3, 0.4, 0.2];
+        let in_range = vec![1u32, 3];
+
+        let out = species.top_k_from_scores(&scores, 3, Some(&in_range));
+
+        // Top-3 by score is species 1 (0.5), 3 (0.4), 2 (0.3).
+        assert_eq!(out[0].scientific_name, "Species 1");
+        assert_eq!(out[0].in_range, Some(true));
+        assert_eq!(out[1].scientific_name, "Species 3");
+        assert_eq!(out[1].in_range, Some(true));
+        assert_eq!(out[2].scientific_name, "Species 2");
+        assert_eq!(out[2].in_range, Some(false));
+    }
+
+    #[test]
+    fn top_k_omits_in_range_when_no_geo_lookup() {
+        let species = make_embeddings(3, 4);
+        let scores = vec![0.1, 0.5, 0.3];
+
+        let out = species.top_k_from_scores(&scores, 3, None);
+
+        // None across the board → field is serialized as absent.
+        for sugg in &out {
+            assert_eq!(sugg.in_range, None);
+        }
+        let json = serde_json::to_string(&out[0]).unwrap();
+        assert!(
+            !json.contains("inRange"),
+            "in_range should not appear in JSON when None: {}",
+            json
+        );
     }
 }

--- a/crates/observing-species-id/src/model.rs
+++ b/crates/observing-species-id/src/model.rs
@@ -113,8 +113,33 @@ impl BioclipModel {
         let input_tensor = preprocessing::preprocess_image(image_bytes)?;
         let embedding = self.run_vision_encoder(input_tensor)?;
         let mut scores = self.species.similarities(&embedding).to_vec();
-        self.apply_geo_prior(&mut scores, lat_lon);
-        Ok(self.species.top_k_from_scores(&scores, limit))
+        let in_range = self.in_range_at(lat_lon);
+        self.apply_geo_prior(&mut scores, lat_lon, in_range);
+        Ok(self.species.top_k_from_scores(&scores, limit, in_range))
+    }
+
+    /// Sorted-ascending slice of species indices whose iNat range covers
+    /// `lat_lon`, or `None` when we can't form an opinion (no coordinates,
+    /// no geo index loaded, or the H3 cell at that point is unknown to
+    /// the index — typically open ocean / Antarctica).
+    ///
+    /// `Some(empty)` means we *can* form an opinion at this location but
+    /// no species in our label set is expected here; that's distinct from
+    /// `None` ("we didn't / couldn't check") and the response surfaces it.
+    fn in_range_at(&self, lat_lon: Option<(f64, f64)>) -> Option<&[u32]> {
+        let (lat, lon) = lat_lon?;
+        let geo = self.geo_index.as_ref()?;
+        let cell_species = geo.species_at(lat, lon);
+        // species_at returns &[] both for "cell unknown" and "cell mapped
+        // to no species". Treat empty as "no opinion" — the only known
+        // populated case in the wild is when the cell is missing entirely,
+        // and we don't want to surface false-negative `in_range = false`
+        // flags on every result for a request near the south pole.
+        if cell_species.is_empty() {
+            None
+        } else {
+            Some(cell_species)
+        }
     }
 
     /// Run the ONNX vision encoder on a preprocessed image tensor and return
@@ -159,24 +184,28 @@ impl BioclipModel {
 
     /// Apply the geo-prior boost in place. Soft boost only — we never
     /// penalize out-of-range species, because iNat range maps undercover
-    /// species in under-surveyed regions. No-op when lat/lon is absent or
-    /// no geo index is loaded.
-    fn apply_geo_prior(&self, scores: &mut [f32], lat_lon: Option<(f64, f64)>) {
-        let (Some((lat, lon)), Some(geo)) = (lat_lon, &self.geo_index) else {
-            return;
-        };
-        let in_range = geo.species_at(lat, lon);
+    /// species in under-surveyed regions. No-op when `in_range` is `None`
+    /// (no lat/lon or no geo opinion at this location).
+    fn apply_geo_prior(
+        &self,
+        scores: &mut [f32],
+        lat_lon: Option<(f64, f64)>,
+        in_range: Option<&[u32]>,
+    ) {
+        let Some(in_range) = in_range else { return };
         for &species_idx in in_range {
             if let Some(s) = scores.get_mut(species_idx as usize) {
                 *s += self.geo_boost;
             }
         }
-        info!(
-            lat,
-            lon,
-            in_range = in_range.len(),
-            boost = self.geo_boost,
-            "Applied geo prior"
-        );
+        if let Some((lat, lon)) = lat_lon {
+            info!(
+                lat,
+                lon,
+                in_range = in_range.len(),
+                boost = self.geo_boost,
+                "Applied geo prior"
+            );
+        }
     }
 }

--- a/crates/observing-species-id/src/types.rs
+++ b/crates/observing-species-id/src/types.rs
@@ -49,6 +49,12 @@ pub struct SpeciesSuggestion {
     pub family: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub genus: Option<String>,
+    /// Whether this species' iNat range covers the request lat/lon.
+    /// `None` when geo lookup wasn't performed (no lat/lon, no geo index)
+    /// or when the cell at the request point is unknown to the index — i.e.
+    /// the field is only populated with an opinion when one is well-founded.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub in_range: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/frontend/src/bindings/SpeciesSuggestion.ts
+++ b/frontend/src/bindings/SpeciesSuggestion.ts
@@ -10,4 +10,10 @@ export type SpeciesSuggestion = {
   order?: string;
   family?: string;
   genus?: string;
+  /**
+   * Whether this species' iNat range covers the request lat/lon.
+   * Absent when no opinion was formed (no coordinates, no geo index,
+   * or the H3 cell at the request point is unknown to the index).
+   */
+  inRange?: boolean;
 };

--- a/frontend/src/components/identification/AiSuggestions.tsx
+++ b/frontend/src/components/identification/AiSuggestions.tsx
@@ -1,6 +1,7 @@
 import { Box, Button, Chip, CircularProgress, IconButton, Stack, Typography } from "@mui/material";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import PlaceIcon from "@mui/icons-material/Place";
 import type { SpeciesSuggestion } from "../../services/api";
 import { nameToSlug } from "../../lib/taxonSlug";
 import { useAiSuggestions } from "../../hooks/useAiSuggestions";
@@ -118,6 +119,20 @@ export function AiSuggestionChips({ suggestions, onSelect }: AiSuggestionChipsPr
                     >
                       {s.commonName}
                     </Typography>
+                  )}
+                  {s.inRange === true && (
+                    <Box
+                      component="span"
+                      sx={{
+                        display: "inline-flex",
+                        alignItems: "center",
+                        color: "success.main",
+                      }}
+                      title="Found in your area"
+                      aria-label="Found in your area"
+                    >
+                      <PlaceIcon sx={{ fontSize: 14 }} />
+                    </Box>
                   )}
                   <Typography
                     variant="caption"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -507,6 +507,12 @@ export interface SpeciesSuggestion {
   order?: string;
   family?: string;
   genus?: string;
+  /**
+   * Whether this species' iNat range covers the request lat/lon. Omitted
+   * when the server couldn't form an opinion (no coordinates, no geo
+   * index, or the request location is outside any mapped H3 cell).
+   */
+  inRange?: boolean;
 }
 
 export interface IdentifyResponse {


### PR DESCRIPTION
## Summary

Surfaces the geo-prior signal (already used internally for reranking by #337) as a per-suggestion `inRange` field. Frontend renders a small place-pin badge — "Found in your area" — only when the value is `true`. `undefined` and `false` produce no badge, so under-surveyed regions never see false-negative warnings on species users are actually holding in their hand.

Conscious choice not to surface raw scores (`visualScore` + `geoBoost` separately): cosine similarity isn't a probability, and a single boolean is honest about what the prior actually knows.

## Tri-state semantics

| Wire | TS | Meaning |
|---|---|---|
| field omitted | `undefined` | No opinion — no lat/lon, no geo index, or H3 cell at request point isn't in the index |
| `true` | `true` | Species' iNat range covers this point |
| `false` | `false` | Species has a range map and it does *not* cover this point |

## Files

**Backend (`observing-species-id`)**
- `types.rs` — new `in_range: Option<bool>` on `SpeciesSuggestion`, `skip_serializing_if = "Option::is_none"`.
- `embeddings.rs` — `top_k_from_scores` takes an optional `&[u32]` of in-range species; binary-searches per top-K hit (k ≤ 20).
- `model.rs` — new `in_range_at(lat_lon)` helper, threaded through `apply_geo_prior` and `top_k_from_scores`. Treats an empty `species_at` slice as "no opinion".

**Backend proxy (`observing-appview`)**
- `species_id_client.rs` — same field on the proxied struct so the flag survives the frontend → appview → species-id hop.
- `frontend/src/bindings/SpeciesSuggestion.ts` — ts-rs regenerated.

**Frontend**
- `services/api.ts` — `inRange?: boolean`.
- `components/identification/AiSuggestions.tsx` — place-pin icon between common name and confidence %, tooltip + aria-label "Found in your area".

## Test plan

- [x] `cargo test -p observing-species-id -p observing-appview` (2 new tests for the decoration; ts-rs export tests pass)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo deny check` clean
- [x] `npm run lint` no new warnings; `npm run fmt:check` clean
- [ ] Manual UI verification (drop a photo, confirm pin appears for in-range species and not for the rest)

## Out of scope (could be follow-ups)

- "Hide species not expected here" filter toggle.
- A different visual for `inRange === false` ("unusual for your area"). High false-positive risk because of range-map gaps; needs eval data first.