### PR TITLE
refactor(ingester): decouple taxon resolution from identification ingest

### DIFF
--- a/crates/observing-ingester/src/bin/resolve_taxa.rs
+++ b/crates/observing-ingester/src/bin/resolve_taxa.rs
@@ -1,18 +1,28 @@
-//! One-shot resolver-cache backfill.
+//! Background resolver-cache worker.
 //!
 //! Walks every distinct `(scientific_name, kingdom)` pair from
 //! `identifications` whose `accepted_taxon_key` is still NULL, runs each
 //! through the taxonomy resolver (populating the local `taxa` cache as a
 //! side effect), and stamps every identification matching that pair with
-//! the resolved key. Refreshes the `community_ids` materialized view once
-//! at the end so downstream filters pick up the new keys.
+//! the resolved key. Refreshes the `community_ids` materialized view at
+//! the end of each pass so downstream filters pick up the new keys.
 //!
-//! Run before the `community_ids`-rebuild migration that uses
-//! `accepted_taxon_key`. Without this, every legacy identification would
-//! drop out of the join.
+//! Two modes:
+//!
+//! - **One-shot** (default): exits after a single pass. Use this from
+//!   Cloud Run Jobs / Cloud Scheduler for periodic runs, or for an
+//!   on-demand backfill.
+//! - **Loop** (with `--interval-secs N`): runs a pass, sleeps `N`
+//!   seconds, repeats. Use this from a long-lived sidecar / for local
+//!   development.
+//!
+//! Identification ingest writes `accepted_taxon_key = NULL`; this worker
+//! is the only path that fills it in. Higher-rank filters (taxon-page,
+//! explore by kingdom) lag new ingests by up to one pass interval.
 //!
 //! Usage:
 //!   cargo run --bin resolve_taxa
+//!   cargo run --bin resolve_taxa -- --interval-secs 300
 //!   cargo run --bin resolve_taxa -- --rate-limit-ms 200 --limit 1000
 
 use std::time::Duration;
@@ -21,11 +31,11 @@ use clap::Parser;
 use observing_db::taxonomy_resolver::Resolver;
 use observing_taxonomy_gbif::GbifUpstream;
 use sqlx::postgres::PgPoolOptions;
-use sqlx::Row;
+use sqlx::{PgPool, Row};
 use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
-#[derive(Parser)]
+#[derive(Parser, Clone)]
 #[command(about = "Resolve and cache taxonomy for already-ingested identifications")]
 struct Cli {
     /// Optional pause between GBIF lookups (defaults to 100ms to be polite).
@@ -33,13 +43,18 @@ struct Cli {
     rate_limit_ms: u64,
 
     /// Cap on the number of distinct (name, kingdom) pairs processed in
-    /// this run. Useful for incremental progress against a large backlog.
+    /// one pass. Useful for incremental progress against a large backlog.
     #[arg(long)]
     limit: Option<i64>,
 
     /// Print what would be resolved without calling GBIF or writing.
     #[arg(long)]
     dry_run: bool,
+
+    /// Run continuously: after each pass, sleep this many seconds and
+    /// start another. Without this flag, exit after one pass.
+    #[arg(long)]
+    interval_secs: Option<u64>,
 }
 
 #[tokio::main]
@@ -74,6 +89,42 @@ async fn main() -> std::process::ExitCode {
         }
     };
 
