### PR TITLE
fix(db): re-issue runtime grants under post-rename role names

### DIFF
--- a/crates/observing-db/migrations/20260428000001_grant_runtime_roles.sql
+++ b/crates/observing-db/migrations/20260428000001_grant_runtime_roles.sql
@@ -1,0 +1,87 @@
+-- Re-issue runtime grants against the post-rename role names.
+--
+-- Earlier migrations granted to the pre-rename roles `appview_reader`
+-- (20260418, 20260419) and `ingester_writer` (20260421). The rename
+-- migrations (20260422, 20260423) preserved those grants on databases that
+-- already had them — but on a from-scratch migrate (e.g. after a wipe),
+-- every grant migration silently no-ops because the pre-rename roles no
+-- longer exist (role memberships at the Cloud SQL instance level survive
+-- DROP DATABASE), and the rename migrations also no-op because the
+-- post-rename roles already exist. Net effect: runtime roles end up with
+-- zero privileges and the services crashloop.
+--
+-- This migration is the canonical source of truth for runtime grants
+-- against the current role names. Older grant migrations are kept for
+-- history; their effect is now subsumed here for any DB where the renames
+-- have already happened.
+--
+-- Idempotent (REVOKE-then-GRANT, OWNER TO is unconditional). No-op on
+-- local/CI where the runtime roles don't exist.
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'appview_runtime') THEN
+        RAISE NOTICE 'appview_runtime role not found; skipping grants (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA public FROM appview_runtime';
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA ingester FROM appview_runtime';
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA appview FROM appview_runtime';
+    EXECUTE 'REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM appview_runtime';
+
+    EXECUTE 'GRANT USAGE ON SCHEMA ingester, appview, public TO appview_runtime';
+
+    -- ingester: SELECT-only, plus UPDATE on notifications.read.
+    EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA ingester TO appview_runtime';
+    EXECUTE 'GRANT UPDATE ON TABLE ingester.notifications TO appview_runtime';
+
+    -- appview: full CRUD (OAuth + private location + notification_reads).
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA appview
+             TO appview_runtime';
+
+    -- public: sensitive_species reference data.
+    EXECUTE 'GRANT SELECT ON TABLE public.sensitive_species TO appview_runtime';
+
+    EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ingester
+             GRANT SELECT ON TABLES TO appview_runtime';
+    EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA appview
+             GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO appview_runtime';
+END
+$$;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_runtime') THEN
+        RAISE NOTICE 'ingester_runtime role not found; skipping grants (expected on local/CI)';
+        RETURN;
+    END IF;
+
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA ingester FROM ingester_runtime';
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA appview FROM ingester_runtime';
+    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA public FROM ingester_runtime';
+    EXECUTE 'REVOKE ALL ON ALL SEQUENCES IN SCHEMA ingester FROM ingester_runtime';
+
+    EXECUTE 'GRANT USAGE ON SCHEMA ingester, appview, public TO ingester_runtime';
+
+    -- ingester: full CRUD on tables, plus sequence access for BIGSERIAL nextval().
+    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ingester
+             TO ingester_runtime';
+    EXECUTE 'GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA ingester
+             TO ingester_runtime';
+
+    -- appview: backfill --all reads oauth_sessions to discover known DIDs.
+    EXECUTE 'GRANT SELECT ON TABLE appview.oauth_sessions TO ingester_runtime';
+
+    -- public: sensitive_species reference data.
+    EXECUTE 'GRANT SELECT ON TABLE public.sensitive_species TO ingester_runtime';
+
+    -- REFRESH MATERIALIZED VIEW CONCURRENTLY requires ownership.
+    EXECUTE 'ALTER MATERIALIZED VIEW ingester.community_ids OWNER TO ingester_runtime';
+
+    EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ingester
+             GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ingester_runtime';
+    EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ingester
+             GRANT USAGE, SELECT, UPDATE ON SEQUENCES TO ingester_runtime';
+END
+$$;

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -102,6 +102,55 @@ DATABASE_URL=<secret: observing-db-admin-url>
 
 Developer note: there is **no** `DATABASE_URL` with `DB_USER=postgres` on any long-running service. If you see a local config that sets it, it's stale.
 
