### PR TITLE
fix(android): make Capacitor auth work end-to-end

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -501,7 +501,7 @@ jobs:
             --region=$REGION \
             --allow-unauthenticated \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=appview_runtime,PUBLIC_URL=$PUBLIC_URL,SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }},HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b,ADMIN_DIDS=did:plc:vozr2os4b4sxrxr6opde5js5 \
+            --set-env-vars="^|^DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db|DB_NAME=observing|DB_USER=appview_runtime|PUBLIC_URL=$PUBLIC_URL|SPECIES_ID_SERVICE_URL=${{ steps.urls.outputs.species_id }}|HIDDEN_DIDS=did:plc:jh6n3ntljfhhtr4jbvrm3k5b|ADMIN_DIDS=did:plc:vozr2os4b4sxrxr6opde5js5|CORS_ORIGINS=https://observ.ing,https://localhost,capacitor://localhost" \
             --set-secrets=DB_PASSWORD=observing-db-appview-password:latest \
             --format='value(status.url)')
           echo "url=$URL" >> $GITHUB_OUTPUT

--- a/capacitor.config.ts
+++ b/capacitor.config.ts
@@ -10,20 +10,16 @@ const config: CapacitorConfig = {
   appId: 'ing.observ.app',
   appName: 'Observ.ing',
   webDir: 'dist/public',
-  ...(serverUrl
-    ? {
-        server: {
-          url: serverUrl,
-          cleartext: true,
-          androidScheme: 'http',
-          // Keep OAuth flow inside the WebView. Without this, the WebView
-          // punts off-origin navigations (the PDS authorize page) to Chrome,
-          // which sets the session cookie in the wrong jar and the app stays
-          // logged out. '*' is fine for dev; production should narrow this.
-          allowNavigation: ['*'],
-        },
-      }
-    : {}),
+  server: {
+    // Keep OAuth flow inside the WebView regardless of build mode. Without
+    // this, off-origin navigations (the PDS authorize page) get punted to
+    // Chrome, which sets the session cookie in the wrong jar. AT Protocol
+    // PDSes can live on user-controlled domains (e.g. self-hosted), so we
+    // can't enumerate hosts ahead of time — using '*' here. Narrowing is
+    // tracked as a hardening follow-up once the auth surface is settled.
+    allowNavigation: ['*'],
+    ...(serverUrl ? { url: serverUrl, cleartext: true, androidScheme: 'http' } : {}),
+  },
 };
 
 export default config;

--- a/crates/observing-appview/src/config.rs
+++ b/crates/observing-appview/src/config.rs
@@ -57,6 +57,11 @@ impl Config {
                 vec![
                     "http://localhost:3000".to_string(),
                     "http://localhost:5173".to_string(),
+                    // Capacitor WebView origins on Android (default and
+                    // legacy) — needed when the bundled APK calls the
+                    // appview cross-origin.
+                    "https://localhost".to_string(),
+                    "capacitor://localhost".to_string(),
                 ]
             });
 

