### PR TITLE
fix(db): reassign ingester/appview tables to postgres owner

### DIFF
--- a/crates/observing-db/migrations/20260425000000_cloudsqlsuperuser_schema_usage.sql
+++ b/crates/observing-db/migrations/20260425000000_cloudsqlsuperuser_schema_usage.sql
@@ -1,0 +1,28 @@
+-- Grant `cloudsqlsuperuser` USAGE on the `ingester` and `appview` schemas.
+--
+-- Tables in those schemas were created by the `postgres` migrator but ended
+-- up owned by `cloudsqlsuperuser` (Cloud SQL's role membership chain). FK
+-- constraint triggers (e.g. `identifications.subject_uri → occurrences.uri`)
+-- run as the table owner — `cloudsqlsuperuser`. Since the new schemas were
+-- only granted USAGE to the runtime roles, the trigger query
+--
+--     SELECT 1 FROM ONLY "ingester"."occurrences" x WHERE "uri" = $1 ...
+--
+-- failed with `permission denied for schema ingester` for every INSERT into
+-- any table with an FK back into `ingester`. The bug was masked while
+-- `cloudsqlsuperuser` membership was inherited by the runtime users; once
+-- 20260424000000_create_runtime_base_role landed and the runbook revoke
+-- ran in prod, every firehose write started erroring (~6 days of lost
+-- identifications/comments/likes/interactions until this grant landed).
+--
+-- Idempotent and a no-op on local/CI where `cloudsqlsuperuser` doesn't exist.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cloudsqlsuperuser') THEN
+        RAISE NOTICE 'cloudsqlsuperuser role not found; skipping (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    EXECUTE 'GRANT USAGE ON SCHEMA ingester, appview TO cloudsqlsuperuser';
+END
+$$;

--- a/crates/observing-db/migrations/20260425000001_reassign_table_ownership.sql
+++ b/crates/observing-db/migrations/20260425000001_reassign_table_ownership.sql
@@ -1,0 +1,66 @@
+-- Move ownership of `ingester` and `appview` tables (and sequences) from
+-- `cloudsqlsuperuser` to `postgres`, then drop the workaround USAGE grant
+-- added in 20260425000000.
+--
+-- Background: those tables were created in `public` long before the schema
+-- split (#324) and ended up owned by `cloudsqlsuperuser` (Cloud SQL's
+-- implicit role for built-in users at table-create time). `ALTER TABLE …
+-- SET SCHEMA` preserved that ownership when the tables were moved. Newer
+-- tables created after migrations standardized on `postgres` (e.g.
+-- `notification_reads`) are owned by `postgres` and don't have this issue.
+--
+-- Why it matters: FK constraint triggers run in the table-owner's context.
+-- With `cloudsqlsuperuser` as the owner and no USAGE on the new schemas,
+-- every FK check failed once #334's runbook revoked `cloudsqlsuperuser`
+-- membership from the runtime users (see 20260425000000 for the full
+-- post-mortem). Rather than keeping the special USAGE grant alive forever,
+-- normalize ownership on `postgres` — which already has full schema access
+-- as the schema owner — so the FK trigger path "just works" without the
+-- grant.
+--
+-- Index ownership follows the table (PG enforces `idx.relowner = tbl.relowner`),
+-- so `ALTER TABLE … OWNER TO` covers indexes implicitly.
+--
+-- Idempotent: only operates on objects currently owned by `cloudsqlsuperuser`.
+-- No-op on local/CI where the role doesn't exist (the catalog query just
+-- returns zero rows).
+DO $$
+DECLARE
+    obj record;
+BEGIN
+    FOR obj IN
+        SELECT n.nspname AS schema_name, c.relname AS rel_name, c.relkind
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        JOIN pg_roles r     ON r.oid = c.relowner
+        WHERE n.nspname IN ('ingester', 'appview')
+          AND r.rolname = 'cloudsqlsuperuser'
+          AND c.relkind IN ('r', 'S', 'm')  -- tables, sequences, materialized views
+    LOOP
+        EXECUTE format(
+            'ALTER %s %I.%I OWNER TO postgres',
+            CASE obj.relkind
+                WHEN 'r' THEN 'TABLE'
+                WHEN 'S' THEN 'SEQUENCE'
+                WHEN 'm' THEN 'MATERIALIZED VIEW'
+            END,
+            obj.schema_name,
+            obj.rel_name
+        );
+    END LOOP;
+END
+$$;
+
+-- Drop the workaround USAGE grant from 20260425000000. With `postgres` now
+-- owning everything in `ingester`/`appview`, FK triggers no longer need
+-- `cloudsqlsuperuser` to be able to see those schemas. No-op on local/CI.
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'cloudsqlsuperuser') THEN
+        RAISE NOTICE 'cloudsqlsuperuser role not found; skipping (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    EXECUTE 'REVOKE USAGE ON SCHEMA ingester, appview FROM cloudsqlsuperuser';
+END
+$$;


