### PR TITLE
fix(db): grant cloudsqlsuperuser USAGE on ingester/appview schemas

### DIFF
--- a/crates/observing-db/migrations/20260425000000_cloudsqlsuperuser_schema_usage.sql
+++ b/crates/observing-db/migrations/20260425000000_cloudsqlsuperuser_schema_usage.sql
@@ -1,0 +1,28 @@
+-- Grant `cloudsqlsuperuser` USAGE on the `ingester` and `appview` schemas.
+--
+-- Tables in those schemas were created by the `postgres` migrator but ended
+-- up owned by `cloudsqlsuperuser` (Cloud SQL's role membership chain). FK
+-- constraint triggers (e.g. `identifications.subject_uri → occurrences.uri`)
+-- run as the table owner — `cloudsqlsuperuser`. Since the new schemas were
+-- only granted USAGE to the runtime roles, the trigger query
+--
+--     SELECT 1 FROM ONLY "ingester"."occurrences" x WHERE "uri" = $1 ...
+--
+-- failed with `permission denied for schema ingester` for every INSERT into
+-- any table with an FK back into `ingester`. The bug was masked while
+-- `cloudsqlsuperuser` membership was inherited by the runtime users; once
+-- 20260424000000_create_runtime_base_role landed and the runbook revoke
+-- ran in prod, every firehose write started erroring (~6 days of lost
+-- identifications/comments/likes/interactions until this grant landed).
+--
+-- Idempotent and a no-op on local/CI where `cloudsqlsuperuser` doesn't exist.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cloudsqlsuperuser') THEN
+        RAISE NOTICE 'cloudsqlsuperuser role not found; skipping (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    EXECUTE 'GRANT USAGE ON SCHEMA ingester, appview TO cloudsqlsuperuser';
+END
+$$;


### PR DESCRIPTION
## Summary
- Grants `cloudsqlsuperuser` USAGE on the `ingester` and `appview` schemas.
- Idempotent and a no-op on local/CI where `cloudsqlsuperuser` doesn't exist.
- Already applied to prod via ad-hoc `GRANT` to stop the bleeding; this migration just keeps the next fresh DB consistent.

## Why
Every firehose write into a table with an FK back into `ingester` (identifications, comments, likes, interactions, occurrence_observers) was failing in prod with `permission denied for schema ingester` and getting silently skipped.

Mechanism:
- `ingester.occurrences`, `ingester.identifications`, etc. are owned by `cloudsqlsuperuser` (legacy of pre-schema-split table creation; `ALTER TABLE … SET SCHEMA` preserved ownership).
- FK constraint triggers run in the table-owner's context. The internal RI check is something like:
  ```
  SELECT 1 FROM ONLY "ingester"."occurrences" x WHERE "uri" = $1 FOR KEY SHARE OF x
  ```
- The schema split (#324) granted USAGE on `ingester` only to `appview_runtime` and `ingester_runtime`. `cloudsqlsuperuser` was never granted USAGE on the new schema.
- This was masked while runtime users still inherited from `cloudsqlsuperuser` (Cloud SQL's default role membership).
- #334's runbook revoked that membership on 2026-04-21. From that point, the FK trigger's bare `SELECT … FROM ingester.occurrences` started failing because `cloudsqlsuperuser` itself has no access to the schema.

Result in prod: ~6 days of dropped identifications/comments/likes/interactions until I ran `GRANT USAGE ON SCHEMA ingester, appview TO cloudsqlsuperuser` ad-hoc. Backfill via `cargo run --bin backfill -- --all` recovered the OAuth users; non-OAuth firehose events from that window are still missing.

## Verification on prod
- Before grant: `INSERT … INTO identifications` as `ingester_runtime` → `permission denied for schema ingester` (FK check).
- After grant: same INSERT succeeds.
- `has_schema_privilege('cloudsqlsuperuser', 'ingester', 'USAGE')` → `t` for both schemas.
- Ingester error count went 48/24h → 0 within minutes of the grant.

## Why not change ownership instead
A cleaner fix is `REASSIGN OWNED BY cloudsqlsuperuser TO postgres` for the affected tables — then the FK trigger runs as `postgres`, which already has full schema access. That's more invasive (12 tables, default-privileges interactions to verify) and out of scope for the immediate bleed-stop. Worth filing as a follow-up if we want to remove the special grant entirely.

## Test plan
- [x] Migration runs cleanly on prod (already applied as ad-hoc GRANT)
- [x] Migration is no-op on local/CI (guarded by `IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cloudsqlsuperuser')`)
- [ ] After deploy, confirm migrate Job applies cleanly and ingester continues to ingest without errors