--- a/crates/observing-appview/src/routes/oauth.rs
+++ b/crates/observing-appview/src/routes/oauth.rs
@@ -81,19 +81,25 @@ pub async fn callback(
                     let did_str = did.to_string();
                     info!(did = %did_str, "OAuth callback successful");
 
-                    // Set session_did cookie and redirect to /
-                    let secure = if state.public_url.is_some() {
-                        "; Secure; SameSite=Lax"
+                    // SameSite=None lets the cookie be sent on cross-site
+                    // requests, which is required when the Capacitor mobile
+                    // app (origin https://localhost) calls the appview at
+                    // observ.ing. Browsers require Secure for SameSite=None,
+                    // so we only set both in production (HTTPS). In local
+                    // dev we omit both — the browser then treats the cookie
+                    // as default Lax, which is fine for same-origin use.
+                    let attrs = if state.public_url.is_some() {
+                        "; Secure; SameSite=None"
                     } else {
                         ""
                     };
                     let cookie = format!(
                         "session_did={}; HttpOnly; Path=/; Max-Age={}{}",
-                        did_str, SESSION_MAX_AGE_SECS, secure,
+                        did_str, SESSION_MAX_AGE_SECS, attrs,
                     );
                     (
                         [(axum::http::header::SET_COOKIE, cookie)],
-                        Redirect::to("/"),
+                        Redirect::to("/?just-authed=1"),
                     )
                         .into_response()
                 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,11 +1,27 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { Capacitor } from "@capacitor/core";
 import { App } from "./App";
 
-const root = document.getElementById("root");
-if (!root) throw new Error("Root element not found");
-createRoot(root).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
-);
+// After OAuth, the appview redirects to /?just-authed=1. In a Capacitor
+// build that means the WebView is sitting on observ.ing — the user logged
+// in, but they're now viewing the website rather than the bundled app.
+// Bounce back to the bundled origin (https://localhost on Android) so the
+// rest of the session runs in the APK shell. The session cookie was set
+// with SameSite=None on observ.ing, so cross-site fetches from the bundled
+// app still authenticate.
+if (
+  Capacitor.isNativePlatform() &&
+  new URLSearchParams(window.location.search).get("just-authed") === "1" &&
+  window.location.hostname !== "localhost"
+) {
+  window.location.replace("https://localhost/");
+} else {
+  const root = document.getElementById("root");
+  if (!root) throw new Error("Root element not found");
+  createRoot(root).render(
+    <StrictMode>
+      <App />
+    </StrictMode>,
+  );
+}


### PR DESCRIPTION
## Summary

The v0.1.1 APK reached the appview but auth failed with "Failed to fetch". Diagnosis: a stack of cross-origin issues that all stem from the same architecture — **bundled-local app + remote API + cookie auth**. Cloud Run logs showed requests arriving with 200s, but the responses were hidden from JS by the SOP.

This PR fixes all four layers.

## The four layers

### 1. CORS — \`config.rs\`, \`ci.yml\`

Production CORS_ORIGINS didn't include the Capacitor WebView origin (\`https://localhost\` on Android). Fetches hit the server (200 in logs) but the browser blocked the response.

- **Code:** Default \`cors_origins\` list now includes \`https://localhost\` and \`capacitor://localhost\` (dev parity).
- **Deploy:** \`CORS_ORIGINS=https://observ.ing,https://localhost,capacitor://localhost\` is set on the appview Cloud Run service. Used \`gcloud\`'s \`^|^\` delimiter syntax so the comma-separated list survives.

### 2. Cookie SameSite — \`oauth.rs\`

\`SameSite=Lax\` blocks cookies on JS-initiated cross-site requests. The bundled APK at \`https://localhost\` calling the API at \`observ.ing\` would always appear logged out, even after a successful login. Switched to \`SameSite=None; Secure\` (production only — local dev keeps default Lax via no-attribute, which is fine for same-origin).

### 3. \`allowNavigation\` — \`capacitor.config.ts\`

Was only emitted when \`CAPACITOR_SERVER_URL\` was set. Without it, off-origin nav (the PDS authorize page) gets punted to Chrome — cookie lands in the wrong jar. Now always set. AT Protocol PDSes can live on user-controlled domains, so we use \`'*'\` for now; narrowing tracked as a hardening follow-up.

### 4. Post-auth bounce — \`oauth.rs\`, \`main.tsx\`

After a successful callback the appview was redirecting to \`/\`, which left the WebView on \`observ.ing\` instead of in the APK shell. Now:

- Backend redirects to \`/?just-authed=1\` instead of \`/\`.
- Frontend (\`main.tsx\`) detects the flag in a Capacitor WebView and \`location.replace\` to \`https://localhost/\` so the rest of the session runs in the bundled app. The cookie set on \`observ.ing\` follows cross-site fetches (because of layer 2), so auth persists.

## Test plan

- [ ] Merge, tag \`v0.1.2\`, sideload the resulting APK
- [ ] Open the app — feed loads
- [ ] Tap login, enter handle, complete OAuth on PDS
- [ ] WebView returns to bundled app at \`localhost\`, user is authenticated
- [ ] Force-stop and reopen the app — session persists (cookie cross-site fetch)
- [ ] Web flow at observ.ing in a regular browser still works (regression check)

## Follow-ups not in this PR

- Narrow \`allowNavigation\` from \`'*'\` to a curated host list once the auth surface is stable
- Consider switching from cookies to bearer tokens for cleaner mobile semantics (no cross-site cookie story)
- Custom URL scheme deep links (\`ing.observ.app://\`) would let us skip the bounce-back hop entirely, but require AndroidManifest changes