### PR TITLE
refactor(species-id): move IdentifyRequest into shared protocol crate

### DIFF
--- a/crates/observing-appview/src/species_id_client.rs
+++ b/crates/observing-appview/src/species_id_client.rs
@@ -1,22 +1,12 @@
 use reqwest::Client;
-use serde::Serialize;
 use std::time::Duration;
 
-pub use observing_species_id_protocol::IdentifyResponse;
+pub use observing_species_id_protocol::{IdentifyRequest, IdentifyResponse};
 
 /// HTTP client for the species identification service
 pub struct SpeciesIdClient {
     client: Client,
     base_url: String,
-}
-
-#[derive(Debug, Serialize)]
-#[serde(rename_all = "camelCase")]
-struct IdentifyRequestBody {
-    image: String,
-    latitude: Option<f64>,
-    longitude: Option<f64>,
-    limit: usize,
 }
 
 impl SpeciesIdClient {
@@ -47,7 +37,7 @@ impl SpeciesIdClient {
     ) -> Result<IdentifyResponse, reqwest::Error> {
         let url = format!("{}/identify", self.base_url);
 
-        let body = IdentifyRequestBody {
+        let body = IdentifyRequest {
             image: image_base64.to_string(),
             latitude,
             longitude,

--- a/crates/observing-species-id-protocol/src/lib.rs
+++ b/crates/observing-species-id-protocol/src/lib.rs
@@ -6,6 +6,27 @@
 use serde::{Deserialize, Serialize};
 use ts_rs::TS;
 
+/// Request body for the species-id `/identify` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IdentifyRequest {
+    /// Base64-encoded image data
+    pub image: String,
+    /// Latitude for geo-prior reranking
+    #[serde(default)]
+    pub latitude: Option<f64>,
+    /// Longitude for geo-prior reranking
+    #[serde(default)]
+    pub longitude: Option<f64>,
+    /// Number of suggestions to return (default: 5)
+    #[serde(default = "default_limit")]
+    pub limit: usize,
+}
+
+fn default_limit() -> usize {
+    5
+}
+
 /// A single ranked species suggestion returned by the identification service.
 ///
 /// `kingdom` is used by the frontend for the taxon link target and is passed

--- a/crates/observing-species-id/src/types.rs
+++ b/crates/observing-species-id/src/types.rs
@@ -2,31 +2,12 @@
 //!
 //! The wire types shared with the appview client live in the
 //! `observing-species-id-protocol` crate — re-exported here so existing
-//! `crate::types::{SpeciesSuggestion, IdentifyResponse}` imports keep working.
+//! `crate::types::{IdentifyRequest, IdentifyResponse, SpeciesSuggestion}`
+//! imports keep working.
 
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
-pub use observing_species_id_protocol::{IdentifyResponse, SpeciesSuggestion};
-
-#[derive(Debug, Deserialize)]
-#[serde(rename_all = "camelCase")]
-pub struct IdentifyRequest {
-    /// Base64-encoded image data
-    pub image: String,
-    /// Latitude for geo-prior reranking (reserved for future use)
-    #[serde(default)]
-    pub latitude: Option<f64>,
-    /// Longitude for geo-prior reranking (reserved for future use)
-    #[serde(default)]
-    pub longitude: Option<f64>,
-    /// Number of suggestions to return (default: 5)
-    #[serde(default = "default_limit")]
-    pub limit: usize,
-}
-
-fn default_limit() -> usize {
-    5
-}
+pub use observing_species_id_protocol::{IdentifyRequest, IdentifyResponse, SpeciesSuggestion};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct HealthResponse {


### PR DESCRIPTION
## Summary
- The `/identify` request body was defined twice — `IdentifyRequest` in `observing-species-id`'s `types` module and `IdentifyRequestBody` privately in `observing-appview/src/species_id_client.rs` — describing the same wire shape.
- Move it into the protocol crate alongside `IdentifyResponse` and `SpeciesSuggestion` (where the wire contract belongs) and re-export through the existing locations so consumers don't break.
- Mirrors the previous protocol extraction in #349.

## Test plan
- [ ] `cargo check --workspace` passes (verified locally)
- [ ] `cargo test --workspace` passes
- [ ] Smoke-test species-id end-to-end: open the AI suggestions panel on an observation page and verify suggestions still load