### PR TITLE
refactor(upload-modal): move location picker above taxon input

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -530,6 +530,14 @@ export function UploadModal() {
           JPG, PNG, or WebP - Max 10MB each - Up to {MAX_IMAGES} photos
         </Typography>
 
+        <LocationPicker
+          latitude={lat ? parseFloat(lat) : null}
+          longitude={lng ? parseFloat(lng) : null}
+          onChange={handleLocationChange}
+          uncertaintyMeters={uncertaintyMeters}
+          onUncertaintyChange={setUncertaintyMeters}
+        />
+
         <TaxaAutocomplete
           value={species}
           onChange={(name) => {
@@ -663,14 +671,6 @@ export function UploadModal() {
           slotProps={{
             inputLabel: { shrink: true },
           }}
-        />
-
-        <LocationPicker
-          latitude={lat ? parseFloat(lat) : null}
-          longitude={lng ? parseFloat(lng) : null}
-          onChange={handleLocationChange}
-          uncertaintyMeters={uncertaintyMeters}
-          onUncertaintyChange={setUncertaintyMeters}
         />
 
         <Stack


### PR DESCRIPTION
## Summary
- Moves the LocationPicker from the bottom of the upload form to right after the photo section, so it sits above the taxon autocomplete.
- Why: with lat/lng set before the user engages the taxon selector, the species-id endpoint can apply iNat geo-prior reranking and surface the in-range indicator on AI suggestions from the very first request, instead of the user having to scroll down, set location, and re-trigger AI suggest.

New form order: Photos → Location → Taxon → Kingdom/Rank → License → Date.

## Test plan
- [ ] Open the upload modal — location picker appears directly under the photo section
- [ ] Drop a pin / set coordinates, then add a photo → AI suggestions arrive with the in-range place icon when applicable
- [ ] Existing flows still work: edit-mode populates location from the observation, EXIF GPS still pre-fills lat/lng, "current location" still pre-fills on open