### PR TITLE
feat(upload-modal): match indicator and optional rank for new taxa

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/auto_id.rs
+++ b/crates/observing-appview/src/routes/occurrences/auto_id.rs
@@ -11,10 +11,13 @@ use crate::state::AppState;
 /// Build an identification record value for a given scientific name.
 ///
 /// Validates taxonomy and constructs the AT Protocol identification record.
+/// `user_taxon_rank` is used only when taxonomy validation cannot resolve a
+/// rank — taxonomy is authoritative for known taxa.
 /// Returns the record JSON value ready to be posted via the agent.
 pub async fn build_identification_record(
     state: &AppState,
     scientific_name: &str,
+    user_taxon_rank: Option<&str>,
     occurrence_uri: &str,
     occurrence_cid: &str,
 ) -> Result<Value, AppError> {
@@ -26,6 +29,10 @@ pub async fn build_identification_record(
             taxon_rank = Some(t.rank.clone());
             kingdom = t.kingdom.clone();
         }
+    }
+
+    if taxon_rank.is_none() {
+        taxon_rank = user_taxon_rank.map(str::to_owned);
     }
 
     let occurrence = auth::build_strong_ref(occurrence_uri, occurrence_cid)?;

--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -36,6 +36,8 @@ pub struct CreateOccurrenceRequest {
     images: Option<Vec<ImageUpload>>,
     #[ts(optional)]
     scientific_name: Option<String>,
+    #[ts(optional)]
+    taxon_rank: Option<String>,
 }
 
 #[derive(Deserialize, TS)]
