### PR TITLE
chore(interactions): drop unused subject_a/b_occurrence_cid from wire

### DIFF
--- a/.sqlx/query-a18f97382781bc63b8fa7a5ebd137c40a377215045e4fbaddc0e6c6b72de0267.json
+++ b/.sqlx/query-a18f97382781bc63b8fa7a5ebd137c40a377215045e4fbaddc0e6c6b72de0267.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did,\n            subject_a_occurrence_uri, subject_a_occurrence_cid,\n            subject_a_taxon_name, subject_a_kingdom,\n            subject_b_occurrence_uri, subject_b_occurrence_cid,\n            subject_b_taxon_name, subject_b_kingdom,\n            interaction_type, direction, comment, created_at, indexed_at\n        FROM interactions\n        WHERE subject_a_occurrence_uri = $1 OR subject_b_occurrence_uri = $1\n        ORDER BY created_at DESC\n        ",
+  "query": "\n        SELECT\n            uri, cid, did,\n            subject_a_occurrence_uri,\n            subject_a_taxon_name, subject_a_kingdom,\n            subject_b_occurrence_uri,\n            subject_b_taxon_name, subject_b_kingdom,\n            interaction_type, direction, comment, created_at, indexed_at\n        FROM interactions\n        WHERE interaction_type = $1\n        ORDER BY created_at DESC\n        LIMIT $2\n        ",
   "describe": {
     "columns": [
       {
@@ -25,76 +25,65 @@
       },
       {
         "ordinal": 4,
-        "name": "subject_a_occurrence_cid",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 5,
         "name": "subject_a_taxon_name",
         "type_info": "Text"
       },
       {
-        "ordinal": 6,
+        "ordinal": 5,
         "name": "subject_a_kingdom",
         "type_info": "Text"
       },
       {
-        "ordinal": 7,
+        "ordinal": 6,
         "name": "subject_b_occurrence_uri",
         "type_info": "Text"
       },
       {
-        "ordinal": 8,
-        "name": "subject_b_occurrence_cid",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
+        "ordinal": 7,
         "name": "subject_b_taxon_name",
         "type_info": "Text"
       },
       {
-        "ordinal": 10,
+        "ordinal": 8,
         "name": "subject_b_kingdom",
         "type_info": "Text"
       },
       {
-        "ordinal": 11,
+        "ordinal": 9,
         "name": "interaction_type",
         "type_info": "Text"
       },
       {
-        "ordinal": 12,
+        "ordinal": 10,
         "name": "direction",
         "type_info": "Text"
       },
       {
-        "ordinal": 13,
+        "ordinal": 11,
         "name": "comment",
         "type_info": "Text"
       },
       {
-        "ordinal": 14,
+        "ordinal": 12,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 15,
+        "ordinal": 13,
         "name": "indexed_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Text"
+        "Text",
+        "Int8"
       ]
     },
     "nullable": [
       false,
       false,
       false,
-      true,
-      true,
       true,
       true,
       true,
@@ -108,5 +97,5 @@
       true
     ]
   },
-  "hash": "d416ed30574f0efaadef690fc0d1f3026c2f6f1a94543b8807823709678fac21"
+  "hash": "a18f97382781bc63b8fa7a5ebd137c40a377215045e4fbaddc0e6c6b72de0267"
 }

--- a/.sqlx/query-ad9a1f33dd76c49bce53c7e316e9e0ac80065f528237525227c60b29438da4ee.json
+++ b/.sqlx/query-ad9a1f33dd76c49bce53c7e316e9e0ac80065f528237525227c60b29438da4ee.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did,\n            subject_a_occurrence_uri, subject_a_occurrence_cid,\n            subject_a_taxon_name, subject_a_kingdom,\n            subject_b_occurrence_uri, subject_b_occurrence_cid,\n            subject_b_taxon_name, subject_b_kingdom,\n            interaction_type, direction, comment, created_at, indexed_at\n        FROM interactions\n        WHERE interaction_type = $1\n        ORDER BY created_at DESC\n        LIMIT $2\n        ",
+  "query": "\n        SELECT\n            uri, cid, did,\n            subject_a_occurrence_uri,\n            subject_a_taxon_name, subject_a_kingdom,\n            subject_b_occurrence_uri,\n            subject_b_taxon_name, subject_b_kingdom,\n            interaction_type, direction, comment, created_at, indexed_at\n        FROM interactions\n        WHERE uri = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -25,77 +25,64 @@
       },
       {
         "ordinal": 4,
-        "name": "subject_a_occurrence_cid",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 5,
         "name": "subject_a_taxon_name",
         "type_info": "Text"
       },
       {
-        "ordinal": 6,
+        "ordinal": 5,
         "name": "subject_a_kingdom",
         "type_info": "Text"
       },
       {
-        "ordinal": 7,
+        "ordinal": 6,
         "name": "subject_b_occurrence_uri",
         "type_info": "Text"
       },
       {
-        "ordinal": 8,
-        "name": "subject_b_occurrence_cid",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
+        "ordinal": 7,
         "name": "subject_b_taxon_name",
         "type_info": "Text"
       },
       {
-        "ordinal": 10,
+        "ordinal": 8,
         "name": "subject_b_kingdom",
         "type_info": "Text"
       },
       {
-        "ordinal": 11,
+        "ordinal": 9,
         "name": "interaction_type",
         "type_info": "Text"
       },
       {
-        "ordinal": 12,
+        "ordinal": 10,
         "name": "direction",
         "type_info": "Text"
       },
       {
-        "ordinal": 13,
+        "ordinal": 11,
         "name": "comment",
         "type_info": "Text"
       },
       {
-        "ordinal": 14,
+        "ordinal": 12,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 15,
+        "ordinal": 13,
         "name": "indexed_at",
         "type_info": "Timestamptz"
       }
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Int8"
+        "Text"
       ]
     },
     "nullable": [
       false,
       false,
       false,
-      true,
-      true,
       true,
       true,
       true,
@@ -109,5 +96,5 @@
       true
     ]
   },
