### PR TITLE
feat(storybook): host on Cloud Run instead of GCS bucket

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,25 +100,63 @@ jobs:
           path: storybook-static/
           retention-days: 1
 
-  # Sync the static Storybook bundle to gs://observing-storybook on push to main.
-  # Bucket is public-read; site lives at https://storage.googleapis.com/observing-storybook/index.html
+  # Bundle the static Storybook output into a small static-web-server image
+  # and deploy it to Cloud Run on push to main. Cheaper than an HTTPS load
+  # balancer in front of GCS — cold starts are fine for a dev tool, and
+  # the free tier covers our traffic.
   storybook-deploy:
     runs-on: ubuntu-latest
     needs: [storybook-build]
     if: github.event_name == 'push'
+    env:
+      REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/storybook
+      REGION: us-central1
     steps:
+      - uses: actions/checkout@v4
       - uses: actions/download-artifact@v4
         with:
           name: storybook-static
           path: storybook-static/
+
+      - uses: docker/setup-buildx-action@v3
+
       - uses: google-github-actions/auth@v2
+        id: gcp-auth
         with:
           credentials_json: ${{ secrets.GCP_SA_KEY }}
+          token_format: access_token
+
       - uses: google-github-actions/setup-gcloud@v2
-      - name: Sync to GCS bucket
+
+      - uses: docker/login-action@v3
+        with:
+          registry: us-central1-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.storybook
+          platforms: linux/amd64
+          push: true
+          tags: ${{ env.REGISTRY }}/storybook:${{ github.sha }},${{ env.REGISTRY }}/storybook:latest
+          cache-from: type=gha,scope=storybook
+          cache-to: type=gha,mode=max,scope=storybook
+
+      - name: Deploy to Cloud Run
         run: |
-          gcloud storage rsync storybook-static/ gs://observing-storybook/ \
-            --recursive --delete-unmatched-destination-objects
+          gcloud run deploy storybook \
+            --image=$REGISTRY/storybook:${{ github.sha }} \
+            --region=$REGION \
+            --platform=managed \
+            --allow-unauthenticated \
+            --port=8080 \
+            --memory=128Mi \
+            --cpu=1 \
+            --max-instances=3 \
+            --min-instances=0
 
   # Rust jobs
   rust-lockfile:

--- a/Dockerfile.storybook
+++ b/Dockerfile.storybook
@@ -4,7 +4,7 @@
 # `npm run build-storybook` in CI). The image just bundles those files
 # behind static-web-server, a small Rust HTTP server that handles
 # compression, cache headers, and SPA routing.
-FROM joseluisq/static-web-server:2-alpine
+FROM ghcr.io/static-web-server/static-web-server:2-alpine
 
 # Cloud Run sends traffic on $PORT (default 8080). static-web-server
 # picks up SERVER_PORT, so we hard-code 8080 to match the default.

--- a/Dockerfile.storybook
+++ b/Dockerfile.storybook
@@ -1,0 +1,19 @@
+# Storybook static-host image, deployed to Cloud Run.
+#
+# Build context expects ./storybook-static/ to already exist (created by
+# `npm run build-storybook` in CI). The image just bundles those files
+# behind static-web-server, a small Rust HTTP server that handles
+# compression, cache headers, and SPA routing.
+FROM joseluisq/static-web-server:2-alpine
+
+# Cloud Run sends traffic on $PORT (default 8080). static-web-server
+# picks up SERVER_PORT, so we hard-code 8080 to match the default.
+ENV SERVER_PORT=8080 \
+    SERVER_ROOT=/public \
+    SERVER_LOG_LEVEL=info \
+    SERVER_COMPRESSION=true \
+    SERVER_CACHE_CONTROL_HEADERS=true
+
+COPY storybook-static/ /public/
+
+EXPOSE 8080


### PR DESCRIPTION
## Summary
- Replace the `gs://observing-storybook` static-bucket setup (which would have needed an $18/mo HTTPS load balancer to put a custom domain in front of) with a tiny Cloud Run service serving the same static files.
- Image is built on top of [`static-web-server`](https://github.com/static-web-server/static-web-server) — a small Rust HTTP server with built-in compression, cache headers, and SPA routing — and just bundles the `storybook-static/` output.
- CI builds the image, pushes to Artifact Registry, and runs `gcloud run deploy` on push to main.
- Domain mapping for `storybook.observ.ing` is provisioned out-of-band (one-time Search Console verification), so CI doesn't touch DNS.

Live at https://storybook.observ.ing.

The old GCS bucket has been deleted.

## Cost
~$0/mo on the free tier (Storybook traffic is trivial). Old plan was ~$18/mo flat for the LB forwarding rule.

## Test plan
- [x] Build storybook locally → build Docker image → run container → verify pages load
- [x] Push image to Artifact Registry → deploy to Cloud Run → verify Service URL responds
- [x] Create domain mapping → add CNAME in Cloud DNS → wait for cert → verify https://storybook.observ.ing/ serves all 155 stories
- [ ] CI run on this PR builds image successfully (gates merge)
- [ ] CI run on push to main re-deploys (verifies SA permissions)