@@ -68,6 +70,8 @@ pub struct UpdateOccurrenceRequest {
     retained_blob_cids: Option<Vec<String>>,
     #[ts(optional)]
     scientific_name: Option<String>,
+    #[ts(optional)]
+    taxon_rank: Option<String>,
 }
 
 pub async fn create_occurrence(
@@ -122,8 +126,16 @@ pub async fn create_occurrence(
     // Auto-create first identification if a scientific name was provided
     if let Some(ref scientific_name) = body.scientific_name {
         if !scientific_name.is_empty() {
-            create_auto_identification(&state, &agent, &user.did, scientific_name, &uri, &cid)
-                .await?;
+            create_auto_identification(
+                &state,
+                &agent,
+                &user.did,
+                scientific_name,
+                body.taxon_rank.as_deref(),
+                &uri,
+                &cid,
+            )
+            .await?;
         }
     }
 
@@ -357,7 +369,16 @@ pub async fn update_occurrence(
                 .iter()
                 .any(|id| id.did == user.did && id.scientific_name == trimmed);
             if !already_identified {
-                create_auto_identification(&state, &agent, &user.did, trimmed, &uri, &cid).await?;
+                create_auto_identification(
+                    &state,
+                    &agent,
+                    &user.did,
+                    trimmed,
+                    body.taxon_rank.as_deref(),
+                    &uri,
+                    &cid,
+                )
+                .await?;
             }
         }
     }
@@ -494,12 +515,14 @@ async fn create_auto_identification(
     agent: &AgentType,
     user_did: &str,
     scientific_name: &str,
+    user_taxon_rank: Option<&str>,
     occurrence_uri: &str,
     occurrence_cid: &str,
 ) -> Result<(), AppError> {
     let id_value = auto_id::build_identification_record(
         state,
         scientific_name,
+        user_taxon_rank,
         occurrence_uri,
         occurrence_cid,
     )

--- a/frontend/src/bindings/CreateOccurrenceRequest.ts
+++ b/frontend/src/bindings/CreateOccurrenceRequest.ts
@@ -8,4 +8,5 @@ export type CreateOccurrenceRequest = {
   eventDate?: string;
   images?: Array<ImageUpload>;
   scientificName?: string;
+  taxonRank?: string;
 };

--- a/frontend/src/bindings/UpdateOccurrenceRequest.ts
+++ b/frontend/src/bindings/UpdateOccurrenceRequest.ts
@@ -17,4 +17,5 @@ export type UpdateOccurrenceRequest = {
    */
   retainedBlobCids?: Array<string>;
   scientificName?: string;
+  taxonRank?: string;
 };

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -4,6 +4,7 @@ import {
   Typography,
   TextField,
   Button,
+  Chip,
   Stack,
   IconButton,
   Alert,
@@ -15,6 +16,8 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
 import ExifReader from "exifreader";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeUploadModal, addToast, consumePendingUploadFiles } from "../../store/uiSlice";
@@ -26,6 +29,7 @@ import { AiSuggestions } from "../identification/AiSuggestions";
 import { LocationPicker } from "../map/LocationPicker";
 import { getObservationUrl, getErrorMessage } from "../../lib/utils";
 import { KINGDOMS } from "../../lib/kingdoms";
+import { TAXON_RANKS } from "../../lib/taxonRanks";
 
 interface ImagePreview {
   file: File;
@@ -60,6 +64,7 @@ export function UploadModal() {
   const [species, setSpecies] = useState("");
   const [matchedTaxon, setMatchedTaxon] = useState<TaxaResult | null>(null);
   const [kingdom, setKingdom] = useState("");
+  const [rank, setRank] = useState("");
   const [license, setLicense] = useState("CC-BY-4.0");
   const [lat, setLat] = useState("");
   const [lng, setLng] = useState("");
@@ -81,6 +86,7 @@ export function UploadModal() {
         setSpecies(editingObservation.effectiveTaxonomy?.scientificName || "");
         setKingdom(editingObservation.effectiveTaxonomy?.kingdom || "");
         setMatchedTaxon(null);
+        setRank("");
         if (editingObservation.eventDate) {
           setObservationDate(toDatetimeLocal(new Date(editingObservation.eventDate)));
         }
@@ -110,6 +116,7 @@ export function UploadModal() {
     setSpecies("");
     setMatchedTaxon(null);
     setKingdom("");
+    setRank("");
     setLicense("CC-BY-4.0");
     images.forEach((img) => URL.revokeObjectURL(img.preview));
     setImages([]);
@@ -294,6 +301,7 @@ export function UploadModal() {
           uri: editingObservation.uri,
           ...(trimmedSpecies ? { scientificName: trimmedSpecies } : {}),
           ...(trimmedSpecies && kingdom ? { kingdom } : {}),
+          ...(trimmedSpecies && !matchedTaxon && rank ? { taxonRank: rank } : {}),
           latitude: parseFloat(lat),
           longitude: parseFloat(lng),
           coordinateUncertaintyInMeters: uncertaintyMeters,
@@ -319,6 +327,7 @@ export function UploadModal() {
         const result = await submitObservation({
           ...(trimmedSpecies ? { scientificName: trimmedSpecies } : {}),
           ...(trimmedSpecies && kingdom ? { kingdom } : {}),
+          ...(trimmedSpecies && !matchedTaxon && rank ? { taxonRank: rank } : {}),
           latitude: parseFloat(lat),
           longitude: parseFloat(lng),
           coordinateUncertaintyInMeters: uncertaintyMeters,
@@ -528,6 +537,7 @@ export function UploadModal() {
             if (name === "") {
               setMatchedTaxon(null);
               setKingdom("");
+              setRank("");
             }
           }}
           onMatchChange={(match) => {
@@ -535,11 +545,36 @@ export function UploadModal() {
             if (match?.kingdom) {
               setKingdom(match.kingdom);
             }
+            if (match) {
+              setRank("");
+            }
           }}
           label="Taxon (optional)"
           placeholder="e.g. Eschscholzia californica - leave blank if unknown"
           bottomContent={
-            aiImageUrl && !species ? (
+            species.trim() ? (
+              matchedTaxon ? (
+                <Chip
+                  icon={<CheckCircleOutlinedIcon />}
+                  label={
+                    matchedTaxon.rank ? `Existing taxon · ${matchedTaxon.rank}` : "Existing taxon"
+                  }
+                  color="success"
+                  size="small"
+                  variant="outlined"
+                  sx={{ mt: 0.5 }}
+                />
+              ) : (
+                <Chip
+                  icon={<AddCircleOutlinedIcon />}
+                  label="New taxon"
+                  color="info"
+                  size="small"
+                  variant="outlined"
+                  sx={{ mt: 0.5 }}
+                />
+              )
+            ) : aiImageUrl ? (
               <AiSuggestions
                 imageUrl={aiImageUrl}
                 latitude={lat ? parseFloat(lat) : undefined}
@@ -579,6 +614,27 @@ export function UploadModal() {
             ))}
           </Select>
         </FormControl>
+
+        {!!species.trim() && !matchedTaxon && (
+          <FormControl fullWidth margin="normal">
+            <InputLabel id="rank-label">Rank (optional)</InputLabel>
+            <Select
+              labelId="rank-label"
+              value={rank}
+              label="Rank (optional)"
+              onChange={(e) => setRank(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
+              </MenuItem>
+              {TAXON_RANKS.map((r) => (
+                <MenuItem key={r} value={r}>
+                  {r}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
 
         <FormControl fullWidth margin="normal">
           <InputLabel id="license-label">License</InputLabel>

--- a/frontend/src/lib/taxonRanks.ts
+++ b/frontend/src/lib/taxonRanks.ts
@@ -1,0 +1,14 @@
+// Mirrors the `knownValues` for `taxonRank` in
+// lexicons/bio/lexicons/temp/identification.json.
+export const TAXON_RANKS: ReadonlyArray<string> = [
+  "kingdom",
+  "phylum",
+  "class",
+  "order",
+  "family",
+  "genus",
+  "species",
+  "subspecies",
+  "variety",
+  "form",
+];


### PR DESCRIPTION
## Summary
- Show a chip below the taxon field — green "Existing taxon · {rank}" when a suggestion is selected from the autocomplete, blue "New taxon" when the user is creating a free-text taxon.
- Render an optional Rank dropdown (kingdom…form, mirroring the lexicon's `knownValues`) only when the taxon is unmatched, so users can specify the rank for new taxa that taxonomy lookup cannot resolve.
- Plumb `taxonRank` through `CreateOccurrenceRequest`/`UpdateOccurrenceRequest`. `build_identification_record` uses it only as a fallback when `taxonomy.validate` doesn't resolve a rank — taxonomy stays authoritative for known taxa.

## Test plan
- [ ] New observation: pick a suggestion from the taxa autocomplete → see green "Existing taxon · {rank}" chip; rank dropdown is hidden.
- [ ] New observation: type a name not in the autocomplete → see blue "New taxon" chip; Rank dropdown appears and is optional.
- [ ] Submit a new free-text observation with a chosen rank and verify the identification record on the PDS has `taxonRank` set.
- [ ] Submit a new free-text observation without a rank and verify nothing breaks.
- [ ] Edit mode: open an existing observation, change the species to free-text, set a rank, save, confirm round-trip.
- [ ] Clearing the taxon field clears matched/rank state.