### PR TITLE
fix(species-id): resolve common names via get_by_name not search

### DIFF
--- a/crates/observing-appview/src/routes/species_id.rs
+++ b/crates/observing-appview/src/routes/species_id.rs
@@ -70,6 +70,13 @@ pub async fn identify(
 /// Fill in missing common names by looking up each scientific name via the
 /// taxonomy service. Failures are silently ignored — common names are
 /// best-effort.
+///
+/// Uses `get_by_name` rather than `search` because the species-search GBIF
+/// endpoint returns only the vernacular names embedded inline on the search
+/// result, which is sparse for many taxa (e.g. *Chelydra serpentina* comes
+/// back with no common name). `get_by_name` resolves to the canonical usage
+/// key and then fetches the full species record, which merges in GBIF's
+/// dedicated vernacular-names endpoint and produces a richer match.
 async fn enrich_common_names(state: &AppState, response: &mut IdentifyResponse) {
     let futures: Vec<_> = response
         .suggestions
@@ -79,11 +86,10 @@ async fn enrich_common_names(state: &AppState, response: &mut IdentifyResponse) 
         .map(|(i, s)| {
             let taxonomy = state.taxonomy.clone();
             let name = s.scientific_name.clone();
+            let kingdom = s.kingdom.clone();
             async move {
-                let result = taxonomy.search(&name, Some(1)).await;
-                let common_name = result
-                    .and_then(|results| results.into_iter().next())
-                    .and_then(|t| t.common_name);
+                let result = taxonomy.get_by_name(&name, kingdom.as_deref()).await;
+                let common_name = result.ok().flatten().and_then(|t| t.common_name);
                 (i, common_name)
             }
         })


### PR DESCRIPTION
## Summary
- The AI-suggestions enrichment in \`enrich_common_names\` (\`crates/observing-appview/src/routes/species_id.rs\`) called \`taxonomy.search(name, 1)\` to fill in common names that the species-id model didn't supply. That hits GBIF's \`species/search\` endpoint, which only exposes the vernacular names embedded inline on the search result — sparse for many taxa.
- *Chelydra serpentina* is the canonical reproducer: \`search\` returns the species with no \`vernacularName\`, so the chip showed only the italic scientific name. The species page (which goes through \`get_by_name\` → \`match_name\` + \`species/{key}\` + the dedicated vernacular-names endpoint) renders "Snapping Turtle" correctly.
- Switch the enrichment to \`get_by_name\` and pass the suggestion's kingdom through for disambiguation. Same path the species page uses, same Moka cache, no new requests in steady state.

## Repro
On https://observ.ing/observation/did:plc:vozr2os4b4sxrxr6opde5js5/3mked6tklqi2b → AI Suggestions panel:

| Suggestion | Before | After (expected) |
| --- | --- | --- |
| *Chelydra serpentina* (53%) | (no common name) | Snapping Turtle |
| *Placobdella parasitica* (45%) | (no common name) | (likely populated; verify) |
| *Pectinatella magnifica* (43%) | Magnificent Bryozoan | Magnificent Bryozoan |
| *Sternotherus odoratus* (42%) | Stinkpot Turtle | Stinkpot Turtle |
| *Chelydra acutirostris* (42%) | South American Snapping Turtle | South American Snapping Turtle |

## Test plan
- [ ] \`cargo check -p observing-appview\` (passes locally)
- [ ] \`cargo clippy -p observing-appview\` (passes locally)
- [ ] On staging: open the same observation, hit "Identify with AI", confirm *Chelydra serpentina* now shows "Snapping Turtle" in the chip.
- [ ] Confirm species that already had a common name (e.g. *Pectinatella magnifica*) still render unchanged.