### PR TITLE
feat: taxonomy resolver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2878,6 +2878,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tokio",
  "tracing",
  "ts-rs",
 ]

--- a/crates/observing-appview/src/gbif_upstream.rs
+++ b/crates/observing-appview/src/gbif_upstream.rs
@@ -1,0 +1,349 @@
+// Wired into the request path in a follow-up branch; for now everything
+// here is constructed only by the unit tests below.
+#![allow(dead_code)]
+
+//! [`TaxonomyUpstream`] implementation backed by the live GBIF v2 API.
+//!
+//! Maps a single `match_name` (or species lookup) response into the
+//! `taxa`-row shape: one [`TaxonRow`] for the target taxon plus one row per
+//! ancestor in the returned classification chain. Denormalized rank columns
+//! on each ancestor row are filled in walking-down-the-classification, so a
+//! family-rank ancestor carries the kingdom/phylum/class/order it sits
+//! inside but no genus or species yet.
+//!
+//! The adapter does not (yet) follow synonym → accepted redirects; a synonym
+//! match is persisted with `status = "SYNONYM"` and `accepted_taxon_key =
+//! None`. Callers that need the accepted taxon should issue a follow-up
+//! lookup once the V2 API surface is extended to expose `acceptedUsage`.
+
+use chrono::Utc;
+use gbif_api::{GbifClient as GbifApiClient, V2MatchResult, V2NameUsage};
+use observing_db::taxa::TaxonRow;
+use observing_db::taxonomy_resolver::{ResolveError, TaxonomyUpstream, UpstreamMatch};
+use std::collections::HashMap;
+
+/// Production [`TaxonomyUpstream`] over the raw GBIF v2 client.
+pub struct GbifUpstream {
+    api: GbifApiClient,
+}
+
+impl GbifUpstream {
+    pub fn new(api: GbifApiClient) -> Self {
+        Self { api }
+    }
+}
+
+impl Default for GbifUpstream {
+    fn default() -> Self {
+        Self::new(GbifApiClient::new())
+    }
+}
+
+impl TaxonomyUpstream for GbifUpstream {
+    async fn match_name(
+        &self,
+        scientific_name: &str,
+        kingdom_hint: Option<&str>,
+    ) -> Result<Option<UpstreamMatch>, ResolveError> {
+        let v2 = self
+            .api
+            .match_name(scientific_name, kingdom_hint)
+            .await
+            .map_err(|e| ResolveError::Upstream(e.to_string()))?;
+        Ok(v2.and_then(build_upstream_match))
+    }
+
+    async fn get_by_key(&self, taxon_key: i64) -> Result<Option<UpstreamMatch>, ResolveError> {
+        // GBIF's species-detail endpoint lacks the keyed classification chain
+        // that `match_name` returns, so we'd need follow-up calls per ancestor
+        // to construct anything resolver-shaped. Until that's wired up,
+        // by-key lookups always miss the upstream — callers will fall back
+        // to whatever's cached. This is fine for now: by-key lookups today
+        // come from `accepted_taxon_key` chases on synonym rows we haven't
+        // finished plumbing.
+        let _ = taxon_key;
+        Ok(None)
+    }
+}
+
+/// Build an [`UpstreamMatch`] from a GBIF v2 match result. Returns `None`
+/// when the match has no usable target (no `usage`, or no integer key).
+fn build_upstream_match(v2: V2MatchResult) -> Option<UpstreamMatch> {
+    let usage = v2.usage.as_ref()?;
+    let target_key = usage.key.map(|k| k as i64)?;
+    let classification = v2.classification.as_deref().unwrap_or(&[]);
+
+    // accumulated[rank] = (name, key) for every rank seen so far in the
+    // classification chain. Used to fill in each row's denormalized
+    // ancestor columns.
+    let mut accumulated: HashMap<String, (String, Option<i64>)> = HashMap::new();
+    let mut rows: Vec<TaxonRow> = Vec::with_capacity(classification.len() + 1);
+    let mut parent_key: Option<i64> = None;
+
+    for ancestor in classification {
+        let Some(row) = ancestor_row(ancestor, &mut accumulated, parent_key) else {
+            continue;
+        };
+        parent_key = Some(row.taxon_key);
+        rows.push(row);
+    }
+
+    rows.push(target_row(
+        usage,
+        &accumulated,
+        parent_key,
+        v2.synonym,
+        target_key,
+    ));
+
+    Some(UpstreamMatch { target_key, rows })
+}
+
+/// Build a [`TaxonRow`] for one classification ancestor, also recording its
+/// (rank, name, key) into `accumulated` so subsequent rows can pick it up.
+/// Returns `None` if the ancestor lacks a usable name or key.
+fn ancestor_row(
+    ancestor: &V2NameUsage,
+    accumulated: &mut HashMap<String, (String, Option<i64>)>,
+    parent_key: Option<i64>,
+) -> Option<TaxonRow> {
+    let rank = ancestor.rank.as_deref()?.to_lowercase();
+    let key = ancestor.key.map(|k| k as i64)?;
+    let name = ancestor
+        .canonical_name
+        .clone()
+        .or_else(|| ancestor.name.clone())?;
+
+    accumulated.insert(rank.clone(), (name.clone(), Some(key)));
+
+    Some(row_with_classification(
+        key,
+        &name,
+        &rank,
+        "ACCEPTED",
+        Some(key),
+        parent_key,
+        accumulated,
+    ))
+}
+
+/// Build the [`TaxonRow`] for the target taxon (the `usage` of the match).
+fn target_row(
+    usage: &V2NameUsage,
+    accumulated: &HashMap<String, (String, Option<i64>)>,
+    parent_key: Option<i64>,
+    synonym: bool,
+    target_key: i64,
+) -> TaxonRow {
+    let name = usage
+        .canonical_name
+        .clone()
+        .or_else(|| usage.name.clone())
+        .unwrap_or_default();
+    let rank = usage
+        .rank
+        .as_deref()
+        .map(|r| r.to_lowercase())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    let (status, accepted_taxon_key) = if synonym {
+        // V2 doesn't expose acceptedUsage in our current client surface;
+        // leave the accepted pointer NULL and rely on a future follow-up.
+        ("SYNONYM", None)
+    } else {
+        ("ACCEPTED", Some(target_key))
+    };
+
+    row_with_classification(
+        target_key,
+        &name,
+        &rank,
+        status,
+        accepted_taxon_key,
+        parent_key,
+        accumulated,
+    )
+}
+
+fn row_with_classification(
+    taxon_key: i64,
+    scientific_name: &str,
+    rank: &str,
+    status: &str,
+    accepted_taxon_key: Option<i64>,
+    parent_key: Option<i64>,
+    accumulated: &HashMap<String, (String, Option<i64>)>,
+) -> TaxonRow {
+    let pick = |r: &str| -> (Option<String>, Option<i64>) {
+        accumulated
+            .get(r)
+            .map(|(n, k)| (Some(n.clone()), *k))
+            .unwrap_or((None, None))
+    };
+    let (kingdom, kingdom_key) = pick("kingdom");
+    let (phylum, phylum_key) = pick("phylum");
+    let (class, class_key) = pick("class");
+    let (order_, order_key) = pick("order");
+    let (family, family_key) = pick("family");
+    let (genus, genus_key) = pick("genus");
+    let (species, species_key) = pick("species");
+
+    TaxonRow {
+        taxon_key,
+        scientific_name: scientific_name.to_string(),
+        authorship: None,
+        rank: rank.to_string(),
+        status: status.to_string(),
+        accepted_taxon_key,
+        parent_key,
+        kingdom,
+        kingdom_key,
+        phylum,
+        phylum_key,
+        class,
+        class_key,
+        order_,
+        order_key,
+        family,
+        family_key,
+        genus,
+        genus_key,
+        species,
+        species_key,
+        vernacular_name: None,
+        extinct: None,
+        fetched_at: Utc::now(),
+        source: "gbif".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use gbif_api::V2NameUsage;
+
+    fn usage(key: u64, name: &str, rank: &str) -> V2NameUsage {
+        V2NameUsage {
+            key: Some(key),
+            name: Some(name.to_string()),
+            canonical_name: Some(name.to_string()),
+            rank: Some(rank.to_string()),
+            kingdom: None,
+            phylum: None,
+            class: None,
+            order: None,
+            family: None,
+            genus: None,
+            species: None,
+        }
+    }
+
+    #[test]
+    fn species_match_produces_rows_for_each_ancestor_plus_target() {
+        let v2 = V2MatchResult {
+            synonym: false,
+            usage: Some(usage(1, "Quercus alba", "species")),
+            classification: Some(vec![
+                usage(10, "Plantae", "kingdom"),
+                usage(20, "Tracheophyta", "phylum"),
+                usage(30, "Magnoliopsida", "class"),
+                usage(40, "Fagales", "order"),
+                usage(50, "Fagaceae", "family"),
+                usage(60, "Quercus", "genus"),
+            ]),
+            additional_status: None,
+            diagnostics: None,
+        };
+
+        let m = build_upstream_match(v2).expect("usage with key produces a match");
+        assert_eq!(m.target_key, 1);
+        assert_eq!(m.rows.len(), 7); // 6 ancestors + target
+
+        let target = m.rows.iter().find(|r| r.taxon_key == 1).unwrap();
+        assert_eq!(target.scientific_name, "Quercus alba");
+        assert_eq!(target.rank, "species");
+        assert_eq!(target.status, "ACCEPTED");
+        assert_eq!(target.kingdom.as_deref(), Some("Plantae"));
+        assert_eq!(target.kingdom_key, Some(10));
+        assert_eq!(target.family.as_deref(), Some("Fagaceae"));
+        assert_eq!(target.genus.as_deref(), Some("Quercus"));
+        assert_eq!(target.parent_key, Some(60));
+    }
+
+    #[test]
+    fn ancestor_rows_carry_only_higher_ranks() {
+        let v2 = V2MatchResult {
+            synonym: false,
+            usage: Some(usage(1, "Quercus alba", "species")),
+            classification: Some(vec![
+                usage(10, "Plantae", "kingdom"),
+                usage(50, "Fagaceae", "family"),
+            ]),
+            additional_status: None,
+            diagnostics: None,
+        };
+
+        let m = build_upstream_match(v2).unwrap();
+        let plantae = m.rows.iter().find(|r| r.taxon_key == 10).unwrap();
+        assert_eq!(plantae.rank, "kingdom");
+        assert_eq!(plantae.kingdom.as_deref(), Some("Plantae"));
+        assert!(plantae.family.is_none()); // no family below kingdom
+        assert!(plantae.parent_key.is_none()); // root of the chain
+
+        let fagaceae = m.rows.iter().find(|r| r.taxon_key == 50).unwrap();
+        assert_eq!(fagaceae.rank, "family");
+        assert_eq!(fagaceae.kingdom.as_deref(), Some("Plantae"));
+        assert_eq!(fagaceae.family.as_deref(), Some("Fagaceae"));
+        assert!(fagaceae.genus.is_none());
+        assert_eq!(fagaceae.parent_key, Some(10));
+    }
+
+    #[test]
+    fn synonym_target_marked_synonym_with_no_accepted_pointer() {
+        let v2 = V2MatchResult {
+            synonym: true,
+            usage: Some(usage(2, "Quercus pedunculata", "species")),
+            classification: Some(vec![usage(10, "Plantae", "kingdom")]),
+            additional_status: None,
+            diagnostics: None,
+        };
+
+        let m = build_upstream_match(v2).unwrap();
+        let target = m.rows.iter().find(|r| r.taxon_key == 2).unwrap();
+        assert_eq!(target.status, "SYNONYM");
+        assert!(target.accepted_taxon_key.is_none());
+    }
+
+    #[test]
+    fn missing_target_key_yields_no_match() {
+        let mut u = usage(0, "Foo", "species");
+        u.key = None;
+        let v2 = V2MatchResult {
+            synonym: false,
+            usage: Some(u),
+            classification: None,
+            additional_status: None,
+            diagnostics: None,
+        };
+        assert!(build_upstream_match(v2).is_none());
+    }
+
+    #[test]
+    fn ancestors_without_keys_are_skipped() {
+        let mut nameless = usage(0, "Mystery", "phylum");
+        nameless.key = None;
+        let v2 = V2MatchResult {
+            synonym: false,
+            usage: Some(usage(1, "Quercus alba", "species")),
+            classification: Some(vec![usage(10, "Plantae", "kingdom"), nameless]),
+            additional_status: None,
+            diagnostics: None,
+        };
+
+        let m = build_upstream_match(v2).unwrap();
+        // Plantae + target only; the keyless phylum is skipped.
+        assert_eq!(m.rows.len(), 2);
+        let target = m.rows.iter().find(|r| r.taxon_key == 1).unwrap();
+        assert!(target.phylum.is_none());
+    }
+}

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -3,6 +3,7 @@ mod config;
 mod constants;
 mod enrichment;
 mod error;
+mod gbif_upstream;
 mod media;
 mod middleware;
 mod oauth_store;

--- a/crates/observing-db/Cargo.toml
+++ b/crates/observing-db/Cargo.toml
@@ -32,3 +32,4 @@ observing-lexicons = { path = "../observing-lexicons", optional = true }
 # Test-only: lexicon constraint validation in processing tests
 [dev-dependencies]
 jacquard-lexicon = "0.12.0-beta.2"
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/observing-db/src/lib.rs
+++ b/crates/observing-db/src/lib.rs
@@ -12,6 +12,8 @@ pub mod occurrences;
 pub mod private_data;
 #[cfg(feature = "processing")]
 pub mod processing;
+pub mod taxa;
+pub mod taxonomy_resolver;
 pub mod types;
 
 pub use sqlx::postgres::PgPool;

--- a/crates/observing-db/src/taxa.rs
+++ b/crates/observing-db/src/taxa.rs
@@ -1,0 +1,168 @@
+//! Read/write access for the `taxa` cache table.
+//!
+//! Backs the [`crate::taxonomy_resolver::Resolver`] orchestration layer.
+//! Pure SQL — no external taxonomy source dependency.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use sqlx::{FromRow, Postgres, QueryBuilder};
+
+/// One row of the `taxa` cache. Mirrors the schema from
+/// `migrations/20260505100000_taxa_cache.sql`.
+#[derive(Debug, Clone, Serialize, Deserialize, FromRow, PartialEq)]
+pub struct TaxonRow {
+    pub taxon_key: i64,
+    pub scientific_name: String,
+    pub authorship: Option<String>,
+    pub rank: String,
+    pub status: String,
+    pub accepted_taxon_key: Option<i64>,
+    pub parent_key: Option<i64>,
+
+    pub kingdom: Option<String>,
+    pub kingdom_key: Option<i64>,
+    pub phylum: Option<String>,
+    pub phylum_key: Option<i64>,
+    pub class: Option<String>,
+    pub class_key: Option<i64>,
+    #[sqlx(rename = "order")]
+    #[serde(rename = "order")]
+    pub order_: Option<String>,
+    pub order_key: Option<i64>,
+    pub family: Option<String>,
+    pub family_key: Option<i64>,
+    pub genus: Option<String>,
+    pub genus_key: Option<i64>,
+    pub species: Option<String>,
+    pub species_key: Option<i64>,
+
+    pub vernacular_name: Option<String>,
+    pub extinct: Option<bool>,
+    pub fetched_at: DateTime<Utc>,
+    pub source: String,
+}
+
+const SELECT_COLUMNS: &str = r#"taxon_key, scientific_name, authorship, rank, status,
+    accepted_taxon_key, parent_key,
+    kingdom, kingdom_key, phylum, phylum_key, class, class_key,
+    "order", order_key, family, family_key, genus, genus_key,
+    species, species_key,
+    vernacular_name, extinct, fetched_at, source"#;
+
+/// Look up a single row by GBIF usageKey.
+pub async fn get_by_key(
+    executor: impl sqlx::PgExecutor<'_>,
+    taxon_key: i64,
+) -> Result<Option<TaxonRow>, sqlx::Error> {
+    let sql = format!("SELECT {SELECT_COLUMNS} FROM taxa WHERE taxon_key = $1");
+    sqlx::query_as::<_, TaxonRow>(&sql)
+        .bind(taxon_key)
+        .fetch_optional(executor)
+        .await
+}
+
+/// Look up a row by case-insensitive scientific name, optionally scoped by
+/// kingdom to disambiguate cross-kingdom homonyms.
+///
+/// When multiple rows match (e.g. an accepted taxon plus a synonym sharing
+/// the same name) the accepted one wins; ties beyond that fall back to the
+/// lowest taxon_key for determinism.
+pub async fn get_by_name(
+    executor: impl sqlx::PgExecutor<'_>,
+    scientific_name: &str,
+    kingdom_hint: Option<&str>,
+) -> Result<Option<TaxonRow>, sqlx::Error> {
+    let sql = format!(
+        r#"SELECT {SELECT_COLUMNS}
+           FROM taxa
+           WHERE LOWER(scientific_name) = LOWER($1)
+             AND ($2::text IS NULL OR kingdom = $2)
+           ORDER BY (status = 'ACCEPTED') DESC, taxon_key ASC
+           LIMIT 1"#
+    );
+    sqlx::query_as::<_, TaxonRow>(&sql)
+        .bind(scientific_name)
+        .bind(kingdom_hint)
+        .fetch_optional(executor)
+        .await
+}
+
+/// Insert or refresh a batch of taxa rows. Conflicting `taxon_key` rows are
+/// updated in place so concurrent resolves of the same name are safe and a
+/// re-fetch overwrites stale ancestry data.
+pub async fn upsert_many(
+    executor: impl sqlx::PgExecutor<'_>,
+    rows: &[TaxonRow],
+) -> Result<(), sqlx::Error> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let mut qb = QueryBuilder::<Postgres>::new(
+        r#"INSERT INTO taxa (
+            taxon_key, scientific_name, authorship, rank, status,
+            accepted_taxon_key, parent_key,
+            kingdom, kingdom_key, phylum, phylum_key, class, class_key,
+            "order", order_key, family, family_key, genus, genus_key,
+            species, species_key,
+            vernacular_name, extinct, fetched_at, source
+        ) "#,
+    );
+    qb.push_values(rows, |mut b, row| {
+        b.push_bind(row.taxon_key)
+            .push_bind(&row.scientific_name)
+            .push_bind(&row.authorship)
+            .push_bind(&row.rank)
+            .push_bind(&row.status)
+            .push_bind(row.accepted_taxon_key)
+            .push_bind(row.parent_key)
+            .push_bind(&row.kingdom)
+            .push_bind(row.kingdom_key)
+            .push_bind(&row.phylum)
+            .push_bind(row.phylum_key)
+            .push_bind(&row.class)
+            .push_bind(row.class_key)
+            .push_bind(&row.order_)
+            .push_bind(row.order_key)
+            .push_bind(&row.family)
+            .push_bind(row.family_key)
+            .push_bind(&row.genus)
+            .push_bind(row.genus_key)
+            .push_bind(&row.species)
+            .push_bind(row.species_key)
+            .push_bind(&row.vernacular_name)
+            .push_bind(row.extinct)
+            .push_bind(row.fetched_at)
+            .push_bind(&row.source);
+    });
+    qb.push(
+        r#" ON CONFLICT (taxon_key) DO UPDATE SET
+            scientific_name = EXCLUDED.scientific_name,
+            authorship = EXCLUDED.authorship,
+            rank = EXCLUDED.rank,
+            status = EXCLUDED.status,
+            accepted_taxon_key = EXCLUDED.accepted_taxon_key,
+            parent_key = EXCLUDED.parent_key,
+            kingdom = EXCLUDED.kingdom,
+            kingdom_key = EXCLUDED.kingdom_key,
+            phylum = EXCLUDED.phylum,
+            phylum_key = EXCLUDED.phylum_key,
+            class = EXCLUDED.class,
+            class_key = EXCLUDED.class_key,
+            "order" = EXCLUDED."order",
+            order_key = EXCLUDED.order_key,
+            family = EXCLUDED.family,
+            family_key = EXCLUDED.family_key,
+            genus = EXCLUDED.genus,
+            genus_key = EXCLUDED.genus_key,
+            species = EXCLUDED.species,
+            species_key = EXCLUDED.species_key,
+            vernacular_name = EXCLUDED.vernacular_name,
+            extinct = EXCLUDED.extinct,
+            fetched_at = EXCLUDED.fetched_at,
+            source = EXCLUDED.source"#,
+    );
+
+    qb.build().execute(executor).await?;
+    Ok(())
+}

