### PR TITLE
fix(observation): show existing taxon as known when editing

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -26,7 +26,12 @@ import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
 import ExifReader from "exifreader";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeUploadModal, addToast, consumePendingUploadFiles } from "../../store/uiSlice";
-import { submitObservation, updateObservation, pollObservation } from "../../services/api";
+import {
+  submitObservation,
+  updateObservation,
+  pollObservation,
+  validateTaxon,
+} from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
@@ -88,35 +93,51 @@ export function UploadModal() {
   const VALID_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
   useEffect(() => {
-    if (isOpen) {
-      setIsDirty(false);
-      if (editingObservation) {
-        setSpecies(editingObservation.effectiveTaxonomy?.scientificName || "");
-        setKingdom(editingObservation.effectiveTaxonomy?.kingdom || "");
-        setMatchedTaxon(null);
-        setRank("");
-        if (editingObservation.eventDate) {
-          setObservationDate(toDatetimeLocal(new Date(editingObservation.eventDate)));
-        }
-        if (editingObservation.location) {
-          setLat(editingObservation.location.latitude.toFixed(6));
-          setLng(editingObservation.location.longitude.toFixed(6));
-          if (editingObservation.location.uncertaintyMeters) {
-            setUncertaintyMeters(editingObservation.location.uncertaintyMeters);
-          }
-        }
-        setExistingImages(editingObservation.images || []);
-      } else {
-        if (currentLocation) {
-          setLat(currentLocation.lat.toFixed(6));
-          setLng(currentLocation.lng.toFixed(6));
-        }
-        const pending = consumePendingUploadFiles();
-        if (pending.length > 0) {
-          addFiles(pending);
-        }
+    if (!isOpen) return undefined;
+    setIsDirty(false);
+    if (!editingObservation) {
+      if (currentLocation) {
+        setLat(currentLocation.lat.toFixed(6));
+        setLng(currentLocation.lng.toFixed(6));
+      }
+      const pending = consumePendingUploadFiles();
+      if (pending.length > 0) {
+        addFiles(pending);
+      }
+      return undefined;
+    }
+
+    const existingName = editingObservation.effectiveTaxonomy?.scientificName || "";
+    const existingKingdom = editingObservation.effectiveTaxonomy?.kingdom || "";
+    setSpecies(existingName);
+    setKingdom(existingKingdom);
+    setMatchedTaxon(null);
+    setRank("");
+    if (editingObservation.eventDate) {
+      setObservationDate(toDatetimeLocal(new Date(editingObservation.eventDate)));
+    }
+    if (editingObservation.location) {
+      setLat(editingObservation.location.latitude.toFixed(6));
+      setLng(editingObservation.location.longitude.toFixed(6));
+      if (editingObservation.location.uncertaintyMeters) {
+        setUncertaintyMeters(editingObservation.location.uncertaintyMeters);
       }
     }
+    setExistingImages(editingObservation.images || []);
+
+    // Resolve the existing taxon name back to a TaxaResult so the form
+    // shows "Existing taxon" instead of incorrectly flagging it as new.
+    if (!existingName) return undefined;
+    let cancelled = false;
+    void validateTaxon(existingName, existingKingdom || undefined).then((result) => {
+      if (cancelled) return;
+      if (result?.valid && result.taxon) {
+        setMatchedTaxon(result.taxon);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
   }, [isOpen, currentLocation, editingObservation]);
 
   const resetForm = () => {

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -371,6 +371,95 @@ describe("api", () => {
     });
   });
 
+  describe("validateTaxon", () => {
+    it("returns the validate response when the name resolves", async () => {
+      const mockResponse = {
+        valid: true,
+        matchedName: "Quercus alba",
+        taxon: { id: 1, name: "Quercus alba" },
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await api.validateTaxon("Quercus alba");
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith("/api/taxa/validate?name=Quercus+alba");
+    });
+
+    it("includes kingdom hint when provided", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      await api.validateTaxon("Pinus", "Plantae");
+
+      expect(mockFetch).toHaveBeenCalledWith("/api/taxa/validate?name=Pinus&kingdom=Plantae");
+    });
+
+    it("omits kingdom param when not provided", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      await api.validateTaxon("Pinus");
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("kingdom");
+    });
+
+    it("omits kingdom param when explicitly empty", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      await api.validateTaxon("Pinus", "");
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("kingdom");
+    });
+
+    it("encodes special characters in the name", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ valid: false }),
+      });
+
+      await api.validateTaxon("Genus species & subsp.");
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toBe("/api/taxa/validate?name=Genus+species+%26+subsp.");
+    });
+
+    it("returns null on a non-ok response", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+      const result = await api.validateTaxon("Quercus alba");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the response body even when valid is false", async () => {
+      const mockResponse = {
+        valid: false,
+        suggestions: [{ id: 2, name: "Quercus rubra" }],
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await api.validateTaxon("Quercus albu");
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
   describe("submitObservation", () => {
     it("submits occurrence data", async () => {
       mockFetch.mockResolvedValue({

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -408,8 +408,7 @@ describe("api", () => {
 
       await api.validateTaxon("Pinus");
 
-      const calledUrl = mockFetch.mock.calls[0][0] as string;
-      expect(calledUrl).not.toContain("kingdom");
+      expect(mockFetch).toHaveBeenCalledWith(expect.not.stringContaining("kingdom"));
     });
 
     it("omits kingdom param when explicitly empty", async () => {
@@ -420,8 +419,7 @@ describe("api", () => {
 
       await api.validateTaxon("Pinus", "");
 
-      const calledUrl = mockFetch.mock.calls[0][0] as string;
-      expect(calledUrl).not.toContain("kingdom");
+      expect(mockFetch).toHaveBeenCalledWith(expect.not.stringContaining("kingdom"));
     });
 
     it("encodes special characters in the name", async () => {
@@ -432,8 +430,7 @@ describe("api", () => {
 
       await api.validateTaxon("Genus species & subsp.");
 
-      const calledUrl = mockFetch.mock.calls[0][0] as string;
-      expect(calledUrl).toBe("/api/taxa/validate?name=Genus+species+%26+subsp.");
+      expect(mockFetch).toHaveBeenCalledWith("/api/taxa/validate?name=Genus+species+%26+subsp.");
     });
 
     it("returns null on a non-ok response", async () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -11,6 +11,7 @@ import type {
   ProfileFeedResponse,
   NotificationsResponse,
   OccurrenceDetailResponse,
+  ValidateResponse,
 } from "./types";
 
 const API_BASE = import.meta.env["VITE_API_URL"] || "";
@@ -203,6 +204,22 @@ export async function searchTaxa(query: string): Promise<TaxaResult[]> {
 
   const data = await response.json();
   return data.results || [];
+}
+
+/**
+ * Validate a scientific name against the taxonomy backend. Returns the
+ * authoritative TaxaResult when the name resolves to an existing taxon
+ * (so callers can mark it as "Existing taxon" rather than "New taxon").
+ */
+export async function validateTaxon(
+  name: string,
+  kingdom?: string,
+): Promise<ValidateResponse | null> {
+  const params = new URLSearchParams({ name });
+  if (kingdom) params.set("kingdom", kingdom);
+  const response = await fetch(`${API_BASE}/api/taxa/validate?${params}`);
+  if (!response.ok) return null;
+  return response.json();
 }
 
 export async function submitObservation(data: {


### PR DESCRIPTION
## Summary

- Edit Observation form always showed "New taxon" under the taxa field, even when the observation already pointed at a known GBIF taxon, because `matchedTaxon` was hard-reset to `null` on entering edit mode and there was nothing that re-hydrated it from the existing scientific name.
- On entering edit mode, validate the scientific name against `/api/taxa/validate` (passing the kingdom hint so genus-level names like "Pinus" disambiguate) and populate `matchedTaxon` with the returned `TaxaResult` when valid. Existing taxa now render the green "Existing taxon" chip.
- Add a thin `validateTaxon` wrapper in `services/api.ts`.

Fixes #423

## Test plan

- [ ] Edit an observation whose taxon is already in GBIF: chip reads "Existing taxon".
- [ ] Edit an observation with a free-text taxon that is NOT in GBIF: chip reads "New taxon".
- [ ] Edit an observation with no taxon set: no chip.
- [ ] Create a new observation: behavior unchanged.