### PR TITLE
chore(process-compose): pass PUBLIC_URL through to appview

### DIFF
--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -11,6 +11,7 @@ processes:
       - PORT=3000
       - CACHE_DIR=./cache/media
       - SPECIES_ID_SERVICE_URL=http://localhost:3005
+      - PUBLIC_URL=${PUBLIC_URL:-}
     readiness_probe:
       http_get:
         host: localhost


### PR DESCRIPTION
## Summary
- Adds `PUBLIC_URL=${PUBLIC_URL:-}` to the `appview` env block in `process-compose.yaml`.
- Lets a developer set `PUBLIC_URL` once in the shell and have process-compose forward it to the appview, instead of editing the yaml.

## Why
`PUBLIC_URL` flips the appview from `AtprotoLocalhostClientMetadata` (loopback redirects only) to `AtprotoClientMetadata` (real `client-metadata.json`). The latter is required any time the auth flow happens off the dev laptop — e.g. on a phone over a cloudflared/ngrok tunnel — because the PDS has to fetch the metadata file from the public internet.

No behavior change when `PUBLIC_URL` is unset; the appview keeps the dev loopback flow.

Pulled out of the Capacitor spike (#403) so it can land on its own.

## Test plan
- [x] `process-compose up -D` with no `PUBLIC_URL` exported → appview starts the same as before
- [x] `PUBLIC_URL=https://… process-compose up -D` → appview boots with `PUBLIC_URL` set, OAuth client metadata served at `<tunnel>/oauth/client-metadata.json`