+    let upstream = GbifUpstream::default();
+    let resolver = Resolver::new(&pool, &upstream);
+
+    loop {
+        match run_pass(&pool, &resolver, &cli).await {
+            Ok(PassOutcome::DryRunDone) => return std::process::ExitCode::SUCCESS,
+            Ok(PassOutcome::Done) => {}
+            Err(code) => return code,
+        }
+
+        let Some(interval) = cli.interval_secs else {
+            return std::process::ExitCode::SUCCESS;
+        };
+        info!(
+            seconds = interval,
+            "Pass complete; sleeping until next pass"
+        );
+        tokio::time::sleep(Duration::from_secs(interval)).await;
+    }
+}
+
+enum PassOutcome {
+    Done,
+    DryRunDone,
+}
+
+/// Run one resolution pass: enumerate unresolved pairs, resolve each,
+/// stamp matching identifications, refresh the matview.
+async fn run_pass<U>(
+    pool: &PgPool,
+    resolver: &Resolver<'_, PgPool, U>,
+    cli: &Cli,
+) -> Result<PassOutcome, std::process::ExitCode>
+where
+    U: observing_db::taxonomy_resolver::TaxonomyUpstream,
+{
     // Distinct (name, kingdom) pairs that still need a key. Pulled in one
     // shot — if the backlog ever grows beyond what fits in memory, switch
     // to keyset pagination over the same set.
@@ -87,7 +138,7 @@ async fn main() -> std::process::ExitCode {
     if let Some(limit) = cli.limit {
         q.push_str(&format!(" LIMIT {limit}"));
     }
-    let pairs = match sqlx::query(&q).fetch_all(&pool).await {
+    let pairs: Vec<(String, Option<String>)> = match sqlx::query(&q).fetch_all(pool).await {
         Ok(rows) => rows
             .into_iter()
             .map(|r| {
@@ -95,10 +146,10 @@ async fn main() -> std::process::ExitCode {
                 let kingdom: Option<String> = r.try_get("kingdom").ok();
                 (name, kingdom)
             })
-            .collect::<Vec<_>>(),
+            .collect(),
         Err(e) => {
             error!(error = %e, "Failed to enumerate identifications needing resolution");
-            return std::process::ExitCode::from(1);
+            return Err(std::process::ExitCode::from(1));
         }
     };
 
@@ -106,15 +157,17 @@ async fn main() -> std::process::ExitCode {
         pairs = pairs.len(),
         "Discovered (name, kingdom) pairs to resolve"
     );
+
+    if pairs.is_empty() {
+        return Ok(PassOutcome::Done);
+    }
+
     if cli.dry_run {
         for (name, kingdom) in &pairs {
             info!(name = %name, kingdom = ?kingdom, "Would resolve");
         }
-        return std::process::ExitCode::SUCCESS;
+        return Ok(PassOutcome::DryRunDone);
     }
-
-    let upstream = GbifUpstream::default();
-    let resolver = Resolver::new(&pool, &upstream);
 
     let mut resolved = 0u64;
     let mut not_found = 0u64;
@@ -129,17 +182,13 @@ async fn main() -> std::process::ExitCode {
             }
             Ok(None) => {
                 not_found += 1;
-                if cli.rate_limit_ms > 0 {
-                    tokio::time::sleep(Duration::from_millis(cli.rate_limit_ms)).await;
-                }
+                rate_limit(cli).await;
                 continue;
             }
             Err(e) => {
                 errors += 1;
                 warn!(name = %name, kingdom = ?kingdom, error = %e, "Resolve failed");
-                if cli.rate_limit_ms > 0 {
-                    tokio::time::sleep(Duration::from_millis(cli.rate_limit_ms)).await;
-                }
+                rate_limit(cli).await;
                 continue;
             }
         };
@@ -156,7 +205,7 @@ async fn main() -> std::process::ExitCode {
             .bind(key)
             .bind(name)
             .bind(kingdom.as_deref())
-            .execute(&pool)
+            .execute(pool)
             .await
         {
             Ok(res) => updated_rows += res.rows_affected(),
@@ -176,9 +225,7 @@ async fn main() -> std::process::ExitCode {
                 "Progress",
             );
         }
-        if cli.rate_limit_ms > 0 {
-            tokio::time::sleep(Duration::from_millis(cli.rate_limit_ms)).await;
-        }
+        rate_limit(cli).await;
     }
 
     info!(
@@ -186,11 +233,16 @@ async fn main() -> std::process::ExitCode {
         not_found, errors, updated_rows, "Resolution pass complete; refreshing community_ids"
     );
 
-    if let Err(e) = observing_db::identifications::refresh_community_ids(&pool).await {
+    if let Err(e) = observing_db::identifications::refresh_community_ids(pool).await {
         error!(error = %e, "Failed to refresh community_ids matview");
-        return std::process::ExitCode::from(1);
+        return Err(std::process::ExitCode::from(1));
     }
 
-    info!("Done");
-    std::process::ExitCode::SUCCESS
+    Ok(PassOutcome::Done)
+}
+
+async fn rate_limit(cli: &Cli) {
+    if cli.rate_limit_ms > 0 {
+        tokio::time::sleep(Duration::from_millis(cli.rate_limit_ms)).await;
+    }
 }

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -7,8 +7,6 @@ use crate::error::Result;
 use crate::media_resolver::MediaResolver;
 use jetstream_client::CommitInfo;
 use observing_db::processing;
-use observing_db::taxonomy_resolver::Resolver;
-use observing_taxonomy_gbif::GbifUpstream;
 use sqlx::postgres::{PgPool, PgPoolOptions};
 use tracing::{debug, info, warn};
 
@@ -76,9 +74,6 @@ macro_rules! process_or_warn {
 pub struct Database {
     pool: PgPool,
     media_resolver: MediaResolver,
-    /// GBIF-backed upstream for the taxonomy resolver. Owned here so the
-    /// reqwest connection pool is reused across identification ingests.
-    taxonomy_upstream: GbifUpstream,
 }
 
 impl Database {
@@ -95,7 +90,6 @@ impl Database {
         Ok(Self {
             pool,
             media_resolver: MediaResolver::new(),
-            taxonomy_upstream: GbifUpstream::default(),
         })
     }
 
@@ -145,13 +139,18 @@ impl Database {
         Ok(())
     }
 
-    /// Upsert an identification record
+    /// Upsert an identification record.
+    ///
+    /// Identifications are written with `accepted_taxon_key = NULL`. The
+    /// `resolve_taxa` background job picks up unresolved rows on its next
+    /// pass and stamps them — keeping ingest decoupled from GBIF
+    /// availability and ingest latency independent of the upstream's.
     pub async fn upsert_identification(&self, commit: &CommitInfo) -> Result<()> {
         debug!("Upserting identification: {}", commit.uri);
 
         let record_json = require_record!(commit, "identification");
 
-        let mut params = process_or_warn!(
+        let params = process_or_warn!(
             commit,
             identification_from_json,
             "identification",
@@ -161,34 +160,6 @@ impl Database {
             commit.did.clone(),
             commit.time,
         );
-
-        // Resolve the consensus taxon key by name + kingdom hint, populating
-        // the local `taxa` cache as a side effect. A failed resolve is
-        // logged and ignored — the identification still ingests with
-        // accepted_taxon_key=NULL, and a later backfill (or a re-resolve
-        // when next observed) can fill it in.
-        let resolver = Resolver::new(&self.pool, &self.taxonomy_upstream);
-        match resolver
-            .resolve_by_name(&params.scientific_name, params.kingdom.as_deref())
-            .await
-        {
-            Ok(Some(row)) => {
-                params.accepted_taxon_key = row.accepted_taxon_key.or(Some(row.taxon_key));
-            }
-            Ok(None) => {
-                debug!(
-                    name = %params.scientific_name,
-                    "Taxonomy upstream returned no match; leaving accepted_taxon_key NULL"
-                );
-            }
-            Err(e) => {
-                warn!(
-                    name = %params.scientific_name,
-                    error = %e,
-                    "Taxonomy resolve failed; leaving accepted_taxon_key NULL",
-                );
-            }
-        }
 
         observing_db::identifications::upsert(&self.pool, &params).await?;
         notify_occurrence_owner(


### PR DESCRIPTION
## Summary

Reverses the synchronous-resolver hook added in #445 in favor of letting the existing \`resolve_taxa\` binary be the only call site. Adds an \`--interval-secs\` flag so the same binary serves as either a one-shot (Cloud Run Job + Cloud Scheduler) or a long-lived sidecar.

## Why

The hook in #445 made identification ingest wait on a synchronous GBIF lookup. That coupling wasn't load-bearing for #440 / #426 — those bugs need every identification to *eventually* have an \`accepted_taxon_key\`, not synchronously. Decoupling means:

- Ingest stays offline-fast and independent of GBIF availability.
- Higher-rank filters (taxon-page, explore by kingdom) lag new ingests by at most one pass interval — the same staleness profile as the \`community_ids\` matview refresh, which we already accept.
- One service to operate (the worker), one knob to tune (\`--interval-secs\`).

## What changed

- \`upsert_identification\` no longer calls the resolver. Identifications write \`accepted_taxon_key = NULL\` and the worker fills it in later.
- \`resolve_taxa\` gains \`--interval-secs N\`: after each pass, sleep N seconds and run again. Without the flag, the binary still exits after one pass (existing one-shot behavior is unchanged).
- Empty-pass case: when there's nothing unresolved, the pass is a no-op (no matview refresh).

## Deployment notes

- Schedule \`resolve_taxa\` to run every few minutes — Cloud Scheduler invoking the existing Cloud Run Job, or a long-running sidecar with \`--interval-secs 300\`.
- New ingests are invisible to higher-rank filters until the next pass. Tune the interval to taste.
- Still required before the \`community_ids\` rebuild (the branch that closes #440 and #426): without a populated cache, legacy IDs would drop out of the join.

## Test plan
- [x] \`cargo check --workspace\` clean
- [x] \`cargo clippy --workspace --tests -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] \`cargo test --workspace\` — all suites pass
- [ ] Run \`cargo run --bin resolve_taxa -- --interval-secs 60\` locally; confirm second pass runs after the first finishes
- [ ] Run \`cargo run --bin resolve_taxa\` (one-shot) against staging; confirm \`taxa\` rows populate and identifications get stamped
- [ ] Submit a fresh identification on staging; confirm the next worker pass picks it up