### PR TITLE
fix(pwa): check for updates on register and visibility change

### DIFF
--- a/frontend/src/components/common/UpdatePrompt.tsx
+++ b/frontend/src/components/common/UpdatePrompt.tsx
@@ -9,11 +9,23 @@ export function UpdatePrompt() {
     updateServiceWorker,
   } = useRegisterSW({
     onRegisteredSW(_swUrl, registration) {
-      if (registration) {
-        setInterval(() => {
+      if (!registration) return;
+      // Check immediately so a freshly opened PWA picks up a deploy without
+      // waiting for the hourly tick (mobile suspends backgrounded tabs, so
+      // a setInterval timer rarely actually fires).
+      registration.update();
+      // Re-check whenever the user returns to the app — the most reliable
+      // moment on mobile, where setInterval timers don't survive a switch
+      // to another app and back.
+      document.addEventListener("visibilitychange", () => {
+        if (document.visibilityState === "visible") {
           registration.update();
-        }, HOUR_MS);
-      }
+        }
+      });
+      // Hourly backup for long-lived foregrounded sessions.
+      setInterval(() => {
+        registration.update();
+      }, HOUR_MS);
     },
   });
 


### PR DESCRIPTION
## Summary
The hourly `setInterval` was the only thing triggering `registration.update()` from `onRegisteredSW`, but mobile OSes routinely suspend backgrounded PWA tabs, so the timer almost never reaches the next tick. A user who opens the installed PWA, browses for a few minutes, and closes it would go indefinitely without ever pulling a newer service worker — they'd be stuck on whatever shell was cached the first time they opened the app.

Two small additions to `onRegisteredSW`:
- `registration.update()` runs **immediately** on first register, so a freshly opened PWA gets a freshness check within seconds rather than an hour.
- A `visibilitychange` listener calls `registration.update()` whenever the doc becomes visible — the natural and most reliable trigger on mobile, where `setInterval` timers don't survive an app switch.

The hourly `setInterval` stays as a backup for long-lived foregrounded sessions (desktops, kiosks).

## Test plan
- [ ] iOS PWA: open after a deploy → "new version" snackbar appears within seconds, not after an hour
- [ ] Same flow on Android Chrome PWA
- [ ] Switch away from the PWA, deploy, come back → snackbar appears on return without manual refresh
- [ ] Long-lived desktop tab still updates hourly

## Notes
This does **not** change the precaching/runtime-cache strategy. If the cache size itself remains a concern, follow-ups could:
- Drop `index.html` from the precache and serve it via `NetworkFirst` so the shell refreshes naturally
- Tighten `maxEntries`/`maxAgeSeconds` on the runtime caches (currently 200 taxa for 7d, 100 media for 30d)