### PR TITLE
chore(feed): remove orphaned userLocation state

### DIFF
--- a/frontend/src/components/feed/ExploreFilterPanel.stories.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.stories.tsx
@@ -32,7 +32,6 @@ export const WithActiveFilters: Story = {
             endDate: "2026-04-30",
           },
           isAuthenticated: false,
-          userLocation: null,
         },
       },
     },

--- a/frontend/src/store/feedSlice.test.ts
+++ b/frontend/src/store/feedSlice.test.ts
@@ -6,7 +6,6 @@ import feedReducer, {
   switchTab,
   resetFeed,
   setFilters,
-  setUserLocation,
 } from "./feedSlice";
 import authReducer from "./authSlice";
 import type {
@@ -56,7 +55,6 @@ interface FeedOverrides {
   hasMore?: boolean;
   filters?: FeedFilters;
   isAuthenticated?: boolean;
-  userLocation?: { lat: number; lng: number } | null;
 }
 
 interface AuthOverrides {
@@ -72,7 +70,6 @@ interface FeedStateShape {
   hasMore: boolean;
   filters: FeedFilters;
   isAuthenticated: boolean;
-  userLocation: { lat: number; lng: number } | null;
 }
 
 describe("feedSlice", () => {
@@ -84,7 +81,6 @@ describe("feedSlice", () => {
     hasMore: true,
     filters: {},
     isAuthenticated: false,
-    userLocation: null,
   };
 
   const createTestStore = (preloadedState?: { feed?: FeedOverrides; auth?: AuthOverrides }) =>
@@ -111,7 +107,6 @@ describe("feedSlice", () => {
       expect(state.currentTab).toBe("explore");
       expect(state.hasMore).toBe(true);
       expect(state.filters).toEqual({});
-      expect(state.userLocation).toBeNull();
     });
   });
 
@@ -173,28 +168,6 @@ describe("feedSlice", () => {
       expect(state.observations).toEqual([]);
       expect(state.cursor).toBeUndefined();
       expect(state.hasMore).toBe(true);
-    });
-  });
-
-  describe("setUserLocation", () => {
-    it("sets user location", () => {
-      const store = createTestStore();
-      store.dispatch(setUserLocation({ lat: 40.7128, lng: -74.006 }));
-
-      expect(store.getState().feed.userLocation).toEqual({
-        lat: 40.7128,
-        lng: -74.006,
-      });
-    });
-
-    it("clears user location with null", () => {
-      const store = createTestStore({
-        feed: { userLocation: { lat: 40, lng: -74 } },
-      });
-
-      store.dispatch(setUserLocation(null));
-
-      expect(store.getState().feed.userLocation).toBeNull();
     });
   });
 

--- a/frontend/src/store/feedSlice.ts
+++ b/frontend/src/store/feedSlice.ts
@@ -27,7 +27,6 @@ interface FeedState {
   hasMore: boolean;
   filters: FeedFilters;
   isAuthenticated: boolean;
-  userLocation: { lat: number; lng: number } | null;
 }
 
 const initialState: FeedState = {
@@ -38,7 +37,6 @@ const initialState: FeedState = {
   hasMore: true,
   filters: {},
   isAuthenticated: false,
-  userLocation: null,
 };
 
 function fetchFeedData(state: { feed: FeedState; auth: { user: User | null } }, cursor?: string) {
@@ -83,9 +81,6 @@ const feedSlice = createSlice({
       state.filters = action.payload;
       resetFeedState(state);
     },
-    setUserLocation: (state, action: PayloadAction<{ lat: number; lng: number } | null>) => {
-      state.userLocation = action.payload;
-    },
   },
   extraReducers: (builder) => {
     builder
@@ -118,5 +113,5 @@ const feedSlice = createSlice({
   },
 });
 
-export const { switchTab, resetFeed, setFilters, setUserLocation } = feedSlice.actions;
+export const { switchTab, resetFeed, setFilters } = feedSlice.actions;
 export default feedSlice.reducer;


### PR DESCRIPTION
## Summary

Follow-up cleanup driven by PR #438 (which removed the explore page's location filter end-to-end). The `userLocation` field and `setUserLocation` action on `feedSlice` predated that filter and survived its removal because they were never the filter itself, just unused state. They are not consumed by any production component, only by the slice's own tests and a Storybook preloadedState.

This PR drops:
- The `userLocation` field from `FeedState` and `initialState`.
- The `setUserLocation` reducer/action and its export.
- The corresponding test cases in `feedSlice.test.ts` (initial-state assertion, `setUserLocation` describe block, `userLocation` field on `FeedOverrides`/`FeedStateShape`/`defaultFeedState`, and the import).
- The `userLocation: null` placeholder in `ExploreFilterPanel.stories.tsx`'s preloadedState.

Verified via `rg "userLocation|setUserLocation"` that no other production or test code references the removed names.

## Test plan

- [x] `npm run fmt:check` passes
- [x] `npm run lint` passes (0 errors; pre-existing warnings unchanged)
- [x] `npx tsc --noEmit` passes (error count unchanged from baseline)
- [x] `npx vitest run frontend/src/store/feedSlice.test.ts` -> 16/16 pass