### PR TITLE
feat(storybook): wire CI to build on PRs and deploy to GCS on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,46 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  # Build Storybook on every PR so a broken story fails the merge gate.
+  # On push to main the static output is uploaded as an artifact for
+  # `storybook-deploy` to publish.
+  storybook-build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm run build-storybook
+      - uses: actions/upload-artifact@v4
+        if: github.event_name == 'push'
+        with:
+          name: storybook-static
+          path: storybook-static/
+          retention-days: 1
+
+  # Sync the static Storybook bundle to gs://observing-storybook on push to main.
+  # Bucket is public-read; site lives at https://storage.googleapis.com/observing-storybook/index.html
+  storybook-deploy:
+    runs-on: ubuntu-latest
+    needs: [storybook-build]
+    if: github.event_name == 'push'
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: storybook-static
+          path: storybook-static/
+      - uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+      - uses: google-github-actions/setup-gcloud@v2
+      - name: Sync to GCS bucket
+        run: |
+          gcloud storage rsync storybook-static/ gs://observing-storybook/ \
+            --recursive --delete-unmatched-destination-objects
+
   # Rust jobs
   rust-lockfile:
     runs-on: ubuntu-latest


### PR DESCRIPTION
M3 of the Storybook track. Adds two CI jobs that close the loop on automatic Storybook publishing.

## Changes
**`storybook-build`** — runs on every PR and main push.
- `npm run build-storybook`. A broken story fails the merge gate.
- On push to main, uploads `storybook-static/` as a 1-day artifact for the deploy job.

**`storybook-deploy`** — runs only on push to main.
- Downloads the artifact, auths with the existing \`GCP_SA_KEY\` service account, and \`gcloud storage rsync\`s into \`gs://observing-storybook\` (provisioned out-of-band, public-read, write granted to the CI SA).
- Uses \`--delete-unmatched-destination-objects\` so the bucket stays clean as story chunks are renamed across builds.

## Independence from prod deploy
The Storybook deploy intentionally does **not** block on \`build-images\` / \`deploy\` (the production app pipeline) and vice versa. Rationale:
- A broken story shouldn't block a prod release.
- A failed prod deploy shouldn't block updating Storybook.
- Storybook is a developer tool, not part of the production runtime.

## Live URL
https://storage.googleapis.com/observing-storybook/index.html

(MainPageSuffix only auto-resolves on a custom-domain CNAME, so for now the explicit \`/index.html\` path is needed. A custom domain would let \`https://storybook.observ.ing\` work bare — happy to do that as a follow-up if you want.)

## Test plan
- [ ] PR CI: `storybook-build` runs and passes; `storybook-deploy` is skipped (since it's gated on `event_name == 'push'`).
- [ ] After merge: both jobs run; `storybook-deploy` re-uploads the static bundle; the live URL serves the latest `main`.
- [ ] Verify the bucket contents change after a content edit (e.g. add or rename a story in a follow-up).