--- a/crates/observing-db/src/taxonomy_resolver.rs
+++ b/crates/observing-db/src/taxonomy_resolver.rs
@@ -1,0 +1,438 @@
+//! Cache-backed taxonomy resolver.
+//!
+//! Fronts the `taxa` table with a write-through cache pattern: lookups hit
+//! the local cache first; on miss, an injected upstream source produces the
+//! target taxon plus its ancestor chain, which the resolver persists before
+//! returning the target.
+//!
+//! Both the upstream and the cache are abstracted behind traits so the
+//! orchestration here is independently testable. The GBIF-backed upstream
+//! lives in `observing-appview`; the production cache impl is over
+//! `sqlx::PgPool` (provided in this module).
+
+use crate::taxa::{self, TaxonRow};
+use std::fmt;
+
+/// Errors surfaced by the resolver.
+#[derive(Debug)]
+pub enum ResolveError {
+    /// Database access failed (cache lookup, upsert, …).
+    Cache(sqlx::Error),
+    /// The upstream taxonomy source failed (HTTP, parse, …).
+    Upstream(String),
+}
+
+impl fmt::Display for ResolveError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Cache(e) => write!(f, "taxonomy cache: {e}"),
+            Self::Upstream(e) => write!(f, "taxonomy upstream: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for ResolveError {}
+
+impl From<sqlx::Error> for ResolveError {
+    fn from(e: sqlx::Error) -> Self {
+        Self::Cache(e)
+    }
+}
+
+/// A target taxon plus the ancestors needed to populate its denormalized
+/// classification, normalized to the shape of `taxa` rows so the resolver
+/// can persist them without further translation.
+///
+/// `target_key` identifies which row in `rows` is the queried taxon —
+/// ancestors come along so the cache is warmed in one shot.
+#[derive(Debug, Clone)]
+pub struct UpstreamMatch {
+    pub target_key: i64,
+    pub rows: Vec<TaxonRow>,
+}
+
+/// External taxonomy source the resolver delegates to on cache miss.
+pub trait TaxonomyUpstream {
+    fn match_name(
+        &self,
+        scientific_name: &str,
+        kingdom_hint: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<Option<UpstreamMatch>, ResolveError>> + Send;
+
+    fn get_by_key(
+        &self,
+        taxon_key: i64,
+    ) -> impl std::future::Future<Output = Result<Option<UpstreamMatch>, ResolveError>> + Send;
+}
+
+/// Local cache the resolver consults before reaching for the upstream.
+pub trait TaxonomyCache {
+    fn get_by_name(
+        &self,
+        scientific_name: &str,
+        kingdom_hint: Option<&str>,
+    ) -> impl std::future::Future<Output = Result<Option<TaxonRow>, sqlx::Error>> + Send;
+
+    fn get_by_key(
+        &self,
+        taxon_key: i64,
+    ) -> impl std::future::Future<Output = Result<Option<TaxonRow>, sqlx::Error>> + Send;
+
+    fn upsert_many(
+        &self,
+        rows: &[TaxonRow],
+    ) -> impl std::future::Future<Output = Result<(), sqlx::Error>> + Send;
+}
+
+/// Production cache impl backed by Postgres via the [`crate::taxa`] module.
+impl TaxonomyCache for sqlx::PgPool {
+    async fn get_by_name(
+        &self,
+        scientific_name: &str,
+        kingdom_hint: Option<&str>,
+    ) -> Result<Option<TaxonRow>, sqlx::Error> {
+        taxa::get_by_name(self, scientific_name, kingdom_hint).await
+    }
+
+    async fn get_by_key(&self, taxon_key: i64) -> Result<Option<TaxonRow>, sqlx::Error> {
+        taxa::get_by_key(self, taxon_key).await
+    }
+
+    async fn upsert_many(&self, rows: &[TaxonRow]) -> Result<(), sqlx::Error> {
+        taxa::upsert_many(self, rows).await
+    }
+}
+
+/// Cache-backed taxon resolver. Looks up the local cache first; on miss,
+/// queries `upstream`, persists the returned rows, and returns the target.
+pub struct Resolver<'a, C: TaxonomyCache, U: TaxonomyUpstream> {
+    cache: &'a C,
+    upstream: &'a U,
+}
+
+impl<'a, C: TaxonomyCache, U: TaxonomyUpstream> Resolver<'a, C, U> {
+    pub fn new(cache: &'a C, upstream: &'a U) -> Self {
+        Self { cache, upstream }
+    }
+
+    /// Resolve by scientific name with an optional kingdom hint. Returns
+    /// `Ok(None)` if upstream has no match for the name.
+    pub async fn resolve_by_name(
+        &self,
+        scientific_name: &str,
+        kingdom_hint: Option<&str>,
+    ) -> Result<Option<TaxonRow>, ResolveError> {
+        if let Some(row) = self
+            .cache
+            .get_by_name(scientific_name, kingdom_hint)
+            .await?
+        {
+            return Ok(Some(row));
+        }
+        let Some(m) = self
+            .upstream
+            .match_name(scientific_name, kingdom_hint)
+            .await?
+        else {
+            return Ok(None);
+        };
+        let target_key = m.target_key;
+        self.cache.upsert_many(&m.rows).await?;
+        Ok(m.rows.into_iter().find(|r| r.taxon_key == target_key))
+    }
+
+    /// Resolve by GBIF usageKey.
+    pub async fn resolve_by_key(&self, taxon_key: i64) -> Result<Option<TaxonRow>, ResolveError> {
+        if let Some(row) = self.cache.get_by_key(taxon_key).await? {
+            return Ok(Some(row));
+        }
+        let Some(m) = self.upstream.get_by_key(taxon_key).await? else {
+            return Ok(None);
+        };
+        let target_key = m.target_key;
+        self.cache.upsert_many(&m.rows).await?;
+        Ok(m.rows.into_iter().find(|r| r.taxon_key == target_key))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+    use std::sync::Mutex;
+
+    fn make_row(taxon_key: i64, name: &str, kingdom: Option<&str>, status: &str) -> TaxonRow {
+        TaxonRow {
+            taxon_key,
+            scientific_name: name.to_string(),
+            authorship: None,
+            rank: "species".to_string(),
+            status: status.to_string(),
+            accepted_taxon_key: Some(taxon_key),
+            parent_key: None,
+            kingdom: kingdom.map(str::to_string),
+            kingdom_key: None,
+            phylum: None,
+            phylum_key: None,
+            class: None,
+            class_key: None,
+            order_: None,
+            order_key: None,
+            family: None,
+            family_key: None,
+            genus: None,
+            genus_key: None,
+            species: None,
+            species_key: None,
+            vernacular_name: None,
+            extinct: None,
+            fetched_at: Utc::now(),
+            source: "test".to_string(),
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeCache {
+        rows: Mutex<Vec<TaxonRow>>,
+        upsert_calls: Mutex<u32>,
+        lookup_calls: Mutex<u32>,
+    }
+
+    impl FakeCache {
+        fn seeded(rows: Vec<TaxonRow>) -> Self {
+            Self {
+                rows: Mutex::new(rows),
+                ..Default::default()
+            }
+        }
+
+        fn upserts(&self) -> u32 {
+            *self.upsert_calls.lock().unwrap()
+        }
+
+        fn lookups(&self) -> u32 {
+            *self.lookup_calls.lock().unwrap()
+        }
+    }
+
+    impl TaxonomyCache for FakeCache {
+        async fn get_by_name(
+            &self,
+            name: &str,
+            kingdom_hint: Option<&str>,
+        ) -> Result<Option<TaxonRow>, sqlx::Error> {
+            *self.lookup_calls.lock().unwrap() += 1;
+            let rows = self.rows.lock().unwrap();
+            // Mirror the real query's preference for ACCEPTED then lowest key.
+            let mut matches: Vec<&TaxonRow> = rows
+                .iter()
+                .filter(|r| r.scientific_name.eq_ignore_ascii_case(name))
+                .filter(|r| match kingdom_hint {
+                    Some(k) => r.kingdom.as_deref() == Some(k),
+                    None => true,
+                })
+                .collect();
+            matches.sort_by_key(|r| (r.status != "ACCEPTED", r.taxon_key));
+            Ok(matches.into_iter().next().cloned())
+        }
+
+        async fn get_by_key(&self, taxon_key: i64) -> Result<Option<TaxonRow>, sqlx::Error> {
+            *self.lookup_calls.lock().unwrap() += 1;
+            let rows = self.rows.lock().unwrap();
+            Ok(rows.iter().find(|r| r.taxon_key == taxon_key).cloned())
+        }
+
+        async fn upsert_many(&self, rows: &[TaxonRow]) -> Result<(), sqlx::Error> {
+            *self.upsert_calls.lock().unwrap() += 1;
+            let mut store = self.rows.lock().unwrap();
+            for incoming in rows {
+                if let Some(existing) = store.iter_mut().find(|r| r.taxon_key == incoming.taxon_key)
+                {
+                    *existing = incoming.clone();
+                } else {
+                    store.push(incoming.clone());
+                }
+            }
+            Ok(())
+        }
+    }
+
+    #[derive(Default)]
+    struct FakeUpstream {
+        by_name: std::collections::HashMap<String, UpstreamMatch>,
+        by_key: std::collections::HashMap<i64, UpstreamMatch>,
+        name_calls: Mutex<u32>,
+        key_calls: Mutex<u32>,
+        upstream_error: Option<String>,
+    }
+
+    impl FakeUpstream {
+        fn name_calls(&self) -> u32 {
+            *self.name_calls.lock().unwrap()
+        }
+    }
+
+    impl TaxonomyUpstream for FakeUpstream {
+        async fn match_name(
+            &self,
+            name: &str,
+            _kingdom_hint: Option<&str>,
+        ) -> Result<Option<UpstreamMatch>, ResolveError> {
+            *self.name_calls.lock().unwrap() += 1;
+            if let Some(err) = &self.upstream_error {
+                return Err(ResolveError::Upstream(err.clone()));
+            }
+            Ok(self.by_name.get(&name.to_lowercase()).cloned())
+        }
+
+        async fn get_by_key(&self, taxon_key: i64) -> Result<Option<UpstreamMatch>, ResolveError> {
+            *self.key_calls.lock().unwrap() += 1;
+            if let Some(err) = &self.upstream_error {
+                return Err(ResolveError::Upstream(err.clone()));
+            }
+            Ok(self.by_key.get(&taxon_key).cloned())
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_hit_skips_upstream() {
+        let cache = FakeCache::seeded(vec![make_row(
+            1,
+            "Quercus alba",
+            Some("Plantae"),
+            "ACCEPTED",
+        )]);
+        let upstream = FakeUpstream::default();
+        let resolver = Resolver::new(&cache, &upstream);
+
+        let row = resolver
+            .resolve_by_name("Quercus alba", Some("Plantae"))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(row.taxon_key, 1);
+        assert_eq!(upstream.name_calls(), 0);
+        assert_eq!(cache.upserts(), 0);
+    }
+
+    #[tokio::test]
+    async fn cache_miss_writes_through() {
+        let cache = FakeCache::default();
+        let mut upstream = FakeUpstream::default();
+        let target = make_row(1, "Quercus alba", Some("Plantae"), "ACCEPTED");
+        let ancestor = make_row(0, "Plantae", None, "ACCEPTED");
+        upstream.by_name.insert(
+            "quercus alba".to_string(),
+            UpstreamMatch {
+                target_key: 1,
+                rows: vec![target.clone(), ancestor.clone()],
+            },
+        );
+        let resolver = Resolver::new(&cache, &upstream);
+
+        let row = resolver
+            .resolve_by_name("Quercus alba", Some("Plantae"))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(row.taxon_key, 1);
+        // Ancestor written too so subsequent rank filters hit the cache.
+        assert_eq!(cache.rows.lock().unwrap().len(), 2);
+        assert_eq!(upstream.name_calls(), 1);
+        assert_eq!(cache.upserts(), 1);
+    }
+
+    #[tokio::test]
+    async fn second_lookup_after_miss_skips_upstream() {
+        let cache = FakeCache::default();
+        let mut upstream = FakeUpstream::default();
+        upstream.by_name.insert(
+            "quercus alba".to_string(),
+            UpstreamMatch {
+                target_key: 1,
+                rows: vec![make_row(1, "Quercus alba", Some("Plantae"), "ACCEPTED")],
+            },
+        );
+        let resolver = Resolver::new(&cache, &upstream);
+
+        resolver
+            .resolve_by_name("Quercus alba", Some("Plantae"))
+            .await
+            .unwrap();
+        resolver
+            .resolve_by_name("Quercus alba", Some("Plantae"))
+            .await
+            .unwrap();
+
+        assert_eq!(upstream.name_calls(), 1);
+        assert_eq!(cache.upserts(), 1);
+        assert_eq!(cache.lookups(), 2);
+    }
+
+    #[tokio::test]
+    async fn upstream_no_match_returns_none() {
+        let cache = FakeCache::default();
+        let upstream = FakeUpstream::default();
+        let resolver = Resolver::new(&cache, &upstream);
+
+        let result = resolver.resolve_by_name("Nonexistens fakeii", None).await;
+
+        assert!(matches!(result, Ok(None)));
+        assert_eq!(upstream.name_calls(), 1);
+        assert_eq!(cache.upserts(), 0);
+    }
+
+    #[tokio::test]
+    async fn resolve_by_key_cache_hit() {
+        let cache = FakeCache::seeded(vec![make_row(42, "Foo bar", None, "ACCEPTED")]);
+        let upstream = FakeUpstream::default();
+        let resolver = Resolver::new(&cache, &upstream);
+
+        let row = resolver.resolve_by_key(42).await.unwrap().unwrap();
+        assert_eq!(row.taxon_key, 42);
+        assert_eq!(upstream.name_calls(), 0);
+    }
+
+    #[tokio::test]
+    async fn synonym_returns_synonym_row_with_accepted_pointer() {
+        // Cache contains both an accepted taxon and one of its synonyms; a
+        // by-name lookup of the synonym should return the synonym row, with
+        // accepted_taxon_key pointing at the accepted record. Callers that
+        // want the accepted taxon recurse via resolve_by_key.
+        let mut accepted = make_row(1, "Quercus robur", Some("Plantae"), "ACCEPTED");
+        accepted.accepted_taxon_key = Some(1);
+        let mut synonym = make_row(2, "Quercus pedunculata", Some("Plantae"), "SYNONYM");
+        synonym.accepted_taxon_key = Some(1);
+
+        let cache = FakeCache::seeded(vec![accepted, synonym]);
+        let upstream = FakeUpstream::default();
+        let resolver = Resolver::new(&cache, &upstream);
+
+        let row = resolver
+            .resolve_by_name("Quercus pedunculata", Some("Plantae"))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(row.taxon_key, 2);
+        assert_eq!(row.status, "SYNONYM");
+        assert_eq!(row.accepted_taxon_key, Some(1));
+    }
+
+    #[tokio::test]
+    async fn upstream_error_propagates() {
+        let cache = FakeCache::default();
+        let upstream = FakeUpstream {
+            upstream_error: Some("boom".into()),
+            ..Default::default()
+        };
+        let resolver = Resolver::new(&cache, &upstream);
+
+        let result = resolver.resolve_by_name("Quercus alba", None).await;
+
+        assert!(matches!(result, Err(ResolveError::Upstream(_))));
+        assert_eq!(cache.upserts(), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Stacked on #443. Adds the cache-backed resolver and a GBIF upstream adapter — the orchestration layer that will populate the \`taxa\` table on demand.

- **observing-db::taxa** — TaxonRow + \`get_by_key\` / \`get_by_name\` / \`upsert_many\`. The by-name lookup folds case and prefers ACCEPTED rows over synonyms when names tie.
- **observing-db::taxonomy_resolver** — \`Resolver\` orchestration with \`TaxonomyUpstream\` (external source) and \`TaxonomyCache\` (local store) traits. Cache hit returns immediately; miss queries upstream, persists target + ancestor rows in one shot, and returns the target. Production cache impl over \`sqlx::PgPool\` is included; observing-db stays free of HTTP/GBIF deps.
- **observing-appview::gbif_upstream** — adapts a GBIF v2 \`match_name\` result into one \`TaxonRow\` per ancestor + one for the target. Each ancestor row carries denormalized rank columns for itself and the ranks above it.

Nothing constructs \`GbifUpstream\` yet (\`#![allow(dead_code)]\`); the ingester wiring lands in the follow-up branch and that's where this earns its keep.

## Test plan
- [x] \`cargo test -p observing-db taxonomy_resolver\` — 7 tests pass
- [x] \`cargo test -p observing-appview gbif_upstream\` — 5 tests pass
- [x] \`cargo clippy --workspace --tests -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [ ] First-run validation against a real DB: \`get_by_name\` / \`get_by_key\` / \`upsert_many\` against the schema added by #443. The queries bypass sqlx-prepare so they'll be checked at runtime, not compile time.
- [ ] Synonym-handling note worth confirming: V2 currently doesn't expose \`acceptedUsage\` in our client surface, so synonyms are persisted with \`accepted_taxon_key = NULL\`. Acceptable for now — branch 3 will revisit if needed.

Steps toward #440 and #426.