### PR TITLE
feat(visual-id): add VisualIdCards with common-ancestor rollup

### DIFF
--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -6,7 +6,7 @@ import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import { submitIdentification } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
-import { VisualIdChips } from "./VisualId";
+import { VisualIdCards } from "./VisualIdCards";
 import { useVisualId } from "../../hooks/useVisualId";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { useAppDispatch } from "../../store";
@@ -182,11 +182,21 @@ export function IdentificationPanel({
                 size="small"
                 margin="none"
                 bottomContent={
-                  <VisualIdChips
+                  <VisualIdCards
                     suggestions={visualId.suggestions}
-                    onSelect={(s) => {
+                    onSelectSpecies={(s) => {
                       setTaxonName(s.scientificName);
                       setMatchedTaxon(s.taxonMatch ?? null);
+                    }}
+                    onSelectAncestor={(ancestor) => {
+                      setTaxonName(ancestor.name);
+                      setMatchedTaxon({
+                        id: `${ancestor.kingdom ?? ""}/${ancestor.name}`,
+                        scientificName: ancestor.name,
+                        rank: ancestor.rank,
+                        ...(ancestor.kingdom ? { kingdom: ancestor.kingdom } : {}),
+                        source: "visual-id-rollup",
+                      });
                     }}
                   />
                 }

--- a/frontend/src/components/identification/VisualId.stories.tsx
+++ b/frontend/src/components/identification/VisualId.stories.tsx
@@ -49,6 +49,7 @@ const meta = {
   args: {
     imageUrl: SAMPLE_IMAGE,
     onSelect: () => undefined,
+    onSelectAncestor: () => undefined,
   },
   decorators: [
     (Story) => (

--- a/frontend/src/components/identification/VisualId.tsx
+++ b/frontend/src/components/identification/VisualId.tsx
@@ -1,16 +1,15 @@
-import { Box, Button, Chip, CircularProgress, IconButton, Stack, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, Typography } from "@mui/material";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
-import PlaceIcon from "@mui/icons-material/Place";
 import type { SpeciesSuggestion } from "../../services/api";
-import { nameToSlug } from "../../lib/taxonSlug";
 import { useVisualId } from "../../hooks/useVisualId";
+import { VisualIdCards, type AncestorSelection } from "./VisualIdCards";
 
 interface VisualIdProps {
   imageUrl: string;
   latitude?: number | undefined;
   longitude?: number | undefined;
   onSelect: (suggestion: SpeciesSuggestion) => void;
+  onSelectAncestor: (ancestor: AncestorSelection) => void;
   disabled?: boolean;
   /** Automatically fetch matches on mount */
   autoFetch?: boolean;
@@ -23,6 +22,7 @@ export function VisualId({
   latitude,
   longitude,
   onSelect,
+  onSelectAncestor,
   disabled,
   autoFetch,
   quiet,
@@ -66,129 +66,11 @@ export function VisualId({
           </Typography>
         </Box>
       )}
-      <VisualIdChips suggestions={suggestions} onSelect={onSelect} />
-    </Box>
-  );
-}
-
-interface VisualIdChipsProps {
-  suggestions: SpeciesSuggestion[];
-  onSelect: (suggestion: SpeciesSuggestion) => void;
-}
-
-export function VisualIdChips({ suggestions, onSelect }: VisualIdChipsProps) {
-  if (suggestions.length === 0) return null;
-
-  return (
-    <Box sx={{ mb: 1 }}>
-      <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 0.5 }}>
-        <AutoFixHighIcon sx={{ fontSize: 14, color: "text.secondary" }} />
-        <Typography
-          variant="caption"
-          sx={{
-            color: "text.secondary",
-          }}
-        >
-          Visual matches
-        </Typography>
-      </Box>
-      <Stack spacing={0.5}>
-        {suggestions.map((s) => (
-          <Chip
-            key={s.scientificName}
-            label={
-              <Box component="span" sx={{ display: "flex", alignItems: "center", gap: 0.5 }}>
-                {s.taxonMatch?.photoUrl && (
-                  <Box
-                    component="img"
-                    src={s.taxonMatch.photoUrl}
-                    alt=""
-                    loading="lazy"
-                    sx={{
-                      width: 24,
-                      height: 24,
-                      borderRadius: 0.5,
-                      objectFit: "cover",
-                      flexShrink: 0,
-                    }}
-                  />
-                )}
-                <Box
-                  component="span"
-                  sx={{
-                    display: "flex",
-                    alignItems: "baseline",
-                    gap: 0.5,
-                    flex: 1,
-                    minWidth: 0,
-                  }}
-                >
-                  <span style={{ fontStyle: "italic" }}>{s.scientificName}</span>
-                  {s.commonName && (
-                    <Typography
-                      variant="caption"
-                      component="span"
-                      sx={{
-                        color: "text.secondary",
-                      }}
-                    >
-                      {s.commonName}
-                    </Typography>
-                  )}
-                  {s.inRange === true && (
-                    <Box
-                      component="span"
-                      sx={{
-                        display: "inline-flex",
-                        alignItems: "center",
-                        color: "success.main",
-                      }}
-                      title="Found in your area"
-                      aria-label="Found in your area"
-                    >
-                      <PlaceIcon sx={{ fontSize: 14 }} />
-                    </Box>
-                  )}
-                  <Typography
-                    variant="caption"
-                    component="span"
-                    sx={{
-                      color: "text.secondary",
-                      ml: "auto",
-                    }}
-                  >
-                    {Math.round(s.confidence * 100)}%
-                  </Typography>
-                </Box>
-                {s.kingdom && (
-                  <IconButton
-                    size="small"
-                    component="a"
-                    href={`/taxon/${s.kingdom}/${nameToSlug(s.scientificName)}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                    sx={{ p: 0, ml: 0.5 }}
-                    title="Open taxon in new tab"
-                  >
-                    <OpenInNewIcon sx={{ fontSize: 14 }} />
-                  </IconButton>
-                )}
-              </Box>
-            }
-            size="small"
-            onClick={() => onSelect(s)}
-            variant="outlined"
-            color="primary"
-            sx={{
-              cursor: "pointer",
-              maxWidth: "100%",
-              height: "auto",
-              "& .MuiChip-label": { width: "100%", px: 1.5, py: 0.5 },
-            }}
-          />
-        ))}
-      </Stack>
+      <VisualIdCards
+        suggestions={suggestions}
+        onSelectSpecies={onSelect}
+        onSelectAncestor={onSelectAncestor}
+      />
     </Box>
   );
 }

--- a/frontend/src/components/identification/VisualIdCards.stories.tsx
+++ b/frontend/src/components/identification/VisualIdCards.stories.tsx
@@ -1,0 +1,229 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { VisualIdCards } from "./VisualIdCards";
+import type { SpeciesSuggestion } from "../../services/api";
+
+const noop = () => undefined;
+
+const JUNCOS: SpeciesSuggestion[] = [
+  {
+    scientificName: "Junco hyemalis",
+    commonName: "Dark-eyed Junco",
+    confidence: 0.32,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Passeriformes",
+    family: "Passerellidae",
+    genus: "Junco",
+    inRange: true,
+  },
+  {
+    scientificName: "Junco phaeonotus",
+    commonName: "Yellow-eyed Junco",
+    confidence: 0.28,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Passeriformes",
+    family: "Passerellidae",
+    genus: "Junco",
+  },
+  {
+    scientificName: "Junco vulcani",
+    commonName: "Volcano Junco",
+    confidence: 0.22,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Passeriformes",
+    family: "Passerellidae",
+    genus: "Junco",
+  },
+  {
+    scientificName: "Junco insularis",
+    commonName: "Guadalupe Junco",
+    confidence: 0.15,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Passeriformes",
+    family: "Passerellidae",
+    genus: "Junco",
+  },
+];
+
+const DOMINANT_JUNCOS: SpeciesSuggestion[] = JUNCOS.map((s, i) => ({
+  ...s,
+  confidence: [0.78, 0.1, 0.06, 0.04][i] ?? s.confidence,
+}));
+
+const SINGLE_SUGGESTION: SpeciesSuggestion[] = [
+  {
+    scientificName: "Junco hyemalis",
+    commonName: "Dark-eyed Junco",
+    confidence: 0.93,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Passeriformes",
+    family: "Passerellidae",
+    genus: "Junco",
+    inRange: true,
+  },
+];
+
+/**
+ * Diverse birds in different orders — model can only narrow it to "some bird".
+ * Common ancestor is class Aves.
+ */
+const AMBIGUOUS_BIRDS: SpeciesSuggestion[] = [
+  {
+    scientificName: "Turdus migratorius",
+    commonName: "American Robin",
+    confidence: 0.32,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Passeriformes",
+    family: "Turdidae",
+    genus: "Turdus",
+  },
+  {
+    scientificName: "Buteo jamaicensis",
+    commonName: "Red-tailed Hawk",
+    confidence: 0.28,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Accipitriformes",
+    family: "Accipitridae",
+    genus: "Buteo",
+  },
+  {
+    scientificName: "Bubo virginianus",
+    commonName: "Great Horned Owl",
+    confidence: 0.22,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Strigiformes",
+    family: "Strigidae",
+    genus: "Bubo",
+  },
+  {
+    scientificName: "Anas platyrhynchos",
+    commonName: "Mallard",
+    confidence: 0.15,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Aves",
+    order: "Anseriformes",
+    family: "Anatidae",
+    genus: "Anas",
+  },
+];
+
+/**
+ * Suggestions across kingdoms — no useful shared ancestor.
+ * Component should fall back to a flat species list.
+ */
+const NO_COMMON_ANCESTOR: SpeciesSuggestion[] = [
+  {
+    scientificName: "Quercus robur",
+    commonName: "English Oak",
+    confidence: 0.4,
+    kingdom: "Plantae",
+    phylum: "Tracheophyta",
+    class: "Magnoliopsida",
+    order: "Fagales",
+    family: "Fagaceae",
+    genus: "Quercus",
+  },
+  {
+    scientificName: "Sciurus carolinensis",
+    commonName: "Eastern Gray Squirrel",
+    confidence: 0.35,
+    kingdom: "Animalia",
+    phylum: "Chordata",
+    class: "Mammalia",
+    order: "Rodentia",
+    family: "Sciuridae",
+    genus: "Sciurus",
+  },
+];
+
+const meta = {
+  title: "Identification/VisualIdCards",
+  component: VisualIdCards,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: 380 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  args: {
+    onSelectSpecies: noop,
+    onSelectAncestor: noop,
+  },
+} satisfies Meta<typeof VisualIdCards>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/**
+ * Four Junco species with split confidence — top result fails both the floor
+ * (50%) and the gap (2× runner-up) tests, so we offer "Junco sp." as the
+ * confident answer at genus level.
+ */
+export const Ambiguous: Story = {
+  args: {
+    suggestions: JUNCOS,
+  },
+};
+
+/**
+ * One species clearly wins (78% top, 10% runner-up). The species takes the
+ * primary slot; the genus is still available as a small affordance for
+ * users who want to hedge.
+ */
+export const Dominant: Story = {
+  args: {
+    suggestions: DOMINANT_JUNCOS,
+  },
+};
+
+/**
+ * Single high-confidence result — no alternatives, no ancestor card.
+ */
+export const Single: Story = {
+  args: {
+    suggestions: SINGLE_SUGGESTION,
+  },
+};
+
+/**
+ * Diverse birds across different orders. Model is very lost — closest shared
+ * ancestor is class Aves. The component still rolls up rather than dumping
+ * a flat list of unrelated candidates.
+ */
+export const AmbiguousAtClass: Story = {
+  args: {
+    suggestions: AMBIGUOUS_BIRDS,
+  },
+};
+
+/**
+ * Suggestions from different kingdoms — no rollup possible. Component falls
+ * back to a flat species list with a "Possible species:" header.
+ */
+export const NoCommonAncestor: Story = {
+  args: {
+    suggestions: NO_COMMON_ANCESTOR,
+  },
+};

--- a/frontend/src/components/identification/VisualIdCards.tsx
+++ b/frontend/src/components/identification/VisualIdCards.tsx
@@ -75,7 +75,12 @@ function findCommonAncestor(suggestions: SpeciesSuggestion[]): AncestorMatch | n
       rank,
       name,
       kingdom: first.kingdom,
-      confidence: suggestions.reduce((sum, s) => sum + s.confidence, 0),
+      // Cap at 1.0: model output isn't always probability-normalized, so the
+      // raw sum of candidate confidences can exceed 100%.
+      confidence: Math.min(
+        1,
+        suggestions.reduce((sum, s) => sum + s.confidence, 0),
+      ),
     };
   }
   return null;

--- a/frontend/src/components/identification/VisualIdCards.tsx
+++ b/frontend/src/components/identification/VisualIdCards.tsx
@@ -1,0 +1,367 @@
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
+import PlaceIcon from "@mui/icons-material/Place";
+import type { SpeciesSuggestion } from "../../services/api";
+
+/**
+ * Ranks we'll roll up to, ordered from most specific to most general.
+ * Capped at kingdom — anything broader (domain, life) isn't a useful ID.
+ */
+const RANK_ORDER = ["genus", "family", "order", "class", "phylum", "kingdom"] as const;
+type AncestorRank = (typeof RANK_ORDER)[number];
+
+const RANK_INITIAL: Record<AncestorRank, string> = {
+  genus: "G",
+  family: "F",
+  order: "O",
+  class: "C",
+  phylum: "P",
+  kingdom: "K",
+};
+
+const RANK_LABEL: Record<AncestorRank, string> = {
+  genus: "Genus",
+  family: "Family",
+  order: "Order",
+  class: "Class",
+  phylum: "Phylum",
+  kingdom: "Kingdom",
+};
+
+interface AncestorMatch {
+  rank: AncestorRank;
+  name: string;
+  kingdom: string | undefined;
+  /** Sum of candidate confidences — what the model would say at this rank. */
+  confidence: number;
+}
+
+export interface AncestorSelection {
+  rank: AncestorRank;
+  name: string;
+  kingdom: string | undefined;
+}
+
+type Mode = "single" | "dominant" | "ambiguous";
+
+/**
+ * Trigger thresholds for "dominant" mode (one species clearly wins).
+ * Top must be both ≥ 50% absolute AND ≥ 2× the runner-up.
+ * Failing either gate, we fall into "ambiguous" mode and offer the ancestor.
+ */
+const DOMINANT_FLOOR = 0.5;
+const DOMINANT_GAP = 2;
+
+function determineMode(sortedByConfidence: SpeciesSuggestion[]): Mode {
+  const top = sortedByConfidence[0];
+  const runnerUp = sortedByConfidence[1];
+  if (!top || !runnerUp) return "single";
+  return top.confidence >= DOMINANT_FLOOR && top.confidence >= DOMINANT_GAP * runnerUp.confidence
+    ? "dominant"
+    : "ambiguous";
+}
+
+function findCommonAncestor(suggestions: SpeciesSuggestion[]): AncestorMatch | null {
+  if (suggestions.length < 2) return null;
+  const first = suggestions[0];
+  if (!first) return null;
+  for (const rank of RANK_ORDER) {
+    const values = suggestions.map((s) => s[rank]);
+    const allPresent = values.every((v): v is string => typeof v === "string" && v.length > 0);
+    if (!allPresent || new Set(values).size !== 1) continue;
+    const name = values[0];
+    if (!name) continue;
+    return {
+      rank,
+      name,
+      kingdom: first.kingdom,
+      confidence: suggestions.reduce((sum, s) => sum + s.confidence, 0),
+    };
+  }
+  return null;
+}
+
+interface VisualIdCardsProps {
+  suggestions: SpeciesSuggestion[];
+  onSelectSpecies: (suggestion: SpeciesSuggestion) => void;
+  onSelectAncestor: (ancestor: AncestorSelection) => void;
+}
+
+export function VisualIdCards({
+  suggestions,
+  onSelectSpecies,
+  onSelectAncestor,
+}: VisualIdCardsProps) {
+  if (suggestions.length === 0) return null;
+
+  const sorted = [...suggestions].sort((a, b) => b.confidence - a.confidence);
+  const top = sorted[0];
+  if (!top) return null;
+  const rest = sorted.slice(1);
+  const mode = determineMode(sorted);
+  const ancestor = mode !== "single" ? findCommonAncestor(sorted) : null;
+
+  const ancestorSelection = ancestor
+    ? { rank: ancestor.rank, name: ancestor.name, kingdom: ancestor.kingdom }
+    : null;
+
+  return (
+    <Box>
+      <SectionHeader />
+      {mode === "single" && (
+        <SpeciesCard suggestion={top} primary onSelect={() => onSelectSpecies(top)} />
+      )}
+
+      {mode === "dominant" && (
+        <Stack spacing={0.75}>
+          <SpeciesCard suggestion={top} primary onSelect={() => onSelectSpecies(top)} />
+          {rest.length > 0 && (
+            <>
+              <SectionLabel text="Other candidates:" />
+              <Stack spacing={0.5}>
+                {rest.map((s) => (
+                  <SpeciesCard
+                    key={s.scientificName}
+                    suggestion={s}
+                    onSelect={() => onSelectSpecies(s)}
+                  />
+                ))}
+              </Stack>
+              {ancestor && ancestorSelection && (
+                <AncestorAffordance
+                  ancestor={ancestor}
+                  onSelect={() => onSelectAncestor(ancestorSelection)}
+                />
+              )}
+            </>
+          )}
+        </Stack>
+      )}
+
+      {mode === "ambiguous" && (
+        <Stack spacing={0.75}>
+          {ancestor && ancestorSelection && (
+            <AncestorCard
+              ancestor={ancestor}
+              onSelect={() => onSelectAncestor(ancestorSelection)}
+            />
+          )}
+          <SectionLabel text={ancestor ? "If you can tell which species:" : "Possible species:"} />
+          <Stack spacing={0.5}>
+            {sorted.map((s) => (
+              <SpeciesCard
+                key={s.scientificName}
+                suggestion={s}
+                onSelect={() => onSelectSpecies(s)}
+              />
+            ))}
+          </Stack>
+        </Stack>
+      )}
+    </Box>
+  );
+}
+
+function SectionHeader() {
+  return (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 0.5, mb: 0.75 }}>
+      <AutoFixHighIcon sx={{ fontSize: 14, color: "text.secondary" }} />
+      <Typography variant="caption" sx={{ color: "text.secondary" }}>
+        Visual matches
+      </Typography>
+    </Box>
+  );
+}
+
+function SectionLabel({ text }: { text: string }) {
+  return (
+    <Typography variant="caption" sx={{ color: "text.secondary", mt: 0.5, mb: 0.25 }}>
+      {text}
+    </Typography>
+  );
+}
+
+function RankChip({ rank, size = 40 }: { rank: AncestorRank; size?: number }) {
+  return (
+    <Box
+      sx={{
+        width: size,
+        height: size,
+        borderRadius: "50%",
+        bgcolor: "action.selected",
+        color: "text.secondary",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        flexShrink: 0,
+        fontWeight: 600,
+        fontSize: size >= 36 ? "0.875rem" : "0.7rem",
+      }}
+      aria-label={RANK_LABEL[rank]}
+    >
+      {RANK_INITIAL[rank]}
+    </Box>
+  );
+}
+
+function AncestorName({ ancestor }: { ancestor: AncestorMatch }) {
+  // "sp." convention applies at genus level. For higher ranks (family, order, etc.)
+  // the rank chip + label is enough; "Aves sp." reads awkwardly to most readers.
+  if (ancestor.rank === "genus") {
+    return (
+      <>
+        <Box component="span" sx={{ fontStyle: "italic" }}>
+          {ancestor.name}
+        </Box>{" "}
+        sp.
+      </>
+    );
+  }
+  return <>{ancestor.name}</>;
+}
+
+function AncestorCard({ ancestor, onSelect }: { ancestor: AncestorMatch; onSelect: () => void }) {
+  return (
+    <ButtonBase
+      onClick={onSelect}
+      sx={{
+        width: "100%",
+        textAlign: "left",
+        borderRadius: 1,
+        border: "1px solid",
+        borderColor: "primary.main",
+        bgcolor: "action.hover",
+        p: 1.25,
+        display: "flex",
+        alignItems: "center",
+        gap: 1.25,
+        minHeight: 64,
+        "&:hover": { bgcolor: "action.selected" },
+      }}
+    >
+      <RankChip rank={ancestor.rank} />
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Typography sx={{ fontWeight: 600 }}>
+          <AncestorName ancestor={ancestor} />
+        </Typography>
+        <Typography variant="caption" sx={{ color: "text.secondary" }}>
+          {RANK_LABEL[ancestor.rank]} · {Math.round(ancestor.confidence * 100)}% match
+        </Typography>
+      </Box>
+    </ButtonBase>
+  );
+}
+
+function AncestorAffordance({
+  ancestor,
+  onSelect,
+}: {
+  ancestor: AncestorMatch;
+  onSelect: () => void;
+}) {
+  return (
+    <ButtonBase
+      onClick={onSelect}
+      sx={{
+        alignSelf: "flex-start",
+        textAlign: "left",
+        borderRadius: 1,
+        px: 0.75,
+        py: 0.5,
+        mt: 0.25,
+        display: "flex",
+        alignItems: "center",
+        gap: 0.75,
+        color: "text.secondary",
+        "&:hover": { bgcolor: "action.hover" },
+      }}
+    >
+      <RankChip rank={ancestor.rank} size={24} />
+      <Typography variant="caption">
+        Pick <AncestorName ancestor={ancestor} /> instead
+      </Typography>
+    </ButtonBase>
+  );
+}
+
+function SpeciesCard({
+  suggestion,
+  primary,
+  onSelect,
+}: {
+  suggestion: SpeciesSuggestion;
+  primary?: boolean;
+  onSelect: () => void;
+}) {
+  const thumbnailSize = primary ? 48 : 40;
+  return (
+    <ButtonBase
+      onClick={onSelect}
+      sx={{
+        width: "100%",
+        textAlign: "left",
+        borderRadius: 1,
+        border: "1px solid",
+        borderColor: primary ? "primary.main" : "divider",
+        bgcolor: primary ? "action.hover" : "transparent",
+        p: primary ? 1.25 : 1,
+        display: "flex",
+        alignItems: "center",
+        gap: 1.25,
+        minHeight: primary ? 56 : 48,
+        "&:hover": { bgcolor: "action.hover" },
+      }}
+    >
+      {suggestion.taxonMatch?.photoUrl ? (
+        <Box
+          component="img"
+          src={suggestion.taxonMatch.photoUrl}
+          alt=""
+          loading="lazy"
+          sx={{
+            width: thumbnailSize,
+            height: thumbnailSize,
+            borderRadius: 1,
+            objectFit: "cover",
+            flexShrink: 0,
+          }}
+        />
+      ) : (
+        <Box
+          sx={{
+            width: thumbnailSize,
+            height: thumbnailSize,
+            borderRadius: 1,
+            bgcolor: "action.disabledBackground",
+            flexShrink: 0,
+          }}
+        />
+      )}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Stack direction="row" spacing={0.75} sx={{ alignItems: "baseline", flexWrap: "wrap" }}>
+          <Typography sx={{ fontStyle: "italic", fontWeight: primary ? 600 : 500 }}>
+            {suggestion.scientificName}
+          </Typography>
+          {suggestion.commonName && (
+            <Typography variant="caption" sx={{ color: "text.secondary" }}>
+              {suggestion.commonName}
+            </Typography>
+          )}
+          {suggestion.inRange === true && (
+            <Box
+              component="span"
+              sx={{ display: "inline-flex", alignItems: "center", color: "success.main" }}
+              title="Found in your area"
+              aria-label="Found in your area"
+            >
+              <PlaceIcon sx={{ fontSize: 14 }} />
+            </Box>
+          )}
+        </Stack>
+      </Box>
+      <Typography variant="caption" sx={{ color: "text.secondary", flexShrink: 0 }}>
+        {Math.round(suggestion.confidence * 100)}%
+      </Typography>
+    </ButtonBase>
+  );
+}

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -600,6 +600,12 @@ export function UploadModal() {
                     setKingdom(s.kingdom);
                   }
                 }}
+                onSelectAncestor={(ancestor) => {
+                  setSpecies(ancestor.name);
+                  setMatchedTaxon(null);
+                  if (ancestor.kingdom) setKingdom(ancestor.kingdom);
+                  setRank(ancestor.rank);
+                }}
                 disabled={isSubmitting}
               />
             ) : undefined


### PR DESCRIPTION
## Summary
- New `VisualIdCards` component (sketch, not yet wired in) — renders Visual ID matches as cards instead of chips.
- When match confidence is split across siblings, rolls up the closest common ancestor and surfaces it as a first-class commitment (e.g., *Junco* sp. when the model can't pick among 4 Juncos).
- Bistable: dominant case shows the top species + a small "Pick X sp. instead" affordance; ambiguous case shows the ancestor card on top with the species list as expert override.

Trigger for dominant mode: top match must be ≥ 50% confidence AND ≥ 2× the runner-up. Rollup walks `genus → family → order → class → phylum → kingdom`, capped at kingdom.

## Test plan
- [ ] View all five stories under `Identification › VisualIdCards` in Storybook
- [ ] Confirm `Ambiguous` shows *Junco* sp. with rolled-up confidence at the top
- [ ] Confirm `Dominant` shows the top species highlighted + small ancestor affordance
- [ ] Confirm `AmbiguousAtClass` rolls up to "Aves" without italics (only genus uses *italic name* + "sp.")
- [ ] Confirm `NoCommonAncestor` falls back to a flat list with "Possible species:" header
- [ ] Confirm `Single` renders one card, no ancestor logic