### PR TITLE
chore(db): drop dead subject_index entry from admin KNOWN_TABLES

### DIFF
--- a/crates/observing-db/src/admin.rs
+++ b/crates/observing-db/src/admin.rs
@@ -285,7 +285,6 @@ pub const KNOWN_TABLES: &[KnownTable] = &[
         name: "community_ids",
         columns: &[
             ("occurrence_uri", "occurrence_uri"),
-            ("subject_index", "subject_index"),
             ("scientific_name", "scientific_name"),
             ("kingdom", "kingdom"),
             ("id_count", "id_count"),


### PR DESCRIPTION
## Summary
- The `20260414000000_drop_subject_index` migration recreated the `community_ids` materialized view without `subject_index`, but `admin.rs` still listed it in the column array.
- The `/admin/tables` endpoint would advertise a column that the view no longer has.

## Test plan
- [ ] `cargo check -p observing-db` succeeds (existing CI build)
- [ ] Manually hit `/admin/tables/community_ids` (or whatever the real route is) and confirm `subject_index` is no longer reported