### PR TITLE
ci: release workflow publishes Android debug APK on tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,78 @@
+name: Release
+
+# Triggered by pushing a tag like `v0.2.0`. Builds an Android debug APK,
+# attaches it to a draft GitHub Release, and auto-fills release notes from
+# PR titles since the last tag. The release stays a draft so the
+# versionName / changelog / APK can be reviewed before publishing.
+#
+# This is a debug-key-signed build — fine for sideloading and TestFlight-
+# style sharing, not for Play Store. For Play Store we'd add a parallel
+# signed-release path (separate keystore + secrets).
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  android-debug-apk:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # rev-list --count needs full history to derive a stable
+          # versionCode that monotonically increases across tags.
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+      - uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - uses: android-actions/setup-android@v3
+        with:
+          packages: 'platform-tools platforms;android-34 build-tools;34.0.0'
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: npm ci
+      - run: npm run build
+      - run: npx cap add android
+      - run: npx cap sync android
+
+      - name: Inject version from tag
+        run: |
+          VERSION_NAME="${GITHUB_REF_NAME#v}"
+          VERSION_CODE=$(git rev-list --count HEAD)
+          sed -i "s/versionName \".*\"/versionName \"${VERSION_NAME}\"/" android/app/build.gradle
+          sed -i "s/versionCode [0-9]*/versionCode ${VERSION_CODE}/" android/app/build.gradle
+          echo "Set versionName=${VERSION_NAME} versionCode=${VERSION_CODE}"
+
+      - name: Build debug APK
+        working-directory: android
+        run: ./gradlew assembleDebug --no-daemon
+
+      - name: Rename APK to include version
+        run: |
+          mv android/app/build/outputs/apk/debug/app-debug.apk \
+             observing-${{ github.ref_name }}-android-debug.apk
+
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: observing-${{ github.ref_name }}-android-debug.apk
+          draft: true
+          generate_release_notes: true
+          body: |
+            **Debug build** — sideload only. Signed with the Android debug key,
+            not a release key, so Play Store install / update is not possible
+            from this APK.
+
+            ## Install on Android
+
+            1. On your phone: Settings → Apps → Special access → "Install
+               unknown apps", grant your browser/file manager permission.
+            2. Download the `.apk` below and open it.


### PR DESCRIPTION
## Summary

Pushing a \`v*\` tag now produces a draft GitHub Release with an Android debug APK attached.

- Builds the same Capacitor + debug APK pipeline as the existing \`android-build\` CI job
- Injects \`versionName\` from the tag (e.g. \`v0.2.0\` → \`0.2.0\`) and \`versionCode\` from \`git rev-list --count HEAD\`, so each release is uniquely versioned and the versionCode monotonically increases
- Creates the release as a **draft**, so the changelog and APK can be reviewed before publishing. Auto-generated release notes pull PR titles since the previous tag.

The APK is signed with the Android debug key — fine for sideloading and TestFlight-style sharing with friends/testers, **not for Play Store**. Adding a signed-release path (release keystore stored as GH secrets, separate \`assembleRelease\` workflow) is a follow-up if/when we need it.

## Test plan

- [ ] After merge, push a \`v0.0.1-test\` tag, confirm a draft release appears with the APK attached
- [ ] Download the APK, sideload it on Android, confirm it installs and opens
- [ ] Confirm versionName / versionCode in the APK match the tag / commit count
- [ ] Delete the test tag and draft release after verifying

## Future: signed release APK

Out of scope here. Would add:
1. One-time keystore generation via \`keytool\`
2. Four GH secrets: \`RELEASE_KEYSTORE_BASE64\`, \`RELEASE_KEYSTORE_PASSWORD\`, \`RELEASE_KEY_ALIAS\`, \`RELEASE_KEY_PASSWORD\`
3. Patch \`android/app/build.gradle\` post-\`cap sync\` to add a \`signingConfigs.release\` block reading those env vars
4. Run \`assembleRelease\` instead of \`assembleDebug\`