+## Wiping the database (pre-launch)
+
+While the project is pre-launch, occasionally we want a clean slate: drop all
+data and re-run migrations from scratch. The trick is that the app tables
+live across three schemas (`public`, `ingester`, `appview`), the sqlx
+migrations ledger lives in `ingester._sqlx_migrations`, and runtime role
+memberships persist at the Cloud SQL instance level (so you can't undo
+"renames already happened" by dropping the database).
+
+```bash
+# 1. Pause the writer.
+gcloud run services update observing-ingester --region=us-central1 --min-instances=0
+
+# 2. Connect via the Cloud SQL proxy as superuser.
+gcloud auth application-default login   # if ADC is stale
+cloud-sql-proxy observ-ing:us-central1:observing-db --port=5433 &
+ADMIN_URL=$(gcloud secrets versions access latest --secret=observing-db-admin-url)
+PGPASSWORD=$(python3 -c "import urllib.parse,sys; print(urllib.parse.urlparse(sys.argv[1]).password)" "$ADMIN_URL") \
+  psql -h 127.0.0.1 -p 5433 -U postgres -d observing <<'SQL'
+BEGIN;
+DROP SCHEMA IF EXISTS appview CASCADE;
+DROP SCHEMA IF EXISTS ingester CASCADE;
+DROP SCHEMA IF EXISTS public CASCADE;
+CREATE SCHEMA public;
+GRANT ALL ON SCHEMA public TO postgres;
+GRANT USAGE ON SCHEMA public TO public;
+COMMIT;
+SQL
+
+# 3. Re-run migrations.
+gcloud run jobs execute observing-migrate --region=us-central1 --wait
+
+# 4. Bounce both services so they pick up fresh connections.
+gcloud run services update observing-ingester --region=us-central1 --min-instances=1 --update-env-vars=BOUNCE=$(date +%s)
+gcloud run services update observing-appview  --region=us-central1 --update-env-vars=BOUNCE=$(date +%s)
+
+# 5. Stop the proxy.
+pkill -f "cloud-sql-proxy observ-ing"
+```
+
+Why drop *all* the schemas, not just `public`: the app tables and the sqlx
+migrations ledger live in `ingester`/`appview`. Dropping only `public` leaves
+the ledger intact, which makes the next migrate Job a no-op.
+
+The grant migrations (20260418, 20260419, 20260421) target the pre-rename
+role names; on a from-scratch migrate they no-op. Migration 20260428000001
+re-issues the canonical grants against `appview_runtime` / `ingester_runtime`
+so this runbook produces a working DB without manual grant SQL.
+
 ## Local development
 
 For running the stack locally, see `docs/development.md`.


### PR DESCRIPTION
## Summary

- Adds migration `20260428000001_grant_runtime_roles.sql` that re-issues the canonical runtime grants against the current role names (`appview_runtime` / `ingester_runtime`).
- Adds a "Wiping the database (pre-launch)" runbook to `docs/deployment.md`.

## Why

The grant migrations (20260418, 20260419, 20260421) target the pre-rename roles `appview_reader` / `ingester_writer`. The rename migrations (20260422, 20260423) preserved grants on databases where they already existed, but on a from-scratch migrate against the Cloud SQL instance — i.e. anytime we wipe the database — both behaviors line up the wrong way:

- The pre-rename roles no longer exist, so the grant migrations silently no-op.
- The post-rename roles already exist (role memberships persist at the instance level, surviving DROP DATABASE), so the rename migrations also no-op.

Net effect: runtime roles end up with zero privileges and both services crashloop on startup with `relation "ingester_state" does not exist`. This bit us today during a wipe.

The new migration is idempotent (REVOKE-then-GRANT, OWNER TO is unconditional) and a no-op on local/CI where the runtime roles don't exist.

The existing rename migrations are unmodified — sqlx checksums applied migrations on each run, so editing history would break the next deploy.

## Test plan

- [ ] CI passes — the new migration's role-existence guard means it no-ops on the CI postgres without runtime roles
- [ ] Verify `cargo sqlx prepare --check` (or equivalent) still passes; this migration only changes grants, no schema or query changes
- [ ] Next deploy to prod runs the new migration successfully (REVOKE-then-GRANT against grants already applied by hand today — same end state)
- [ ] Try a wipe end-to-end against the documented runbook and confirm both services come up clean without manual grant SQL