### PR TITLE
fix(db): handle ingester.community_ids in runtime grants migration

### DIFF
--- a/crates/observing-db/migrations/20260428000001_grant_runtime_roles.sql
+++ b/crates/observing-db/migrations/20260428000001_grant_runtime_roles.sql
@@ -15,10 +15,24 @@
 -- history; their effect is now subsumed here for any DB where the renames
 -- have already happened.
 --
--- Idempotent (REVOKE-then-GRANT, OWNER TO is unconditional). No-op on
--- local/CI where the runtime roles don't exist.
+-- Subtle: this migration runs as `postgres`, but #334 revoked
+-- `cloudsqlsuperuser` membership from the runtime roles (the path postgres
+-- relied on to operate on objects owned by them). After that point,
+-- postgres can no longer GRANT on or ALTER OWNER of objects owned by a
+-- runtime role. The only such object today is `ingester.community_ids`
+-- (owned by `ingester_runtime` since 20260421), so the `ingester` schema
+-- grants enumerate over postgres-owned tables instead of using the
+-- schema-wide ON ALL TABLES form, and ALTER OWNER is guarded on current
+-- ownership. On a from-scratch migrate, community_ids is still owned by
+-- postgres at this point, the enumeration includes it, and the ALTER
+-- OWNER transfers it; on existing prod the enumeration skips it and the
+-- ALTER OWNER is a no-op.
+--
+-- Idempotent. No-op on local/CI where the runtime roles don't exist.
 
 DO $$
+DECLARE
+    tbl text;
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'appview_runtime') THEN
         RAISE NOTICE 'appview_runtime role not found; skipping grants (expected on local/CI)';
@@ -26,14 +40,38 @@ BEGIN
     END IF;
 
     EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA public FROM appview_runtime';
-    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA ingester FROM appview_runtime';
     EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA appview FROM appview_runtime';
     EXECUTE 'REVOKE ALL ON ALL SEQUENCES IN SCHEMA public FROM appview_runtime';
+    -- ingester schema: REVOKE iterates per-table and errors on objects
+    -- postgres can't operate on (community_ids), so enumerate over
+    -- postgres-owned tables/matviews only.
+    FOR tbl IN
+        SELECT format('%I.%I', n.nspname, c.relname)
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'ingester'
+          AND c.relkind IN ('r', 'p', 'm')
+          AND pg_catalog.pg_get_userbyid(c.relowner) = 'postgres'
+    LOOP
+        EXECUTE format('REVOKE ALL ON TABLE %s FROM appview_runtime', tbl);
+    END LOOP;
 
     EXECUTE 'GRANT USAGE ON SCHEMA ingester, appview, public TO appview_runtime';
 
-    -- ingester: SELECT-only, plus UPDATE on notifications.read.
-    EXECUTE 'GRANT SELECT ON ALL TABLES IN SCHEMA ingester TO appview_runtime';
+    -- ingester: SELECT-only, plus UPDATE on notifications.read. Enumerated
+    -- over postgres-owned tables/matviews; appview_runtime's SELECT on
+    -- ingester.community_ids was already granted by ingester_runtime in a
+    -- prior run.
+    FOR tbl IN
+        SELECT format('%I.%I', n.nspname, c.relname)
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'ingester'
+          AND c.relkind IN ('r', 'p', 'm')
+          AND pg_catalog.pg_get_userbyid(c.relowner) = 'postgres'
+    LOOP
+        EXECUTE format('GRANT SELECT ON TABLE %s TO appview_runtime', tbl);
+    END LOOP;
     EXECUTE 'GRANT UPDATE ON TABLE ingester.notifications TO appview_runtime';
 
     -- appview: full CRUD (OAuth + private location + notification_reads).
@@ -51,22 +89,44 @@ END
 $$;
 
 DO $$
+DECLARE
+    tbl text;
 BEGIN
     IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_runtime') THEN
         RAISE NOTICE 'ingester_runtime role not found; skipping grants (expected on local/CI)';
         RETURN;
     END IF;
 
-    EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA ingester FROM ingester_runtime';
     EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA appview FROM ingester_runtime';
     EXECUTE 'REVOKE ALL ON ALL TABLES IN SCHEMA public FROM ingester_runtime';
     EXECUTE 'REVOKE ALL ON ALL SEQUENCES IN SCHEMA ingester FROM ingester_runtime';
