### PR TITLE
chore(atproto): drop dead service_type/type fields from DID resolver wire types

### DIFF
--- a/crates/atproto-blob-resolver/src/types.rs
+++ b/crates/atproto-blob-resolver/src/types.rs
@@ -11,9 +11,6 @@ pub struct PlcDirectoryResponse {
 #[derive(Debug, Deserialize)]
 pub struct PlcService {
     pub id: String,
-    #[serde(rename = "type")]
-    #[allow(dead_code)]
-    pub service_type: String,
     #[serde(rename = "serviceEndpoint")]
     pub service_endpoint: String,
 }

--- a/crates/atproto-identity/src/types.rs
+++ b/crates/atproto-identity/src/types.rs
@@ -29,8 +29,6 @@ pub struct ResolveResult {
 #[derive(Debug, Clone, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DidDocument {
-    #[allow(dead_code)]
-    pub(crate) id: String,
     pub(crate) also_known_as: Option<Vec<String>>,
     pub(crate) service: Option<Vec<DidService>>,
 }
@@ -39,8 +37,6 @@ pub(crate) struct DidDocument {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct DidService {
     pub(crate) id: String,
-    #[allow(dead_code)]
-    pub(crate) r#type: String,
     pub(crate) service_endpoint: String,
 }
 


### PR DESCRIPTION
## Summary
- The PLC/DID resolver in `atproto-blob-resolver` and `atproto-identity` only reads `id` and `service_endpoint` from each service entry.
- `PlcService.service_type`, `DidService.r#type`, and `DidDocument.id` were carried solely so the structs deserialized completely — each marked `#[allow(dead_code)]`.
- Serde drops unknown JSON keys silently, so removing the fields doesn't break parsing of real DID documents.

## Test plan
- [ ] `cargo test -p atproto-blob-resolver` passes (the existing PLC parsing test still validates round-trip)
- [ ] `cargo test -p atproto-identity` passes