### PR TITLE
feat(ingester): resolve consensus taxon during identification ingest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2967,6 +2967,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "observing-taxonomy-gbif"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "gbif-api",
+ "observing-db",
+ "tokio",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2896,6 +2896,7 @@ dependencies = [
  "jetstream-client",
  "observing-db",
  "observing-lexicons",
+ "observing-taxonomy-gbif",
  "reqwest 0.13.3",
  "serde",
  "serde_json",

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -3,7 +3,6 @@ mod config;
 mod constants;
 mod enrichment;
 mod error;
-mod gbif_upstream;
 mod media;
 mod middleware;
 mod oauth_store;

--- a/crates/observing-db/src/identifications.rs
+++ b/crates/observing-db/src/identifications.rs
@@ -6,32 +6,38 @@ use std::collections::HashMap;
 ///
 /// NOTE: Must take `&PgPool` because `REFRESH MATERIALIZED VIEW CONCURRENTLY`
 /// cannot be executed within a transaction block.
+///
+/// Uses the dynamic query API rather than the `query!` macro so the new
+/// `accepted_taxon_key` column doesn't require regenerating the offline
+/// sqlx-prepare cache.
 pub async fn upsert(pool: &PgPool, p: &UpsertIdentificationParams) -> Result<(), sqlx::Error> {
-    sqlx::query!(
+    sqlx::query(
         r#"
         INSERT INTO identifications (
             uri, cid, did, subject_uri, subject_cid, scientific_name,
-            taxon_rank, taxon_id, date_identified, kingdom
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            taxon_rank, taxon_id, date_identified, kingdom, accepted_taxon_key
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
         ON CONFLICT (uri) DO UPDATE SET
             cid = $2,
             scientific_name = $6,
             taxon_rank = COALESCE($7, identifications.taxon_rank),
             taxon_id = COALESCE($8, identifications.taxon_id),
             kingdom = COALESCE($10, identifications.kingdom),
+            accepted_taxon_key = COALESCE($11, identifications.accepted_taxon_key),
             indexed_at = NOW()
         "#,
-        p.uri,
-        p.cid,
-        p.did,
-        p.subject_uri,
-        p.subject_cid,
-        p.scientific_name,
-        p.taxon_rank as _,
-        p.taxon_id as _,
-        p.date_identified,
-        p.kingdom as _,
     )
+    .bind(&p.uri)
+    .bind(&p.cid)
+    .bind(&p.did)
+    .bind(&p.subject_uri)
+    .bind(&p.subject_cid)
+    .bind(&p.scientific_name)
+    .bind(&p.taxon_rank)
+    .bind(&p.taxon_id)
+    .bind(p.date_identified)
+    .bind(&p.kingdom)
+    .bind(p.accepted_taxon_key)
     .execute(pool)
     .await?;
 

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -257,6 +257,9 @@ pub fn identification_from_json(
         taxon_id,
         date_identified,
         kingdom,
+        // Resolved by the taxonomy resolver before upsert; the JSON record
+        // carries no consensus taxon information.
+        accepted_taxon_key: None,
     })
 }
 

--- a/crates/observing-db/src/types.rs
+++ b/crates/observing-db/src/types.rs
@@ -249,6 +249,10 @@ pub struct UpsertIdentificationParams {
     pub taxon_id: Option<String>,
     pub date_identified: DateTime<Utc>,
     pub kingdom: Option<String>,
+    /// Resolved GBIF taxon key for the consensus taxon. Populated by the
+    /// taxonomy resolver before the upsert; downstream queries
+    /// (community_ids matview, taxon-page filters) join on this.
+    pub accepted_taxon_key: Option<i64>,
 }
 
 /// Parameters for upserting a comment

--- a/crates/observing-ingester/Cargo.toml
+++ b/crates/observing-ingester/Cargo.toml
@@ -26,6 +26,9 @@ sqlx = { workspace = true }
 observing-db = { path = "../observing-db", features = ["processing"] }
 observing-lexicons = { path = "../observing-lexicons" }
 
+# Taxonomy resolver upstream (GBIF live API → local `taxa` cache)
+observing-taxonomy-gbif = { path = "../observing-taxonomy-gbif" }
+
 # HTTP server
 axum = { workspace = true }
 tower-http = { workspace = true }

--- a/crates/observing-ingester/src/bin/resolve_taxa.rs
+++ b/crates/observing-ingester/src/bin/resolve_taxa.rs
@@ -1,0 +1,196 @@
+//! One-shot resolver-cache backfill.
+//!
+//! Walks every distinct `(scientific_name, kingdom)` pair from
+//! `identifications` whose `accepted_taxon_key` is still NULL, runs each
+//! through the taxonomy resolver (populating the local `taxa` cache as a
+//! side effect), and stamps every identification matching that pair with
+//! the resolved key. Refreshes the `community_ids` materialized view once
+//! at the end so downstream filters pick up the new keys.
+//!
+//! Run before the `community_ids`-rebuild migration that uses
+//! `accepted_taxon_key`. Without this, every legacy identification would
+//! drop out of the join.
+//!
+//! Usage:
+//!   cargo run --bin resolve_taxa
+//!   cargo run --bin resolve_taxa -- --rate-limit-ms 200 --limit 1000
+
+use std::time::Duration;
+
+use clap::Parser;
+use observing_db::taxonomy_resolver::Resolver;
+use observing_taxonomy_gbif::GbifUpstream;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::Row;
+use tracing::{error, info, warn};
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+#[derive(Parser)]
+#[command(about = "Resolve and cache taxonomy for already-ingested identifications")]
+struct Cli {
+    /// Optional pause between GBIF lookups (defaults to 100ms to be polite).
+    #[arg(long, default_value_t = 100)]
+    rate_limit_ms: u64,
+
+    /// Cap on the number of distinct (name, kingdom) pairs processed in
+    /// this run. Useful for incremental progress against a large backlog.
+    #[arg(long)]
+    limit: Option<i64>,
+
+    /// Print what would be resolved without calling GBIF or writing.
+    #[arg(long)]
+    dry_run: bool,
+}
+
+#[tokio::main]
+async fn main() -> std::process::ExitCode {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("resolve_taxa=info,observing_db=info"));
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_stackdriver::layer())
+        .init();
+
+    let cli = Cli::parse();
+
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => {
+            error!("DATABASE_URL is required");
+            return std::process::ExitCode::from(2);
+        }
+    };
+
+    let pool = match PgPoolOptions::new()
+        .max_connections(2)
+        .acquire_timeout(Duration::from_secs(10))
+        .connect(&database_url)
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            error!(error = %e, "Failed to connect to database");
+            return std::process::ExitCode::from(1);
+        }
+    };
+
+    // Distinct (name, kingdom) pairs that still need a key. Pulled in one
+    // shot — if the backlog ever grows beyond what fits in memory, switch
+    // to keyset pagination over the same set.
+    let mut q = String::from(
+        r#"SELECT DISTINCT scientific_name, kingdom
+           FROM identifications
+           WHERE accepted_taxon_key IS NULL
+             AND scientific_name <> ''
+           ORDER BY scientific_name, kingdom"#,
+    );
+    if let Some(limit) = cli.limit {
+        q.push_str(&format!(" LIMIT {limit}"));
+    }
+    let pairs = match sqlx::query(&q).fetch_all(&pool).await {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|r| {
+                let name: String = r.get("scientific_name");
+                let kingdom: Option<String> = r.try_get("kingdom").ok();
+                (name, kingdom)
+            })
+            .collect::<Vec<_>>(),
+        Err(e) => {
+            error!(error = %e, "Failed to enumerate identifications needing resolution");
+            return std::process::ExitCode::from(1);
+        }
+    };
+
+    info!(
+        pairs = pairs.len(),
+        "Discovered (name, kingdom) pairs to resolve"
+    );
+    if cli.dry_run {
+        for (name, kingdom) in &pairs {
+            info!(name = %name, kingdom = ?kingdom, "Would resolve");
+        }
+        return std::process::ExitCode::SUCCESS;
+    }
+
+    let upstream = GbifUpstream::default();
+    let resolver = Resolver::new(&pool, &upstream);
+
+    let mut resolved = 0u64;
+    let mut not_found = 0u64;
+    let mut errors = 0u64;
+    let mut updated_rows = 0u64;
+
+    for (i, (name, kingdom)) in pairs.iter().enumerate() {
+        let key = match resolver.resolve_by_name(name, kingdom.as_deref()).await {
+            Ok(Some(row)) => {
+                resolved += 1;
+                row.accepted_taxon_key.unwrap_or(row.taxon_key)
+            }
+            Ok(None) => {
+                not_found += 1;
+                if cli.rate_limit_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(cli.rate_limit_ms)).await;
+                }
+                continue;
+            }
+            Err(e) => {
+                errors += 1;
+                warn!(name = %name, kingdom = ?kingdom, error = %e, "Resolve failed");
+                if cli.rate_limit_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(cli.rate_limit_ms)).await;
+                }
+                continue;
+            }
+        };
+
+        // Stamp every matching identification in one update. Uses the same
+        // (name, optional-kingdom) shape as resolution so multi-row hits
+        // share the cost.
+        let update_sql = r#"UPDATE identifications
+            SET accepted_taxon_key = $1, indexed_at = NOW()
+            WHERE accepted_taxon_key IS NULL
+              AND scientific_name = $2
+              AND ($3::text IS NULL OR kingdom = $3)"#;
+        match sqlx::query(update_sql)
+            .bind(key)
+            .bind(name)
+            .bind(kingdom.as_deref())
+            .execute(&pool)
+            .await
+        {
+            Ok(res) => updated_rows += res.rows_affected(),
+            Err(e) => {
+                errors += 1;
+                warn!(name = %name, error = %e, "Failed to update identifications");
+            }
+        }
+
+        if (i + 1) % 50 == 0 {
+            info!(
+                processed = i + 1,
+                total = pairs.len(),
+                resolved,
+                not_found,
+                updated_rows,
+                "Progress",
+            );
+        }
+        if cli.rate_limit_ms > 0 {
+            tokio::time::sleep(Duration::from_millis(cli.rate_limit_ms)).await;
+        }
+    }
+
+    info!(
+        resolved,
+        not_found, errors, updated_rows, "Resolution pass complete; refreshing community_ids"
+    );
+
+    if let Err(e) = observing_db::identifications::refresh_community_ids(&pool).await {
+        error!(error = %e, "Failed to refresh community_ids matview");
+        return std::process::ExitCode::from(1);
+    }
+
+    info!("Done");
+    std::process::ExitCode::SUCCESS
+}

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -7,6 +7,8 @@ use crate::error::Result;
 use crate::media_resolver::MediaResolver;
 use jetstream_client::CommitInfo;
 use observing_db::processing;
