### PR TITLE
fix(taxonomy): round-trip GBIF kingdom hint through identifications

### DIFF
--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -266,10 +266,19 @@ async fn resolve_effective_taxonomy(
 ) -> Option<EffectiveTaxonomy> {
     let effective_name = community_id?;
 
+    // GBIF can't disambiguate genus-level names without a kingdom hint
+    // (e.g. "Pinus" in plants vs. unrelated genera in other kingdoms), so
+    // fall back to any identification's kingdom when the occurrence row
+    // doesn't carry one. Identifications all share at least the LCA's
+    // ancestry, so any identification's kingdom is safe to use.
+    let kingdom_hint = occurrence_kingdom
+        .map(str::to_string)
+        .or_else(|| identifications.iter().find_map(|id| id.kingdom.clone()));
+
     // GBIF is the source of truth for vernacular names, so always try it first.
     // The Moka cache fronting the client keeps repeat lookups cheap.
     if let Some(detail) = taxonomy
-        .get_by_name(effective_name, occurrence_kingdom)
+        .get_by_name(effective_name, kingdom_hint.as_deref())
         .await
         .unwrap_or(None)
     {

--- a/crates/observing-appview/src/routes/identifications.rs
+++ b/crates/observing-appview/src/routes/identifications.rs
@@ -47,6 +47,11 @@ pub struct CreateIdentificationRequest {
     scientific_name: String,
     #[ts(optional)]
     taxon_rank: Option<String>,
+    /// Optional kingdom hint from a GBIF autocomplete pick. Disambiguates
+    /// genus-level names for the GBIF validate call and acts as a fallback
+    /// when validation doesn't return a kingdom of its own.
+    #[ts(optional)]
+    kingdom: Option<String>,
     #[ts(optional)]
     is_agreement: Option<bool>,
 }
@@ -68,6 +73,7 @@ pub async fn create_identification(
         &state.taxonomy,
         &body.scientific_name,
         body.taxon_rank.clone(),
+        body.kingdom.as_deref(),
     )
     .await;
 

--- a/crates/observing-appview/src/routes/occurrences/auto_id.rs
+++ b/crates/observing-appview/src/routes/occurrences/auto_id.rs
@@ -12,19 +12,23 @@ use crate::state::AppState;
 ///
 /// Validates taxonomy and constructs the AT Protocol identification record.
 /// `user_taxon_rank` is used only when taxonomy validation cannot resolve a
-/// rank — taxonomy is authoritative for known taxa.
+/// rank — taxonomy is authoritative for known taxa. `user_kingdom` is
+/// forwarded to GBIF as a disambiguator and used as a fallback when
+/// validation doesn't return a kingdom (e.g. genus-level names without a
+/// hint).
 /// Returns the record JSON value ready to be posted via the agent.
 pub async fn build_identification_record(
     state: &AppState,
     scientific_name: &str,
     user_taxon_rank: Option<&str>,
+    user_kingdom: Option<&str>,
     occurrence_uri: &str,
     occurrence_cid: &str,
 ) -> Result<Value, AppError> {
     let mut taxon_rank = None;
     let mut kingdom = None;
 
-    if let Some(validation) = state.taxonomy.validate(scientific_name).await {
+    if let Some(validation) = state.taxonomy.validate(scientific_name, user_kingdom).await {
         if let Some(ref t) = validation.taxon {
             taxon_rank = Some(t.rank.clone());
             kingdom = t.kingdom.clone();
@@ -33,6 +37,9 @@ pub async fn build_identification_record(
 
     if taxon_rank.is_none() {
         taxon_rank = user_taxon_rank.map(str::to_owned);
+    }
+    if kingdom.is_none() {
+        kingdom = user_kingdom.map(str::to_owned);
     }
 
     let occurrence = auth::build_strong_ref(occurrence_uri, occurrence_cid)?;

--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -38,6 +38,11 @@ pub struct CreateOccurrenceRequest {
     scientific_name: Option<String>,
     #[ts(optional)]
     taxon_rank: Option<String>,
+    /// Optional kingdom hint from a GBIF autocomplete pick. Disambiguates
+    /// genus-level names for the auto-identification's GBIF validate call
+    /// and acts as a fallback when validation doesn't return a kingdom.
+    #[ts(optional)]
+    kingdom: Option<String>,
 }
 
 #[derive(Deserialize, TS)]
@@ -72,6 +77,9 @@ pub struct UpdateOccurrenceRequest {
     scientific_name: Option<String>,
     #[ts(optional)]
     taxon_rank: Option<String>,
+    /// See `CreateOccurrenceRequest::kingdom`.
+    #[ts(optional)]
+    kingdom: Option<String>,
 }
 
 pub async fn create_occurrence(
@@ -132,6 +140,7 @@ pub async fn create_occurrence(
                 &user.did,
                 scientific_name,
                 body.taxon_rank.as_deref(),
+                body.kingdom.as_deref(),
                 &uri,
                 &cid,
             )
@@ -375,6 +384,7 @@ pub async fn update_occurrence(
                     &user.did,
                     trimmed,
                     body.taxon_rank.as_deref(),
+                    body.kingdom.as_deref(),
                     &uri,
                     &cid,
                 )
@@ -516,6 +526,7 @@ async fn create_auto_identification(
     user_did: &str,
     scientific_name: &str,
     user_taxon_rank: Option<&str>,
+    user_kingdom: Option<&str>,
     occurrence_uri: &str,
     occurrence_cid: &str,
 ) -> Result<(), AppError> {
@@ -523,6 +534,7 @@ async fn create_auto_identification(
         state,
         scientific_name,
         user_taxon_rank,
+        user_kingdom,
         occurrence_uri,
         occurrence_cid,
     )

--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -520,6 +520,7 @@ fn build_occurrence_record_json(
 /// Jetstream delivers commits in repo order, so the preceding occurrence
 /// upsert (needed to satisfy the FK on `identifications.subject_uri`) is
 /// guaranteed to run first.
+#[allow(clippy::too_many_arguments)]
 async fn create_auto_identification(
     state: &AppState,
     agent: &AgentType,

--- a/crates/observing-appview/src/routes/species_id.rs
+++ b/crates/observing-appview/src/routes/species_id.rs
@@ -114,7 +114,7 @@ async fn enrich_suggestions(
         let needs_common_name = s.common_name.is_none();
         async move {
             let (validate_result, by_name_common_name) =
-                tokio::join!(taxonomy.validate(&name), async {
+                tokio::join!(taxonomy.validate(&name, kingdom.as_deref()), async {
                     if needs_common_name {
                         taxonomy
                             .get_by_name(&name, kingdom.as_deref())

--- a/crates/observing-appview/src/routes/taxonomy.rs
+++ b/crates/observing-appview/src/routes/taxonomy.rs
@@ -43,6 +43,7 @@ pub async fn search(
 #[derive(Deserialize)]
 pub struct ValidateParams {
     name: Option<String>,
+    kingdom: Option<String>,
 }
 
 pub async fn validate(
@@ -53,7 +54,11 @@ pub async fn validate(
         .name
         .ok_or_else(|| AppError::BadRequest("name is required".into()))?;
 
-    match state.taxonomy.validate(&name).await {
+    match state
+        .taxonomy
+        .validate(&name, params.kingdom.as_deref())
+        .await
+    {
         Some(result) => Ok(Json(result)),
         None => Ok(Json(ValidateResponse {
             valid: false,

--- a/crates/observing-appview/src/taxonomy/gbif.rs
+++ b/crates/observing-appview/src/taxonomy/gbif.rs
@@ -136,9 +136,13 @@ impl GbifClient {
         !canonical.eq_ignore_ascii_case(scientific_name)
     }
 
-    /// Validate a scientific name
-    pub async fn validate(&self, name: &str) -> ValidateResponse {
-        let gbif_match = match self.api.match_name(name, None).await {
+    /// Validate a scientific name. `kingdom_hint` is forwarded to GBIF's
+    /// `match_name` to disambiguate names shared across kingdoms (e.g.
+    /// genus-level names like "Pinus") — without a hint a non-EXACT result
+    /// can leave us with `taxon: None` and no kingdom for the caller to
+    /// store.
+    pub async fn validate(&self, name: &str, kingdom_hint: Option<&str>) -> ValidateResponse {
+        let gbif_match = match self.api.match_name(name, kingdom_hint).await {
             Ok(Some(m)) => m,
             _ => {
                 return ValidateResponse {

--- a/crates/observing-appview/src/taxonomy_client.rs
+++ b/crates/observing-appview/src/taxonomy_client.rs
@@ -217,17 +217,23 @@ impl TaxonFields {
     ///
     /// `rank_override` is an optional caller-supplied rank (e.g. from user
     /// input). When present it takes priority over the rank returned by GBIF.
+    ///
+    /// `kingdom_hint` is forwarded to GBIF for disambiguation (essential for
+    /// genus-level names that overlap across kingdoms, where a hint-less
+    /// validate often returns no taxon at all). It also acts as a fallback
+    /// when the validation succeeds but doesn't carry a kingdom of its own.
     pub async fn from_validation(
         taxonomy: &TaxonomyClient,
         scientific_name: &str,
         rank_override: Option<String>,
+        kingdom_hint: Option<&str>,
     ) -> Self {
         let mut fields = TaxonFields {
             taxon_rank: rank_override,
             ..Default::default()
         };
 
-        if let Some(validation) = taxonomy.validate(scientific_name).await {
+        if let Some(validation) = taxonomy.validate(scientific_name, kingdom_hint).await {
             if let Some(ref t) = validation.taxon {
                 fields.taxon_id = Some(t.id.clone());
                 if fields.taxon_rank.is_none() {
@@ -240,6 +246,11 @@ impl TaxonFields {
                 fields.family = t.family.clone();
                 fields.genus = t.genus.clone();
             }
+        }
+
+        // Don't lose the caller's kingdom if validation didn't supply one.
+        if fields.kingdom.is_none() {
+            fields.kingdom = kingdom_hint.map(str::to_string);
         }
 
         fields
@@ -267,10 +278,15 @@ impl TaxonomyClient {
         Some(self.inner.search(query, limit.unwrap_or(10)).await)
     }
 
-    /// Validate a taxon name. Returns `None` if the lookup itself failed —
+    /// Validate a taxon name with an optional kingdom hint for GBIF
+    /// disambiguation. Returns `None` if the lookup itself failed —
     /// preserved for parity with the prior HTTP client.
-    pub async fn validate(&self, name: &str) -> Option<ValidateResponse> {
-        Some(self.inner.validate(name).await)
+    pub async fn validate(
+        &self,
+        name: &str,
+        kingdom_hint: Option<&str>,
+    ) -> Option<ValidateResponse> {
+        Some(self.inner.validate(name, kingdom_hint).await)
     }
 
     /// Get taxon detail by GBIF ID (`gbif:NNN` or bare numeric).

--- a/frontend/src/bindings/CreateIdentificationRequest.ts
+++ b/frontend/src/bindings/CreateIdentificationRequest.ts
@@ -5,5 +5,11 @@ export type CreateIdentificationRequest = {
   occurrenceCid: string;
   scientificName: string;
   taxonRank?: string;
+  /**
+   * Optional kingdom hint from a GBIF autocomplete pick. Disambiguates
+   * genus-level names for the GBIF validate call and acts as a fallback
+   * when validation doesn't return a kingdom of its own.
+   */
+  kingdom?: string;
   isAgreement?: boolean;
 };

--- a/frontend/src/bindings/CreateOccurrenceRequest.ts
+++ b/frontend/src/bindings/CreateOccurrenceRequest.ts
@@ -9,4 +9,10 @@ export type CreateOccurrenceRequest = {
   images?: Array<ImageUpload>;
   scientificName?: string;
   taxonRank?: string;
+  /**
+   * Optional kingdom hint from a GBIF autocomplete pick. Disambiguates
+   * genus-level names for the auto-identification's GBIF validate call
+   * and acts as a fallback when validation doesn't return a kingdom.
+   */
+  kingdom?: string;
 };

--- a/frontend/src/bindings/UpdateOccurrenceRequest.ts
+++ b/frontend/src/bindings/UpdateOccurrenceRequest.ts
@@ -18,4 +18,8 @@ export type UpdateOccurrenceRequest = {
   retainedBlobCids?: Array<string>;
   scientificName?: string;
   taxonRank?: string;
+  /**
+   * See `CreateOccurrenceRequest::kingdom`.
+   */
+  kingdom?: string;
 };

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -4,6 +4,7 @@ import CheckIcon from "@mui/icons-material/Check";
 import EditIcon from "@mui/icons-material/Edit";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import { submitIdentification } from "../../services/api";
+import type { TaxaResult } from "../../services/types";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { AiSuggestionChips } from "./AiSuggestions";
 import { useAiSuggestions } from "../../hooks/useAiSuggestions";
@@ -38,6 +39,7 @@ export function IdentificationPanel({
   const dispatch = useAppDispatch();
   const [showSuggestForm, setShowSuggestForm] = useState(false);
   const [taxonName, setTaxonName] = useState("");
+  const [matchedTaxon, setMatchedTaxon] = useState<TaxaResult | null>(null);
 
   const currentId = observation.communityId || observation.scientificName || "Unknown";
 
@@ -63,9 +65,11 @@ export function IdentificationPanel({
         occurrenceUri: observation.uri,
         occurrenceCid: observation.cid,
         scientificName: taxonName.trim(),
+        ...(matchedTaxon?.kingdom ? { kingdom: matchedTaxon.kingdom } : {}),
+        ...(matchedTaxon?.rank ? { taxonRank: matchedTaxon.rank } : {}),
         isAgreement: false,
       }),
-    [observation.uri, observation.cid, taxonName],
+    [observation.uri, observation.cid, taxonName, matchedTaxon],
   );
 
   const { isSubmitting: isSuggesting, handleSubmit: doSuggest } = useFormSubmit(suggestFn, {
@@ -73,6 +77,7 @@ export function IdentificationPanel({
     onSuccess: () => {
       setShowSuggestForm(false);
       setTaxonName("");
+      setMatchedTaxon(null);
       onSuccess?.();
     },
   });
@@ -167,13 +172,22 @@ export function IdentificationPanel({
             <Box sx={{ flex: 1 }}>
               <TaxaAutocomplete
                 value={taxonName}
-                onChange={setTaxonName}
+                onChange={(name) => {
+                  setTaxonName(name);
+                  if (name === "") {
+                    setMatchedTaxon(null);
+                  }
+                }}
+                onMatchChange={setMatchedTaxon}
                 size="small"
                 margin="none"
                 bottomContent={
                   <AiSuggestionChips
                     suggestions={ai.suggestions}
-                    onSelect={(s) => setTaxonName(s.scientificName)}
+                    onSelect={(s) => {
+                      setTaxonName(s.scientificName);
+                      setMatchedTaxon(s.taxonMatch ?? null);
+                    }}
                   />
                 }
               />
@@ -212,6 +226,7 @@ export function IdentificationPanel({
               onClick={() => {
                 setShowSuggestForm(false);
                 setTaxonName("");
+                setMatchedTaxon(null);
               }}
             >
               Cancel

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -284,6 +284,7 @@ export async function submitIdentification(data: {
   occurrenceCid: string;
   scientificName: string;
   taxonRank?: string;
+  kingdom?: string;
   isAgreement?: boolean;
 }): Promise<{ uri: string; cid: string }> {
   return fetchApi(`${API_BASE}/api/identifications`, "Failed to submit identification", {


### PR DESCRIPTION
## Summary
- Capture the matched-taxon kingdom from `IdentificationPanel`'s autocomplete (and AI suggestion) and forward it through the create-identification API and into the AT Protocol record. Same hint is now also accepted on the create/update occurrence routes for the auto-id record.
- Plumb the kingdom hint into `TaxonomyClient::validate` / `gbif::validate` so GBIF can disambiguate genus-level names like "Pinus" instead of returning `taxon: None`.
- In `resolve_effective_taxonomy`, fall back to any sibling identification's kingdom when the occurrence row doesn't carry one — salvages display for the LCA case where the community ID is a bare genus.

## Why
On https://observ.ing/observation/did:plc:kipb7stkroxenbqsmixcsley/3mkquiac7h22i, "Pinus" rendered upright instead of italic. The frontend italicization heuristic relies on `effectiveTaxonomy.rank`, which was missing because GBIF needs a kingdom hint to resolve "Pinus" alone, and we were dropping that hint at every layer.

## Test plan
- [ ] Submit a new "Suggest Different ID" using the GBIF autocomplete pick of "Pinus" — verify `/api/identifications` request body includes `kingdom: "Plantae"`, the resulting AT Protocol record carries it, and the observation page italicizes once the community ID resolves.
- [ ] Submit via AI suggestion that includes a `taxonMatch` — same expectation.
- [ ] Existing observations whose identifications have no kingdom in the DB still render best-effort (no regressions); a re-id by an authenticated user is what brings rank back.
- [ ] `cargo check -p observing-appview`, `cargo fmt --check`, `npm run fmt:check`, `npx tsc --noEmit`, `npx oxlint` all clean.