-  "hash": "9853de18559fb5a82c74fc8fe1837235cb6bfcffa68ca7eab34a99414d6a0a2d"
+  "hash": "ad9a1f33dd76c49bce53c7e316e9e0ac80065f528237525227c60b29438da4ee"
 }

--- a/.sqlx/query-fb7b2f33b227f8f418b749c137eed629c6dcf73e50aba727fc9c0b693233eeac.json
+++ b/.sqlx/query-fb7b2f33b227f8f418b749c137eed629c6dcf73e50aba727fc9c0b693233eeac.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did,\n            subject_a_occurrence_uri, subject_a_occurrence_cid,\n            subject_a_taxon_name, subject_a_kingdom,\n            subject_b_occurrence_uri, subject_b_occurrence_cid,\n            subject_b_taxon_name, subject_b_kingdom,\n            interaction_type, direction, comment, created_at, indexed_at\n        FROM interactions\n        WHERE uri = $1\n        ",
+  "query": "\n        SELECT\n            uri, cid, did,\n            subject_a_occurrence_uri,\n            subject_a_taxon_name, subject_a_kingdom,\n            subject_b_occurrence_uri,\n            subject_b_taxon_name, subject_b_kingdom,\n            interaction_type, direction, comment, created_at, indexed_at\n        FROM interactions\n        WHERE subject_a_occurrence_uri = $1 OR subject_b_occurrence_uri = $1\n        ORDER BY created_at DESC\n        ",
   "describe": {
     "columns": [
       {
@@ -25,61 +25,51 @@
       },
       {
         "ordinal": 4,
-        "name": "subject_a_occurrence_cid",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 5,
         "name": "subject_a_taxon_name",
         "type_info": "Text"
       },
       {
-        "ordinal": 6,
+        "ordinal": 5,
         "name": "subject_a_kingdom",
         "type_info": "Text"
       },
       {
-        "ordinal": 7,
+        "ordinal": 6,
         "name": "subject_b_occurrence_uri",
         "type_info": "Text"
       },
       {
-        "ordinal": 8,
-        "name": "subject_b_occurrence_cid",
-        "type_info": "Text"
-      },
-      {
-        "ordinal": 9,
+        "ordinal": 7,
         "name": "subject_b_taxon_name",
         "type_info": "Text"
       },
       {
-        "ordinal": 10,
+        "ordinal": 8,
         "name": "subject_b_kingdom",
         "type_info": "Text"
       },
       {
-        "ordinal": 11,
+        "ordinal": 9,
         "name": "interaction_type",
         "type_info": "Text"
       },
       {
-        "ordinal": 12,
+        "ordinal": 10,
         "name": "direction",
         "type_info": "Text"
       },
       {
-        "ordinal": 13,
+        "ordinal": 11,
         "name": "comment",
         "type_info": "Text"
       },
       {
-        "ordinal": 14,
+        "ordinal": 12,
         "name": "created_at",
         "type_info": "Timestamptz"
       },
       {
-        "ordinal": 15,
+        "ordinal": 13,
         "name": "indexed_at",
         "type_info": "Timestamptz"
       }
@@ -99,8 +89,6 @@
       true,
       true,
       true,
-      true,
-      true,
       false,
       false,
       true,
@@ -108,5 +96,5 @@
       true
     ]
   },