+    -- ingester schema: enumerate, same reason as in the appview_runtime block.
+    FOR tbl IN
+        SELECT format('%I.%I', n.nspname, c.relname)
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'ingester'
+          AND c.relkind IN ('r', 'p', 'm')
+          AND pg_catalog.pg_get_userbyid(c.relowner) = 'postgres'
+    LOOP
+        EXECUTE format('REVOKE ALL ON TABLE %s FROM ingester_runtime', tbl);
+    END LOOP;
 
     EXECUTE 'GRANT USAGE ON SCHEMA ingester, appview, public TO ingester_runtime';
 
-    -- ingester: full CRUD on tables, plus sequence access for BIGSERIAL nextval().
-    EXECUTE 'GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA ingester
-             TO ingester_runtime';
+    -- ingester: full CRUD. Enumerated over postgres-owned tables/matviews;
+    -- ingester_runtime is the owner of community_ids in existing prod and
+    -- already has full privileges implicitly there.
+    FOR tbl IN
+        SELECT format('%I.%I', n.nspname, c.relname)
+        FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE n.nspname = 'ingester'
+          AND c.relkind IN ('r', 'p', 'm')
+          AND pg_catalog.pg_get_userbyid(c.relowner) = 'postgres'
+    LOOP
+        EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %s TO ingester_runtime', tbl);
+    END LOOP;
     EXECUTE 'GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA ingester
              TO ingester_runtime';
 
@@ -76,8 +136,18 @@ BEGIN
     -- public: sensitive_species reference data.
     EXECUTE 'GRANT SELECT ON TABLE public.sensitive_species TO ingester_runtime';
 
-    -- REFRESH MATERIALIZED VIEW CONCURRENTLY requires ownership.
-    EXECUTE 'ALTER MATERIALIZED VIEW ingester.community_ids OWNER TO ingester_runtime';
+    -- REFRESH MATERIALIZED VIEW CONCURRENTLY requires ownership. Guarded on
+    -- current ownership: ALTER OWNER TO requires the runner to be a member
+    -- of the target role, and #334 revoked the path postgres relied on.
+    -- 20260421 originally transferred ownership when postgres still had it,
+    -- and 20260423 preserved it through the rename, so this is a no-op on
+    -- every environment that reached the predecessor; on a from-scratch
+    -- migrate the matview is still postgres-owned here and gets transferred.
+    IF pg_catalog.pg_get_userbyid(
+        (SELECT relowner FROM pg_class WHERE oid = 'ingester.community_ids'::regclass)
+    ) <> 'ingester_runtime' THEN
+        EXECUTE 'ALTER MATERIALIZED VIEW ingester.community_ids OWNER TO ingester_runtime';
+    END IF;
 
     EXECUTE 'ALTER DEFAULT PRIVILEGES FOR ROLE postgres IN SCHEMA ingester
              GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO ingester_runtime';


### PR DESCRIPTION
## Summary

`20260428000001_grant_runtime_roles.sql` has been failing on every deploy since #370 merged, blocking the migrate Job and therefore the ingester/appview rollouts (most recent failure: PR #375).

The migration was written under the assumption that "OWNER TO is unconditional" (per the inline comment) and used schema-wide `REVOKE`/`GRANT` on the `ingester` schema. That holds on a from-scratch wipe, where every object in `ingester` is still postgres-owned — but on existing prod, `ingester.community_ids` has been owned by `ingester_runtime` since #20260421 transferred it, and #334's `cloudsqlsuperuser` revoke removed the path postgres had to operate on objects owned by runtime roles. Every iteration of the schema-wide statements over `community_ids` raised `permission denied for table community_ids` and rolled the whole migration back.

The fix:
- Replace the `ingester`-schema `REVOKE ALL ON ALL TABLES` and `GRANT … ON ALL TABLES` calls in both DO blocks with explicit per-table loops filtered to postgres-owned tables/matviews. On from-scratch this still includes `community_ids` (postgres-owned at this point); on existing prod it's skipped, since `ingester_runtime` already has full implicit privileges as owner and `appview_runtime`'s SELECT was preserved from the original grant.
- Guard `ALTER MATERIALIZED VIEW … OWNER TO ingester_runtime` on current ownership, so the post-rename no-op doesn't hit the same membership check.
- The `public` and `appview` schemas are entirely postgres-owned, so their schema-wide REVOKE/GRANT statements stay as-is.

## Verification

- `BEGIN; <migration>; ROLLBACK;` against prod completes cleanly (the same statements that previously failed now run end-to-end).
- `cargo test -p observing-db` passes.

## Test plan
- [ ] Migrate Job runs to completion on the next main deploy.
- [ ] Post-deploy, `appview_runtime` retains SELECT on `ingester.community_ids` (research-grade community IDs continue to enrich).
- [ ] Post-deploy, `ingester_runtime` can still REFRESH the matview after identification upserts.