### PR TITLE
refactor(taxa-autocomplete): split into view + container

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.stories.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.stories.tsx
@@ -5,6 +5,12 @@ import { Box } from "@mui/material";
 import { TaxaAutocomplete } from "./TaxaAutocomplete";
 import type { TaxaResult } from "../../services/types";
 
+/**
+ * Container stories: exercise the live `useAutocomplete` wiring against MSW.
+ * For prop-driven visual variants (results, loading, empty) see
+ * `TaxaAutocompleteView.stories`.
+ */
+
 const SAMPLE_RESULTS: TaxaResult[] = [
   {
     id: "Plantae/Quercus robur",
@@ -16,27 +22,6 @@ const SAMPLE_RESULTS: TaxaResult[] = [
     genus: "Quercus",
     source: "gbif",
     conservationStatus: { category: "LC", source: "IUCN" },
-  },
-  {
-    id: "Plantae/Quercus alba",
-    scientificName: "Quercus alba",
-    commonName: "White Oak",
-    rank: "species",
-    kingdom: "Plantae",
-    family: "Fagaceae",
-    genus: "Quercus",
-    source: "gbif",
-    conservationStatus: { category: "LC", source: "IUCN" },
-  },
-  {
-    id: "Plantae/Quercus rubra",
-    scientificName: "Quercus rubra",
-    commonName: "Northern Red Oak",
-    rank: "species",
-    kingdom: "Plantae",
-    family: "Fagaceae",
-    genus: "Quercus",
-    source: "gbif",
   },
 ];
 
@@ -63,33 +48,14 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
-export const WithResults: Story = {
+export const Default: Story = {
   args: {
-    value: "Quercus",
+    value: "",
     onChange: () => undefined,
   },
   parameters: {
     msw: {
       handlers: [http.get("/api/taxa/search", () => HttpResponse.json(SAMPLE_RESULTS))],
     },
-  },
-};
-
-export const NoResults: Story = {
-  args: {
-    value: "asdjkfhasdf",
-    onChange: () => undefined,
-  },
-  parameters: {
-    msw: {
-      handlers: [http.get("/api/taxa/search", () => HttpResponse.json([]))],
-    },
-  },
-};
-
-export const Empty: Story = {
-  args: {
-    value: "",
-    onChange: () => undefined,
   },
 };

--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -1,11 +1,9 @@
 import { useCallback, type ReactNode } from "react";
-import { Autocomplete, Box, Stack, Typography } from "@mui/material";
 import { searchTaxa } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
-import { ConservationStatus } from "./ConservationStatus";
 import { useAutocomplete } from "../../hooks/useAutocomplete";
 import { MAX_AUTOCOMPLETE_RESULTS } from "../../lib/utils";
-import { renderAutocompleteInput } from "./autocompleteInput";
+import { TaxaAutocompleteView } from "./TaxaAutocompleteView";
 
 interface TaxaAutocompleteProps {
   value: string;
@@ -24,16 +22,7 @@ interface TaxaAutocompleteProps {
   bottomContent?: ReactNode;
 }
 
-export function TaxaAutocomplete({
-  value,
-  onChange,
-  onMatchChange,
-  label = "Species Name",
-  placeholder = "Search by common or scientific name...",
-  size,
-  margin = "normal",
-  bottomContent,
-}: TaxaAutocompleteProps) {
+export function TaxaAutocomplete(props: TaxaAutocompleteProps) {
   const searchFn = useCallback((query: string) => searchTaxa(query), []);
   const { options, loading, handleSearch, clearOptions } = useAutocomplete<TaxaResult>({
     searchFn,
@@ -41,122 +30,12 @@ export function TaxaAutocomplete({
   });
 
   return (
-    <Box>
-      <Autocomplete
-        freeSolo
-        options={options}
-        loading={loading}
-        getOptionLabel={(option) => (typeof option === "string" ? option : option.scientificName)}
-        inputValue={value}
-        onInputChange={(_, v, reason) => {
-          onChange(v);
-          if (reason === "input") onMatchChange?.(null);
-          handleSearch(v);
-        }}
-        onChange={(_, v) => {
-          if (v && typeof v !== "string") {
-            onChange(v.scientificName);
-            onMatchChange?.(v);
-            clearOptions();
-          } else if (typeof v === "string") {
-            onChange(v);
-            onMatchChange?.(null);
-          }
-        }}
-        filterOptions={(x) => x}
-        {...(size ? { size } : {})}
-        renderInput={(params) =>
-          renderAutocompleteInput({ params, loading, label, placeholder, margin })
-        }
-        renderOption={(props, option) => {
-          const { key, ...otherProps } = props;
-          return (
-            <Box
-              component="li"
-              key={key}
-              {...otherProps}
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 1.5,
-                p: 1.5,
-              }}
-            >
-              {option.photoUrl && (
-                <Box
-                  component="img"
-                  src={option.photoUrl}
-                  alt=""
-                  loading="lazy"
-                  sx={{
-                    width: 40,
-                    height: 40,
-                    borderRadius: 1,
-                    objectFit: "cover",
-                    flexShrink: 0,
-                  }}
-                />
-              )}
-              <Box sx={{ flex: 1, minWidth: 0 }}>
-                <Stack
-                  direction="row"
-                  spacing={1}
-                  sx={{
-                    alignItems: "center",
-                    flexWrap: "wrap",
-                  }}
-                >
-                  <Typography
-                    sx={{
-                      fontWeight: 600,
-                    }}
-                  >
-                    {option.scientificName}
-                  </Typography>
-                  {option.isSynonym && (
-                    <Typography
-                      variant="caption"
-                      sx={{
-                        bgcolor: "action.selected",
-                        px: 0.75,
-                        py: 0.25,
-                        borderRadius: 0.5,
-                        fontSize: "0.65rem",
-                      }}
-                    >
-                      synonym
-                    </Typography>
-                  )}
-                  {option.conservationStatus && (
-                    <ConservationStatus status={option.conservationStatus} size="sm" />
-                  )}
-                </Stack>
-                {option.isSynonym && option.acceptedName && (
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: "text.disabled",
-                    }}
-                  >
-                    → {option.acceptedName}
-                  </Typography>
-                )}
-                {option.commonName && !option.isSynonym && (
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: "text.disabled",
-                    }}
-                  >
-                    {option.commonName}
-                  </Typography>
-                )}
-              </Box>
-            </Box>
-          );
-        }}
-      />
-      {bottomContent}
-    </Box>
+    <TaxaAutocompleteView
+      {...props}
+      options={options}
+      loading={loading}
+      onSearch={handleSearch}
+      onClear={clearOptions}
+    />
   );
 }

