### PR TITLE
chore(deps): bump hickory-{proto,net,resolver} to 0.26.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,9 +1703,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hickory-net"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c61c8db47fae51ba9f8f2a2748bd87542acfbe22f2ec9cf9c8ec72d1ee6e9a6"
+checksum = "e2295ed2f9c31e471e1428a8f88a3f0e1f4b27c15049592138d1eebe9c35b183"
 dependencies = [
  "async-trait",
  "cfg-if",
@@ -1727,9 +1727,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-proto"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a916d0494600d99ecb15aadfab677ad97c4de559e8f1af0c129353a733ac1fcc"
+checksum = "0bab31817bfb44672a252e97fe81cd0c18d1b2cf892108922f6818820df8c643"
 dependencies = [
  "data-encoding",
  "idna",
@@ -1747,9 +1747,9 @@ dependencies = [
 
 [[package]]
 name = "hickory-resolver"
-version = "0.26.0"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10bd64d950b4d38ca21e25c8ae230712e4955fb8290cfcb29a5e5dc6017e544"
+checksum = "f0d58d28879ceecde6607729660c2667a081ccdc082e082675042793960f178c"
 dependencies = [
  "cfg-if",
  "futures-util",

--- a/deny.toml
+++ b/deny.toml
@@ -5,6 +5,10 @@ ignore = [
 # observing-appview -> jacquard-common -> cid -> ipld-core -> atrium-api -> core2
 # (atrium/cid stack hasn't yet migrated off core2; we don't call into it directly)
     { id = "RUSTSEC-2026-0105", reason = "core2 unmaintained, transitive dep via atrium-api/cid" },
+# Advisory text states the vulnerable code was migrated from hickory-proto to
+# hickory-net in 0.26.0 and the fix lives in hickory-net 0.26.1 (which we have).
+# The advisory is still tagged against hickory-proto with no patched version.
+    { id = "RUSTSEC-2026-0118", reason = "vulnerable code lives in hickory-net (patched to 0.26.1); advisory misattributed to hickory-proto" },
 ]
 
 [licenses]


### PR DESCRIPTION
## Summary
Three RustSec advisories against the `hickory-*` crate family started failing CI today (rust-deny job). This patches the lockfile to the fixed versions:

- **RUSTSEC-2026-0119** — `hickory-proto`: CPU exhaustion in `BinEncoder` due to O(n²) name compression. Fixed in 0.26.1.
- **RUSTSEC-2026-0120** — `hickory-net`: NSEC3 closest-encloser proof validation enters an unbounded loop on cross-zone responses. Fixed in 0.26.1.
- **RUSTSEC-2026-0118** — Same NSEC3 bug, but the advisory is tagged against `hickory-proto`. Per the advisory text, the vulnerable code was migrated from `hickory-proto` to `hickory-net` in 0.26.0, and the actual fix lives in `hickory-net` 0.26.1 — `cargo-deny` reports "No safe upgrade is available!" for `hickory-proto`. Added to the `deny.toml` ignore list with a reason; the real fix comes from the `hickory-net` 0.26.1 bump.

## Test plan
- [x] `cargo deny check` (advisories ok, bans ok, licenses ok, sources ok)
- [x] `cargo build` succeeds
- [ ] CI rust-deny job passes