+use observing_db::taxonomy_resolver::Resolver;
+use observing_taxonomy_gbif::GbifUpstream;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use tracing::{debug, info, warn};
 
@@ -74,6 +76,9 @@ macro_rules! process_or_warn {
 pub struct Database {
     pool: PgPool,
     media_resolver: MediaResolver,
+    /// GBIF-backed upstream for the taxonomy resolver. Owned here so the
+    /// reqwest connection pool is reused across identification ingests.
+    taxonomy_upstream: GbifUpstream,
 }
 
 impl Database {
@@ -90,6 +95,7 @@ impl Database {
         Ok(Self {
             pool,
             media_resolver: MediaResolver::new(),
+            taxonomy_upstream: GbifUpstream::default(),
         })
     }
 
@@ -145,7 +151,7 @@ impl Database {
 
         let record_json = require_record!(commit, "identification");
 
-        let params = process_or_warn!(
+        let mut params = process_or_warn!(
             commit,
             identification_from_json,
             "identification",
@@ -155,6 +161,34 @@ impl Database {
             commit.did.clone(),
             commit.time,
         );
+
+        // Resolve the consensus taxon key by name + kingdom hint, populating
+        // the local `taxa` cache as a side effect. A failed resolve is
+        // logged and ignored — the identification still ingests with
+        // accepted_taxon_key=NULL, and a later backfill (or a re-resolve
+        // when next observed) can fill it in.
+        let resolver = Resolver::new(&self.pool, &self.taxonomy_upstream);
+        match resolver
+            .resolve_by_name(&params.scientific_name, params.kingdom.as_deref())
+            .await
+        {
+            Ok(Some(row)) => {
+                params.accepted_taxon_key = row.accepted_taxon_key.or(Some(row.taxon_key));
+            }
+            Ok(None) => {
+                debug!(
+                    name = %params.scientific_name,
+                    "Taxonomy upstream returned no match; leaving accepted_taxon_key NULL"
+                );
+            }
+            Err(e) => {
+                warn!(
+                    name = %params.scientific_name,
+                    error = %e,
+                    "Taxonomy resolve failed; leaving accepted_taxon_key NULL",
+                );
+            }
+        }
 
         observing_db::identifications::upsert(&self.pool, &params).await?;
         notify_occurrence_owner(

--- a/crates/observing-taxonomy-gbif/Cargo.toml
+++ b/crates/observing-taxonomy-gbif/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "observing-taxonomy-gbif"
+version = "0.1.0"
+edition = "2021"
+description = "GBIF-backed TaxonomyUpstream impl for observing-db's resolver"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+gbif-api = { path = "../gbif-api" }
+observing-db = { path = "../observing-db" }
+chrono = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/observing-taxonomy-gbif/src/lib.rs
+++ b/crates/observing-taxonomy-gbif/src/lib.rs
@@ -1,7 +1,3 @@
-// Wired into the request path in a follow-up branch; for now everything
-// here is constructed only by the unit tests below.
-#![allow(dead_code)]
-
 //! [`TaxonomyUpstream`] implementation backed by the live GBIF v2 API.
 //!
 //! Maps a single `match_name` (or species lookup) response into the


### PR DESCRIPTION
## Summary

Stacked on #444. Wires the resolver into the firehose path and adds the one-shot backfill binary.

- **Extract \`observing-taxonomy-gbif\` crate** — lifts the GBIF upstream out of \`observing-appview\` so the ingester can use it without pulling in the appview's HTTP/auth surface.
- **Plumb \`accepted_taxon_key\`** through \`UpsertIdentificationParams\` and \`identifications::upsert\`. The upsert switches from \`query!\` macro to dynamic SQL so the new column doesn't require regenerating the offline sqlx-prepare cache.
- **Ingester wiring** — \`upsert_identification\` calls \`Resolver::resolve_by_name\` before writing the row, populating the local \`taxa\` cache as a side effect and stamping the resolved key onto the identification. Resolver failures are logged + skipped; the row still ingests with \`accepted_taxon_key = NULL\`.
- **\`resolve_taxa\` binary** — one-shot backfill for legacy identifications: walks distinct \`(scientific_name, kingdom)\` pairs whose key is NULL, resolves each, batch-updates every match, refreshes \`community_ids\` once at the end.

## Heads-up

1. **Synchronous GBIF call in the firehose path.** Every new identification waits for a GBIF lookup on cache miss; cache hits stay purely DB. Failure mode is graceful (log + skip, NULL key, backfillable later) but if GBIF is slow ingest latency follows. Easy to add a timeout wrapper if needed.

2. **Run \`resolve_taxa\` before the next branch lands.** When \`community_ids\` is rebuilt to join on \`accepted_taxon_key\` (the branch that actually closes #440 and #426), legacy identifications with NULL would silently drop out of every taxon-page and explore filter. Deploy order:
   - Land schema/query changes (next branch)
   - Run \`cargo run --bin resolve_taxa\` against prod (rate-limited; estimate < an hour for a fresh project)
   - Bug fixes go live

3. **First real DB exercise.** Dynamic-SQL changes in \`identifications::upsert\` and the backfill binary haven't been validated against a live Postgres in this session.

## Test plan
- [x] \`cargo check --workspace\` clean
- [x] \`cargo clippy --workspace --tests -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] All workspace tests pass (resolver + GBIF adapter unit tests carry through)
- [ ] \`cargo run -p observing-ingester --bin resolve_taxa -- --dry-run\` against a real DB
- [ ] Real run against staging: confirm \`taxa\` rows get populated, \`identifications.accepted_taxon_key\` filled
- [ ] Submit a fresh identification on staging, watch ingester logs for resolve success
- [ ] Simulate GBIF outage (drop egress to api.gbif.org): identification still ingests, key NULL, no crash

Steps toward #440 and #426.