### PR TITLE
feat(upload-modal): show GBIF photo thumbnail on matched taxa

### DIFF
--- a/crates/observing-appview/src/routes/species_id.rs
+++ b/crates/observing-appview/src/routes/species_id.rs
@@ -93,16 +93,17 @@ pub async fn identify(
     }
 }
 
-/// Hydrate AI suggestions with GBIF match data and any missing common names.
+/// Hydrate AI suggestions with GBIF match data, photo, and common name.
 ///
-/// For each suggestion, validate against GBIF and (in parallel) look up the
-/// canonical species record when the AI didn't return a common name. We use
-/// `get_by_name` for common names — not the validate result's `taxon` —
-/// because validate returns the species-search shape, which has sparse
-/// vernacular names; `get_by_name` resolves to the canonical usage key and
-/// merges in GBIF's dedicated vernacular-names endpoint.
+/// For each suggestion we run `validate` (decides whether the AI's name
+/// resolves to a known taxon) and `get_by_name` in parallel. The validate
+/// result's `taxon` field comes from the GBIF species-search shape, which
+/// has sparse photoUrl/vernacular fields — so when validate matches, we
+/// pull `photoUrl` and `commonName` off the `get_by_name` `TaxonDetail`
+/// (which resolves to the canonical usage key, sources the photo from
+/// Wikidata Commons P18, and merges in GBIF's vernacular-names endpoint).
 ///
-/// Failures are silently ignored — both fields are best-effort.
+/// Failures are silently ignored — all three fields are best-effort.
 async fn enrich_suggestions(
     state: &AppState,
     response: IdentifyResponse,
@@ -111,24 +112,32 @@ async fn enrich_suggestions(
         let taxonomy = state.taxonomy.clone();
         let name = s.scientific_name.clone();
         let kingdom = s.kingdom.clone();
-        let needs_common_name = s.common_name.is_none();
         async move {
-            let (validate_result, by_name_common_name) =
+            let (validate_result, by_name_detail) =
                 tokio::join!(taxonomy.validate(&name, kingdom.as_deref()), async {
-                    if needs_common_name {
-                        taxonomy
-                            .get_by_name(&name, kingdom.as_deref())
-                            .await
-                            .ok()
-                            .flatten()
-                            .and_then(|t| t.common_name)
-                    } else {
-                        None
-                    }
+                    taxonomy
+                        .get_by_name(&name, kingdom.as_deref())
+                        .await
+                        .ok()
+                        .flatten()
                 },);
 
-            let taxon_match = validate_result.filter(|v| v.valid).and_then(|v| v.taxon);
-            (taxon_match, by_name_common_name)
+            let taxon_match = validate_result
+                .filter(|v| v.valid)
+                .and_then(|v| v.taxon)
+                .map(|mut t| {
+                    if let Some(ref detail) = by_name_detail {
+                        if t.photo_url.is_none() {
+                            t.photo_url = detail.photo_url.clone();
+                        }
+                        if t.common_name.is_none() {
+                            t.common_name = detail.common_name.clone();
+                        }
+                    }
+                    t
+                });
+            let extra_common_name = by_name_detail.and_then(|t| t.common_name);
+            (taxon_match, extra_common_name)
         }
     });
 

--- a/frontend/src/components/identification/AiSuggestions.tsx
+++ b/frontend/src/components/identification/AiSuggestions.tsx
@@ -98,6 +98,21 @@ export function AiSuggestionChips({ suggestions, onSelect }: AiSuggestionChipsPr
             key={s.scientificName}
             label={
               <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
+                {s.taxonMatch?.photoUrl && (
+                  <Box
+                    component="img"
+                    src={s.taxonMatch.photoUrl}
+                    alt=""
+                    loading="lazy"
+                    sx={{
+                      width: 24,
+                      height: 24,
+                      borderRadius: 0.5,
+                      objectFit: "cover",
+                      flexShrink: 0,
+                    }}
+                  />
+                )}
                 <Box
                   component="span"
                   sx={{

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, type FormEvent, type ChangeEvent, useRef } from "react";
 import {
+  Avatar,
   Box,
   Typography,
   TextField,
@@ -563,10 +564,12 @@ export function UploadModal() {
             species.trim() ? (
               matchedTaxon ? (
                 <Chip
-                  icon={<CheckCircleOutlinedIcon />}
-                  label={
-                    matchedTaxon.rank ? `Existing taxon · ${matchedTaxon.rank}` : "Existing taxon"
-                  }
+                  {...(matchedTaxon.photoUrl
+                    ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
+                    : { icon: <CheckCircleOutlinedIcon /> })}
+                  label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
+                    .filter((p): p is string => Boolean(p))
+                    .join(" · ")}
                   color="success"
                   size="small"
                   variant="outlined"


### PR DESCRIPTION
## Summary
Surfaces the matched taxon's photo as the leading visual on:
- **Match indicator chip** (after picking from autocomplete or an AI suggestion): photo Avatar replaces the success-check icon when `photoUrl` is available; the label expands to `Existing taxon · {commonName} · {rank}` (any pieces missing are dropped).
- **AI suggestion chips**: a 24×24 thumbnail prepends each chip when the AI suggestion was hydrated against GBIF and has a `photoUrl`.

Also fixes a hydration gap on the backend: `validate` returns a TaxonResult shaped from GBIF's species-search payload, which has sparse `photoUrl` / vernacular fields. When validate succeeds, we now copy `photoUrl` and `commonName` from the parallel `get_by_name` TaxonDetail (which resolves to the canonical usage key, sources the photo from Wikidata Commons P18 via the GBIF taxon ID — see #390 — and merges in GBIF's vernacular-names endpoint), so the frontend can actually surface the thumbnail.

## Why
Visual confirmation that "yes, this is the species I meant" is the strongest trust signal in the upload flow — much stronger than reading the scientific name back. Especially valuable when AI confidence is borderline (matched a near-relative) or when scientific names are easily confused.

## Test plan
- [x] Autocomplete pick (e.g. type `quercus`, pick *Quercusia quercus / Purple Hairstreak*) → "Existing taxon · Purple Hairstreak · species" chip shows the Wikidata Commons thumbnail
- [x] AI suggest on a butterfly photo → first suggestion (*Favonius quercus*) shows a thumbnail on the chip; clicking it sets matchedTaxon and the indicator chip also shows the photo
- [x] Suggestions / matches without `photoUrl` (some species don't have a Wikidata image and no GBIF media fallback) fall back gracefully — text-only chip, success-check icon on indicator