### PR TITLE
fix(profile): match skeleton observation card image to loaded card

### DIFF
--- a/frontend/src/components/profile/ProfileObservationCardSkeleton.tsx
+++ b/frontend/src/components/profile/ProfileObservationCardSkeleton.tsx
@@ -1,16 +1,25 @@
-import { Box, Card, Skeleton } from "@mui/material";
+import { Box, Card, CardContent, Skeleton, Typography } from "@mui/material";
 
 /**
  * Skeleton for profile observation card grid items
  */
 export function ProfileObservationCardSkeleton() {
   return (
-    <Card>
-      <Skeleton variant="rectangular" sx={{ aspectRatio: "1", width: "100%" }} />
-      <Box sx={{ p: 1.5 }}>
-        <Skeleton variant="text" width="70%" height={20} />
-        <Skeleton variant="text" width="50%" height={16} />
+    <Card sx={{ display: "flex", flexDirection: "column" }}>
+      <Box sx={{ position: "relative", aspectRatio: "1", width: "100%" }}>
+        <Skeleton
+          variant="rectangular"
+          sx={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
+        />
       </Box>
+      <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
+        <Typography variant="body2">
+          <Skeleton width="70%" />
+        </Typography>
+        <Typography variant="caption">
+          <Skeleton width="50%" />
+        </Typography>
+      </CardContent>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- The skeleton observation cards on the loading profile view rendered with a thin ~19px-tall image placeholder instead of a square, so the layout jumped when content loaded.
- Root cause: MUI `Skeleton`'s base style sets `height: '1.2em'` and `variant="rectangular"` doesn't override it. When both `height` and `aspect-ratio` are set in CSS, height wins and `aspect-ratio` is ignored.
- Fix: wrap the Skeleton in a Box that establishes the aspect ratio and have the Skeleton fill it absolutely. Also mirrored the loaded card's `Card sx={{ display: flex, flexDirection: column }}` and `CardContent` + `Typography` structure so the overall card height matches.

## Test plan
- [ ] Visit https://storybook.observ.ing/?path=/story/profile-profileview--loading (after deploy) and confirm skeleton cards are square and match the `--loaded` story dimensions
- [ ] Locally: `npm run storybook`, compare `Profile/ProfileView` Loading vs Loaded stories side-by-side