### PR TITLE
feat(upload-modal): confirm before discarding in-progress changes

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -14,6 +14,10 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
@@ -75,6 +79,8 @@ export function UploadModal() {
   const [observationDate, setObservationDate] = useState(() => toDatetimeLocal(new Date()));
   const [uncertaintyMeters, setUncertaintyMeters] = useState(50);
   const [visualIdImageUrl, setVisualIdImageUrl] = useState<string | null>(null);
+  const [isDirty, setIsDirty] = useState(false);
+  const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   const MAX_IMAGES = 10;
@@ -83,6 +89,7 @@ export function UploadModal() {
 
   useEffect(() => {
     if (isOpen) {
+      setIsDirty(false);
       if (editingObservation) {
         setSpecies(editingObservation.effectiveTaxonomy?.scientificName || "");
         setKingdom(editingObservation.effectiveTaxonomy?.kingdom || "");
@@ -112,8 +119,7 @@ export function UploadModal() {
     }
   }, [isOpen, currentLocation, editingObservation]);
 
-  const handleClose = () => {
-    dispatch(closeUploadModal());
+  const resetForm = () => {
     setSpecies("");
     setMatchedTaxon(null);
     setKingdom("");
@@ -125,6 +131,22 @@ export function UploadModal() {
     setObservationDate(toDatetimeLocal(new Date()));
     setUncertaintyMeters(50);
     setVisualIdImageUrl(null);
+    setIsDirty(false);
+  };
+
+  const handleRequestClose = () => {
+    if (isDirty) {
+      setDiscardConfirmOpen(true);
+      return;
+    }
+    dispatch(closeUploadModal());
+    resetForm();
+  };
+
+  const handleConfirmDiscard = () => {
+    setDiscardConfirmOpen(false);
+    dispatch(closeUploadModal());
+    resetForm();
   };
 
   const addFiles = (files: File[]) => {
@@ -161,6 +183,7 @@ export function UploadModal() {
 
       const preview = URL.createObjectURL(file);
       setImages((prev) => [...prev, { file, preview }]);
+      setIsDirty(true);
 
       if (images.length === 0) {
         extractExifData(file);
@@ -246,10 +269,12 @@ export function UploadModal() {
       if (removed) URL.revokeObjectURL(removed.preview);
       return prev.filter((_, i) => i !== index);
     });
+    setIsDirty(true);
   };
 
   const handleRemoveExistingImage = (index: number) => {
     setExistingImages((prev) => prev.filter((_, i) => i !== index));
+    setIsDirty(true);
   };
 
   const handleUploadClick = () => {
@@ -388,328 +413,370 @@ export function UploadModal() {
   const handleLocationChange = (newLat: number, newLng: number) => {
     setLat(newLat.toFixed(6));
     setLng(newLng.toFixed(6));
+    setIsDirty(true);
   };
 
   return (
-    <ModalOverlay isOpen={isOpen} onClose={handleClose}>
-      {user && (
-        <Alert severity="success" sx={{ mb: 2, mx: -1, mt: -1 }}>
-          Posting as {user.handle ? `@${user.handle}` : user.did}
-        </Alert>
-      )}
-      <Typography variant="h5" sx={{ fontWeight: 600, mb: 2 }}>
-        {isEditMode ? "Edit Observation" : "New Observation"}
-      </Typography>
-      <form onSubmit={handleSubmit}>
-        <Typography
-          variant="body2"
-          sx={{
-            color: "text.secondary",
-            mb: 1,
-          }}
-        >
-          Photos (optional)
-        </Typography>
-
-        <input
-          ref={fileInputRef}
-          type="file"
-          accept="image/jpeg,image/png,image/webp"
-          multiple
-          onChange={handleImageSelect}
-          style={{ display: "none" }}
-        />
-
-        {(existingImages.length > 0 || images.length > 0) && (
-          <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: "wrap", gap: 1 }}>
-            {existingImages.map((url, index) => (
-              <Box
-                key={`existing-${index}`}
-                sx={{
-                  position: "relative",
-                  width: 80,
-                  height: 80,
-                  borderRadius: 1,
-                  overflow: "hidden",
-                  border: 1,
-                  borderColor: "divider",
-                }}
-              >
-                <Box
-                  component="img"
-                  src={url}
-                  alt={`Existing ${index + 1}`}
-                  sx={{ width: "100%", height: "100%", objectFit: "cover" }}
-                />
-                <IconButton
-                  size="small"
-                  onClick={() => handleRemoveExistingImage(index)}
-                  aria-label="Remove image"
-                  sx={{
-                    position: "absolute",
-                    top: 2,
-                    right: 2,
-                    bgcolor: "rgba(0, 0, 0, 0.7)",
-                    color: "white",
-                    width: 20,
-                    height: 20,
-                    "&:hover": { bgcolor: "error.main" },
-                  }}
-                >
-                  <CloseIcon sx={{ fontSize: 14 }} />
-                </IconButton>
-              </Box>
-            ))}
-            {images.map((img, index) => (
-              <Box
-                key={`new-${index}`}
-                sx={{
-                  position: "relative",
-                  width: 80,
-                  height: 80,
-                  borderRadius: 1,
-                  overflow: "hidden",
-                  border: 1,
-                  borderColor: "divider",
-                }}
-              >
-                <Box
-                  component="img"
-                  src={img.preview}
-                  alt={`Preview ${index + 1}`}
-                  sx={{ width: "100%", height: "100%", objectFit: "cover" }}
-                />
-                <IconButton
-                  size="small"
-                  onClick={() => handleRemoveImage(index)}
-                  aria-label="Remove image"
-                  sx={{
-                    position: "absolute",
-                    top: 2,
-                    right: 2,
-                    bgcolor: "rgba(0, 0, 0, 0.7)",
-                    color: "white",
-                    width: 20,
-                    height: 20,
-                    "&:hover": { bgcolor: "error.main" },
-                  }}
-                >
-                  <CloseIcon sx={{ fontSize: 14 }} />
-                </IconButton>
-              </Box>
-            ))}
-          </Stack>
+    <>
+      <ModalOverlay isOpen={isOpen} onClose={handleRequestClose}>
+        {user && (
+          <Alert severity="success" sx={{ mb: 2, mx: -1, mt: -1 }}>
+            Posting as {user.handle ? `@${user.handle}` : user.did}
+          </Alert>
         )}
-
-        {existingImages.length + images.length < MAX_IMAGES && (
-          <Button
-            fullWidth
-            variant="outlined"
-            onClick={handleUploadClick}
-            startIcon={<AddPhotoAlternateIcon />}
+        <Typography variant="h5" sx={{ fontWeight: 600, mb: 2 }}>
+          {isEditMode ? "Edit Observation" : "New Observation"}
+        </Typography>
+        <form onSubmit={handleSubmit}>
+          <Typography
+            variant="body2"
             sx={{
-              borderStyle: "dashed",
-              color: "text.disabled",
-              "&:hover": {
-                borderColor: "primary.main",
-                color: "primary.main",
-              },
+              color: "text.secondary",
+              mb: 1,
             }}
           >
-            {images.length === 0 ? "Add photos" : "Add more photos"}
-          </Button>
-        )}
+            Photos (optional)
+          </Typography>
 
-        <Typography
-          variant="caption"
-          sx={{
-            color: "text.disabled",
-            display: "block",
-            mt: 0.5,
-          }}
-        >
-          JPG, PNG, or WebP - Max 10MB each - Up to {MAX_IMAGES} photos
-        </Typography>
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png,image/webp"
+            multiple
+            onChange={handleImageSelect}
+            style={{ display: "none" }}
+          />
 
-        <LocationPicker
-          latitude={lat ? parseFloat(lat) : null}
-          longitude={lng ? parseFloat(lng) : null}
-          onChange={handleLocationChange}
-          uncertaintyMeters={uncertaintyMeters}
-          onUncertaintyChange={setUncertaintyMeters}
-        />
-
-        <TaxaAutocomplete
-          value={species}
-          onChange={(name) => {
-            setSpecies(name);
-            if (name === "") {
-              setMatchedTaxon(null);
-              setKingdom("");
-              setRank("");
-            }
-          }}
-          onMatchChange={(match) => {
-            setMatchedTaxon(match);
-            if (match?.kingdom) {
-              setKingdom(match.kingdom);
-            }
-            if (match) {
-              setRank("");
-            }
-          }}
-          label="Taxon (optional)"
-          placeholder="e.g. Eschscholzia californica - leave blank if unknown"
-          bottomContent={
-            species.trim() ? (
-              matchedTaxon ? (
-                <Chip
-                  {...(matchedTaxon.photoUrl
-                    ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
-                    : { icon: <CheckCircleOutlinedIcon /> })}
-                  label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
-                    .filter((p): p is string => Boolean(p))
-                    .join(" · ")}
-                  color="success"
-                  size="small"
-                  variant="outlined"
-                  sx={{ mt: 0.5 }}
-                />
-              ) : (
-                <Chip
-                  icon={<AddCircleOutlinedIcon />}
-                  label="New taxon"
-                  color="info"
-                  size="small"
-                  variant="outlined"
-                  sx={{ mt: 0.5 }}
-                />
-              )
-            ) : visualIdImageUrl ? (
-              <VisualId
-                imageUrl={visualIdImageUrl}
-                latitude={lat ? parseFloat(lat) : undefined}
-                longitude={lng ? parseFloat(lng) : undefined}
-                onSelect={(s) => {
-                  setSpecies(s.scientificName);
-                  if (s.taxonMatch) {
-                    setMatchedTaxon(s.taxonMatch);
-                    setKingdom(s.taxonMatch.kingdom ?? "");
-                    setRank("");
-                  } else if (s.kingdom) {
-                    setKingdom(s.kingdom);
-                  }
-                }}
-                onSelectAncestor={(ancestor) => {
-                  setSpecies(ancestor.name);
-                  setMatchedTaxon(null);
-                  if (ancestor.kingdom) setKingdom(ancestor.kingdom);
-                  setRank(ancestor.rank);
-                }}
-                disabled={isSubmitting}
-              />
-            ) : undefined
-          }
-        />
-
-        {!!species.trim() && !matchedTaxon && (
-          <FormControl fullWidth margin="normal" required>
-            <InputLabel id="kingdom-label">Kingdom</InputLabel>
-            <Select
-              labelId="kingdom-label"
-              value={kingdom}
-              label="Kingdom"
-              onChange={(e) => setKingdom(e.target.value)}
-            >
-              <MenuItem value="">
-                <em>None</em>
-              </MenuItem>
-              {KINGDOMS.map((k) => (
-                <MenuItem key={k.value} value={k.value}>
-                  {k.label}
-                </MenuItem>
+          {(existingImages.length > 0 || images.length > 0) && (
+            <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: "wrap", gap: 1 }}>
+              {existingImages.map((url, index) => (
+                <Box
+                  key={`existing-${index}`}
+                  sx={{
+                    position: "relative",
+                    width: 80,
+                    height: 80,
+                    borderRadius: 1,
+                    overflow: "hidden",
+                    border: 1,
+                    borderColor: "divider",
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={url}
+                    alt={`Existing ${index + 1}`}
+                    sx={{ width: "100%", height: "100%", objectFit: "cover" }}
+                  />
+                  <IconButton
+                    size="small"
+                    onClick={() => handleRemoveExistingImage(index)}
+                    aria-label="Remove image"
+                    sx={{
+                      position: "absolute",
+                      top: 2,
+                      right: 2,
+                      bgcolor: "rgba(0, 0, 0, 0.7)",
+                      color: "white",
+                      width: 20,
+                      height: 20,
+                      "&:hover": { bgcolor: "error.main" },
+                    }}
+                  >
+                    <CloseIcon sx={{ fontSize: 14 }} />
+                  </IconButton>
+                </Box>
               ))}
-            </Select>
-          </FormControl>
-        )}
+              {images.map((img, index) => (
+                <Box
+                  key={`new-${index}`}
+                  sx={{
+                    position: "relative",
+                    width: 80,
+                    height: 80,
+                    borderRadius: 1,
+                    overflow: "hidden",
+                    border: 1,
+                    borderColor: "divider",
+                  }}
+                >
+                  <Box
+                    component="img"
+                    src={img.preview}
+                    alt={`Preview ${index + 1}`}
+                    sx={{ width: "100%", height: "100%", objectFit: "cover" }}
+                  />
+                  <IconButton
+                    size="small"
+                    onClick={() => handleRemoveImage(index)}
+                    aria-label="Remove image"
+                    sx={{
+                      position: "absolute",
+                      top: 2,
+                      right: 2,
+                      bgcolor: "rgba(0, 0, 0, 0.7)",
+                      color: "white",
+                      width: 20,
+                      height: 20,
+                      "&:hover": { bgcolor: "error.main" },
+                    }}
+                  >
+                    <CloseIcon sx={{ fontSize: 14 }} />
+                  </IconButton>
+                </Box>
+              ))}
+            </Stack>
+          )}
 
-        {!!species.trim() && !matchedTaxon && (
+          {existingImages.length + images.length < MAX_IMAGES && (
+            <Button
+              fullWidth
+              variant="outlined"
+              onClick={handleUploadClick}
+              startIcon={<AddPhotoAlternateIcon />}
+              sx={{
+                borderStyle: "dashed",
+                color: "text.disabled",
+                "&:hover": {
+                  borderColor: "primary.main",
+                  color: "primary.main",
+                },
+              }}
+            >
+              {images.length === 0 ? "Add photos" : "Add more photos"}
+            </Button>
+          )}
+
+          <Typography
+            variant="caption"
+            sx={{
+              color: "text.disabled",
+              display: "block",
+              mt: 0.5,
+            }}
+          >
+            JPG, PNG, or WebP - Max 10MB each - Up to {MAX_IMAGES} photos
+          </Typography>
+
+          <LocationPicker
+            latitude={lat ? parseFloat(lat) : null}
+            longitude={lng ? parseFloat(lng) : null}
+            onChange={handleLocationChange}
+            uncertaintyMeters={uncertaintyMeters}
+            onUncertaintyChange={(m) => {
+              setUncertaintyMeters(m);
+              setIsDirty(true);
+            }}
+          />
+
+          <TaxaAutocomplete
+            value={species}
+            onChange={(name) => {
+              setSpecies(name);
+              setIsDirty(true);
+              if (name === "") {
+                setMatchedTaxon(null);
+                setKingdom("");
+                setRank("");
+              }
+            }}
+            onMatchChange={(match) => {
+              setMatchedTaxon(match);
+              if (match?.kingdom) {
+                setKingdom(match.kingdom);
+              }
+              if (match) {
+                setRank("");
+              }
+            }}
+            label="Taxon (optional)"
+            placeholder="e.g. Eschscholzia californica - leave blank if unknown"
+            bottomContent={
+              species.trim() ? (
+                matchedTaxon ? (
+                  <Chip
+                    {...(matchedTaxon.photoUrl
+                      ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
+                      : { icon: <CheckCircleOutlinedIcon /> })}
+                    label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
+                      .filter((p): p is string => Boolean(p))
+                      .join(" · ")}
+                    color="success"
+                    size="small"
+                    variant="outlined"
+                    sx={{ mt: 0.5 }}
+                  />
+                ) : (
+                  <Chip
+                    icon={<AddCircleOutlinedIcon />}
+                    label="New taxon"
+                    color="info"
+                    size="small"
+                    variant="outlined"
+                    sx={{ mt: 0.5 }}
+                  />
+                )
+              ) : visualIdImageUrl ? (
+                <VisualId
+                  imageUrl={visualIdImageUrl}
+                  latitude={lat ? parseFloat(lat) : undefined}
+                  longitude={lng ? parseFloat(lng) : undefined}
+                  onSelect={(s) => {
+                    setSpecies(s.scientificName);
+                    setIsDirty(true);
+                    if (s.taxonMatch) {
+                      setMatchedTaxon(s.taxonMatch);
+                      setKingdom(s.taxonMatch.kingdom ?? "");
+                      setRank("");
+                    } else if (s.kingdom) {
+                      setKingdom(s.kingdom);
+                    }
+                  }}
+                  onSelectAncestor={(ancestor) => {
+                    setSpecies(ancestor.name);
+                    setMatchedTaxon(null);
+                    setIsDirty(true);
+                    if (ancestor.kingdom) setKingdom(ancestor.kingdom);
+                    setRank(ancestor.rank);
+                  }}
+                  disabled={isSubmitting}
+                />
+              ) : undefined
+            }
+          />
+
+          {!!species.trim() && !matchedTaxon && (
+            <FormControl fullWidth margin="normal" required>
+              <InputLabel id="kingdom-label">Kingdom</InputLabel>
+              <Select
+                labelId="kingdom-label"
+                value={kingdom}
+                label="Kingdom"
+                onChange={(e) => {
+                  setKingdom(e.target.value);
+                  setIsDirty(true);
+                }}
+              >
+                <MenuItem value="">
+                  <em>None</em>
+                </MenuItem>
+                {KINGDOMS.map((k) => (
+                  <MenuItem key={k.value} value={k.value}>
+                    {k.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+
+          {!!species.trim() && !matchedTaxon && (
+            <FormControl fullWidth margin="normal">
+              <InputLabel id="rank-label">Rank (optional)</InputLabel>
+              <Select
+                labelId="rank-label"
+                value={rank}
+                label="Rank (optional)"
+                onChange={(e) => {
+                  setRank(e.target.value);
+                  setIsDirty(true);
+                }}
+              >
+                <MenuItem value="">
+                  <em>None</em>
+                </MenuItem>
+                {TAXON_RANKS.map((r) => (
+                  <MenuItem key={r} value={r}>
+                    {r}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+
           <FormControl fullWidth margin="normal">
-            <InputLabel id="rank-label">Rank (optional)</InputLabel>
+            <InputLabel id="license-label">License</InputLabel>
             <Select
-              labelId="rank-label"
-              value={rank}
-              label="Rank (optional)"
-              onChange={(e) => setRank(e.target.value)}
+              labelId="license-label"
+              value={license}
+              label="License"
+              onChange={(e) => {
+                setLicense(e.target.value);
+                setIsDirty(true);
+              }}
             >
-              <MenuItem value="">
-                <em>None</em>
-              </MenuItem>
-              {TAXON_RANKS.map((r) => (
-                <MenuItem key={r} value={r}>
-                  {r}
+              {LICENSE_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>
+                  {opt.label}
                 </MenuItem>
               ))}
             </Select>
           </FormControl>
-        )}
 
-        <FormControl fullWidth margin="normal">
-          <InputLabel id="license-label">License</InputLabel>
-          <Select
-            labelId="license-label"
-            value={license}
-            label="License"
-            onChange={(e) => setLicense(e.target.value)}
+          <TextField
+            fullWidth
+            label="Observation date"
+            type="datetime-local"
+            value={observationDate}
+            onChange={(e) => {
+              setObservationDate(e.target.value);
+              setIsDirty(true);
+            }}
+            margin="normal"
+            slotProps={{
+              inputLabel: { shrink: true },
+            }}
+          />
+
+          <Stack
+            direction="row"
+            spacing={1}
+            sx={{
+              justifyContent: "flex-end",
+              mt: 2,
+            }}
           >
-            {LICENSE_OPTIONS.map((opt) => (
-              <MenuItem key={opt.value} value={opt.value}>
-                {opt.label}
-              </MenuItem>
-            ))}
-          </Select>
-        </FormControl>
-
-        <TextField
-          fullWidth
-          label="Observation date"
-          type="datetime-local"
-          value={observationDate}
-          onChange={(e) => setObservationDate(e.target.value)}
-          margin="normal"
-          slotProps={{
-            inputLabel: { shrink: true },
-          }}
-        />
-
-        <Stack
-          direction="row"
-          spacing={1}
-          sx={{
-            justifyContent: "flex-end",
-            mt: 2,
-          }}
-        >
-          <Button onClick={handleClose} color="inherit">
-            Cancel
+            <Button onClick={handleRequestClose} color="inherit">
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              variant="contained"
+              color="primary"
+              disabled={isSubmitting}
+              startIcon={isSubmitting ? <CircularProgress size={16} color="inherit" /> : undefined}
+            >
+              {isSubmitting
+                ? isEditMode
+                  ? "Saving..."
+                  : "Submitting..."
+                : isEditMode
+                  ? "Save Changes"
+                  : "Submit"}
+            </Button>
+          </Stack>
+        </form>
+      </ModalOverlay>
+      <Dialog
+        open={discardConfirmOpen}
+        onClose={() => setDiscardConfirmOpen(false)}
+        maxWidth="xs"
+        fullWidth
+      >
+        <DialogTitle>Discard changes?</DialogTitle>
+        <DialogContent>
+          <Typography>
+            You have unsaved changes. If you close now, your in-progress data will be lost.
+          </Typography>
+        </DialogContent>
+        <DialogActions sx={{ px: 3, pb: 2 }}>
+          <Button onClick={() => setDiscardConfirmOpen(false)} color="inherit">
+            Keep editing
           </Button>
-          <Button
-            type="submit"
-            variant="contained"
-            color="primary"
-            disabled={isSubmitting}
-            startIcon={isSubmitting ? <CircularProgress size={16} color="inherit" /> : undefined}
-          >
-            {isSubmitting
-              ? isEditMode
-                ? "Saving..."
-                : "Submitting..."
-              : isEditMode
-                ? "Save Changes"
-                : "Submit"}
+          <Button onClick={handleConfirmDiscard} color="error" variant="contained">
+            Discard
           </Button>
-        </Stack>
-      </form>
-    </ModalOverlay>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- Track an `isDirty` flag in `UploadModal` that flips on user-driven edits (photos, taxon, kingdom/rank, license, location, uncertainty, date) and resets on open / close / discard.
- Closing the modal while dirty (Cancel, backdrop, or ESC) now opens a small MUI confirmation dialog. "Keep editing" leaves the form intact; "Discard" closes the modal and clears all in-progress data (including revoking image-preview object URLs).
- Auto-population paths (currentLocation prefill, edit-mode init from `editingObservation`) intentionally do not mark dirty. Files supplied via the FAB pending-files bridge do.

## Test plan
- [ ] Open "New Observation" via FAB, edit any field, click Cancel → confirm dialog appears; "Keep editing" preserves state, "Discard" closes and clears.
- [ ] Same flow but close via backdrop click and via ESC.
- [ ] Open with a pre-filled `currentLocation` and immediately Cancel → no confirm dialog (location prefill alone is not "dirty").
- [ ] Open via FAB quick-photo flow (pending files) → confirm dialog appears on close (the photo counts as in-progress data).
- [ ] Open Edit Observation, change nothing, Cancel → no confirm. Change a field, Cancel → confirm.
- [ ] Submit successfully → no confirm dialog interferes with navigation.