### PR TITLE
fix(taxon): prevent IUCN tooltips from overlapping

### DIFF
--- a/frontend/src/components/taxon/TaxonDetail.tsx
+++ b/frontend/src/components/taxon/TaxonDetail.tsx
@@ -17,7 +17,6 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Tooltip,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
@@ -327,11 +326,7 @@ export function TaxonDetail() {
                 }}
               >
                 {taxon.conservationStatus && (
-                  <Tooltip title={`${taxon.conservationStatus.category} — IUCN Red List`} arrow>
-                    <span>
-                      <ConservationStatus status={taxon.conservationStatus} showLabel />
-                    </span>
-                  </Tooltip>
+                  <ConservationStatus status={taxon.conservationStatus} showLabel />
                 )}
                 {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
                 <Typography

--- a/frontend/src/components/taxon/TaxonDetailPanel.tsx
+++ b/frontend/src/components/taxon/TaxonDetailPanel.tsx
@@ -13,7 +13,6 @@ import {
   Accordion,
   AccordionSummary,
   AccordionDetails,
-  Tooltip,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
@@ -159,11 +158,7 @@ export function TaxonDetailPanel({
               }}
             >
               {taxon.conservationStatus && (
-                <Tooltip title={`${taxon.conservationStatus.category} — IUCN Red List`} arrow>
-                  <span>
-                    <ConservationStatus status={taxon.conservationStatus} showLabel />
-                  </span>
-                </Tooltip>
+                <ConservationStatus status={taxon.conservationStatus} showLabel />
               )}
               {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
               <Typography


### PR DESCRIPTION
## Summary

PR #400 added a multi-line MUI `Tooltip` directly to the `ConservationStatus` component (showing the IUCN Red List source), but the existing call sites in `TaxonDetail` and `TaxonDetailPanel` still wrapped the component in their own `Tooltip`. This caused two MUI tooltips to render on top of each other when hovering the conservation status chip.

This change drops the redundant outer `Tooltip` wrappers (and removes the now-unused `Tooltip` import) so the component's own tooltip is the only one shown.

## Root cause

Double tooltip nesting after #400 — the component already brings its own `Tooltip`, so wrapping it externally creates a second overlapping tooltip.

## Test plan

- [ ] Visual: hover the conservation status chip on a taxon detail page (e.g. an Endangered species) and confirm only the rich \"Endangered / Classified by IUCN Red List / International Union for Conservation of Nature\" tooltip is shown
- [ ] Same check on the `TaxonDetailPanel` (taxon explorer split view)
- [x] `npm run fmt:check` clean
- [x] `npm run lint` no new warnings (9 pre-existing warnings unrelated)
- [x] `npx tsc --noEmit` no new errors (existing errors are pre-existing missing-module errors in storybook/capacitor files unrelated to this change)

Note: I did not start a dev server to visually confirm the fix in this worktree. The change is mechanical — removing the outer wrapper `<Tooltip>` that was double-rendering on top of the component's own internal `<Tooltip>`.

Fixes #429