### PR TITLE
feat(taxon): show Wikidata thumbnails alongside each tree item

### DIFF
--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -89,6 +89,20 @@ export function TaxonExplorer() {
     return thumb.replace(/\?width=\d+/, "?width=600");
   }, [taxon, heroThumbnails]);
 
+  // Wikidata thumbnails for every taxon currently in the tree
+  const treeNames = useMemo(() => {
+    const names: string[] = [];
+    function walk(items: TaxonTreeItem[]) {
+      for (const item of items) {
+        names.push(String(item.label));
+        if (item.children) walk(item.children);
+      }
+    }
+    walk(treeItems);
+    return names;
+  }, [treeItems]);
+  const treeThumbnails = useWikidataThumbnails(treeNames, 48);
+
   /** Merge a taxon detail's ancestors + children into the tree node map */
   const mergeIntoTree = useCallback(
     (detail: TaxonDetail) => {
@@ -384,6 +398,7 @@ export function TaxonExplorer() {
     expandedItems,
     selectedItems: selectedItem,
     loadingNodeId,
+    thumbnails: treeThumbnails,
     disabled: loading,
     onExpandedItemsChange: setExpandedItems,
     onSelectedItemsChange: handleTreeSelect,

--- a/frontend/src/components/taxon/TaxonTreePanel.stories.tsx
+++ b/frontend/src/components/taxon/TaxonTreePanel.stories.tsx
@@ -75,6 +75,7 @@ const meta = {
   },
   tags: ["autodocs"],
   args: {
+    thumbnails: new Map<string, string>(),
     onExpandedItemsChange: () => undefined,
     onSelectedItemsChange: () => undefined,
     onItemExpansionToggle: () => undefined,

--- a/frontend/src/components/taxon/TaxonTreePanel.tsx
+++ b/frontend/src/components/taxon/TaxonTreePanel.tsx
@@ -9,48 +9,77 @@ interface TaxonTreePanelProps {
   expandedItems: string[];
   selectedItems: string;
   loadingNodeId: string | null;
+  thumbnails: Map<string, string>;
   disabled?: boolean;
   onExpandedItemsChange: (ids: string[]) => void;
   onSelectedItemsChange: (id: string) => void;
   onItemExpansionToggle: (id: string, isExpanded: boolean) => void;
 }
 
-function renderTreeItems(items: TaxonTreeItem[], selectedId: string, loadingNodeId: string | null) {
-  return items.map((item) => (
-    <TreeItem
-      key={item.id}
-      itemId={item.id}
-      label={
-        <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, py: 0.25 }}>
-          <Typography
-            variant="body2"
-            component="span"
-            sx={{
-              fontStyle: shouldItalicizeTaxonName(String(item.label), item.rank)
-                ? "italic"
-                : "normal",
-              fontWeight: item.id === selectedId ? 700 : 400,
-            }}
-          >
-            {item.label}
-          </Typography>
-          <Typography
-            variant="caption"
-            component="span"
-            sx={{
-              color: "text.disabled",
-              flexShrink: 0,
-            }}
-          >
-            {item.rank}
-          </Typography>
-          {loadingNodeId === item.id && <CircularProgress size={14} />}
-        </Box>
-      }
-    >
-      {item.children && renderTreeItems(item.children, selectedId, loadingNodeId)}
-    </TreeItem>
-  ));
+function renderTreeItems(
+  items: TaxonTreeItem[],
+  selectedId: string,
+  loadingNodeId: string | null,
+  thumbnails: Map<string, string>,
+) {
+  return items.map((item) => {
+    const thumb = thumbnails.get(String(item.label));
+    return (
+      <TreeItem
+        key={item.id}
+        itemId={item.id}
+        label={
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, py: 0.25 }}>
+            <Box
+              sx={{
+                width: 20,
+                height: 20,
+                flexShrink: 0,
+                borderRadius: 0.5,
+                overflow: "hidden",
+                bgcolor: "action.hover",
+              }}
+            >
+              {thumb && (
+                <Box
+                  component="img"
+                  src={thumb}
+                  alt=""
+                  loading="lazy"
+                  sx={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+                />
+              )}
+            </Box>
+            <Typography
+              variant="body2"
+              component="span"
+              sx={{
+                fontStyle: shouldItalicizeTaxonName(String(item.label), item.rank)
+                  ? "italic"
+                  : "normal",
+                fontWeight: item.id === selectedId ? 700 : 400,
+              }}
+            >
+              {item.label}
+            </Typography>
+            <Typography
+              variant="caption"
+              component="span"
+              sx={{
+                color: "text.disabled",
+                flexShrink: 0,
+              }}
+            >
+              {item.rank}
+            </Typography>
+            {loadingNodeId === item.id && <CircularProgress size={14} />}
+          </Box>
+        }
+      >
+        {item.children && renderTreeItems(item.children, selectedId, loadingNodeId, thumbnails)}
+      </TreeItem>
+    );
+  });
 }
 
 export function TaxonTreePanel({
@@ -58,6 +87,7 @@ export function TaxonTreePanel({
   expandedItems,
   selectedItems,
   loadingNodeId,
+  thumbnails,
   disabled,
   onExpandedItemsChange,
   onSelectedItemsChange,
@@ -93,7 +123,7 @@ export function TaxonTreePanel({
         }}
         onItemExpansionToggle={(_e, id, isExpanded) => onItemExpansionToggle(id, isExpanded)}
       >
-        {renderTreeItems(items, selectedItems, loadingNodeId)}
+        {renderTreeItems(items, selectedItems, loadingNodeId, thumbnails)}
       </SimpleTreeView>
     </Box>
   );


### PR DESCRIPTION
## Summary
- Walks the rendered taxa tree to collect every scientific name and batch-fetches Wikidata images via the existing `useWikidataThumbnails` hook (single SPARQL query, module-level cache).
- Each tree item now renders a 20px thumbnail next to the name; an empty placeholder reserves space when no image exists so the layout doesn't shift as fetches resolve.

## Test plan
- [ ] Visit `/taxon/Plantae/Liliopsida` and confirm thumbnails appear next to each taxon as they load.
- [ ] Confirm taxa without a Wikidata image show an empty placeholder (no layout shift).
- [ ] Expand a node lazily and confirm the new children's thumbnails populate without re-fetching previously loaded ones (cache hit).
- [ ] Confirm the storybook `Taxon/TaxonTreePanel` stories still render.