### PR TITLE
feat(frontend): runtime-cache taxa lookups and media blobs (PWA Phase 4)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,6 +20,44 @@ export default defineConfig({
         // Bumped from default 2 MiB so the current bundle precaches.
         // Code-splitting is the proper fix; tracked separately.
         maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
+        // Only cache routes whose responses are independent of the viewer.
+        // /api/taxa/{...}/occurrences and other enrichment-touched routes
+        // embed `viewer_has_liked` and must NOT be cached without per-user
+        // keying.
+        runtimeCaching: [
+          {
+            urlPattern: ({ url, sameOrigin, request }) =>
+              sameOrigin &&
+              request.method === "GET" &&
+              url.pathname.startsWith("/api/taxa/") &&
+              !url.pathname.endsWith("/occurrences"),
+            handler: "StaleWhileRevalidate",
+            options: {
+              cacheName: "taxa",
+              expiration: {
+                maxEntries: 200,
+                maxAgeSeconds: 7 * 24 * 60 * 60,
+              },
+              cacheableResponse: { statuses: [200] },
+            },
+          },
+          {
+            urlPattern: ({ url, sameOrigin, request }) =>
+              sameOrigin &&
+              request.method === "GET" &&
+              /^\/media\/(blob|thumb)\/[^/]+\/[^/]+$/.test(url.pathname),
+            handler: "CacheFirst",
+            options: {
+              cacheName: "media",
+              expiration: {
+                maxEntries: 100,
+                maxAgeSeconds: 30 * 24 * 60 * 60,
+                purgeOnQuotaError: true,
+              },
+              cacheableResponse: { statuses: [200] },
+            },
+          },
+        ],
       },
     }),
   ],

--- a/tests/playwright.config.ts
+++ b/tests/playwright.config.ts
@@ -16,6 +16,11 @@ export default defineConfig({
     navigationTimeout: 30_000,
     trace: "on-first-retry",
     screenshot: "only-on-failure",
+    // Block the PWA service worker. Playwright's page.route() does not
+    // intercept fetches made from a service worker, so an active SW would
+    // route around our mock fixtures (e.g. /api/taxa/*) and hit the real
+    // backend. App behavior under the SW should be tested separately.
+    serviceWorkers: "block",
   },
   projects: [
     // Real e2e: signs in to Bluesky and runs a CRUD flow against the live PDS.


### PR DESCRIPTION
## Summary
Phase 4 of the PWA rollout — selective runtime caching of API responses in the service worker. Strictly limited to endpoints whose responses are independent of the logged-in viewer, so there is **zero risk of cached data leaking across users**.

### What's cached

| Pattern | Strategy | Cache | Expiration | Notes |
|---|---|---|---|---|
| `/api/taxa/{...}` (excluding `/occurrences`) | `StaleWhileRevalidate` | `taxa` | 200 entries, 7 days | Pure GBIF taxonomy lookups (`get_taxon_by_id`, `get_children_by_kingdom_name`, `search`, `validate`). No enrichment, no viewer state. |
| `/media/(blob\|thumb)/{did}/{cid}` | `CacheFirst` | `media` | 100 entries, 30 days, `purgeOnQuotaError` | URLs are content-addressed by CID — once cached, the response never changes within the maxAge. |

Both rules also gate on `sameOrigin` and `request.method === "GET"`, and use `cacheableResponse: { statuses: [200] }` so error responses don't poison the cache.

### What's deliberately **not** cached

Anything routed through `crates/observing-appview/src/enrichment.rs::enrich_occurrences`, which adds per-viewer fields like `viewer_has_liked` to the response body. Caching those by URL alone would mean user A's "liked" state could be served to user B on a cache hit. That covers:
- `/api/occurrences/*`, `/api/feeds/*`, `/api/identifications/*`, `/api/interactions/*`, `/api/profiles/*`
- `/api/taxa/{kingdom}/{name}/occurrences` and `/api/taxa/{id}/occurrences`

Caching these is doable but requires a per-user cache-keying plugin (~30 lines of custom Workbox code) and tight test coverage. Worth a separate PR if/when we decide the perf win justifies the complexity.

Mutations (`POST`/`PUT`/`DELETE`), `/oauth/*`, and admin routes are pass-through — they don't match either pattern and the `navigateFallbackDenylist` already excludes them from the navigation handler.

### Why these strategies

- **`StaleWhileRevalidate` for taxa**: instant load from cache on repeat visits, fresh data fetched in the background for the next visit. Tolerable staleness for GBIF reference data.
- **`CacheFirst` for media**: content-addressed URLs are immutable, so once cached we should serve the cached blob without touching the network. `purgeOnQuotaError` lets Workbox auto-evict if the user runs out of storage.

### Test infrastructure

Two changes to the test setup:

1. **`serviceWorkers: "block"`** in the global Playwright config. Without this, `species-input.spec.ts` flakes because Playwright's `page.route()` does not intercept fetches made from a service worker — so the SW would route around `mockTaxaSearchRoute` and hit the real backend, returning whatever GBIF sorts first (e.g. `Quercusia quercus`, a butterfly, instead of the mocked `Quercus alba`).
2. **`tests/pwa.spec.ts`** — new spec that overrides `serviceWorkers: "allow"` for itself and exercises the SW directly. Five tests:
   - SW registers and controls the page after first load
   - Generated `sw.js` contains the runtime caching rules (catches silent `vite.config.ts` regressions)
   - Workbox precache contains `/manifest.webmanifest`
   - App shell loads after going offline and reloading
   - `/unregister.html` kill switch clears all registrations and caches

Combined, the rest of the test suite runs as if the SW didn't exist (clean, deterministic mocks), while a small dedicated spec asserts the SW infrastructure works.

## Test plan
- [x] `npm run build` succeeds; generated `sw.js` contains both `registerRoute` calls (verified via grep)
- [x] `npm audit --audit-level=high`, `npm run lint`, `npx tsc` all clean
- [ ] CI e2e passes — both the existing `species-input.spec.ts` (SW now blocked, mocks work) and the new `pwa.spec.ts` (SW allowed, infrastructure asserted)
- [ ] Visit a taxon page online; reload offline — taxonomy chrome still renders from cache
- [ ] Scroll a feed online; reload offline — already-loaded thumbnails still render from cache, new ones fail (expected)
- [ ] Log out; log in as a different user; visit taxa pages — no cross-user contamination
- [ ] Visit `/api/occurrences/at://...` directly while offline → 503/network error (this endpoint is intentionally NOT cached)
- [ ] DevTools → Application → Cache Storage shows separate `taxa` and `media` caches with bounded entry counts