### PR TITLE
refactor(upload-modal): only render Kingdom for unmatched taxa

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -591,29 +591,26 @@ export function UploadModal() {
           }
         />
 
-        <FormControl
-          fullWidth
-          margin="normal"
-          required={!!species.trim() && !matchedTaxon}
-          disabled={!!matchedTaxon}
-        >
-          <InputLabel id="kingdom-label">Kingdom</InputLabel>
-          <Select
-            labelId="kingdom-label"
-            value={kingdom}
-            label="Kingdom"
-            onChange={(e) => setKingdom(e.target.value)}
-          >
-            <MenuItem value="">
-              <em>None</em>
-            </MenuItem>
-            {KINGDOMS.map((k) => (
-              <MenuItem key={k.value} value={k.value}>
-                {k.label}
+        {!!species.trim() && !matchedTaxon && (
+          <FormControl fullWidth margin="normal" required>
+            <InputLabel id="kingdom-label">Kingdom</InputLabel>
+            <Select
+              labelId="kingdom-label"
+              value={kingdom}
+              label="Kingdom"
+              onChange={(e) => setKingdom(e.target.value)}
+            >
+              <MenuItem value="">
+                <em>None</em>
               </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
+              {KINGDOMS.map((k) => (
+                <MenuItem key={k.value} value={k.value}>
+                  {k.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        )}
 
         {!!species.trim() && !matchedTaxon && (
           <FormControl fullWidth margin="normal">

--- a/tests/species-input.spec.ts
+++ b/tests/species-input.spec.ts
@@ -75,25 +75,22 @@ authTest.describe("Species Input", () => {
   );
 
   authTest(
-    "selecting an autocomplete suggestion auto-fills and disables the kingdom select",
+    "selecting an autocomplete suggestion hides the kingdom select",
     async ({ authenticatedPage: page }) => {
       await searchSpecies(page, "quercus");
       await page.locator(".MuiAutocomplete-option").first().click();
-      const kingdomCombo = page.getByRole("combobox", { name: "Kingdom" });
-      await authExpect(kingdomCombo).toHaveText("Plants");
-      await authExpect(kingdomCombo).toHaveAttribute("aria-disabled", "true");
+      await authExpect(page.getByRole("combobox", { name: "Kingdom" })).toHaveCount(0);
     },
   );
 
   authTest(
-    "free-text species enables the kingdom select and clears any prior match",
+    "free-text species reveals the kingdom select after a prior match is cleared",
     async ({ authenticatedPage: page }) => {
       await searchSpecies(page, "quercus");
       await page.locator(".MuiAutocomplete-option").first().click();
       const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.fill("My Custom Species");
-      const kingdomCombo = page.getByRole("combobox", { name: "Kingdom" });
-      await authExpect(kingdomCombo).not.toHaveAttribute("aria-disabled", "true");
+      await authExpect(page.getByRole("combobox", { name: "Kingdom" })).toBeVisible();
     },
   );
 });


### PR DESCRIPTION
## Summary
- Hide the Kingdom dropdown by default; render it only when the user has typed a free-text taxon that did not match the autocomplete — the one case where the appview cannot resolve the kingdom from taxonomy.
- Mirrors the conditional pattern just introduced for Rank in #375. Eliminates a `disabled` control that contributed nothing in the matched case.
- Submit-time validation (`kingdom` required when free-text) is unchanged; matched taxa still set `kingdom` via `onMatchChange`.

## Test plan
- [ ] Open the modal with no taxon → Kingdom is hidden.
- [ ] Pick a suggestion from the autocomplete → Kingdom stays hidden; submitting still sends the matched taxon's kingdom.
- [ ] Type a free-text taxon → Kingdom appears, marked required; submitting without a selection shows the existing toast.
- [ ] Clear the taxon field → Kingdom hides again and `kingdom` state is reset.
- [ ] Edit mode for an existing observation with a free-text taxon → Kingdom is visible and prefilled.