### PR TITLE
fix(upload-modal): autopopulate kingdom from AI species suggestion

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -575,7 +575,12 @@ export function UploadModal() {
                 imageUrl={aiImageUrl}
                 latitude={lat ? parseFloat(lat) : undefined}
                 longitude={lng ? parseFloat(lng) : undefined}
-                onSelect={(s) => setSpecies(s.scientificName)}
+                onSelect={(s) => {
+                  setSpecies(s.scientificName);
+                  if (s.kingdom) {
+                    setKingdom(s.kingdom);
+                  }
+                }}
                 disabled={isSubmitting}
               />
             ) : undefined


### PR DESCRIPTION
## Summary
- The AI suggestion chips render inside `TaxaAutocomplete` as `bottomContent`, so users perceive them as part of the autocomplete suggestions.
- The GBIF dropdown's `onMatchChange` already populated the kingdom select, but the AI chip's `onSelect` only called `setSpecies(s.scientificName)` — leaving the kingdom empty and `required` even though `SpeciesSuggestion` carries a `kingdom` field.
- Mirror the dropdown behavior: when the picked suggestion has a kingdom, also call `setKingdom(s.kingdom)`.

## Test plan
- [ ] Open the upload modal with a photo so AI suggestions appear
- [ ] Click an AI suggestion chip and verify the Kingdom select fills in (e.g. "Plants" for *Quercus*)
- [ ] Submit and confirm the observation gets the right kingdom
- [ ] Sanity-check that the existing GBIF autocomplete dropdown path still autofills + disables the kingdom select