### PR TITLE
fix(ingester): use firehose commit time as createdAt fallback for occurrences

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -99,7 +99,6 @@ pub async fn create_occurrence(
         body.longitude,
         body.coordinate_uncertainty_in_meters,
         body.event_date.as_deref(),
-        None,
         media_refs,
         body.recorded_by.as_deref(),
     )?;
@@ -259,10 +258,6 @@ pub async fn update_occurrence(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
-    let existing_created_at = existing_value
-        .get("createdAt")
-        .and_then(|v| v.as_str())
-        .map(str::to_owned);
 
     // Load the local DB row: its blob_entries are index-aligned with the PDS
     // associatedMedia strong refs (both are written together by create_occurrence),
@@ -307,7 +302,6 @@ pub async fn update_occurrence(
         body.longitude,
         body.coordinate_uncertainty_in_meters,
         body.event_date.as_deref(),
-        existing_created_at.as_deref(),
         media_refs,
         body.recorded_by.as_deref(),
     )?;
@@ -465,16 +459,11 @@ async fn upload_media_records(
 /// `recorded_by` is serialized as the extension field `recordedBy` — it is
 /// not part of the `bio.lexicons.temp.occurrence` schema, but the ingester
 /// reads it back out of the raw record JSON to populate `occurrence_observers`.
-///
-/// `createdAt` is also injected as an extension field — the ingester uses it
-/// for feed ordering. On edit, pass the existing record's `createdAt` so the
-/// post doesn't get bumped to the top of feeds.
 fn build_occurrence_record_json(
     latitude: f64,
     longitude: f64,
     coordinate_uncertainty_in_meters: Option<i32>,
     event_date: Option<&str>,
-    created_at: Option<&str>,
     media_refs: Vec<StrongRef>,
     recorded_by: Option<&[String]>,
 ) -> Result<serde_json::Value, AppError> {
@@ -503,12 +492,10 @@ fn build_occurrence_record_json(
         .build();
 
     let mut value = auth::serialize_at_record(&record)?;
-    if let Some(obj) = value.as_object_mut() {
-        let created_at_str = created_at.map(str::to_owned).unwrap_or(now_rfc3339);
-        obj.insert("createdAt".to_string(), json!(created_at_str));
-        if let Some(dids) = recorded_by {
-            let filtered: Vec<&String> = dids.iter().filter(|d| !d.is_empty()).collect();
-            if !filtered.is_empty() {
+    if let Some(dids) = recorded_by {
+        let filtered: Vec<&String> = dids.iter().filter(|d| !d.is_empty()).collect();
+        if !filtered.is_empty() {
+            if let Some(obj) = value.as_object_mut() {
                 obj.insert("recordedBy".to_string(), json!(filtered));
             }
         }

--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -99,6 +99,7 @@ pub async fn create_occurrence(
         body.longitude,
         body.coordinate_uncertainty_in_meters,
         body.event_date.as_deref(),
+        None,
         media_refs,
         body.recorded_by.as_deref(),
     )?;
@@ -258,6 +259,10 @@ pub async fn update_occurrence(
         .and_then(|v| v.as_array())
         .cloned()
         .unwrap_or_default();
+    let existing_created_at = existing_value
+        .get("createdAt")
+        .and_then(|v| v.as_str())
+        .map(str::to_owned);
 
     // Load the local DB row: its blob_entries are index-aligned with the PDS
     // associatedMedia strong refs (both are written together by create_occurrence),
@@ -302,6 +307,7 @@ pub async fn update_occurrence(
         body.longitude,
         body.coordinate_uncertainty_in_meters,
         body.event_date.as_deref(),
+        existing_created_at.as_deref(),
         media_refs,
         body.recorded_by.as_deref(),
     )?;
@@ -459,11 +465,16 @@ async fn upload_media_records(
 /// `recorded_by` is serialized as the extension field `recordedBy` — it is
 /// not part of the `bio.lexicons.temp.occurrence` schema, but the ingester
 /// reads it back out of the raw record JSON to populate `occurrence_observers`.
+///
+/// `createdAt` is also injected as an extension field — the ingester uses it
+/// for feed ordering. On edit, pass the existing record's `createdAt` so the
+/// post doesn't get bumped to the top of feeds.
 fn build_occurrence_record_json(
     latitude: f64,
     longitude: f64,
     coordinate_uncertainty_in_meters: Option<i32>,
     event_date: Option<&str>,
+    created_at: Option<&str>,
     media_refs: Vec<StrongRef>,
     recorded_by: Option<&[String]>,
 ) -> Result<serde_json::Value, AppError> {
@@ -492,10 +503,12 @@ fn build_occurrence_record_json(
         .build();
 
     let mut value = auth::serialize_at_record(&record)?;
-    if let Some(dids) = recorded_by {
-        let filtered: Vec<&String> = dids.iter().filter(|d| !d.is_empty()).collect();
-        if !filtered.is_empty() {
-            if let Some(obj) = value.as_object_mut() {
+    if let Some(obj) = value.as_object_mut() {
+        let created_at_str = created_at.map(str::to_owned).unwrap_or(now_rfc3339);
+        obj.insert("createdAt".to_string(), json!(created_at_str));
+        if let Some(dids) = recorded_by {
+            let filtered: Vec<&String> = dids.iter().filter(|d| !d.is_empty()).collect();
+            if !filtered.is_empty() {
                 obj.insert("recordedBy".to_string(), json!(filtered));
             }
         }

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -74,6 +74,12 @@ pub struct ParsedOccurrence {
 /// The `record_json` should be the full AT Protocol record value (a `serde_json::Value`).
 /// Fields like `blobs` are extracted from the raw JSON to populate `associated_media`.
 ///
+/// `fallback_time` is used for `created_at` when the record's `createdAt` is
+/// missing or unparseable — typically the firehose commit time, which closely
+/// tracks when the record was authored on the PDS. Using event_date as the
+/// fallback would conflate post time with observation time and make backdated
+/// observations sort to the wrong place in feeds.
+///
 /// Returns a [`ParsedOccurrence`] containing the upsert params and the typed
 /// `recorded_by` list so callers can process co-observers without re-parsing JSON.
 pub fn occurrence_from_json(
@@ -81,6 +87,7 @@ pub fn occurrence_from_json(
     uri: String,
     cid: String,
     did: String,
+    fallback_time: DateTime<Utc>,
 ) -> Result<ParsedOccurrence, ProcessingError> {
     let record_str = record_json.to_string();
     let record: Occurrence =
@@ -135,7 +142,7 @@ pub fn occurrence_from_json(
         .get("createdAt")
         .and_then(|v| v.as_str())
         .and_then(parse_datetime)
-        .unwrap_or(event_date);
+        .unwrap_or(fallback_time);
 
     let recorded_by: Option<Vec<String>> = record_json
         .get("recordedBy")
@@ -860,6 +867,7 @@ mod tests {
             "at://did:plc:author/bio.lexicons.temp.occurrence/xyz".to_string(),
             "bafyreioccurrence".to_string(),
             "did:plc:author".to_string(),
+            Utc::now(),
         )
         .expect("record should parse");
 
@@ -883,6 +891,44 @@ mod tests {
             parsed.params.associated_media.is_none(),
             "synchronous parser should not populate associated_media from strong \
              refs — that is the ingester's async job"
+        );
+    }
+
+    /// `occurrence_from_json` falls back to the supplied time for `created_at`
+    /// when the record's `createdAt` is missing. The ingester passes the
+    /// firehose commit time, which is the right signal for feed ordering —
+    /// using `event_date` instead would sort backdated observations (e.g. an
+    /// observation taken last month but posted today) to the wrong place.
+    #[test]
+    fn test_occurrence_from_json_uses_fallback_time_for_created_at() {
+        let record = serde_json::json!({
+            "$type": "bio.lexicons.temp.occurrence",
+            "decimalLatitude": "37.7749",
+            "decimalLongitude": "-122.4194",
+            "coordinateUncertaintyInMeters": 10,
+            "eventDate": "2024-06-15T08:30:45Z"
+            // no createdAt
+        });
+
+        assert_valid_lexicon::<Occurrence>(&record);
+
+        let fallback = DateTime::parse_from_rfc3339("2026-04-26T12:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let parsed = occurrence_from_json(
+            &record,
+            "at://did:plc:author/bio.lexicons.temp.occurrence/xyz".into(),
+            "bafyreioccurrence".into(),
+            "did:plc:author".into(),
+            fallback,
+        )
+        .expect("record should parse without createdAt");
+
+        assert_eq!(
+            parsed.params.created_at, fallback,
+            "missing createdAt must fall back to the firehose commit time, \
+             not event_date — otherwise feeds sort by observation date"
         );
     }
 }

--- a/crates/observing-ingester/src/bin/backfill.rs
+++ b/crates/observing-ingester/src/bin/backfill.rs
@@ -253,6 +253,7 @@ fn parse_record(
                 record.uri.clone(),
                 record.cid.clone(),
                 did.to_string(),
+                now,
             )?;
         }
         IDENTIFICATION_COLLECTION => {
@@ -322,6 +323,7 @@ async fn process_and_store(
                 record.uri.clone(),
                 record.cid.clone(),
                 did.to_string(),
+                now,
             )?;
             observing_db::occurrences::upsert(pool, &parsed.params).await?;
             let co_observers = processing::extract_co_observers(parsed.recorded_by.as_deref(), did);

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -107,6 +107,7 @@ impl Database {
             commit.uri.clone(),
             commit.cid.clone(),
             commit.did.clone(),
+            commit.time,
         );
 
         // Resolve associatedMedia strong refs → media records → blob entries.


### PR DESCRIPTION
## Summary

Feeds (`crates/observing-db/src/feeds.rs`) sort by `occurrences.created_at DESC`, but `occurrence_from_json` was filling `created_at` from `event_date` whenever the PDS record had no `createdAt` field — which is the case for every record our app currently writes. A freshly-posted observation with `eventDate = 2026-04-11` would appear two weeks back in the feed instead of at the top.

`identification_from_json`, `comment_from_json`, etc. already follow the right pattern: take a `fallback_time: DateTime<Utc>` parameter and use it when the record's `createdAt` is missing. The ingester passes `commit.time` (jetstream's `time_us`, which closely tracks PDS commit time). Only `occurrence_from_json` was using event_date as the fallback instead.

This PR brings occurrence parsing in line with the other types: add `fallback_time` and pass `commit.time` from the ingester (and `Utc::now()` from the backfill binary, matching how it calls every other `*_from_json` function).

No lexicon / record-shape changes. The first commit on this branch attempted to inject `createdAt` as an extension field on the PDS record from the appview — that approach was scrapped because it pollutes the lexicon. The cumulative diff is just the new approach.

## What this does NOT do

No backfill of existing rows. Rows where `created_at == event_date` come from two indistinguishable sources — the bug fixed here, and legitimately backdated PDS records (e.g. iNat imports with their original observation date). Without re-fetching every PDS record we can't tell them apart, and `indexed_at` is mutated on every upsert so it isn't a clean source either. Old rows naturally fall down feeds as new (correctly-stamped) records flow in above them.

## Test plan
- [x] `cargo build -p observing-db -p observing-ingester -p observing-appview`
- [x] `cargo test -p observing-db --features processing` (33 passed, including new `test_occurrence_from_json_uses_fallback_time_for_created_at`)
- [x] `cargo test -p observing-ingester -p observing-appview` (all green)
- [ ] Post a new observation in staging with a backdated `eventDate`; confirm it appears at the top of the explore feed