### PR TITLE
feat(ingester): use Slingshot edge cache for media record fetches

### DIFF
--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -77,8 +77,9 @@ pub struct Database {
 }
 
 impl Database {
-    /// Connect to the database
-    pub async fn connect(database_url: &str) -> Result<Self> {
+    /// Connect to the database. `slingshot_url` is the optional Slingshot
+    /// endpoint for media record fetches; `None` keeps the direct-PDS path.
+    pub async fn connect(database_url: &str, slingshot_url: Option<String>) -> Result<Self> {
         info!("Connecting to database...");
         let pool = PgPoolOptions::new()
             .max_connections(10)
@@ -89,7 +90,7 @@ impl Database {
         info!("Database connection established");
         Ok(Self {
             pool,
-            media_resolver: MediaResolver::new(),
+            media_resolver: MediaResolver::new(slingshot_url),
         })
     }
 

--- a/crates/observing-ingester/src/main.rs
+++ b/crates/observing-ingester/src/main.rs
@@ -58,6 +58,10 @@ async fn main() -> Result<()> {
     info!("Relay: {}", config.relay_url);
     info!("Port: {}", config.port);
     info!("Collections: {:?}", config.collections);
+    match &config.slingshot_url {
+        Some(url) => info!("Slingshot: {} (media fetches will try this first)", url),
+        None => info!("Slingshot: disabled (media fetches go directly to PDSes)"),
+    }
 
     // Create shared state for HTTP server
     let state: SharedState = Arc::new(RwLock::new(ServerState::new()));
@@ -74,7 +78,7 @@ async fn main() -> Result<()> {
     // Migrations run out-of-band in a dedicated Cloud Run Job; see
     // crates/observing-migrate. The runtime role used here has no DDL
     // privileges and should never attempt to migrate.
-    let db = Database::connect(&config.database_url).await?;
+    let db = Database::connect(&config.database_url, config.slingshot_url.clone()).await?;
 
     // Load saved cursor
     let saved_cursor = db.get_cursor().await?;
@@ -105,8 +109,10 @@ async fn main() -> Result<()> {
         }
     });
 
-    // Spawn cursor saver (every 30 seconds)
-    let cursor_db = Database::connect(&config.database_url).await?;
+    // Spawn cursor saver (every 30 seconds). The cursor path doesn't fetch
+    // media, so the slingshot URL is irrelevant here — pass None to keep this
+    // resolver inert.
+    let cursor_db = Database::connect(&config.database_url, None).await?;
     let cursor_state = state.clone();
     tokio::spawn(async move {
         let mut ticker = interval(Duration::from_secs(30));
@@ -283,6 +289,14 @@ fn load_config(cli: &Cli) -> Result<IngesterConfig> {
         .and_then(|s| s.parse::<u16>().ok())
         .unwrap_or(8080);
 
+    // Slingshot is opt-in. When set (e.g. https://slingshot.microcosm.blue),
+    // the media resolver tries it first to avoid plc.directory + cold-PDS
+    // round trips. Empty string is treated as unset.
+    let slingshot_url = std::env::var("SLINGSHOT_URL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
     let collections = match &cli.collections {
         Some(names) => resolve_collection_names(names).map_err(IngesterError::Config)?,
         None => ALL_COLLECTIONS
@@ -297,5 +311,6 @@ fn load_config(cli: &Cli) -> Result<IngesterConfig> {
         cursor,
         port,
         collections,
+        slingshot_url,
     })
 }

--- a/crates/observing-ingester/src/media_resolver.rs
+++ b/crates/observing-ingester/src/media_resolver.rs
@@ -6,6 +6,12 @@
 //! only the strong refs, so the ingester performs the network round trip to
 //! materialize the blobs into the `associated_media` JSONB column.
 //!
+//! When a Slingshot endpoint is configured, the resolver tries it first.
+//! Slingshot is a firehose-warmed edge cache (https://slingshot.microcosm.blue)
+//! that mirrors `com.atproto.repo.getRecord`, so a hit avoids both the
+//! plc.directory DID lookup and the cold PDS round trip. On any non-success
+//! response the resolver falls back to the direct PDS path.
+//!
 //! Best-effort: if a media record cannot be fetched (e.g. firehose
 //! out-of-order delivery, PDS error), that ref is skipped with a warning
 //! rather than failing the whole occurrence upsert. Most of the time media
@@ -22,21 +28,27 @@ use serde_json::Value;
 use std::time::Duration;
 use tracing::warn;
 
-/// Fetches `bio.lexicons.temp.v0-1.media` records from PDSes and converts them to
-/// the `BlobEntry` shape stored in `occurrences.associated_media`.
+/// Fetches `bio.lexicons.temp.v0-1.media` records from PDSes (or Slingshot when
+/// configured) and converts them to the `BlobEntry` shape stored in
+/// `occurrences.associated_media`.
 pub struct MediaResolver {
     client: Client,
     blob_resolver: BlobResolver,
+    /// Optional Slingshot base URL (e.g. `https://slingshot.microcosm.blue`).
+    /// Trailing slash is normalized away at construction.
+    slingshot_url: Option<String>,
 }
 
 impl MediaResolver {
-    pub fn new() -> Self {
+    pub fn new(slingshot_url: Option<String>) -> Self {
         Self {
             client: Client::builder()
                 .timeout(Duration::from_secs(10))
+                .user_agent(concat!("observing-ingester/", env!("CARGO_PKG_VERSION")))
                 .build()
                 .expect("reqwest client build should not fail with defaults"),
             blob_resolver: BlobResolver::new(),
+            slingshot_url: slingshot_url.map(|s| s.trim_end_matches('/').to_string()),
         }
     }
 
@@ -56,6 +68,16 @@ impl MediaResolver {
 
     async fn resolve_one(&self, r: &AssociatedMediaRef) -> Option<BlobEntry> {
         let at_uri = AtUri::parse(&r.uri)?;
+
+        if let Some(base) = &self.slingshot_url {
+            if let Some(record) = self
+                .fetch_record(base, &at_uri.did, &at_uri.collection, &at_uri.rkey)
+                .await
+            {
+                return media_record_to_blob_entry(&record);
+            }
+        }
+
         let did = Did::parse(&at_uri.did).ok()?;
         let pds_url = self.blob_resolver.resolve_pds_url(&did).await.ok()?;
         let record = self
@@ -66,18 +88,12 @@ impl MediaResolver {
 
     async fn fetch_record(
         &self,
-        pds_url: &str,
+        base_url: &str,
         did: &str,
         collection: &str,
         rkey: &str,
     ) -> Option<Value> {
-        let url = format!(
-            "{}/xrpc/com.atproto.repo.getRecord?repo={}&collection={}&rkey={}",
-            pds_url.trim_end_matches('/'),
-            urlencoding::encode(did),
-            urlencoding::encode(collection),
-            urlencoding::encode(rkey),
-        );
+        let url = build_get_record_url(base_url, did, collection, rkey);
         let resp = self.client.get(&url).send().await.ok()?;
         if !resp.status().is_success() {
             return None;
@@ -90,8 +106,18 @@ impl MediaResolver {
 
 impl Default for MediaResolver {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
+}
+
+fn build_get_record_url(base_url: &str, did: &str, collection: &str, rkey: &str) -> String {
+    format!(
+        "{}/xrpc/com.atproto.repo.getRecord?repo={}&collection={}&rkey={}",
+        base_url.trim_end_matches('/'),
+        urlencoding::encode(did),
+        urlencoding::encode(collection),
+        urlencoding::encode(rkey),
+    )
 }
 
 /// Pull the blob ref, mime type, and alt text out of a `bio.lexicons.temp.v0-1.media`
@@ -180,5 +206,44 @@ mod tests {
             "image": { "ref": { "$link": "bafyreiabc" } }
         });
         assert!(media_record_to_blob_entry(&record).is_none());
+    }
+
+    #[test]
+    fn builds_get_record_url_with_url_encoding() {
+        let url = build_get_record_url(
+            "https://slingshot.microcosm.blue",
+            "did:plc:z72i7hdynmk6r22z27h6tvur",
+            "bio.lexicons.temp.v0-1.media",
+            "3kabc",
+        );
+        assert_eq!(
+            url,
+            "https://slingshot.microcosm.blue/xrpc/com.atproto.repo.getRecord\
+             ?repo=did%3Aplc%3Az72i7hdynmk6r22z27h6tvur\
+             &collection=bio.lexicons.temp.v0-1.media\
+             &rkey=3kabc"
+        );
+    }
+
+    #[test]
+    fn build_get_record_url_normalizes_trailing_slash() {
+        let with = build_get_record_url("https://example.com/", "did:plc:x", "c", "r");
+        let without = build_get_record_url("https://example.com", "did:plc:x", "c", "r");
+        assert_eq!(with, without);
+    }
+
+    #[test]
+    fn slingshot_url_trims_trailing_slash_at_construction() {
+        let r = MediaResolver::new(Some("https://slingshot.microcosm.blue/".to_string()));
+        assert_eq!(
+            r.slingshot_url.as_deref(),
+            Some("https://slingshot.microcosm.blue")
+        );
+    }
+
+    #[test]
+    fn slingshot_disabled_when_none() {
+        let r = MediaResolver::new(None);
+        assert!(r.slingshot_url.is_none());
     }
 }

--- a/crates/observing-ingester/src/types.rs
+++ b/crates/observing-ingester/src/types.rs
@@ -32,6 +32,9 @@ pub struct IngesterConfig {
     pub port: u16,
     /// Full NSIDs of collections to subscribe to
     pub collections: Vec<String>,
+    /// When set, the media resolver tries this Slingshot endpoint before
+    /// falling back to a direct PDS fetch.
+    pub slingshot_url: Option<String>,
 }
 
 impl Default for IngesterConfig {
@@ -45,6 +48,7 @@ impl Default for IngesterConfig {
                 .iter()
                 .map(|(_, nsid)| nsid.to_string())
                 .collect(),
+            slingshot_url: None,
         }
     }
 }

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -77,6 +77,13 @@ CACHE_TTL_SECS=...            # Optional, seconds
 PORT=8080
 JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe
 
+# Optional: when set, the media resolver tries this Slingshot endpoint
+# (https://slingshot.microcosm.blue) before falling back to a direct PDS
+# fetch. Slingshot is a firehose-warmed edge cache, so a hit avoids both
+# the plc.directory DID lookup and the cold PDS round trip. Unset to
+# disable.
+SLINGSHOT_URL=https://slingshot.microcosm.blue
+
 DB_HOST=/cloudsql/<project>:<region>:observing-db
 DB_NAME=observing
 DB_USER=ingester_runtime

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -30,6 +30,7 @@ processes:
     working_dir: crates/observing-ingester
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:${DB_PASSWORD}@localhost:5432/observing}
+      - SLINGSHOT_URL=${SLINGSHOT_URL:-https://slingshot.microcosm.blue}
 
   species-id:
     command: cargo run -p observing-species-id


### PR DESCRIPTION
## Summary
- When `SLINGSHOT_URL` is set, `MediaResolver` tries it first via `com.atproto.repo.getRecord`; on any non-success it falls back to the existing `plc.directory` + direct-PDS path. Behavior is unchanged when the env var is unset.
- `process-compose.yaml` sets `SLINGSHOT_URL=https://slingshot.microcosm.blue` for dev so the path is exercised locally; override with empty to disable.
- `docs/deployment.md` documents the new env var in the ingester section as optional with the public URL recommended.
- The resolver's reqwest client now sends `User-Agent: observing-ingester/<version>` (courtesy + identifies traffic to PDS / Slingshot operators).

## Motivation
The current `media_resolver.rs` path makes two HTTP calls per `associatedMedia` ref — one to `plc.directory` for DID resolution, one to the author's PDS — across many different hosts with no connection reuse. Per the existing docstring, refs that fail to resolve are dropped silently with a `warn!`, so any hiccup on `plc.directory` or any individual PDS quietly degrades `occurrences.associated_media`.

Slingshot ([microcosm.blue](https://www.microcosm.blue/)) is a firehose-warmed, community-run edge cache that mirrors `com.atproto.repo.getRecord` and resolves identities internally. Routing through it on the success path:

- Eliminates the `plc.directory` round trip
- Avoids cold TCP/TLS handshakes per author PDS (one host → keepalive + HTTP/2)
- Survives PDS or `plc.directory` outages — Slingshot has the record cached from the firehose
- Improves out-of-order firehose tolerance — Slingshot pre-caches eagerly

The fallback to direct-PDS preserves existing behavior on Slingshot misses or outages, so this is opt-in via env var with no regression risk when unset.

## Test plan
- [x] `cargo check --workspace` passes
- [x] `cargo test -p observing-ingester --lib` — 32 passed (4 new for URL construction + constructor wiring)
- [x] `cargo clippy -p observing-ingester --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Run the ingester locally via `process-compose up` and confirm the startup log line `Slingshot: https://slingshot.microcosm.blue (media fetches will try this first)` appears
- [ ] Tail logs and confirm `Failed to resolve associatedMedia ref` warning rate drops vs. baseline
- [ ] After merge, set `SLINGSHOT_URL` on the prod ingester Cloud Run service via `--set-env-vars`