### PR TITLE
feat(species-id): hydrate AI suggestions with GBIF taxon match

### DIFF
--- a/crates/observing-appview/src/routes/species_id.rs
+++ b/crates/observing-appview/src/routes/species_id.rs
@@ -5,6 +5,7 @@ use tracing::{debug, error};
 use crate::auth::AuthUser;
 use crate::species_id_client::IdentifyResponse;
 use crate::state::AppState;
+use crate::taxonomy_client::TaxonResult;
 
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -22,6 +23,34 @@ pub struct IdentifyRequest {
 #[derive(Serialize)]
 pub struct ErrorResponse {
     error: String,
+}
+
+/// A single ranked AI suggestion enriched with the GBIF match (when the
+/// scientific name resolves to a known taxon). The frontend treats a
+/// suggestion with `taxonMatch` set the same as a user picking from the
+/// autocomplete: the kingdom/rank fields disappear and the match indicator
+/// shows "Existing taxon".
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnrichedSpeciesSuggestion {
+    pub scientific_name: String,
+    pub confidence: f32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub common_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kingdom: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub in_range: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub taxon_match: Option<TaxonResult>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnrichedIdentifyResponse {
+    pub suggestions: Vec<EnrichedSpeciesSuggestion>,
+    pub model_version: String,
+    pub inference_time_ms: u64,
 }
 
 /// POST /api/species-id
@@ -50,10 +79,7 @@ pub async fn identify(
         .identify(&body.image, body.latitude, body.longitude, body.limit)
         .await
     {
-        Ok(mut response) => {
-            enrich_common_names(&state, &mut response).await;
-            Json(response).into_response()
-        }
+        Ok(response) => Json(enrich_suggestions(&state, response).await).into_response(),
         Err(e) => {
             error!(error = %e, "Species identification failed");
             (
@@ -67,38 +93,75 @@ pub async fn identify(
     }
 }
 
-/// Fill in missing common names by looking up each scientific name via the
-/// taxonomy service. Failures are silently ignored — common names are
-/// best-effort.
+/// Hydrate AI suggestions with GBIF match data and any missing common names.
 ///
-/// Uses `get_by_name` rather than `search` because the species-search GBIF
-/// endpoint returns only the vernacular names embedded inline on the search
-/// result, which is sparse for many taxa (e.g. *Chelydra serpentina* comes
-/// back with no common name). `get_by_name` resolves to the canonical usage
-/// key and then fetches the full species record, which merges in GBIF's
-/// dedicated vernacular-names endpoint and produces a richer match.
-async fn enrich_common_names(state: &AppState, response: &mut IdentifyResponse) {
-    let futures: Vec<_> = response
+/// For each suggestion, validate against GBIF and (in parallel) look up the
+/// canonical species record when the AI didn't return a common name. We use
+/// `get_by_name` for common names — not the validate result's `taxon` —
+/// because validate returns the species-search shape, which has sparse
+/// vernacular names; `get_by_name` resolves to the canonical usage key and
+/// merges in GBIF's dedicated vernacular-names endpoint.
+///
+/// Failures are silently ignored — both fields are best-effort.
+async fn enrich_suggestions(
+    state: &AppState,
+    response: IdentifyResponse,
+) -> EnrichedIdentifyResponse {
+    let futures = response.suggestions.iter().map(|s| {
+        let taxonomy = state.taxonomy.clone();
+        let name = s.scientific_name.clone();
+        let kingdom = s.kingdom.clone();
+        let needs_common_name = s.common_name.is_none();
+        async move {
+            let (validate_result, by_name_common_name) =
+                tokio::join!(taxonomy.validate(&name), async {
+                    if needs_common_name {
+                        taxonomy
+                            .get_by_name(&name, kingdom.as_deref())
+                            .await
+                            .ok()
+                            .flatten()
+                            .and_then(|t| t.common_name)
+                    } else {
+                        None
+                    }
+                },);
+
+            let taxon_match = validate_result.filter(|v| v.valid).and_then(|v| v.taxon);
+            (taxon_match, by_name_common_name)
+        }
+    });
+
+    let results: Vec<_> = futures::future::join_all(futures).await;
+
+    let suggestions = response
         .suggestions
-        .iter()
-        .enumerate()
-        .filter(|(_, s)| s.common_name.is_none())
-        .map(|(i, s)| {
-            let taxonomy = state.taxonomy.clone();
-            let name = s.scientific_name.clone();
-            let kingdom = s.kingdom.clone();
-            async move {
-                let result = taxonomy.get_by_name(&name, kingdom.as_deref()).await;
-                let common_name = result.ok().flatten().and_then(|t| t.common_name);
-                (i, common_name)
+        .into_iter()
+        .zip(results)
+        .map(|(s, (taxon_match, extra_common_name))| {
+            let common_name = s.common_name.or(extra_common_name);
+            if let Some(ref m) = taxon_match {
+                debug!(
+                    scientific_name = %s.scientific_name,
+                    matched_id = %m.id,
+                    matched_rank = %m.rank,
+                    "Hydrated AI suggestion with GBIF match"
+                );
+            }
+            EnrichedSpeciesSuggestion {
+                scientific_name: s.scientific_name,
+                confidence: s.confidence,
+                common_name,
+                kingdom: s.kingdom,
+                in_range: s.in_range,
+                taxon_match,
             }
         })
         .collect();
 
-    for (i, common_name) in futures::future::join_all(futures).await {
-        if let Some(name) = common_name {
-            debug!(scientific_name = %response.suggestions[i].scientific_name, common_name = %name, "Enriched common name");
-            response.suggestions[i].common_name = Some(name);
-        }
+    EnrichedIdentifyResponse {
+        suggestions,
+        model_version: response.model_version,
+        inference_time_ms: response.inference_time_ms,
     }
 }

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -581,7 +581,11 @@ export function UploadModal() {
                 longitude={lng ? parseFloat(lng) : undefined}
                 onSelect={(s) => {
                   setSpecies(s.scientificName);
-                  if (s.kingdom) {
+                  if (s.taxonMatch) {
+                    setMatchedTaxon(s.taxonMatch);
+                    setKingdom(s.taxonMatch.kingdom ?? "");
+                    setRank("");
+                  } else if (s.kingdom) {
                     setKingdom(s.kingdom);
                   }
                 }}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -486,6 +486,13 @@ export interface SpeciesSuggestion {
    * index, or the request location is outside any mapped H3 cell).
    */
   inRange?: boolean;
+  /**
+   * Set when the AI suggestion's scientific name resolved to a known GBIF
+   * taxon. The frontend treats this like an autocomplete pick: matchedTaxon
+   * is set, so the kingdom and rank fields disappear and the indicator
+   * shows "Existing taxon".
+   */
+  taxonMatch?: TaxaResult;
 }
 
 export interface IdentifyResponse {


### PR DESCRIPTION
## Summary
- Backend: `/api/species-id` now runs `taxonomy.validate(name)` in parallel for each AI suggestion and attaches the resulting `TaxonResult` as `taxonMatch` when the name resolves to a known GBIF taxon. The existing common-name lookup runs alongside in the same parallel pass.
- Frontend: when the user picks an AI suggestion with `taxonMatch` set, the upload modal sets `matchedTaxon` (just like an autocomplete pick) — kingdom and rank fields disappear and the indicator shows "Existing taxon · {rank}".
- Falls back to the previous behavior (set kingdom from AI's own `kingdom` string, show "New taxon" + rank field) when GBIF doesn't recognize the name.

## Test plan
- [ ] Upload modal: pick an AI suggestion that exists in GBIF (e.g. *Aquila chrysaetos*) → "Existing taxon · {rank}" chip shows; kingdom and rank fields are not rendered
- [ ] Upload modal: pick an AI suggestion not in GBIF → "New taxon" chip; kingdom field appears and is required
- [ ] Submit observation from each path and verify the resulting record has the correct kingdom/rank
- [ ] Verify species-id endpoint latency is still acceptable (validate + get_by_name run in parallel per suggestion, all suggestions in parallel)