### PR TITLE
chore(appview): drop unused direct tower dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2903,7 +2903,6 @@ dependencies = [
  "serde_json",
  "sqlx",
  "tokio",
- "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/crates/observing-appview/Cargo.toml
+++ b/crates/observing-appview/Cargo.toml
@@ -31,7 +31,6 @@ tokio = { workspace = true }
 axum = { workspace = true, features = ["macros"] }
 axum-extra = { version = "0.12", features = ["cookie"] }
 tower-http = { workspace = true, features = ["cors", "compression-full", "fs"] }
-tower = { workspace = true }
 
 # Database
 sqlx = { workspace = true }


### PR DESCRIPTION
## Summary
- No source file under `crates/observing-appview/src/` uses `tower::` directly — only `tower_http::*`.
- Tower still gets pulled in transitively via axum, so the runtime/build is unaffected.

## Test plan
- [ ] `cargo check -p observing-appview` passes (already verified locally)
- [ ] CI passes