### PR TITLE
chore(atproto-identity): trim Profile to fields actually consumed

### DIFF
--- a/crates/atproto-identity/src/types.rs
+++ b/crates/atproto-identity/src/types.rs
@@ -9,12 +9,7 @@ pub struct Profile {
     pub did: String,
     pub handle: String,
     pub display_name: Option<String>,
-    pub description: Option<String>,
     pub avatar: Option<String>,
-    pub banner: Option<String>,
-    pub followers_count: Option<u64>,
-    pub follows_count: Option<u64>,
-    pub posts_count: Option<u64>,
 }
 
 /// Result of resolving a handle or DID
@@ -56,12 +51,7 @@ pub(crate) struct ProfileResponse {
     pub(crate) did: String,
     pub(crate) handle: String,
     pub(crate) display_name: Option<String>,
-    pub(crate) description: Option<String>,
     pub(crate) avatar: Option<String>,
-    pub(crate) banner: Option<String>,
-    pub(crate) followers_count: Option<u64>,
-    pub(crate) follows_count: Option<u64>,
-    pub(crate) posts_count: Option<u64>,
 }
 
 impl From<ProfileResponse> for Profile {
@@ -70,12 +60,7 @@ impl From<ProfileResponse> for Profile {
             did: resp.did,
             handle: resp.handle,
             display_name: resp.display_name,
-            description: resp.description,
             avatar: resp.avatar,
-            banner: resp.banner,
-            followers_count: resp.followers_count,
-            follows_count: resp.follows_count,
-            posts_count: resp.posts_count,
         }
     }
 }

--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -587,12 +587,7 @@ mod tests {
                 did: "did:plc:alice".to_string(),
                 handle: "alice.bsky.social".to_string(),
                 display_name: Some("Alice".to_string()),
-                description: None,
                 avatar: Some("https://cdn.example.com/avatar.jpg".to_string()),
-                banner: None,
-                followers_count: None,
-                follows_count: None,
-                posts_count: None,
             }),
         );
         let summary = profile_summary("did:plc:alice", &profiles);


### PR DESCRIPTION
## Summary
- `Profile` and the `ProfileResponse` it converts from carried `description / banner / followers_count / follows_count / posts_count`.
- The only consumer (observing-appview's `enrichment.rs`, which feeds the frontend's TS `Profile` binding) reads just `did / handle / display_name / avatar`.
- Drop the unused fields and the corresponding `From` conversion lines. Serde drops unknown JSON keys silently, so the upstream Bluesky API parse still works.

## Test plan
- [ ] `cargo check --workspace` passes (verified locally)
- [ ] `cargo test -p atproto-identity` passes
- [ ] Smoke-test profile-rendering pages — avatar/handle/display_name still resolve end-to-end