### PR TITLE
fix(taxon): make tree arrow toggle expansion, label only selects

### DIFF
--- a/frontend/src/components/taxon/TaxonTreePanel.tsx
+++ b/frontend/src/components/taxon/TaxonTreePanel.tsx
@@ -85,6 +85,7 @@ export function TaxonTreePanel({
         Classification
       </Typography>
       <SimpleTreeView
+        expansionTrigger="iconContainer"
         expandedItems={expandedItems}
         selectedItems={selectedItems}
         onExpandedItemsChange={(_e, ids) => onExpandedItemsChange(ids)}


### PR DESCRIPTION
## Summary
- In the taxa tree view, clicking a node's label both selected and toggled expansion, so collapse and select were the same action.
- Set MUI `SimpleTreeView`'s `expansionTrigger="iconContainer"` so the arrow toggles expansion and the label only selects.

## Test plan
- [ ] Visit `/taxon/Plantae/Liliopsida` and confirm clicking the arrow expands/collapses without changing selection.
- [ ] Confirm clicking a node's label selects it without toggling expansion.
- [ ] Confirm keyboard navigation still works (arrow keys / Enter).