### PR TITLE
feat(taxon): replace stretched hero with constrained image card

### DIFF
--- a/frontend/src/components/taxon/TaxonDetail.tsx
+++ b/frontend/src/components/taxon/TaxonDetail.tsx
@@ -220,30 +220,6 @@ export function TaxonDetail() {
           </Typography>
         </Box>
 
-        {/* Hero Image */}
-        {heroUrl && (
-          <Box
-            sx={{
-              width: "100%",
-              maxHeight: 280,
-              overflow: "hidden",
-              backgroundColor: "action.hover",
-            }}
-          >
-            <Box
-              component="img"
-              src={heroUrl}
-              alt={taxon.scientificName}
-              sx={{
-                width: "100%",
-                maxHeight: 280,
-                objectFit: "cover",
-                display: "block",
-              }}
-            />
-          </Box>
-        )}
-
         {/* Main Content */}
         <Box sx={{ p: 3 }}>
           {/* Breadcrumb */}
@@ -276,94 +252,132 @@ export function TaxonDetail() {
             </Stack>
           )}
 
-          {/* Scientific Name */}
-          <Typography
-            variant="h5"
-            sx={{
-              fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
-                ? "italic"
-                : "normal",
-              color: "primary.main",
-              fontWeight: 600,
-            }}
-          >
-            {taxon.scientificName}
-          </Typography>
-
-          {/* Common Name */}
-          {taxon.commonName && (
-            <Typography
-              variant="h6"
-              component="p"
-              sx={{
-                color: "text.secondary",
-                mt: 0.5,
-              }}
-            >
-              {taxon.commonName}
-            </Typography>
-          )}
-
-          {/* Stats + External Links */}
+          {/* Image card + title block */}
           <Stack
-            direction="row"
-            spacing={1}
-            sx={{
-              alignItems: "center",
-              mt: 2,
-              flexWrap: "wrap",
-            }}
+            direction={{ xs: "column", sm: "row" }}
+            spacing={2}
+            sx={{ alignItems: { xs: "stretch", sm: "flex-start" } }}
           >
