### PR TITLE
ci: add migrations-prodlike job to catch superuser-bypass assumptions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,42 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
 
+  # Migrations replay: verify the latest migration runs cleanly under prod's
+  # role topology (non-superuser admin in cloudsqlsuperuser, runtime roles
+  # without cloudsqlsuperuser membership, community_ids owned by
+  # ingester_runtime). Catches migrations that quietly assume superuser
+  # bypass — see scripts/test-migrations-prodlike.sh.
+  migrations-prodlike:
+    runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          # Use a separate bootstrap superuser so the script can NOSUPERUSER
+          # the `postgres` role it creates later (PG14+ refuses to
+          # NOSUPERUSER the cluster's bootstrap user). The `observing`
+          # database is created by the script, not by the image init.
+          POSTGRES_USER: ci_bootstrap
+          POSTGRES_PASSWORD: ci_bootstrap
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U ci_bootstrap"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - uses: Swatinem/rust-cache@v2
+      - uses: taiki-e/cache-cargo-install-action@v3
+        with:
+          tool: sqlx-cli
+          no-default-features: true
+          features: postgres
+      - name: Replay latest migration in prod-like role topology
+        run: ./scripts/test-migrations-prodlike.sh
+
   # Backfill: fetch real PDS records, parse, and write to a test database
   backfill:
     runs-on: ubuntu-latest
@@ -260,7 +296,7 @@ jobs:
   # Build Docker images in parallel with caching
   build-images:
     runs-on: ubuntu-latest
-    needs: [frontend-audit, fmt, frontend-lint, ts-bindings-check, ts-typecheck, frontend-build, rust-lockfile, rust-fmt, rust-deny, rust-clippy, rust-sqlx, rust-lexicons-check, rust-test, e2e]
+    needs: [frontend-audit, fmt, frontend-lint, ts-bindings-check, ts-typecheck, frontend-build, rust-lockfile, rust-fmt, rust-deny, rust-clippy, rust-sqlx, rust-lexicons-check, rust-test, e2e, migrations-prodlike]
     if: github.event_name == 'push'
     env:
       REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/observing

