### PR TITLE
rename(upload-modal): label species field as "Taxon (optional)"

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -294,7 +294,7 @@ export function UploadModal() {
     if (trimmedSpecies && !matchedTaxon && !kingdom) {
       dispatch(
         addToast({
-          message: "Please select a kingdom for the species name you entered",
+          message: "Please select a kingdom for the taxon name you entered",
           type: "error",
         }),
       );
@@ -567,7 +567,7 @@ export function UploadModal() {
               setKingdom(match.kingdom);
             }
           }}
-          label="Species (optional)"
+          label="Taxon (optional)"
           placeholder="e.g. Eschscholzia californica - leave blank if unknown"
           bottomContent={
             aiImageUrl && !species ? (

--- a/tests/accessibility.spec.ts
+++ b/tests/accessibility.spec.ts
@@ -34,9 +34,9 @@ authTest.describe("Accessibility - Authenticated", () => {
   authTest("pressing Escape closes upload modal", async ({ authenticatedPage: page }) => {
     await page.goto("/");
     await openUploadModal(page);
-    await authExpect(page.getByLabel(/Species/i)).toBeVisible();
+    await authExpect(page.getByLabel(/Taxon/i)).toBeVisible();
     await page.keyboard.press("Escape");
-    await authExpect(page.getByLabel(/Species/i)).not.toBeVisible();
+    await authExpect(page.getByLabel(/Taxon/i)).not.toBeVisible();
   });
 
   // TC-A11Y-003: Autocomplete keyboard navigation
@@ -45,7 +45,7 @@ authTest.describe("Accessibility - Authenticated", () => {
     await page.goto("/");
     await openUploadModal(page);
 
-    const speciesInput = page.getByLabel(/Species/i);
+    const speciesInput = page.getByLabel(/Taxon/i);
     await speciesInput.click();
     await Promise.all([
       page.waitForResponse((r) => r.url().includes("/api/taxa/search")),

--- a/tests/auto-identification.spec.ts
+++ b/tests/auto-identification.spec.ts
@@ -64,7 +64,7 @@ authTest.describe("Auto-Identification on Upload", () => {
       await page.goto("/");
       await openUploadModal(page);
 
-      const speciesInput = page.getByLabel(/Species/i);
+      const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.click();
       await Promise.all([
         page.waitForResponse((r) => r.url().includes("/api/taxa/search")),

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -24,7 +24,7 @@ authTest.describe("E2E CRUD flow", () => {
       await mockTaxaSearchRoute(page);
       await openUploadModal(page);
 
-      const speciesInput = page.getByLabel(/Species/i);
+      const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.click();
       await Promise.all([
         page.waitForResponse((r) => r.url().includes("/api/taxa/search")),

--- a/tests/helpers/navigation.ts
+++ b/tests/helpers/navigation.ts
@@ -16,5 +16,5 @@ export async function openUploadModal(page: Page) {
   await newObsAction.waitFor({ state: "visible", timeout: 5_000 });
   await newObsAction.click();
   // Wait for the modal content to actually render instead of a fixed delay
-  await page.getByLabel(/Species/i).waitFor({ state: "visible", timeout: 10_000 });
+  await page.getByLabel(/Taxon/i).waitFor({ state: "visible", timeout: 10_000 });
 }

--- a/tests/observation-edit.spec.ts
+++ b/tests/observation-edit.spec.ts
@@ -104,7 +104,7 @@ authTest.describe("Observation Edit - Logged In", () => {
     await authExpect(page.getByText("Edit Observation")).toBeVisible({ timeout: 5000 });
 
     // Species input should have value
-    const speciesInput = page.getByLabel(/Species/i);
+    const speciesInput = page.getByLabel(/Taxon/i);
     await authExpect(speciesInput).toHaveValue("Quercus alba");
   });
 

--- a/tests/species-input.spec.ts
+++ b/tests/species-input.spec.ts
@@ -5,7 +5,7 @@ import { mockOwnObservationFeed } from "./helpers/mock-observation";
 
 /** Type into the species input and wait for the autocomplete options to appear. */
 async function searchSpecies(page: import("@playwright/test").Page, query: string) {
-  const speciesInput = page.getByLabel(/Species/i);
+  const speciesInput = page.getByLabel(/Taxon/i);
   await speciesInput.click();
   await Promise.all([
     page.waitForResponse(
@@ -90,7 +90,7 @@ authTest.describe("Species Input", () => {
     async ({ authenticatedPage: page }) => {
       await searchSpecies(page, "quercus");
       await page.locator(".MuiAutocomplete-option").first().click();
-      const speciesInput = page.getByLabel(/Species/i);
+      const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.fill("My Custom Species");
       const kingdomCombo = page.getByRole("combobox", { name: "Kingdom" });
       await authExpect(kingdomCombo).not.toHaveAttribute("aria-disabled", "true");

--- a/tests/upload.spec.ts
+++ b/tests/upload.spec.ts
@@ -37,7 +37,7 @@ authTest.describe("Upload Modal - Logged In", () => {
     await page.goto("/");
     await openUploadModal(page);
     await page.getByRole("button", { name: "Cancel" }).click();
-    await authExpect(page.getByLabel(/Species/i)).not.toBeVisible();
+    await authExpect(page.getByLabel(/Taxon/i)).not.toBeVisible();
   });
 
   // TC-UPLOAD-003: Authenticated mode banner
@@ -56,7 +56,7 @@ authTest.describe("Upload Modal - Logged In", () => {
     });
     if (await poppyChip.isVisible()) {
       await poppyChip.click();
-      const speciesInput = page.getByLabel(/Species/i);
+      const speciesInput = page.getByLabel(/Taxon/i);
       await authExpect(speciesInput).not.toHaveValue("");
     }
   });
@@ -67,7 +67,7 @@ authTest.describe("Upload Modal - Logged In", () => {
     async ({ authenticatedPage: page }) => {
       await page.goto("/");
       await openUploadModal(page);
-      const speciesInput = page.getByLabel(/Species/i);
+      const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.click();
       await Promise.all([
         page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
@@ -121,7 +121,7 @@ authTest.describe("Upload Modal - Logged In", () => {
     await page.goto("/");
     await openUploadModal(page);
 
-    const speciesInput = page.getByLabel(/Species/i);
+    const speciesInput = page.getByLabel(/Taxon/i);
     await speciesInput.fill("Quercus alba");
     const option = page.locator(".MuiAutocomplete-option").first();
     if (await option.isVisible({ timeout: 3000 }).catch(() => false)) {


### PR DESCRIPTION
## Summary
- The upload modal's species field is for any taxonomic rank — observers can record a genus, family, etc., not just a species. The "Species" label was misleading.
- Rename the visible label to **Taxon (optional)** and update the matching toast ("select a kingdom for the taxon name you entered").
- Internal state names (`species`/`setSpecies`) and the placeholder example are left alone to keep the diff scoped.
- Test selectors that found the input via `getByLabel(/Species/i)` switch to `/Taxon/i` so they keep matching.

## Test plan
- [ ] Open the upload modal and confirm the field renders as "Taxon (optional)"
- [ ] Type a free-text taxon name without picking a GBIF match and submit; the kingdom-required toast should now read "Please select a kingdom for the taxon name you entered"
- [ ] `npm run test:integration` still passes (label-based selectors updated to `/Taxon/i`)