### PR TITLE
refactor(identification): rename AI suggestions to Visual ID

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -20,7 +20,7 @@ interface TaxaAutocompleteProps {
   placeholder?: string;
   size?: "small" | "medium";
   margin?: "normal" | "dense" | "none";
-  /** Content rendered below the input field (e.g. AI suggestions) */
+  /** Content rendered below the input field (e.g. visual ID matches) */
   bottomContent?: ReactNode;
 }
 

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -6,8 +6,8 @@ import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import { submitIdentification } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
-import { AiSuggestionChips } from "./AiSuggestions";
-import { useAiSuggestions } from "../../hooks/useAiSuggestions";
+import { VisualIdChips } from "./VisualId";
+import { useVisualId } from "../../hooks/useVisualId";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { useAppDispatch } from "../../store";
 import { addToast } from "../../store/uiSlice";
@@ -20,7 +20,7 @@ interface IdentificationPanelProps {
     scientificName?: string | undefined;
     communityId?: string | undefined;
   };
-  /** Full URL of the observation's primary image, for AI species suggestion */
+  /** Full URL of the observation's primary image, for visual ID matching */
   imageUrl?: string | undefined;
   /** Observation latitude, passed to species-id for geo-prior context */
   latitude?: number | undefined;
@@ -84,7 +84,7 @@ export function IdentificationPanel({
 
   const isSubmitting = isAgreeing || isSuggesting;
 
-  const ai = useAiSuggestions({
+  const visualId = useVisualId({
     imageUrl: imageUrl ?? "",
     latitude,
     longitude,
@@ -182,8 +182,8 @@ export function IdentificationPanel({
                 size="small"
                 margin="none"
                 bottomContent={
-                  <AiSuggestionChips
-                    suggestions={ai.suggestions}
+                  <VisualIdChips
+                    suggestions={visualId.suggestions}
                     onSelect={(s) => {
                       setTaxonName(s.scientificName);
                       setMatchedTaxon(s.taxonMatch ?? null);
@@ -192,14 +192,14 @@ export function IdentificationPanel({
                 }
               />
             </Box>
-            {imageUrl && !ai.hasLoaded && (
+            {imageUrl && !visualId.hasLoaded && (
               <Button
                 variant="outlined"
                 size="small"
-                onClick={ai.handleFetch}
-                disabled={isSubmitting || ai.isLoading}
+                onClick={visualId.handleFetch}
+                disabled={isSubmitting || visualId.isLoading}
                 startIcon={
-                  ai.isLoading ? (
+                  visualId.isLoading ? (
                     <CircularProgress size={16} color="inherit" />
                   ) : (
                     <AutoFixHighIcon fontSize="small" />
@@ -207,7 +207,7 @@ export function IdentificationPanel({
                 }
                 sx={{ whiteSpace: "nowrap", height: 40 }}
               >
-                AI Suggest
+                Visual ID
               </Button>
             )}
           </Stack>

--- a/frontend/src/components/identification/VisualId.stories.tsx
+++ b/frontend/src/components/identification/VisualId.stories.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { http, HttpResponse, delay } from "msw";
 import { Box } from "@mui/material";
-import { AiSuggestions } from "./AiSuggestions";
+import { VisualId } from "./VisualId";
 import type { SpeciesSuggestion } from "../../services/api";
 
 const SUGGESTIONS: SpeciesSuggestion[] = [
@@ -40,8 +40,8 @@ const SAMPLE_IMAGE =
   "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=";
 
 const meta = {
-  title: "Identification/AiSuggestions",
-  component: AiSuggestions,
+  title: "Identification/VisualId",
+  component: VisualId,
   parameters: {
     layout: "padded",
   },
@@ -57,7 +57,7 @@ const meta = {
       </Box>
     ),
   ],
-} satisfies Meta<typeof AiSuggestions>;
+} satisfies Meta<typeof VisualId>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/frontend/src/components/identification/VisualId.tsx
+++ b/frontend/src/components/identification/VisualId.tsx
@@ -4,21 +4,21 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import PlaceIcon from "@mui/icons-material/Place";
 import type { SpeciesSuggestion } from "../../services/api";
 import { nameToSlug } from "../../lib/taxonSlug";
-import { useAiSuggestions } from "../../hooks/useAiSuggestions";
+import { useVisualId } from "../../hooks/useVisualId";
 
-interface AiSuggestionsProps {
+interface VisualIdProps {
   imageUrl: string;
   latitude?: number | undefined;
   longitude?: number | undefined;
   onSelect: (suggestion: SpeciesSuggestion) => void;
   disabled?: boolean;
-  /** Automatically fetch suggestions on mount */
+  /** Automatically fetch matches on mount */
   autoFetch?: boolean;
   /** Suppress error toasts (e.g. for best-effort background identification) */
   quiet?: boolean;
 }
 
-export function AiSuggestions({
+export function VisualId({
   imageUrl,
   latitude,
   longitude,
@@ -26,8 +26,8 @@ export function AiSuggestions({
   disabled,
   autoFetch,
   quiet,
-}: AiSuggestionsProps) {
-  const { suggestions, isLoading, hasLoaded, handleFetch } = useAiSuggestions({
+}: VisualIdProps) {
+  const { suggestions, isLoading, hasLoaded, handleFetch } = useVisualId({
     imageUrl,
     latitude,
     longitude,
@@ -50,7 +50,7 @@ export function AiSuggestions({
           fullWidth
           sx={{ mb: 1 }}
         >
-          AI Suggest
+          Visual ID
         </Button>
       )}
       {isLoading && autoFetch && (
@@ -66,17 +66,17 @@ export function AiSuggestions({
           </Typography>
         </Box>
       )}
-      <AiSuggestionChips suggestions={suggestions} onSelect={onSelect} />
+      <VisualIdChips suggestions={suggestions} onSelect={onSelect} />
     </Box>
   );
 }
 
-interface AiSuggestionChipsProps {
+interface VisualIdChipsProps {
   suggestions: SpeciesSuggestion[];
   onSelect: (suggestion: SpeciesSuggestion) => void;
 }
 
-export function AiSuggestionChips({ suggestions, onSelect }: AiSuggestionChipsProps) {
+export function VisualIdChips({ suggestions, onSelect }: VisualIdChipsProps) {
   if (suggestions.length === 0) return null;
 
   return (
@@ -89,7 +89,7 @@ export function AiSuggestionChips({ suggestions, onSelect }: AiSuggestionChipsPr
             color: "text.secondary",
           }}
         >
-          AI suggestions
+          Visual matches
         </Typography>
       </Box>
       <Stack spacing={0.5}>

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -26,7 +26,7 @@ import { submitObservation, updateObservation, pollObservation } from "../../ser
 import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
-import { AiSuggestions } from "../identification/AiSuggestions";
+import { VisualId } from "../identification/VisualId";
 import { LocationPicker } from "../map/LocationPicker";
 import { getObservationUrl, getErrorMessage } from "../../lib/utils";
 import { KINGDOMS } from "../../lib/kingdoms";
@@ -74,7 +74,7 @@ export function UploadModal() {
   const [existingImages, setExistingImages] = useState<string[]>([]);
   const [observationDate, setObservationDate] = useState(() => toDatetimeLocal(new Date()));
   const [uncertaintyMeters, setUncertaintyMeters] = useState(50);
-  const [aiImageUrl, setAiImageUrl] = useState<string | null>(null);
+  const [visualIdImageUrl, setVisualIdImageUrl] = useState<string | null>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const MAX_IMAGES = 10;
@@ -124,7 +124,7 @@ export function UploadModal() {
     setExistingImages([]);
     setObservationDate(toDatetimeLocal(new Date()));
     setUncertaintyMeters(50);
-    setAiImageUrl(null);
+    setVisualIdImageUrl(null);
   };
 
   const addFiles = (files: File[]) => {
@@ -165,7 +165,7 @@ export function UploadModal() {
       if (images.length === 0) {
         extractExifData(file);
         if (!species && !isEditMode) {
-          setAiImageUrl(preview);
+          setVisualIdImageUrl(preview);
         }
       }
     }
@@ -585,9 +585,9 @@ export function UploadModal() {
                   sx={{ mt: 0.5 }}
                 />
               )
-            ) : aiImageUrl ? (
-              <AiSuggestions
-                imageUrl={aiImageUrl}
+            ) : visualIdImageUrl ? (
+              <VisualId
+                imageUrl={visualIdImageUrl}
                 latitude={lat ? parseFloat(lat) : undefined}
                 longitude={lng ? parseFloat(lng) : undefined}
                 onSelect={(s) => {

--- a/frontend/src/hooks/useVisualId.ts
+++ b/frontend/src/hooks/useVisualId.ts
@@ -3,24 +3,24 @@ import { identifySpecies, type SpeciesSuggestion } from "../services/api";
 import { useAppDispatch } from "../store";
 import { addToast } from "../store/uiSlice";
 
-interface UseAiSuggestionsOptions {
+interface UseVisualIdOptions {
   imageUrl: string;
   latitude?: number | undefined;
   longitude?: number | undefined;
   disabled?: boolean | undefined;
-  /** Automatically fetch suggestions on mount */
+  /** Automatically fetch matches on mount */
   autoFetch?: boolean | undefined;
   /** Suppress error toasts (e.g. for best-effort background identification) */
   quiet?: boolean | undefined;
 }
 
-export function useAiSuggestions({
+export function useVisualId({
   imageUrl,
   latitude,
   longitude,
   autoFetch,
   quiet,
-}: UseAiSuggestionsOptions) {
+}: UseVisualIdOptions) {
   const dispatch = useAppDispatch();
   const [suggestions, setSuggestions] = useState<SpeciesSuggestion[]>([]);
   const [isLoading, setIsLoading] = useState(false);

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -488,7 +488,7 @@ export interface SpeciesSuggestion {
    */
   inRange?: boolean;
   /**
-   * Set when the AI suggestion's scientific name resolved to a known GBIF
+   * Set when the visual ID match's scientific name resolved to a known GBIF
    * taxon. The frontend treats this like an autocomplete pick: matchedTaxon
    * is set, so the kingdom and rank fields disappear and the indicator
    * shows "Existing taxon".


### PR DESCRIPTION
## Summary
Drops "AI" from the user-facing feature name for image-based species identification.

- Button label: **"AI Suggest" → "Visual ID"**
- Chip caption: **"AI suggestions" → "Visual matches"**

Internal renames mirror the new name (file renames done via `git mv` so blame is preserved):
- `AiSuggestions` component → `VisualId`
- `AiSuggestionChips` → `VisualIdChips`
- `useAiSuggestions` hook → `useVisualId`
- `aiImageUrl` state → `visualIdImageUrl`

## Out of scope
The `/api/species-id` route, the `species_id_client.rs` backend, and the `SpeciesSuggestion` type are unchanged — those are stable contracts and renaming them adds risk without changing what the user sees.

## Test plan
- [ ] Storybook: `Identification/VisualId` stories render (ManualFetch, AutoFetched, AutoFetchLoading, NoSuggestions, Disabled)
- [ ] Upload modal: choose a photo with no species filled in, confirm "Visual ID" button appears under the species input and "Visual matches" caption shows above chips after fetching
- [ ] Identification panel: on an observation detail page, click "Suggest Different ID" and confirm the "Visual ID" button appears next to the taxon input