### PR DESCRIPTION
## Summary
Follow-up to #340. Move ownership of `ingester` and `appview` tables (and sequences) from `cloudsqlsuperuser` to `postgres`, then revoke the `cloudsqlsuperuser` USAGE grant added in #340.

> **Stacked on #340.** The new migration uses timestamp `20260425000001` (one second after #340's), so they apply in order. GitHub may show #340's commits in this PR's diff until #340 lands and this branch is rebased.

## Why
#340 stopped the bleeding by granting `cloudsqlsuperuser` USAGE on the new schemas — necessary because FK constraint triggers run in the **table-owner's** context, and the affected tables are owned by `cloudsqlsuperuser`. That ownership is a legacy artifact: the tables were originally created in `public` (Cloud SQL's implicit role membership at create-time made them `cloudsqlsuperuser`-owned), then moved into the new schemas in #324 via `ALTER TABLE … SET SCHEMA`, which preserved ownership.

Normalizing ownership on `postgres` — already the schema owner — makes the FK trigger path resolve naturally. The workaround USAGE grant is then strictly unnecessary and gets dropped in the same migration to avoid ambient-privilege drift.

## Mechanics
- Loops through `pg_class` for objects in `ingester`/`appview` owned by `cloudsqlsuperuser` and runs `ALTER TABLE/SEQUENCE/MATERIALIZED VIEW … OWNER TO postgres`.
- Index ownership in PG must equal the parent table's owner; PG updates indexes automatically when the table owner changes.
- The `community_ids` matview is already owned by `ingester_runtime` (per 20260421000000) and isn't matched by the loop.
- Then `REVOKE USAGE ON SCHEMA ingester, appview FROM cloudsqlsuperuser`.

## Why this is safe
- Nobody connects as `cloudsqlsuperuser` (verified: only `cloudsqlagent`/`cloudsqlimportexport`/`cloudsqllogical`/`postgres` are members; runtime users were revoked in #334). Removing its USAGE doesn't affect any live connection.
- Existing per-table grants to `appview_runtime` / `ingester_runtime` are stored in `pg_class.relacl` and persist through ownership changes.
- `ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ingester` (from 20260421000000) was already in place for tables `postgres` creates — that path is now consistent end-to-end since `postgres` will own everything.
- The migration is fully idempotent: only operates on objects whose current owner is `cloudsqlsuperuser`.

## Test plan
- [x] Migration is no-op on local/CI (catalog query returns 0 rows when role is absent)
- [ ] After deploy, `SELECT n.nspname, c.relname, c.relowner::regrole FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE n.nspname IN ('ingester','appview') AND c.relkind IN ('r','S','m')` shows `postgres` for everything except `ingester.community_ids` (which stays `ingester_runtime`)
- [ ] After deploy, `has_schema_privilege('cloudsqlsuperuser','ingester','USAGE')` returns `f` (and `appview` too)
- [ ] Smoke test: a fresh observation + identification post via the frontend lands in the appview DB and the firehose-ingester loop reports zero new errors