--- a/frontend/src/components/common/TaxaAutocompleteView.stories.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.stories.tsx
@@ -1,0 +1,112 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { TaxaAutocompleteView } from "./TaxaAutocompleteView";
+import type { TaxaResult } from "../../services/types";
+
+const SAMPLE_RESULTS: TaxaResult[] = [
+  {
+    id: "Plantae/Quercus robur",
+    scientificName: "Quercus robur",
+    commonName: "English Oak",
+    rank: "species",
+    kingdom: "Plantae",
+    family: "Fagaceae",
+    genus: "Quercus",
+    source: "gbif",
+    conservationStatus: { category: "LC", source: "IUCN" },
+  },
+  {
+    id: "Plantae/Quercus alba",
+    scientificName: "Quercus alba",
+    commonName: "White Oak",
+    rank: "species",
+    kingdom: "Plantae",
+    family: "Fagaceae",
+    genus: "Quercus",
+    source: "gbif",
+    conservationStatus: { category: "LC", source: "IUCN" },
+  },
+  {
+    id: "Plantae/Quercus rubra",
+    scientificName: "Quercus rubra",
+    commonName: "Northern Red Oak",
+    rank: "species",
+    kingdom: "Plantae",
+    family: "Fagaceae",
+    genus: "Quercus",
+    source: "gbif",
+  },
+];
+
+const meta = {
+  title: "Common/TaxaAutocompleteView",
+  component: TaxaAutocompleteView,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: 380 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <TaxaAutocompleteView {...args} value={value} onChange={setValue} />;
+  },
+} satisfies Meta<typeof TaxaAutocompleteView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+const noop = () => undefined;
+
+export const WithResults: Story = {
+  args: {
+    value: "Quercus",
+    options: SAMPLE_RESULTS,
+    loading: false,
+    open: true,
+    onChange: noop,
+    onSearch: noop,
+    onClear: noop,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    value: "Quercus",
+    options: [],
+    loading: true,
+    open: true,
+    onChange: noop,
+    onSearch: noop,
+    onClear: noop,
+  },
+};
+
+export const NoResults: Story = {
+  args: {
+    value: "asdjkfhasdf",
+    options: [],
+    loading: false,
+    open: true,
+    onChange: noop,
+    onSearch: noop,
+    onClear: noop,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: "",
+    options: [],
+    loading: false,
+    onChange: noop,
+    onSearch: noop,
+    onClear: noop,
+  },
+};

