### PR TITLE
fix(android): bake production API origin into the APK bundle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,11 @@ jobs:
           packages: 'platform-tools platforms;android-34 build-tools;34.0.0'
       - uses: gradle/actions/setup-gradle@v4
       - run: npm ci
+      # Match the release workflow so this artifact reflects the same bundle
+      # users would get from a tagged release.
       - run: npm run build
+        env:
+          VITE_API_URL: https://observ.ing
       - run: npx cap add android
       - run: npx cap sync android
       - name: Build debug APK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,12 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - run: npm ci
+      # Bake the production API origin into the bundle. Without this, fetches
+      # in services/api.ts use relative URLs that resolve against the WebView's
+      # local origin — there's no backend there, so every API call hangs.
       - run: npm run build
+        env:
+          VITE_API_URL: https://observ.ing
       - run: npx cap add android
       - run: npx cap sync android
 


### PR DESCRIPTION
## Summary

The v0.1.0 APK can't reach the backend — every API call hangs and surfaces to the user as a database timeout. The actual cause:

\`frontend/src/services/api.ts:16\` — \`API_BASE = import.meta.env[\"VITE_API_URL\"] || \"\"\`. Without \`VITE_API_URL\` at build time, \`API_BASE\` is empty and every fetch uses a relative URL like \`/api/observations/feed\`.

- **On the web** (served from observ.ing): relative URLs resolve to \`https://observ.ing/api/...\` → works.
- **In the Capacitor APK**: the WebView loads bundled \`index.html\` from a local origin (\`https://localhost\`). Relative URLs resolve to *that* origin, where nothing's listening, so every request hangs.

Cloud Run logs confirm the appview itself is fine — it's just not seeing any requests from the APK because they go to the wrong origin.

## Fix

Set \`VITE_API_URL=https://observ.ing\` for both:
- \`.github/workflows/release.yml\` — distributed APKs
- \`.github/workflows/ci.yml\` (\`android-build\` job) — so the verification artifact matches what users get

Web build is unchanged — Cloud Run still serves frontend and API from the same origin, so relative URLs continue to work without \`VITE_API_URL\`.

## Test plan

- [ ] After merge, push \`v0.1.1\` tag
- [ ] Confirm the new draft release lands with the rebuilt APK
- [ ] Sideload v0.1.1 on Android, confirm feed loads / OAuth works