### PR TITLE
fix(taxon): /api/taxa/{id} accepts a scientific name as fallback

### DIFF
--- a/crates/observing-appview/src/routes/taxonomy.rs
+++ b/crates/observing-appview/src/routes/taxonomy.rs
@@ -9,7 +9,9 @@ use crate::enrichment;
 use crate::error::AppError;
 use crate::responses::{OccurrenceListResponse, TaxonSearchResponse};
 use crate::state::AppState;
-use crate::taxonomy_client::{TaxonDetailWithCount, ValidateResponse};
+use crate::taxonomy_client::{
+    TaxonDetail, TaxonDetailWithCount, TaxonomyClientError, ValidateResponse,
+};
 
 #[derive(Deserialize)]
 pub struct SearchParams {
@@ -173,13 +175,27 @@ pub async fn get_taxon_occurrences_by_kingdom_name(
     }))
 }
 
+/// Resolve `/api/taxa/{id}`-style input to a TaxonDetail. Accepts either a
+/// GBIF id (`gbif:NNN` / bare numeric) or a scientific name (e.g. a kingdom
+/// name like `Animalia`).
+async fn resolve_taxon_by_id_or_name(
+    state: &AppState,
+    id: &str,
+) -> Result<Option<TaxonDetail>, TaxonomyClientError> {
+    if let Some(detail) = state.taxonomy.get_by_id(id).await? {
+        return Ok(Some(detail));
+    }
+    if id.starts_with("gbif:") || id.parse::<u64>().is_ok() {
+        return Ok(None);
+    }
+    state.taxonomy.get_by_name(id, None).await
+}
+
 pub async fn get_taxon_by_id(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<TaxonDetailWithCount>, AppError> {
-    let detail = state
-        .taxonomy
-        .get_by_id(&id)
+    let detail = resolve_taxon_by_id_or_name(&state, &id)
         .await?
         .ok_or_else(|| AppError::NotFound("Taxon not found".into()))?;
 
@@ -210,7 +226,9 @@ pub async fn get_taxon_occurrences_by_id(
         .min(constants::MAX_FEED_LIMIT);
 
     // Look up taxon to get name + rank
-    let detail = state.taxonomy.get_by_id(&id).await.unwrap_or(None);
+    let detail = resolve_taxon_by_id_or_name(&state, &id)
+        .await
+        .unwrap_or(None);
 
     let (name, rank, kingdom) = match detail {
         Some(ref d) => (d.scientific_name.clone(), d.rank.clone(), d.kingdom.clone()),


### PR DESCRIPTION
## Summary
- The frontend already produces kingdom-level URLs like `/taxon/Animalia` (see `TaxonExplorer`, `TaxonLink`, `VisualIdCards`), which hit `/api/taxa/{id}`. The handler only resolved numeric GBIF ids, so kingdom names returned 404.
- Add a name-lookup fallback in the route handler: if `get_by_id` misses and the input isn't `gbif:`-prefixed or numeric, try `get_by_name` so requests like `/api/taxa/Animalia` resolve via GBIF's match-name endpoint.

## Why route-level instead of `get_by_id`
A naive fallback inside `get_by_id` creates an `async fn` recursion cycle (`get_by_id` → `get_by_name` → `get_by_id`), which Rust rejects without `Box::pin`. Doing the fallback in the route handler keeps the inner service strictly id-only and avoids the indirection.

## Test plan
- [ ] `curl https://<deploy>/api/taxa/Animalia` returns a TaxonDetail (was 404).
- [ ] `curl https://<deploy>/api/taxa/Plantae` returns a TaxonDetail (was 404).
- [ ] `curl https://<deploy>/api/taxa/gbif:1` still returns Animalia (numeric path unaffected).
- [ ] `curl https://<deploy>/api/taxa/NotARealName` returns 404.
- [ ] Visit `https://<deploy>/taxon/Animalia` and confirm the kingdom page renders with its phyla.