--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -1,0 +1,169 @@
+import type { ReactNode } from "react";
+import { Autocomplete, Box, Stack, Typography } from "@mui/material";
+import type { TaxaResult } from "../../services/types";
+import { ConservationStatus } from "./ConservationStatus";
+import { renderAutocompleteInput } from "./autocompleteInput";
+
+interface TaxaAutocompleteViewProps {
+  value: string;
+  onChange: (name: string) => void;
+  /**
+   * Fires whenever the user picks a suggestion (with the full TaxaResult)
+   * or types free text that no longer corresponds to a pick (with null).
+   * Lets callers know whether they have authoritative taxonomy data.
+   */
+  onMatchChange?: (match: TaxaResult | null) => void;
+  label?: string;
+  placeholder?: string;
+  size?: "small" | "medium";
+  margin?: "normal" | "dense" | "none";
+  /** Content rendered below the input field (e.g. visual ID matches) */
+  bottomContent?: ReactNode;
+  options: TaxaResult[];
+  loading: boolean;
+  /** Called when the input text changes (reason === "input"); use to drive a search. */
+  onSearch: (query: string) => void;
+  /** Called when the user picks a suggestion; use to reset any in-flight search state. */
+  onClear: () => void;
+  /** Force the popup open state. Uncontrolled when omitted. */
+  open?: boolean;
+}
+
+export function TaxaAutocompleteView({
+  value,
+  onChange,
+  onMatchChange,
+  label = "Species Name",
+  placeholder = "Search by common or scientific name...",
+  size,
+  margin = "normal",
+  bottomContent,
+  options,
+  loading,
+  onSearch,
+  onClear,
+  open,
+}: TaxaAutocompleteViewProps) {
+  return (
+    <Box>
+      <Autocomplete
+        freeSolo
+        options={options}
+        loading={loading}
+        getOptionLabel={(option) => (typeof option === "string" ? option : option.scientificName)}
+        inputValue={value}
+        {...(open !== undefined ? { open } : {})}
+        onInputChange={(_, v, reason) => {
+          onChange(v);
+          if (reason === "input") {
+            onMatchChange?.(null);
+            onSearch(v);
+          }
+        }}
+        onChange={(_, v) => {
+          if (v && typeof v !== "string") {
+            onChange(v.scientificName);
+            onMatchChange?.(v);
+            onClear();
+          } else if (typeof v === "string") {
+            onChange(v);
+            onMatchChange?.(null);
+          }
+        }}
+        filterOptions={(x) => x}
+        {...(size ? { size } : {})}
+        renderInput={(params) =>
+          renderAutocompleteInput({ params, loading, label, placeholder, margin })
+        }
+        renderOption={(props, option) => {
+          const { key, ...otherProps } = props;
+          return (
+            <Box
+              component="li"
+              key={key}
+              {...otherProps}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                gap: 1.5,
+                p: 1.5,
+              }}
+            >
+              {option.photoUrl && (
+                <Box
+                  component="img"
+                  src={option.photoUrl}
+                  alt=""
+                  loading="lazy"
+                  sx={{
+                    width: 40,
+                    height: 40,
+                    borderRadius: 1,
+                    objectFit: "cover",
+                    flexShrink: 0,
+                  }}
+                />
+              )}
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Stack
+                  direction="row"
+                  spacing={1}
+                  sx={{
+                    alignItems: "center",
+                    flexWrap: "wrap",
+                  }}
+                >
+                  <Typography
+                    sx={{
+                      fontWeight: 600,
+                    }}
+                  >
+                    {option.scientificName}
+                  </Typography>
+                  {option.isSynonym && (
+                    <Typography
+                      variant="caption"
+                      sx={{
+                        bgcolor: "action.selected",
+                        px: 0.75,
+                        py: 0.25,
+                        borderRadius: 0.5,
+                        fontSize: "0.65rem",
+                      }}
+                    >
+                      synonym
+                    </Typography>
+                  )}
+                  {option.conservationStatus && (
+                    <ConservationStatus status={option.conservationStatus} size="sm" />
+                  )}
+                </Stack>
+                {option.isSynonym && option.acceptedName && (
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: "text.disabled",
+                    }}
+                  >
+                    → {option.acceptedName}
+                  </Typography>
+                )}
+                {option.commonName && !option.isSynonym && (
+                  <Typography
+                    variant="caption"
+                    sx={{
+                      color: "text.disabled",
+                    }}
+                  >
+                    {option.commonName}
+                  </Typography>
+                )}
+              </Box>
+            </Box>
+          );
+        }}
+      />
+      {bottomContent}
+    </Box>
+  );
+}


### PR DESCRIPTION
## Summary
- Extract pure presentation into `TaxaAutocompleteView` (takes `options`/`loading`/`onSearch`/`onClear` as props, plus an optional `open` pass-through)
- Reduce `TaxaAutocomplete` to a thin wrapper around `useAutocomplete` that renders the view — same external API, no caller updates needed
- Move prop-driven story variants (`WithResults`, `Loading`, `NoResults`, `Empty`) onto the view, where stubbing options no longer requires MSW or a `play` function. The container keeps a single `Default` story that exercises the live wiring against MSW.

Motivation: the previous `WithResults` story didn't actually display results on load — `useAutocomplete` only fetches in response to `onInputChange`, so MSW's stub never fired until the user typed. The split eliminates that coupling cleanly without putting test-only props on the production component.

## Test plan
- [ ] `npm run fmt:check`
- [ ] `npx oxlint`
- [ ] `npx tsc --noEmit`
- [ ] `node scripts/check-stories.mjs`
- [ ] In Storybook: `Common/TaxaAutocompleteView/With Results` shows the dropdown populated on first render
- [ ] In Storybook: `Common/TaxaAutocomplete/Default` still fetches via MSW when the user types
- [ ] Smoke-test the upload modal in the app to confirm no behavioral regression in the live container