### PR TITLE
fix(upload): treat (0, 0) EXIF GPS as missing, not as null island

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -200,7 +200,12 @@ export function UploadModal() {
             ? gpsLng.description
             : parseFloat(String(gpsLng.description));
 
-        if (Number.isFinite(latitude) && Number.isFinite(longitude)) {
+        // Reject (0, 0). Android's photo picker (and some other privacy-
+        // scrubbed providers) returns the EXIF GPS *structure* with values
+        // zeroed instead of removing the tags. A real observation at the
+        // null island is so unlikely that treating zero as "missing" is safe.
+        const isZeroIsland = latitude === 0 && longitude === 0;
+        if (Number.isFinite(latitude) && Number.isFinite(longitude) && !isZeroIsland) {
           // Apply hemisphere signs
           const latRefValue = Array.isArray(latRef?.value) ? latRef.value[0] : undefined;
           const lngRefValue = Array.isArray(lngRef?.value) ? lngRef.value[0] : undefined;


### PR DESCRIPTION
## Summary
In `extractExifData`, reject `latitude === 0 && longitude === 0` as a sentinel for "no GPS in this photo" instead of trusting it as a real coordinate.

## Why
Android 13+'s system photo picker returns photos with the EXIF GPS *structure* preserved (the `GPSLatitude`, `GPSLongitude`, `GPSLatitudeRef`, etc. tags are present) but with the coordinate values zeroed for privacy. Some other privacy-scrubbing providers do the same. Today the upload modal happily reads those zeros, sets the form's lat/lng to `(0, 0)`, and the user has no obvious indication it picked the null island over the actual photo location.

A genuine observation at `(0, 0)` is in the ocean off the coast of Africa and statistically vanishingly rare. Treating it as missing is the standard heuristic — `exiftool`, `exif-js`, and most photo apps do the same.

Pulled out of the Capacitor spike (#403) so it can land on its own.

## Test plan
- [x] Photo with real GPS EXIF → location auto-fills as before
- [x] Photo with EXIF GPS values zeroed (Android 14+ picker) → location is left untouched, no toast
- [x] Photo with no EXIF GPS at all → no behavior change