### PR TITLE
fix(taxonomy): italicize genus-rank scientific names

### DIFF
--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -70,6 +70,10 @@ pub struct EffectiveTaxonomy {
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub vernacular_name: Option<String>,
+    /// Lowercase Darwin Core rank of `scientific_name` (e.g. "genus", "species").
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub rank: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     #[ts(optional)]
     pub kingdom: Option<String>,
@@ -272,6 +276,7 @@ async fn resolve_effective_taxonomy(
         return Some(EffectiveTaxonomy {
             scientific_name: detail.scientific_name,
             vernacular_name: detail.common_name,
+            rank: Some(detail.rank.to_lowercase()),
             kingdom: detail.kingdom,
             phylum: detail.phylum,
             class: detail.class,
@@ -289,6 +294,7 @@ async fn resolve_effective_taxonomy(
         return Some(EffectiveTaxonomy {
             scientific_name: id.scientific_name.clone(),
             vernacular_name: None,
+            rank: id.taxon_rank.as_deref().map(str::to_lowercase),
             kingdom: id.kingdom.clone(),
             phylum: id.phylum.clone(),
             class: id.class.clone(),
@@ -302,6 +308,7 @@ async fn resolve_effective_taxonomy(
     Some(EffectiveTaxonomy {
         scientific_name: effective_name.to_string(),
         vernacular_name: None,
+        rank: None,
         kingdom: None,
         phylum: None,
         class: None,

--- a/frontend/src/bindings/EffectiveTaxonomy.ts
+++ b/frontend/src/bindings/EffectiveTaxonomy.ts
@@ -3,6 +3,10 @@
 export type EffectiveTaxonomy = {
   scientificName: string;
   vernacularName?: string;
+  /**
+   * Lowercase Darwin Core rank of `scientific_name` (e.g. "genus", "species").
+   */
+  rank?: string;
   kingdom?: string;
   phylum?: string;
   class?: string;

--- a/frontend/src/components/feed/ExploreGridCard.tsx
+++ b/frontend/src/components/feed/ExploreGridCard.tsx
@@ -59,7 +59,10 @@ export const ExploreGridCard = memo(function ExploreGridCard({
           <Typography
             variant="body2"
             sx={{
-              fontStyle: species && shouldItalicizeTaxonName(species) ? "italic" : "normal",
+              fontStyle:
+                species && shouldItalicizeTaxonName(species, observation.effectiveTaxonomy?.rank)
+                  ? "italic"
+                  : "normal",
               color: "primary.main",
               fontWeight: 500,
               overflow: "hidden",

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -198,7 +198,7 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
               <TaxonLink
                 name={species}
                 kingdom={taxonomy?.kingdom}
-                rank={undefined}
+                rank={taxonomy?.rank}
                 onClick={(e) => e.stopPropagation()}
               />
             ) : (

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -268,7 +268,7 @@ export function ObservationDetail() {
         {/* Species Header */}
         <Box sx={{ px: 3, pt: 2, pb: 1 }}>
           {species ? (
-            <TaxonLink name={species} kingdom={taxonomy?.kingdom} />
+            <TaxonLink name={species} kingdom={taxonomy?.kingdom} rank={taxonomy?.rank} />
           ) : (
             <Typography
               variant="h5"

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -335,6 +335,7 @@ export function ProfileView() {
                     sx={{
                       fontStyle: shouldItalicizeTaxonName(
                         occ.communityId || occ.effectiveTaxonomy?.scientificName || "",
+                        occ.effectiveTaxonomy?.rank,
                       )
                         ? "italic"
                         : "normal",


### PR DESCRIPTION
## Summary
- `EffectiveTaxonomy` returned by the appview did not include a rank for `scientificName`, so consumers had no way to tell `TaxonLink`/`shouldItalicizeTaxonName` what rank they were rendering. The italic heuristic fell back to "italicize only multi-word names," leaving single-word genus names (e.g. *Glechoma*) upright on the observation page, feed cards, profile grid, and explore grid.
- Add a lowercase `rank` field to `EffectiveTaxonomy`, populated from the GBIF `TaxonDetail.rank` and from the identification fallback's `taxon_rank`. Pass it from each affected consumer.

## Test plan
- [x] `cargo test -p observing-appview` (52 passed, ts-rs binding regenerated)
- [x] `tsc --noEmit` clean, `oxlint` shows no new warnings
- [x] Inserted a test occurrence + identification at genus rank for *Glechoma*; confirmed `/api/occurrences/...` returns `effectiveTaxonomy.rank: "genus"` and the species header + identification history both render in italic in the browser
- [ ] Spot-check feed and profile views on a deployment with real genus-level observations