### PR TITLE
feat(frontend): one-reload deploys + in-app update prompt

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -246,6 +246,7 @@ async fn main() {
             info!(path = %path.display(), "Serving pre-built frontend");
             let fallback = ServeDir::new(&path).fallback(ServeFile::new(path.join("index.html")));
             app.fallback_service(fallback)
+                .layer(axum_middleware::from_fn(middleware::static_cache_control))
         }
         None => {
             let vite_url = "http://localhost:5173";

--- a/crates/observing-appview/src/middleware.rs
+++ b/crates/observing-appview/src/middleware.rs
@@ -1,4 +1,6 @@
-use axum::http::HeaderValue;
+use axum::extract::Request;
+use axum::http::{header, HeaderValue};
+use axum::middleware::Next;
 use axum::response::Response;
 
 /// Adds security headers to all responses.
@@ -18,6 +20,39 @@ pub async fn security_headers(mut response: Response, is_production: bool) -> Re
             "Strict-Transport-Security",
             HeaderValue::from_static("max-age=63072000; includeSubDomains"),
         );
+    }
+    response
+}
+
+/// Per-path `Cache-Control` for the static frontend.
+///
+/// Without this, browsers fall back to heuristic freshness on `index.html`
+/// and `sw.js` — meaning a deploy can take two reloads to surface (the
+/// first reload pulls a stale `index.html` from HTTP cache, which still
+/// references the previous asset hash; only the second reload picks up
+/// the new bundle). `no-cache` forces a conditional GET so revisiting
+/// users always revalidate the entry points.
+///
+/// Hashed assets under `/assets/` and Workbox runtime files are content-
+/// addressed, so they get a long-lived `immutable` directive.
+pub async fn static_cache_control(req: Request, next: Next) -> Response {
+    let path = req.uri().path().to_owned();
+    let mut response = next.run(req).await;
+
+    let value: Option<&'static str> = match path.as_str() {
+        "/" | "/index.html" | "/sw.js" | "/registerSW.js" | "/manifest.webmanifest" => {
+            Some("no-cache")
+        }
+        p if p.starts_with("/assets/") || p.starts_with("/workbox-") => {
+            Some("public, max-age=31536000, immutable")
+        }
+        _ => None,
+    };
+
+    if let Some(value) = value {
+        response
+            .headers_mut()
+            .insert(header::CACHE_CONTROL, HeaderValue::from_static(value));
     }
     response
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -21,6 +21,7 @@ import { FAB } from "./components/common/FAB";
 import { ToastContainer } from "./components/common/Toast";
 import { NotFound } from "./components/common/NotFound";
 import { OfflineBanner } from "./components/common/OfflineBanner";
+import { UpdatePrompt } from "./components/common/UpdatePrompt";
 import { LexiconView } from "./components/lexicon/LexiconView";
 import { NotificationsPage } from "./components/notifications/NotificationsPage";
 import { SettingsPage } from "./components/settings/SettingsPage";
@@ -136,6 +137,7 @@ function AppContent() {
       <UploadModal />
       <DeleteConfirmDialog />
       <ToastContainer />
+      <UpdatePrompt />
     </Box>
   );
 }

--- a/frontend/src/components/common/UpdatePrompt.tsx
+++ b/frontend/src/components/common/UpdatePrompt.tsx
@@ -1,0 +1,40 @@
+import { Snackbar, Button } from "@mui/material";
+import { useRegisterSW } from "virtual:pwa-register/react";
+
+const HOUR_MS = 60 * 60 * 1000;
+
+export function UpdatePrompt() {
+  const {
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW({
+    onRegisteredSW(_swUrl, registration) {
+      if (registration) {
+        setInterval(() => {
+          registration.update();
+        }, HOUR_MS);
+      }
+    },
+  });
+
+  const close = () => setNeedRefresh(false);
+
+  return (
+    <Snackbar
+      open={needRefresh}
+      onClose={close}
+      message="A new version is available."
+      anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+      action={
+        <>
+          <Button color="inherit" size="small" onClick={() => updateServiceWorker(true)}>
+            Reload
+          </Button>
+          <Button color="inherit" size="small" onClick={close}>
+            Dismiss
+          </Button>
+        </>
+      }
+    />
+  );
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -10,7 +10,10 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
-      registerType: "autoUpdate",
+      // `prompt` so the app can surface "new version available" via
+      // `useRegisterSW` and let the user click to reload, instead of
+      // relying on the user to refresh blindly. See UpdatePrompt.tsx.
+      registerType: "prompt",
       manifest: false,
       workbox: {
         navigateFallback: "/index.html",


### PR DESCRIPTION
## Summary
Two complementary fixes for stale frontend after a deploy. Background: the most recent deploy needed two reloads in the browser to surface — once to update the SW, once for the page itself to pick up the new bundle.

### 1. `Cache-Control` on the static fallback
Without this, browsers used heuristic freshness on `index.html`. After a deploy, the first reload would pull the stale HTML from HTTP cache, which referenced the previous asset hash, so the SW updated in the background but the page kept running the old code. The second reload finally got fresh HTML.

- `/`, `/index.html`, `/sw.js`, `/registerSW.js`, `/manifest.webmanifest` → `Cache-Control: no-cache` (forces conditional GET; `tower-http`'s `ServeDir`/`ServeFile` already emit `Last-Modified` so the round-trip almost always 304s).
- `/assets/*` and `/workbox-*` → `Cache-Control: public, max-age=31536000, immutable` (these are content-addressed).
- Anything else → unchanged.

Implemented as an `axum::middleware::from_fn` layer applied only on the static-fallback branch in `main.rs`. API routes are unaffected (their paths don't match any of the conditions, so the middleware is a no-op for them).

### 2. In-app "new version available" prompt
Switched `vite-plugin-pwa` from `registerType: "autoUpdate"` to `"prompt"` and added a `Snackbar` (`UpdatePrompt.tsx`) that shows when `useRegisterSW`'s `needRefresh` flips. Reload button calls `updateServiceWorker(true)` (skip-waiting + reload). Also calls `registration.update()` hourly so users who keep the PWA open for long stretches still get notified.

Pairs with #1: the snackbar's reload is the one that picks up fresh HTML (because of #1), so it's effectively a single click to update.

## Test plan
- [x] `cargo check -p observing-appview` clean
- [x] `cargo clippy -p observing-appview` clean
- [x] `npx tsc --project tsconfig.json` clean
- [x] `npm run build` produces `sw.js` and `workbox-<hash>.js` as expected
- [ ] After this merges and deploys: ship a follow-up tiny change, verify (a) snackbar appears in an open tab/PWA, (b) clicking Reload picks up the new bundle on first reload, (c) `curl -I https://observ.ing/` returns `Cache-Control: no-cache` and hashed assets return `immutable`.