### PR TITLE
chore(species-id): drop dead phylum/class/order/family/genus from suggestions

### DIFF
--- a/crates/observing-appview/src/species_id_client.rs
+++ b/crates/observing-appview/src/species_id_client.rs
@@ -17,18 +17,10 @@ pub struct SpeciesSuggestion {
     pub confidence: f32,
     #[ts(optional)]
     pub common_name: Option<String>,
+    /// Used by the frontend for the taxon link target and passed to GBIF
+    /// match_name as a disambiguator when filling in missing common names.
     #[ts(optional)]
     pub kingdom: Option<String>,
-    #[ts(optional)]
-    pub phylum: Option<String>,
-    #[ts(optional)]
-    pub class: Option<String>,
-    #[ts(optional)]
-    pub order: Option<String>,
-    #[ts(optional)]
-    pub family: Option<String>,
-    #[ts(optional)]
-    pub genus: Option<String>,
     /// Whether this species' iNat range covers the request lat/lon.
     /// Absent when no opinion was formed (no coordinates, no geo index,
     /// or the H3 cell at the request point is unknown to the index).

--- a/crates/observing-species-id/src/embeddings.rs
+++ b/crates/observing-species-id/src/embeddings.rs
@@ -18,7 +18,11 @@ use serde::Deserialize;
 use std::path::Path;
 use tracing::info;
 
-/// Species label metadata loaded from JSON
+/// Species label metadata loaded from JSON.
+///
+/// The on-disk labels file may include richer fields (phylum/class/order/
+/// family/genus etc.) — serde silently ignores them. We only deserialize
+/// the fields that the response actually carries.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct SpeciesLabel {
@@ -27,16 +31,6 @@ pub struct SpeciesLabel {
     pub common_name: Option<String>,
     #[serde(default)]
     pub kingdom: Option<String>,
-    #[serde(default)]
-    pub phylum: Option<String>,
-    #[serde(default)]
-    pub class: Option<String>,
-    #[serde(default)]
-    pub order: Option<String>,
-    #[serde(default)]
-    pub family: Option<String>,
-    #[serde(default)]
-    pub genus: Option<String>,
 }
 
 /// Pre-computed species embeddings and their metadata
@@ -163,11 +157,6 @@ impl SpeciesEmbeddings {
                     confidence: score,
                     common_name: label.common_name.clone(),
                     kingdom: label.kingdom.clone(),
-                    phylum: label.phylum.clone(),
-                    class: label.class.clone(),
-                    order: label.order.clone(),
-                    family: label.family.clone(),
-                    genus: label.genus.clone(),
                     in_range,
                 }
             })
@@ -191,11 +180,6 @@ mod tests {
                 scientific_name: format!("Species {}", i),
                 common_name: None,
                 kingdom: None,
-                phylum: None,
-                class: None,
-                order: None,
-                family: None,
-                genus: None,
             })
             .collect();
         SpeciesEmbeddings {

--- a/crates/observing-species-id/src/types.rs
+++ b/crates/observing-species-id/src/types.rs
@@ -37,18 +37,11 @@ pub struct SpeciesSuggestion {
     pub confidence: f32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub common_name: Option<String>,
+    /// Used by the frontend to build the taxon link target
+    /// (`/taxon/{kingdom}/{slug}`); also passed to GBIF's match_name as a
+    /// disambiguator when the appview enriches missing common names.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub kingdom: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub phylum: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub class: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub order: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub family: Option<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub genus: Option<String>,
     /// Whether this species' iNat range covers the request lat/lon.
     /// `None` when geo lookup wasn't performed (no lat/lon, no geo index)
     /// or when the cell at the request point is unknown to the index — i.e.

--- a/frontend/src/bindings/SpeciesSuggestion.ts
+++ b/frontend/src/bindings/SpeciesSuggestion.ts
@@ -4,12 +4,11 @@ export type SpeciesSuggestion = {
   scientificName: string;
   confidence: number;
   commonName?: string;
+  /**
+   * Used by the frontend for the taxon link target and passed to GBIF
+   * match_name as a disambiguator when filling in missing common names.
+   */
   kingdom?: string;
-  phylum?: string;
-  class?: string;
-  order?: string;
-  family?: string;
-  genus?: string;
   /**
    * Whether this species' iNat range covers the request lat/lon.
    * Absent when no opinion was formed (no coordinates, no geo index,


### PR DESCRIPTION
## Summary
Five \`Option<String>\` fields on \`SpeciesSuggestion\` (\`phylum\`, \`class\`, \`order\`, \`family\`, \`genus\`) were populated by the species-id service from its labels file, sent across the wire to the appview, deserialized, re-serialized to the client, and never read. The frontend (\`AiSuggestions.tsx\` for chip rendering, \`IdentificationPanel.tsx\` for the suggestion-accept handler) consumes only \`scientificName\`, \`confidence\`, \`commonName\`, \`kingdom\`, and \`inRange\`.

\`kingdom\` stays — it's used to build the taxon link target (\`/taxon/{kingdom}/{slug}\`) and is passed to GBIF's \`match_name\` as a disambiguator during the appview's common-name enrichment (#345).

## Wire compatibility
Safe across rolling deploys:
- new species-id → old appview: missing fields default to \`None\` for \`Option\` types
- old species-id → new appview: extra fields are silently ignored (no \`deny_unknown_fields\`)

\`SpeciesLabel\` (the on-disk labels deserializer) was also trimmed; serde ignores the extra fields the labels file may still carry, so no labels-file regeneration is needed.

## Test plan
- [ ] \`cargo check --workspace --offline\` (passes locally)
- [ ] \`cargo clippy --workspace --offline\` (passes locally)
- [ ] \`cargo test -p observing-species-id\` (passes locally)
- [ ] \`cargo test -p observing-appview -- export_bindings\` (regenerated; only \`SpeciesSuggestion.ts\` changed)
- [ ] \`npx tsc --noEmit\` (passes locally)
- [ ] \`npm run fmt:check\` (passes locally)
- [ ] On staging: open the AI Suggest panel; chips render with the same scientific name + common name + in-range badge + confidence + taxon link.