--- a/scripts/test-migrations-prodlike.sh
+++ b/scripts/test-migrations-prodlike.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Verify the latest migration runs cleanly in a topology that mirrors prod.
+#
+# The existing CI jobs (rust-test, e2e, backfill) run migrations as a real
+# Postgres SUPERUSER, which bypasses every ownership and role-membership
+# check. Prod runs them as `postgres` — a non-superuser admin in
+# `cloudsqlsuperuser`, where the runtime roles have had their
+# `cloudsqlsuperuser` membership revoked (#334). That divergence let the
+# original `20260428000001_grant_runtime_roles` migration crashloop the
+# migrate Job for ~10 days while CI stayed green.
+#
+# Strategy:
+#   1. Bootstrap roles to mirror prod (`cloudsqlsuperuser`, `runtime_base`,
+#      `appview_runtime`, `ingester_runtime`, and a non-superuser `postgres`
+#      admin in `cloudsqlsuperuser`).
+#   2. Run all migrations as `postgres` while it is temporarily SUPERUSER
+#      so the historical ALTER OWNER / GRANT statements work the same way
+#      they did in prod when `cloudsqlsuperuser` membership gave postgres
+#      a path to every built-in user. This gets the schema into a current-
+#      main state, the same as the other CI jobs.
+#   3. Reproduce the prod ownership state by transferring
+#      `ingester.community_ids` to `ingester_runtime`.
+#   4. Strip `postgres` of SUPERUSER via the cluster's bootstrap superuser.
+#   5. Forget the latest migration's `_sqlx_migrations` row and re-run
+#      sqlx-migrate. A migration that quietly assumes superuser bypass
+#      (schema-wide GRANT/REVOKE that touches a runtime-role-owned object,
+#      ALTER OWNER without an ownership guard, etc.) fails here.
+set -euo pipefail
+
+# The cluster's bootstrap superuser. Distinct from `postgres` so we can
+# NOSUPERUSER `postgres` later (PG14+ refuses to NOSUPERUSER the bootstrap
+# user). The CI workflow sets `POSTGRES_USER=ci_bootstrap` on the service.
+: "${BOOTSTRAP_USER:=ci_bootstrap}"
+: "${BOOTSTRAP_PASSWORD:=ci_bootstrap}"
+: "${PGHOST:=localhost}"
+: "${PGPORT:=5432}"
+: "${PGDATABASE:=observing}"
+export PGHOST PGPORT PGDATABASE
+
+ADMIN_USER=postgres
+ADMIN_PASSWORD=postgres
+
+run_as_bootstrap() {
+    PGUSER="$BOOTSTRAP_USER" PGPASSWORD="$BOOTSTRAP_PASSWORD" \
+        psql -v ON_ERROR_STOP=1 "$@"
+}
+run_as_admin() {
+    PGUSER="$ADMIN_USER" PGPASSWORD="$ADMIN_PASSWORD" \
+        psql -v ON_ERROR_STOP=1 "$@"
+}
+
+ADMIN_URL="postgresql://$ADMIN_USER:$ADMIN_PASSWORD@$PGHOST:$PGPORT/$PGDATABASE"
+
+echo "::group::Bootstrap prod-like role topology"
+run_as_bootstrap -d postgres <<SQL
+CREATE ROLE cloudsqlsuperuser CREATEROLE CREATEDB;
+CREATE ROLE runtime_base;
+CREATE ROLE appview_runtime LOGIN PASSWORD 'unused' IN ROLE runtime_base;
+CREATE ROLE ingester_runtime LOGIN PASSWORD 'unused' IN ROLE runtime_base;
+-- The prod-equivalent admin. Temporarily SUPERUSER so the historical
+-- ALTER OWNER / cross-role GRANT statements work during migration setup
+-- — we strip it after, before replaying the migration under test.
+CREATE ROLE $ADMIN_USER LOGIN PASSWORD '$ADMIN_PASSWORD' SUPERUSER
+    IN ROLE cloudsqlsuperuser;
+CREATE DATABASE $PGDATABASE OWNER $ADMIN_USER;
+SQL
+echo "::endgroup::"
+
+echo "::group::Run all migrations as postgres (still SUPERUSER)"
+sqlx migrate run \
+    --source crates/observing-db/migrations \
+    --database-url "$ADMIN_URL"
+echo "::endgroup::"
+
+echo "::group::Mirror prod state: transfer community_ids to ingester_runtime"
+# Migration 20260421 transferred this in prod when postgres still had a path
+# through cloudsqlsuperuser to ingester_writer. That migration no-ops in CI
+# because ingester_writer never exists here, so set the ownership directly.
+run_as_admin -c \
+    "ALTER MATERIALIZED VIEW ingester.community_ids OWNER TO ingester_runtime"
+echo "::endgroup::"
+
+echo "::group::Strip postgres of SUPERUSER (mirror prod admin role)"
+run_as_bootstrap -d postgres -c "ALTER ROLE $ADMIN_USER NOSUPERUSER"
+echo "::endgroup::"
+
+echo "::group::Replay latest migration in post-#334 state"
+LATEST_VERSION=$(
+    ls crates/observing-db/migrations/*.sql \
+        | sort -V \
+        | tail -1 \
+        | xargs basename \
+        | cut -d_ -f1
+)
+echo "Latest migration version: $LATEST_VERSION"
+run_as_admin -c \
+    "DELETE FROM _sqlx_migrations WHERE version = $LATEST_VERSION"
+sqlx migrate run \
+    --source crates/observing-db/migrations \
+    --database-url "$ADMIN_URL"
+echo "::endgroup::"
+
+echo "migrations-prodlike: ok"


### PR DESCRIPTION
## Summary
- Adds a CI job that replays the latest migration in a topology mirroring prod's role setup (non-superuser admin in `cloudsqlsuperuser`, runtime roles outside `cloudsqlsuperuser`, `ingester.community_ids` owned by `ingester_runtime`).
- Catches migrations that quietly assume superuser bypass — the gap that let #377's bug crashloop the migrate Job for ~10 days while every existing CI job stayed green.
- Uses a separate `ci_bootstrap` cluster superuser so the script can `NOSUPERUSER` the `postgres` role afterward (PG14+ refuses to do this to the cluster's bootstrap user).

## Why the existing CI jobs missed it
`rust-test`, `e2e`, and `backfill` all run migrations as the cluster's bootstrap superuser. Superuser bypasses every ownership and role-membership check, so a migration that does `GRANT ON ALL TABLES IN SCHEMA ingester` against a runtime-role-owned matview just works. Prod's `postgres` admin doesn't have that bypass, hence the divergence.

## How it works
`scripts/test-migrations-prodlike.sh`:
1. Bootstraps `cloudsqlsuperuser`, `runtime_base`, `appview_runtime`, `ingester_runtime`, and a `postgres` admin (temporarily SUPERUSER) inside `cloudsqlsuperuser`.
2. Runs all migrations as the temporarily-superuser `postgres` (gets schema to current-main state, same as other CI jobs).
3. Reproduces prod's ownership: transfers `ingester.community_ids` to `ingester_runtime`.
4. Strips `postgres` of SUPERUSER via the bootstrap user.
5. Forgets the latest migration's `_sqlx_migrations` row and replays it. A migration that assumes superuser bypass fails here.

## Test plan
- [x] Verified locally (Docker postgis:16-3.4) that the script exits 1 with `permission denied for table community_ids` against the pre-fix `20260428000001_grant_runtime_roles.sql` (the bug fixed by #377).
- [x] Verified the script exits 0 against the post-fix migration that's now on main.
- [ ] CI run on this PR exercises both the new job and confirms it doesn't break other jobs.