### PR TITLE
feat(taxonomy): use Wikidata Commons primary image for taxon hero

### DIFF
--- a/crates/observing-appview/src/taxonomy/gbif.rs
+++ b/crates/observing-appview/src/taxonomy/gbif.rs
@@ -210,13 +210,16 @@ impl GbifClient {
             None => return Ok(None),
         };
 
-        // Fetch children, descriptions, references, media, and Wikidata URL in parallel
-        let (children, descriptions, references, media, wikidata_url) = tokio::join!(
+        // Fetch children, descriptions, references, media, Wikidata URL, and
+        // Wikidata's primary image (P18) in parallel.
+        let key_slice = [key];
+        let (children, descriptions, references, media, wikidata_url, wikidata_images) = tokio::join!(
             self.get_children(taxon_id, 20),
             self.api.get_descriptions(key, 5),
             self.api.get_references(key, 10),
             self.api.get_media(key, 10),
             self.wikidata.get_entity_url(key),
+            self.wikidata.get_images_for_keys(&key_slice, 600),
         );
 
         let children = children.unwrap_or_default();
@@ -281,8 +284,12 @@ impl GbifClient {
             .map(|r| r.to_lowercase())
             .unwrap_or_else(|| "unknown".to_string());
 
-        // Get photo from first media item if available
-        let photo_url = media.first().map(|m| m.url.clone());
+        // Prefer Wikidata's primary image (P18); fall back to the first GBIF
+        // media item when Wikidata has no image for this taxon.
+        let photo_url = wikidata_images
+            .get(&key)
+            .cloned()
+            .or_else(|| media.first().map(|m| m.url.clone()));
 
         let taxon_detail = TaxonDetail {
             id: build_taxon_path(resolved_name, &resolved_rank, data.kingdom.as_deref()),
@@ -447,7 +454,7 @@ impl GbifClient {
         let keys: Vec<u64> = data.iter().filter_map(|item| item.key).collect();
 
         // Fetch photos from Wikidata using GBIF taxon IDs (single batched SPARQL query)
-        let photos = self.wikidata.get_images_for_keys(&keys).await;
+        let photos = self.wikidata.get_images_for_keys(&keys, 100).await;
 
         // Convert to TaxonResults with photos
         let basic_results: Vec<(TaxonResult, Option<u64>)> = data

--- a/crates/observing-appview/src/taxonomy/wikidata.rs
+++ b/crates/observing-appview/src/taxonomy/wikidata.rs
@@ -18,12 +18,19 @@ impl WikidataClient {
     }
 
     /// Fetch images for multiple taxa by their GBIF taxon IDs.
-    /// Returns a map of gbif_key -> thumbnail URL.
-    pub async fn get_images_for_keys(&self, keys: &[u64]) -> HashMap<u64, String> {
+    /// Returns a map of gbif_key -> thumbnail URL rendered at `thumbnail_width` pixels.
+    pub async fn get_images_for_keys(
+        &self,
+        keys: &[u64],
+        thumbnail_width: u32,
+    ) -> HashMap<u64, String> {
         let string_keys: Vec<String> = keys.iter().map(|k| k.to_string()).collect();
         let str_keys: Vec<&str> = string_keys.iter().map(|s| s.as_str()).collect();
 
-        let results = self.client.get_images_by_property("P846", &str_keys).await;
+        let results = self
+            .client
+            .get_images_by_property("P846", &str_keys, thumbnail_width)
+            .await;
 
         results
             .into_iter()

--- a/crates/wikidata-client/src/lib.rs
+++ b/crates/wikidata-client/src/lib.rs
@@ -20,7 +20,7 @@
 //! ).await.unwrap();
 //!
 //! // Fetch images for GBIF taxon IDs
-//! let images = client.get_images_by_property("P846", &["2480528", "5219243"]).await;
+//! let images = client.get_images_by_property("P846", &["2480528", "5219243"], 100).await;
 //! # }
 //! ```
 
@@ -156,14 +156,15 @@ impl WikidataClient {
 
     /// Fetch images (Wikidata property P18) for items matching external IDs.
     ///
-    /// Returns a map of external ID to Wikimedia Commons thumbnail URL.
+    /// Returns a map of external ID to Wikimedia Commons thumbnail URL, with the
+    /// thumbnail rendered at `thumbnail_width` pixels.
     ///
     /// For example, to get images for GBIF taxon IDs:
     /// ```no_run
     /// # use wikidata_client::WikidataClient;
     /// # async fn example() {
     /// let client = WikidataClient::new();
-    /// let images = client.get_images_by_property("P846", &["2480528", "5219243"]).await;
+    /// let images = client.get_images_by_property("P846", &["2480528", "5219243"], 100).await;
     /// // Returns: {"2480528": "http://commons.wikimedia.org/...?width=100"}
     /// # }
     /// ```
@@ -171,6 +172,7 @@ impl WikidataClient {
         &self,
         property: &str,
         ids: &[&str],
+        thumbnail_width: u32,
     ) -> HashMap<String, String> {
         if ids.is_empty() {
             return HashMap::new();
@@ -201,7 +203,7 @@ impl WikidataClient {
         let mut result = HashMap::new();
         for binding in bindings {
             if let (Some(id), Some(image)) = (binding.get("external_id"), binding.get("image")) {
-                let thumb_url = to_thumbnail_url(&image.value, 100);
+                let thumb_url = to_thumbnail_url(&image.value, thumbnail_width);
                 result.insert(id.value.clone(), thumb_url);
             }
         }


### PR DESCRIPTION
## Summary
- Source the taxon detail hero image from Wikidata's primary image (P18) via the GBIF taxon ID (P846) link, instead of GBIF's first media item.
- Fall back to the first GBIF media item only when Wikidata has no image for the taxon.
- Plumb a `thumbnail_width` parameter through `wikidata-client::get_images_by_property` and the appview wrapper so search results can keep using 100px while the detail hero requests 600px.

Closes #389

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p wikidata-client -p observing-appview -- -D warnings`
- [x] `cargo test -p wikidata-client -p observing-appview`
- [ ] Manual: open a taxon detail page (e.g. one whose Wikidata entity has a P18 image, like Q14683's GBIF counterpart) and confirm the hero image now comes from Wikimedia Commons.
- [ ] Manual: open a taxon with no Wikidata image and confirm the first GBIF media item still renders.