### PR TITLE
ci(storybook): enforce every component has a Storybook story

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,17 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+  # Enforce that every component in frontend/src/components has a sibling
+  # *.stories.tsx file. Catches new components that ship without a story.
+  storybook-coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+      - run: npm run check:stories
+
   # Build Storybook on every PR so a broken story fails the merge gate.
   # On push to main the static output is uploaded as an artifact for
   # `storybook-deploy` to publish.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "vite build -c frontend/vite.config.ts",
     "build-storybook": "storybook build",
+    "check:stories": "node scripts/check-stories.mjs",
     "generate-rust-types": "./scripts/generate-rust-types.sh",
     "dev": "vite -c frontend/vite.config.ts",
     "fmt": "oxfmt frontend/src tests scripts",

--- a/scripts/check-stories.mjs
+++ b/scripts/check-stories.mjs
@@ -32,9 +32,7 @@ for (const file of files) {
 }
 
 if (missing.length > 0) {
-  console.error(
-    `Missing Storybook stories for ${missing.length} component(s):\n`,
-  );
+  console.error(`Missing Storybook stories for ${missing.length} component(s):\n`);
   for (const f of missing) console.error(`  - ${f}`);
   console.error(
     `\nEvery component in frontend/src/components must have a sibling *.stories.tsx file.`,

--- a/scripts/check-stories.mjs
+++ b/scripts/check-stories.mjs
@@ -1,0 +1,47 @@
+#!/usr/bin/env node
+import { readdirSync, statSync } from "node:fs";
+import { join, relative } from "node:path";
+
+const ROOT = new URL("../frontend/src/components/", import.meta.url).pathname;
+
+function walk(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      out.push(...walk(full));
+    } else {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+const files = walk(ROOT);
+const stories = new Set(files.filter((f) => f.endsWith(".stories.tsx")));
+const missing = [];
+
+for (const file of files) {
+  if (!file.endsWith(".tsx")) continue;
+  if (file.endsWith(".stories.tsx")) continue;
+  if (file.endsWith(".test.tsx")) continue;
+  const expected = file.replace(/\.tsx$/, ".stories.tsx");
+  if (!stories.has(expected)) {
+    missing.push(relative(process.cwd(), file));
+  }
+}
+
+if (missing.length > 0) {
+  console.error(
+    `Missing Storybook stories for ${missing.length} component(s):\n`,
+  );
+  for (const f of missing) console.error(`  - ${f}`);
+  console.error(
+    `\nEvery component in frontend/src/components must have a sibling *.stories.tsx file.`,
+  );
+  process.exit(1);
+}
+
+console.log(
+  `OK: all ${files.filter((f) => f.endsWith(".tsx") && !f.endsWith(".stories.tsx") && !f.endsWith(".test.tsx")).length} components have stories.`,
+);


### PR DESCRIPTION
## Summary
- Adds `scripts/check-stories.mjs`, which walks `frontend/src/components/**` and fails if any `*.tsx` (excluding `*.stories.tsx` / `*.test.tsx`) lacks a sibling `*.stories.tsx`.
- Exposes it as `npm run check:stories`.
- Adds a `storybook-coverage` CI job that runs the check on every PR.

Coverage is already 100% after #394, so this is purely a regression gate — no allowlist needed. If we ever need an escape hatch for a non-component `.tsx` in `components/`, we can add one then.

## Test plan
- [x] `npm run check:stories` passes on a clean tree
- [x] Verified failure mode by temporarily removing `FAB.stories.tsx` — script exits 1 and lists the offender