### PR TITLE
chore(explore): remove location filter pending redesign

### DIFF
--- a/crates/observing-appview/src/responses.rs
+++ b/crates/observing-appview/src/responses.rs
@@ -39,9 +39,6 @@ pub struct OccurrenceListResponse {
 pub struct ExploreFilters {
     pub taxon: Option<String>,
     pub kingdom: Option<String>,
-    pub lat: Option<f64>,
-    pub lng: Option<f64>,
-    pub radius: Option<f64>,
     pub start_date: Option<String>,
     pub end_date: Option<String>,
 }

--- a/crates/observing-appview/src/routes/feeds.rs
+++ b/crates/observing-appview/src/routes/feeds.rs
@@ -16,9 +16,6 @@ pub struct ExploreParams {
     cursor: Option<String>,
     taxon: Option<String>,
     kingdom: Option<String>,
-    lat: Option<f64>,
-    lng: Option<f64>,
-    radius: Option<f64>,
     #[serde(rename = "startDate")]
     start_date: Option<String>,
     #[serde(rename = "endDate")]
@@ -40,9 +37,6 @@ pub async fn get_explore(
         cursor: params.cursor,
         taxon: params.taxon.clone(),
         kingdom: params.kingdom.clone(),
-        lat: params.lat,
-        lng: params.lng,
-        radius: params.radius,
         start_date: params.start_date.clone(),
         end_date: params.end_date.clone(),
     };
@@ -73,9 +67,6 @@ pub async fn get_explore(
             filters: ExploreFilters {
                 taxon: params.taxon,
                 kingdom: params.kingdom,
-                lat: params.lat,
-                lng: params.lng,
-                radius: params.radius,
                 start_date: params.start_date,
                 end_date: params.end_date,
             },

--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -43,17 +43,6 @@ pub async fn get_explore_feed(
         qb.push_bind(end_date);
     }
 
-    if let (Some(lat), Some(lng)) = (options.lat, options.lng) {
-        let radius = options.radius.unwrap_or(10000.0);
-        qb.push(" AND ST_DWithin(location, ST_SetSRID(ST_MakePoint(");
-        qb.push_bind(lng);
-        qb.push(", ");
-        qb.push_bind(lat);
-        qb.push("), 4326)::geography, ");
-        qb.push_bind(radius);
-        qb.push(")");
-    }
-
     if let Some(cursor) = options.cursor.as_deref() {
         qb.push(" AND created_at < ");
         qb.push_bind(cursor);

--- a/crates/observing-db/src/types.rs
+++ b/crates/observing-db/src/types.rs
@@ -307,9 +307,6 @@ pub struct ExploreFeedOptions {
     pub cursor: Option<String>,
     pub taxon: Option<String>,
     pub kingdom: Option<String>,
-    pub lat: Option<f64>,
-    pub lng: Option<f64>,
-    pub radius: Option<f64>,
     pub start_date: Option<String>,
     pub end_date: Option<String>,
 }

--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -27,12 +27,9 @@ import { useAppDispatch, useAppSelector } from "../../store";
 import { setFilters, loadInitialFeed } from "../../store/feedSlice";
 import type { FeedFilters } from "../../services/types";
 import { useDebouncedTaxaSearch } from "../../hooks/useDebouncedTaxaSearch";
-import { LocationPicker } from "../map/LocationPicker";
 import { KINGDOMS as KINGDOM_OPTIONS } from "../../lib/kingdoms";
 
 const KINGDOMS = [{ value: "", label: "All Kingdoms" }, ...KINGDOM_OPTIONS];
-
-const DEFAULT_RADIUS = 10000; // 10km
 
 export function ExploreFilterPanel() {
   const dispatch = useAppDispatch();
@@ -45,11 +42,6 @@ export function ExploreFilterPanel() {
   const { suggestions: taxonSuggestions, search: searchTaxon } = useDebouncedTaxaSearch();
   const [selectedTaxon, setSelectedTaxon] = useState<string | null>(filters.taxon || null);
 
-  const [useLocation, setUseLocation] = useState(filters.lat !== undefined);
-  const [lat, setLat] = useState(filters.lat ?? 37.7749);
-  const [lng, setLng] = useState(filters.lng ?? -122.4194);
-  const [radius, setRadius] = useState(filters.radius ?? DEFAULT_RADIUS);
-
   const [kingdom, setKingdom] = useState(filters.kingdom || "");
 
   const [startDate, setStartDate] = useState<Date | null>(
@@ -60,20 +52,13 @@ export function ExploreFilterPanel() {
   );
 
   // Count active filters for badge
-  const activeFilterCount = [selectedTaxon, useLocation, kingdom, startDate, endDate].filter(
-    Boolean,
-  ).length;
+  const activeFilterCount = [selectedTaxon, kingdom, startDate, endDate].filter(Boolean).length;
 
   // Apply filters
   const handleApplyFilters = () => {
     const newFilters: FeedFilters = {};
 
     if (selectedTaxon) newFilters.taxon = selectedTaxon;
-    if (useLocation) {
-      newFilters.lat = lat;
-      newFilters.lng = lng;
-      newFilters.radius = radius;
-    }
     if (kingdom) newFilters.kingdom = kingdom;
     if (startDate) newFilters.startDate = startDate.toISOString().split("T")[0] ?? "";
     if (endDate) newFilters.endDate = endDate.toISOString().split("T")[0] ?? "";
@@ -86,20 +71,12 @@ export function ExploreFilterPanel() {
   const handleClearFilters = () => {
     setSelectedTaxon(null);
     setTaxonQuery("");
-    setUseLocation(false);
     setKingdom("");
     setStartDate(null);
     setEndDate(null);
 
     dispatch(setFilters({}));
     dispatch(loadInitialFeed());
-  };
-
-  // Location change handler
-  const handleLocationChange = (newLat: number, newLng: number) => {
-    setLat(newLat);
-    setLng(newLng);
-    setUseLocation(true);
   };
 
   return (
@@ -243,67 +220,6 @@ export function ExploreFilterPanel() {
               />
             </Stack>
           </LocalizationProvider>
-
-          {/* Location Filter */}
-          <Box sx={{ mb: 2 }}>
-            <Stack
-              direction="row"
-              spacing={1}
-              sx={{
-                alignItems: "center",
-                mb: 1,
-              }}
-            >
-              <Typography
-                variant="body2"
-                sx={{
-                  color: "text.secondary",
-                }}
-              >
-                Location
-              </Typography>
-              {useLocation && (
-                <Chip
-                  size="small"
-                  label="Active"
-                  color="primary"
-                  onDelete={() => setUseLocation(false)}
-                  sx={{ height: 20 }}
-                />
-              )}
-            </Stack>
-
-            {useLocation ? (
-              <LocationPicker
-                latitude={lat}
-                longitude={lng}
-                onChange={handleLocationChange}
-                uncertaintyMeters={radius}
-                onUncertaintyChange={setRadius}
-              />
-            ) : (
-              <Button
-                variant="outlined"
-                size="small"
-                onClick={() => {
-                  // Try to get current location
-                  navigator.geolocation?.getCurrentPosition(
-                    (pos) => {
-                      setLat(pos.coords.latitude);
-                      setLng(pos.coords.longitude);
-                      setUseLocation(true);
-                    },
-                    () => {
-                      // Default to San Francisco on error
-                      setUseLocation(true);
-                    },
-                  );
-                }}
-              >
-                Add Location Filter
-              </Button>
-            )}
-          </Box>
 
           {/* Action Buttons */}
           <Stack

--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -173,13 +173,13 @@ describe("api", () => {
 
       await api.fetchExploreFeed("cursor123", {
         taxon: "Quercus",
-        lat: 40.7128,
-        lng: -74.006,
-        radius: 50,
+        kingdom: "Plantae",
+        startDate: "2024-01-01",
+        endDate: "2024-12-31",
       });
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "/api/feeds/explore?limit=20&cursor=cursor123&taxon=Quercus&lat=40.7128&lng=-74.006&radius=50",
+        "/api/feeds/explore?limit=20&cursor=cursor123&taxon=Quercus&kingdom=Plantae&startDate=2024-01-01&endDate=2024-12-31",
       );
     });
 

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -105,9 +105,6 @@ export async function fetchExploreFeed(
   const params = new URLSearchParams({ limit: DEFAULT_PAGE_SIZE });
   if (cursor) params.set("cursor", cursor);
   if (filters?.taxon) params.set("taxon", filters.taxon);
-  if (filters?.lat !== undefined) params.set("lat", filters.lat.toString());
-  if (filters?.lng !== undefined) params.set("lng", filters.lng.toString());
-  if (filters?.radius) params.set("radius", filters.radius.toString());
   if (filters?.kingdom) params.set("kingdom", filters.kingdom);
   if (filters?.startDate) params.set("startDate", filters.startDate);
   if (filters?.endDate) params.set("endDate", filters.endDate);

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -55,9 +55,6 @@ export type TaxaResult = GeneratedTaxaResult & {
 
 export interface FeedFilters {
   taxon?: string;
-  lat?: number;
-  lng?: number;
-  radius?: number;
   kingdom?: string;
   startDate?: string;
   endDate?: string;

--- a/frontend/src/store/feedSlice.test.ts
+++ b/frontend/src/store/feedSlice.test.ts
@@ -166,10 +166,10 @@ describe("feedSlice", () => {
         },
       });
 
-      store.dispatch(setFilters({ taxon: "Quercus", lat: 40, lng: -74 }));
+      store.dispatch(setFilters({ taxon: "Quercus", kingdom: "Plantae" }));
 
       const state = store.getState().feed;
-      expect(state.filters).toEqual({ taxon: "Quercus", lat: 40, lng: -74 });
+      expect(state.filters).toEqual({ taxon: "Quercus", kingdom: "Plantae" });
       expect(state.observations).toEqual([]);
       expect(state.cursor).toBeUndefined();
       expect(state.hasMore).toBe(true);


### PR DESCRIPTION
## Summary
- Remove the explore page's location filter UI. It reused the upload modal's `LocationPicker` and mislabeled the search radius as "Coordinate Uncertainty", which made no sense for filtering nearby observations.
- Strip the now-dead `lat`/`lng`/`radius` plumbing across the stack: `FeedFilters` type, `fetchExploreFeed` query string, `/api/feeds/explore` handler params/response, `ExploreFeedOptions`, and the `ST_DWithin` clause in `get_explore_feed`.
- Update the affected unit tests to reference filters that still exist (kingdom + date range).

This is a temporary removal pending a purpose-built redesign of the location filter UX.

Fixes #427

## Test plan
- [x] `cargo check -p observing-appview -p observing-db`
- [x] `cargo clippy -p observing-appview -p observing-db --no-deps`
- [x] `cargo fmt --check`
- [x] `npx tsc --noEmit` in `frontend/`
- [x] `npx vitest run src/store/feedSlice.test.ts` (18 passed)
- [x] `npx oxlint` on changed TS files
- [x] `npm run fmt:check`
- [ ] Manual smoke: open `/explore`, expand the filter panel, confirm Taxon / Kingdom / Start Date / End Date still work and Apply/Clear behave correctly.