### PR TITLE
fix(taxonomy): fall back to GBIF when identification lacks vernacular name

### DIFF
--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -311,7 +311,11 @@ async fn resolve_effective_taxonomy(
         .iter()
         .find(|id| id.scientific_name == effective_name && id.kingdom.is_some());
 
-    if let Some(id) = matching_id {
+    // Short-circuit on the identification only when it has a vernacular name —
+    // ingester writes leave vernacular_name null (the lexicon record doesn't
+    // carry one), so without this check the resolver would skip the GBIF
+    // fallback that would have supplied a common name.
+    if let Some(id) = matching_id.filter(|id| id.vernacular_name.is_some()) {
         return Some(EffectiveTaxonomy {
             scientific_name: id.scientific_name.clone(),
             vernacular_name: id.vernacular_name.clone(),
@@ -339,6 +343,20 @@ async fn resolve_effective_taxonomy(
             order: detail.order,
             family: detail.family,
             genus: detail.genus,
+        });
+    }
+
+    // GBIF unavailable — keep whatever taxonomy the matching identification has.
+    if let Some(id) = matching_id {
+        return Some(EffectiveTaxonomy {
+            scientific_name: id.scientific_name.clone(),
+            vernacular_name: id.vernacular_name.clone(),
+            kingdom: id.kingdom.clone(),
+            phylum: id.phylum.clone(),
+            class: id.class.clone(),
+            order: id.order_.clone(),
+            family: id.family.clone(),
+            genus: id.genus.clone(),
         });
     }
 


### PR DESCRIPTION
## Summary
- The effective-taxonomy resolver short-circuits on any matching identification that has a kingdom, returning its row verbatim. Ingester writes always set `vernacular_name = NULL` (the lexicon record doesn't carry one), so for every observation the resolver returned an `EffectiveTaxonomy` with no common name and the GBIF fallback never ran.
- Treat a kingdom-bearing identification as authoritative only when it also has a vernacular name; otherwise fall through to the GBIF lookup. If GBIF is unavailable, use the identification's taxonomy as a last-resort fallback so we don't regress when GBIF is down.
- Reproduces on https://observ.ing/observation/did:plc:vozr2os4b4sxrxr6opde5js5/3mked6tklqi2b — the page shows *Chelydra serpentina* with no "Snapping Turtle" line, and the API response has `effectiveTaxonomy.vernacularName` missing.

## Test plan
- [ ] `cargo check -p observing-appview` (passes locally)
- [ ] `cargo clippy -p observing-appview` (passes locally)
- [ ] Verify on staging/prod: the affected observation now renders the common name, and an unidentified-via-GBIF community ID still falls through to bare-minimum taxonomy without panicking.

## Follow-up
A separate PR will remove `vernacular_name` from `occurrences` / `identifications` / `community_ids` and route all reads through the taxonomy client, eliminating this entire two-source-of-truth code path.