-  "hash": "9b6faa8c1fb5c6978e9cb3f9e8bf17fdab37be36caa65eafb6953a288b702e90"
+  "hash": "fb7b2f33b227f8f418b749c137eed629c6dcf73e50aba727fc9c0b693233eeac"
 }

--- a/crates/observing-db/src/interactions.rs
+++ b/crates/observing-db/src/interactions.rs
@@ -70,9 +70,9 @@ pub async fn get_for_occurrence(
         r#"
         SELECT
             uri, cid, did,
-            subject_a_occurrence_uri, subject_a_occurrence_cid,
+            subject_a_occurrence_uri,
             subject_a_taxon_name, subject_a_kingdom,
-            subject_b_occurrence_uri, subject_b_occurrence_cid,
+            subject_b_occurrence_uri,
             subject_b_taxon_name, subject_b_kingdom,
             interaction_type, direction, comment, created_at, indexed_at
         FROM interactions
@@ -96,9 +96,9 @@ pub async fn get_by_type(
         r#"
         SELECT
             uri, cid, did,
-            subject_a_occurrence_uri, subject_a_occurrence_cid,
+            subject_a_occurrence_uri,
             subject_a_taxon_name, subject_a_kingdom,
-            subject_b_occurrence_uri, subject_b_occurrence_cid,
+            subject_b_occurrence_uri,
             subject_b_taxon_name, subject_b_kingdom,
             interaction_type, direction, comment, created_at, indexed_at
         FROM interactions
@@ -123,9 +123,9 @@ pub async fn get(
         r#"
         SELECT
             uri, cid, did,
-            subject_a_occurrence_uri, subject_a_occurrence_cid,
+            subject_a_occurrence_uri,
             subject_a_taxon_name, subject_a_kingdom,
-            subject_b_occurrence_uri, subject_b_occurrence_cid,
+            subject_b_occurrence_uri,
             subject_b_taxon_name, subject_b_kingdom,
             interaction_type, direction, comment, created_at, indexed_at
         FROM interactions

--- a/crates/observing-db/src/types.rs
+++ b/crates/observing-db/src/types.rs
@@ -181,16 +181,12 @@ pub struct InteractionRow {
     #[ts(optional)]
     pub subject_a_occurrence_uri: Option<String>,
     #[ts(optional)]
-    pub subject_a_occurrence_cid: Option<String>,
-    #[ts(optional)]
     pub subject_a_taxon_name: Option<String>,
     #[ts(optional)]
     pub subject_a_kingdom: Option<String>,
     // Subject B
     #[ts(optional)]
     pub subject_b_occurrence_uri: Option<String>,
-    #[ts(optional)]
-    pub subject_b_occurrence_cid: Option<String>,
     #[ts(optional)]
     pub subject_b_taxon_name: Option<String>,
     #[ts(optional)]

--- a/frontend/src/bindings/EnrichedInteraction.ts
+++ b/frontend/src/bindings/EnrichedInteraction.ts
@@ -11,11 +11,9 @@ export type EnrichedInteraction = {
   cid: string;
   did: string;
   subject_a_occurrence_uri?: string;
-  subject_a_occurrence_cid?: string;
   subject_a_taxon_name?: string;
   subject_a_kingdom?: string;
   subject_b_occurrence_uri?: string;
-  subject_b_occurrence_cid?: string;
   subject_b_taxon_name?: string;
   subject_b_kingdom?: string;
   interaction_type: string;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -396,11 +396,9 @@ export interface InteractionResponse {
   cid: string;
   did: string;
   subject_a_occurrence_uri: string | null;
-  subject_a_occurrence_cid: string | null;
   subject_a_taxon_name: string | null;
   subject_a_kingdom: string | null;
   subject_b_occurrence_uri: string | null;
-  subject_b_occurrence_cid: string | null;
   subject_b_taxon_name: string | null;
   subject_b_kingdom: string | null;
   interaction_type: string;


### PR DESCRIPTION
## Summary
- Frontend declared `subject_a_occurrence_cid` / `subject_b_occurrence_cid` on `EnrichedInteraction.ts` and the manual `InteractionResponse` type in `api.ts` but never read them — only the `*_occurrence_uri` / `*_taxon_name` / `*_kingdom` side gets consumed.
- Drop the fields from `InteractionRow`, the `SELECT` projections in the read paths, and the matching frontend types.
- Upserts still write the underlying columns so existing rows are preserved (no migration needed).

## Test plan
- [ ] `SQLX_OFFLINE=true cargo check --workspace` passes (verified locally; sqlx cache regenerated)
- [ ] `cargo test -p observing-db` passes
- [ ] Smoke-test the interactions feed page — interaction list still renders with creator/taxon names