### PR TITLE
feat(frontend): show offline banner when network is unavailable (PWA Phase 3)

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,6 +20,7 @@ import { DeleteConfirmDialog } from "./components/modals/DeleteConfirmDialog";
 import { FAB } from "./components/common/FAB";
 import { ToastContainer } from "./components/common/Toast";
 import { NotFound } from "./components/common/NotFound";
+import { OfflineBanner } from "./components/common/OfflineBanner";
 import { LexiconView } from "./components/lexicon/LexiconView";
 import { NotificationsPage } from "./components/notifications/NotificationsPage";
 import { SettingsPage } from "./components/settings/SettingsPage";
@@ -76,6 +77,7 @@ function AppContent() {
 
   return (
     <Box sx={{ display: "flex", flex: 1, flexDirection: "column", minHeight: 0 }}>
+      <OfflineBanner />
       {!showLanding && (
         <>
           <TopBar onMobileMenuClick={handleDrawerOpen} unreadCount={unreadCount} />

--- a/frontend/src/components/common/OfflineBanner.tsx
+++ b/frontend/src/components/common/OfflineBanner.tsx
@@ -1,0 +1,38 @@
+import { useEffect, useState } from "react";
+import { Alert } from "@mui/material";
+
+export function OfflineBanner() {
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+    window.addEventListener("online", handleOnline);
+    window.addEventListener("offline", handleOffline);
+    return () => {
+      window.removeEventListener("online", handleOnline);
+      window.removeEventListener("offline", handleOffline);
+    };
+  }, []);
+
+  if (isOnline) return null;
+
+  return (
+    <Alert
+      severity="info"
+      sx={{
+        borderRadius: 0,
+        py: 0.5,
+        flexShrink: 0,
+        borderBottom: 1,
+        borderColor: "info.main",
+        "& .MuiAlert-message": {
+          width: "100%",
+          textAlign: "center",
+        },
+      }}
+    >
+      You're offline. Some content may be unavailable until you reconnect.
+    </Alert>
+  );
+}


### PR DESCRIPTION
## Summary
Phase 3 of the PWA rollout. The service worker (#366) already lets the app shell render offline; this gives users an in-context cue that explains why fetched data may be missing or stale, instead of leaving them staring at empty states.

- New `OfflineBanner` component (`frontend/src/components/common/OfflineBanner.tsx`) — info-severity MUI Alert that renders only when `navigator.onLine` is false, driven by the `online` / `offline` window events
- Mounted at the top of `AppContent`'s layout, above the existing pre-release banner. Visible on every route including the landing page

### Caveat: `navigator.onLine` is a coarse signal
It returns `false` only when the OS reports no network interfaces, and `true` even when connected to a captive portal or a network that can't reach our backend. So this banner catches "no wifi / airplane mode" cleanly, but won't catch all network problems users experience. A more accurate offline indicator would track failed API calls — that's worth doing later if users complain, but this is the canonical first step and the standard PWA pattern.

## Test plan
- [ ] DevTools → Network → Offline: banner appears at the top within ~1s
- [ ] Switch back to Online: banner disappears
- [ ] Banner shows on `/` (landing), feed, observation detail, etc.
- [ ] Build, typecheck, lint, audit all green (verified locally)