### PR TITLE
fix(explore): filter kingdom via identifications, not occurrences column

### DIFF
--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -28,9 +28,16 @@ pub async fn get_explore_feed(
         qb.push_bind(format!("{taxon}%"));
     }
 
+    // Kingdom is sourced from identifications (the occurrence record itself
+    // doesn't carry taxonomy in the bio.lexicons.temp.v0-1.occurrence lexicon),
+    // so filter via an EXISTS over identifications for this occurrence.
     if let Some(kingdom) = options.kingdom.as_deref() {
-        qb.push(" AND kingdom = ");
+        qb.push(
+            " AND EXISTS (SELECT 1 FROM identifications i \
+             WHERE i.subject_uri = occurrences.uri AND i.kingdom = ",
+        );
         qb.push_bind(kingdom);
+        qb.push(")");
     }
 
     if let Some(start_date) = options.start_date.as_deref() {


### PR DESCRIPTION
## Summary
- The explore feed's Kingdom filter (Plants/Animals/Fungi/...) matched on `occurrences.kingdom`, but the ingester never populates that column — the `bio.lexicons.temp.v0-1.occurrence` lexicon doesn't carry taxonomy, so the column has been NULL for every row written through the firehose path.
- Selecting "Plants" therefore returned no results even when plant observations were present.
- Move the filter to an EXISTS over `identifications`, where `kingdom` is populated from the identification record's `kingdom` field. An observation with at least one identification tagged `Plantae` now correctly shows up under Plants.

Fixes #426

## Test plan
- [ ] Visit `/explore` on a deployment with plant observations
- [ ] Open the Filters panel and select Kingdom = Plants
- [ ] Click Apply Filters; verify plant observations appear in the feed
- [ ] Repeat with Animals, Fungi to confirm other kingdoms also work
- [ ] Verify the unfiltered feed (Kingdom = All Kingdoms) is unchanged