-            {taxon.conservationStatus && (
-              <Tooltip title={`${taxon.conservationStatus.category} — IUCN Red List`} arrow>
-                <span>
-                  <ConservationStatus status={taxon.conservationStatus} showLabel />
-                </span>
-              </Tooltip>
+            {heroUrl && (
+              <Box
+                sx={{
+                  width: 240,
+                  height: 240,
+                  maxWidth: "100%",
+                  flexShrink: 0,
+                  borderRadius: 1,
+                  overflow: "hidden",
+                  backgroundColor: "action.hover",
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  mx: { xs: "auto", sm: 0 },
+                }}
+              >
+                <Box
+                  component="img"
+                  src={heroUrl}
+                  alt={taxon.scientificName}
+                  sx={{
+                    width: "100%",
+                    height: "100%",
+                    objectFit: "contain",
+                    display: "block",
+                  }}
+                />
+              </Box>
             )}
-            {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
-            <Typography
-              variant="body2"
-              sx={{
-                color: "text.secondary",
-              }}
-            >
-              {taxon.observationCount} observation{taxon.observationCount !== 1 ? "s" : ""} on
-              Observ.ing
-              {taxon.numDescendants !== undefined && taxon.numDescendants > 0 && (
-                <> &middot; {taxon.numDescendants.toLocaleString()} descendant taxa</>
+            <Box sx={{ flex: 1, minWidth: 0 }}>
+              {/* Scientific Name */}
+              <Typography
+                variant="h5"
+                sx={{
+                  fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
+                    ? "italic"
+                    : "normal",
+                  color: "primary.main",
+                  fontWeight: 600,
+                }}
+              >
+                {taxon.scientificName}
+              </Typography>
+
+              {/* Common Name */}
+              {taxon.commonName && (
+                <Typography
+                  variant="h6"
+                  component="p"
+                  sx={{
+                    color: "text.secondary",
+                    mt: 0.5,
+                  }}
+                >
+                  {taxon.commonName}
+                </Typography>
               )}
-            </Typography>
-            {(gbifUrl || wikidataUrl) && (
-              <>
-                {gbifUrl && (
-                  <Chip
-                    component="a"
-                    href={gbifUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    label="GBIF"
-                    size="small"
-                    variant="outlined"
-                    clickable
-                    icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                  />
+
+              {/* Stats + External Links */}
+              <Stack
+                direction="row"
+                spacing={1}
+                sx={{
+                  alignItems: "center",
+                  mt: 2,
+                  flexWrap: "wrap",
+                }}
+              >
+                {taxon.conservationStatus && (
+                  <Tooltip title={`${taxon.conservationStatus.category} — IUCN Red List`} arrow>
+                    <span>
+                      <ConservationStatus status={taxon.conservationStatus} showLabel />
+                    </span>
+                  </Tooltip>
                 )}
-                {wikidataUrl && (
-                  <Chip
-                    component="a"
-                    href={wikidataUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    label="Wikidata"
-                    size="small"
-                    variant="outlined"
-                    clickable
-                    icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                  />
+                {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
+                <Typography
+                  variant="body2"
+                  sx={{
+                    color: "text.secondary",
+                  }}
+                >
+                  {taxon.observationCount} observation{taxon.observationCount !== 1 ? "s" : ""} on
+                  Observ.ing
+                  {taxon.numDescendants !== undefined && taxon.numDescendants > 0 && (
+                    <> &middot; {taxon.numDescendants.toLocaleString()} descendant taxa</>
+                  )}
+                </Typography>
+                {(gbifUrl || wikidataUrl) && (
+                  <>
+                    {gbifUrl && (
+                      <Chip
+                        component="a"
+                        href={gbifUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        label="GBIF"
+                        size="small"
+                        variant="outlined"
+                        clickable
+                        icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                      />
+                    )}
+                    {wikidataUrl && (
+                      <Chip
+                        component="a"
+                        href={wikidataUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        label="Wikidata"
+                        size="small"
+                        variant="outlined"
+                        clickable
+                        icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                      />
+                    )}
+                  </>
                 )}
-              </>
-            )}
+              </Stack>
+            </Box>
           </Stack>
 
           {/* Taxonomy Tree */}

--- a/frontend/src/components/taxon/TaxonDetailPanel.tsx
+++ b/frontend/src/components/taxon/TaxonDetailPanel.tsx
@@ -82,119 +82,134 @@ export function TaxonDetailPanel({
           </IconButton>
         )}
       </Box>
-      {/* Hero Image */}
-      {heroUrl && (
-        <Box
-          sx={{
-            width: "100%",
-            maxHeight: 280,
-            overflow: "hidden",
-            backgroundColor: "action.hover",
-          }}
-        >
-          <Box
-            component="img"
-            src={heroUrl}
-            alt={taxon.scientificName}
-            sx={{
-              width: "100%",
-              maxHeight: 280,
-              objectFit: "cover",
-              display: "block",
-            }}
-          />
-        </Box>
-      )}
       {/* Main Content */}
       <Box sx={{ p: 3 }}>
-        {/* Scientific Name */}
-        <Typography
-          variant="h5"
-          sx={{
-            fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
-              ? "italic"
-              : "normal",
-            color: "primary.main",
-            fontWeight: 600,
-          }}
-        >
-          {taxon.scientificName}
-        </Typography>
-
-        {/* Common Name */}
-        {taxon.commonName && (
-          <Typography
-            variant="h6"
-            component="p"
-            sx={{
-              color: "text.secondary",
-              mt: 0.5,
-            }}
-          >
-            {taxon.commonName}
-          </Typography>
-        )}
-
-        {/* Stats + External Links */}
+        {/* Image card + title block */}
         <Stack
-          direction="row"
-          spacing={1}
-          sx={{
-            alignItems: "center",
-            mt: 2,
-            flexWrap: "wrap",
-          }}
+          direction={{ xs: "column", sm: "row" }}
+          spacing={2}
+          sx={{ alignItems: { xs: "stretch", sm: "flex-start" } }}
         >
-          {taxon.conservationStatus && (
-            <Tooltip title={`${taxon.conservationStatus.category} — IUCN Red List`} arrow>
-              <span>
-                <ConservationStatus status={taxon.conservationStatus} showLabel />
-              </span>
-            </Tooltip>
+          {heroUrl && (
+            <Box
+              sx={{
+                width: 240,
+                height: 240,
+                maxWidth: "100%",
+                flexShrink: 0,
+                borderRadius: 1,
+                overflow: "hidden",
+                backgroundColor: "action.hover",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                mx: { xs: "auto", sm: 0 },
+              }}
+            >
+              <Box
+                component="img"
+                src={heroUrl}
+                alt={taxon.scientificName}
+                sx={{
+                  width: "100%",
+                  height: "100%",
+                  objectFit: "contain",
+                  display: "block",
+                }}
+              />
+            </Box>
           )}
-          {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
-          <Typography
-            variant="body2"
-            sx={{
-              color: "text.secondary",
-            }}
-          >
-            {taxon.observationCount} observation{taxon.observationCount !== 1 ? "s" : ""} on
-            Observ.ing
-            {taxon.numDescendants !== undefined && taxon.numDescendants > 0 && (
-              <> &middot; {taxon.numDescendants.toLocaleString()} descendant taxa</>
+          <Box sx={{ flex: 1, minWidth: 0 }}>
+            {/* Scientific Name */}
+            <Typography
+              variant="h5"
+              sx={{
+                fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
+                  ? "italic"
+                  : "normal",
+                color: "primary.main",
+                fontWeight: 600,
+              }}
+            >
+              {taxon.scientificName}
+            </Typography>
+
+            {/* Common Name */}
+            {taxon.commonName && (
+              <Typography
+                variant="h6"
+                component="p"
+                sx={{
+                  color: "text.secondary",
+                  mt: 0.5,
+                }}
+              >
+                {taxon.commonName}
+              </Typography>
             )}
-          </Typography>
-          {(gbifUrl || wikidataUrl) && (
-            <>
-              {gbifUrl && (
-                <Chip
-                  component="a"
-                  href={gbifUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  label="GBIF"
-                  size="small"
-                  variant="outlined"
-                  clickable
-                  icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                />
+
+            {/* Stats + External Links */}
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{
+                alignItems: "center",
+                mt: 2,
+                flexWrap: "wrap",
+              }}
+            >
+              {taxon.conservationStatus && (
+                <Tooltip title={`${taxon.conservationStatus.category} — IUCN Red List`} arrow>
+                  <span>
+                    <ConservationStatus status={taxon.conservationStatus} showLabel />
+                  </span>
+                </Tooltip>
               )}
-              {wikidataUrl && (
-                <Chip
-                  component="a"
-                  href={wikidataUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  label="Wikidata"
-                  size="small"
-                  variant="outlined"
-                  clickable
-                  icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                />
+              {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
+              <Typography
+                variant="body2"
+                sx={{
+                  color: "text.secondary",
+                }}
+              >
+                {taxon.observationCount} observation{taxon.observationCount !== 1 ? "s" : ""} on
+                Observ.ing
+                {taxon.numDescendants !== undefined && taxon.numDescendants > 0 && (
+                  <> &middot; {taxon.numDescendants.toLocaleString()} descendant taxa</>
+                )}
+              </Typography>
+              {(gbifUrl || wikidataUrl) && (
+                <>
+                  {gbifUrl && (
+                    <Chip
+                      component="a"
+                      href={gbifUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      label="GBIF"
+                      size="small"
+                      variant="outlined"
+                      clickable
+                      icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                    />
+                  )}
+                  {wikidataUrl && (
+                    <Chip
+                      component="a"
+                      href={wikidataUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      label="Wikidata"
+                      size="small"
+                      variant="outlined"
+                      clickable
+                      icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                    />
+                  )}
+                </>
               )}
-            </>
-          )}
+            </Stack>
+          </Box>
         </Stack>
 
         {/* Media Gallery — lazy-loaded */}


### PR DESCRIPTION
## Summary
- The taxon page's full-bleed hero band stretched single source images to 280px height. Most taxa only have one or two images, so the result was typically distorted (especially for portrait-orientation source images).
- Replaced with an infobox-style 240x240 image card placed next to the scientific-name / common-name / stats block on `sm+`, and stacked above on `xs`. Uses `object-fit: contain` over a soft `action.hover` background so any aspect ratio looks intentional and never crops or stretches.
- Applied to both `TaxonDetail` (full page) and `TaxonDetailPanel` (explorer side pane) for consistency.

## Test plan
- [ ] Open a taxon with a tall/portrait source image — image is letterboxed inside the card, not stretched.
- [ ] Open a taxon with a wide/landscape source image — image fits horizontally, no crop.
- [ ] Open a taxon with no `photoUrl` and no Wikidata thumbnail — title block fills the row, no empty card.
- [ ] Resize window across the `sm` breakpoint (600px): image moves between left-of-title (desktop) and centered-above-title (mobile).
- [ ] Same checks on `TaxonDetailPanel` (explorer side pane / split view).

> Note: changes are layout-only and typecheck cleanly; not visually verified in a live dev server.