### PR TITLE
fix(taxa): filter occurrences via consensus taxon ancestry

### DIFF
--- a/crates/observing-db/migrations/20260506000000_community_ids_via_taxa.sql
+++ b/crates/observing-db/migrations/20260506000000_community_ids_via_taxa.sql
@@ -1,0 +1,66 @@
+-- Rebuild `community_ids` to expose the consensus identification's
+-- `accepted_taxon_key`, and reduce it to one row per occurrence (the winner).
+--
+-- Why: filters like `/explore?kingdom=Plantae` and `/taxon/Plantae/...`
+-- need to match against the *consensus* taxon's full Linnaean ancestry,
+-- not whatever the submitter typed into their occurrence record. Joining
+-- `community_ids` → `taxa` on `accepted_taxon_key` gives us the canonical
+-- ranks (kingdom, phylum, …, species) and disambiguates synonyms.
+--
+-- Shape change: previously one row per (occurrence, taxon-vote-group).
+-- Now one row per occurrence — the highest-vote group wins, ties broken
+-- by `subject_uri` for determinism. Existing consumers that already used
+-- `DISTINCT ON (occurrence_uri) … ORDER BY id_count DESC` keep working;
+-- the new shape just makes that ordering implicit.
+--
+-- Deployment order: requires `accepted_taxon_key` to be populated on
+-- existing identifications first (run `cargo run --bin resolve_taxa`
+-- before applying this), or kingdom/rank filters return empty during the
+-- gap.
+
+DROP MATERIALIZED VIEW IF EXISTS ingester.community_ids;
+
+CREATE MATERIALIZED VIEW ingester.community_ids AS
+WITH latest_ids AS (
+    SELECT DISTINCT ON (did, subject_uri)
+        subject_uri, scientific_name, kingdom, accepted_taxon_key
+    FROM ingester.identifications
+    ORDER BY did, subject_uri, date_identified DESC
+),
+votes AS (
+    SELECT
+        subject_uri,
+        scientific_name,
+        kingdom,
+        accepted_taxon_key,
+        COUNT(*) AS id_count
+    FROM latest_ids
+    GROUP BY subject_uri, scientific_name, kingdom, accepted_taxon_key
+)
+SELECT DISTINCT ON (o.uri)
+    o.uri AS occurrence_uri,
+    v.scientific_name,
+    v.kingdom,
+    v.accepted_taxon_key,
+    v.id_count
+FROM ingester.occurrences o
+JOIN votes v ON v.subject_uri = o.uri
+ORDER BY o.uri, v.id_count DESC, v.scientific_name;
+
+CREATE UNIQUE INDEX community_ids_occurrence_uri_idx
+    ON ingester.community_ids (occurrence_uri);
+
+-- Speeds the JOIN to `taxa` for filter queries (kingdom=Plantae etc.).
+CREATE INDEX community_ids_accepted_taxon_key_idx
+    ON ingester.community_ids (accepted_taxon_key)
+    WHERE accepted_taxon_key IS NOT NULL;
+
+-- The runtime role refreshes this view; CREATE leaves it owned by whoever
+-- ran the migration, which on prod is not `ingester_runtime`. Mirror the
+-- guard from 20260428000001_grant_runtime_roles.sql so REFRESH continues
+-- to work without manual intervention.
+DO $$ BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_runtime') THEN
+        EXECUTE 'ALTER MATERIALIZED VIEW ingester.community_ids OWNER TO ingester_runtime';
+    END IF;
+END $$;

--- a/crates/observing-db/src/admin.rs
+++ b/crates/observing-db/src/admin.rs
@@ -265,6 +265,7 @@ pub const KNOWN_TABLES: &[KnownTable] = &[
             ("occurrence_uri", "occurrence_uri"),
             ("scientific_name", "scientific_name"),
             ("kingdom", "kingdom"),
+            ("accepted_taxon_key", "accepted_taxon_key"),
             ("id_count", "id_count"),
         ],
         order_by: "occurrence_uri",

--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -28,9 +28,13 @@ pub async fn get_explore_feed(
         qb.push_bind(format!("{taxon}%"));
     }
 
+    // Filter by the consensus taxon's kingdom (via community_ids → taxa)
+    // rather than the submitter's `occurrences.kingdom`. Submitters often
+    // skip ancestry columns, so the old direct filter dropped legitimate
+    // observations whose community ID resolves under the requested kingdom.
     if let Some(kingdom) = options.kingdom.as_deref() {
-        qb.push(" AND kingdom = ");
-        qb.push_bind(kingdom);
+        qb.push(" AND ");
+        push_consensus_rank_filter(&mut qb, "kingdom", kingdom);
     }
 
     if let Some(start_date) = options.start_date.as_deref() {
@@ -249,7 +253,7 @@ pub async fn get_occurrences_by_taxon(
         " FROM occurrences WHERE "
     ));
 
-    push_taxon_filter(&mut qb, &rank_lower, taxon_name);
+    push_consensus_rank_filter(&mut qb, &rank_lower, taxon_name);
 
     if !hidden_dids.is_empty() {
         qb.push(" AND did != ALL(");
@@ -259,8 +263,8 @@ pub async fn get_occurrences_by_taxon(
 
     if let Some(kingdom) = options.kingdom.as_deref() {
         if rank_lower != "kingdom" {
-            qb.push(" AND kingdom = ");
-            qb.push_bind(kingdom);
+            qb.push(" AND ");
+            push_consensus_rank_filter(&mut qb, "kingdom", kingdom);
         }
     }
 
@@ -289,12 +293,12 @@ pub async fn count_occurrences_by_taxon(
 
     let mut qb = QueryBuilder::<Postgres>::new("SELECT COUNT(*) FROM occurrences WHERE ");
 
-    push_taxon_filter(&mut qb, &rank_lower, taxon_name);
+    push_consensus_rank_filter(&mut qb, &rank_lower, taxon_name);
 
     if let Some(kingdom) = kingdom {
         if rank_lower != "kingdom" {
-            qb.push(" AND kingdom = ");
-            qb.push_bind(kingdom);
+            qb.push(" AND ");
+            push_consensus_rank_filter(&mut qb, "kingdom", kingdom);
         }
     }
 
@@ -302,47 +306,32 @@ pub async fn count_occurrences_by_taxon(
     Ok(count)
 }
 
-/// Push the appropriate taxon filter condition onto a query builder
-fn push_taxon_filter<'a>(
+/// Restrict the outer occurrences query to rows whose consensus
+/// identification places them at `taxon_name` for the given rank.
+///
+/// Uses `community_ids` (one row per occurrence, the winning vote) joined
+/// to `taxa` so the rank columns reflect the canonical Linnaean ancestry,
+/// not whatever the submitter typed into their occurrence record.
+/// Submitters routinely leave higher-rank columns blank, so filtering on
+/// `occurrences.kingdom` directly drops legitimate observations.
+fn push_consensus_rank_filter<'a>(
     qb: &mut QueryBuilder<'a, Postgres>,
     rank_lower: &str,
     taxon_name: &'a str,
 ) {
-    match rank_lower {
-        "species" | "subspecies" | "variety" => {
-            qb.push("scientific_name = ");
-            qb.push_bind(taxon_name);
-        }
-        "genus" => {
-            qb.push("(genus = ");
-            qb.push_bind(taxon_name);
-            qb.push(" OR scientific_name ILIKE ");
-            qb.push_bind(format!("{taxon_name} %"));
-            qb.push(")");
-        }
-        "family" => {
-            qb.push("family = ");
-            qb.push_bind(taxon_name);
-        }
-        "order" => {
-            qb.push(r#""order" = "#);
-            qb.push_bind(taxon_name);
-        }
-        "class" => {
-            qb.push("class = ");
-            qb.push_bind(taxon_name);
-        }
-        "phylum" => {
-            qb.push("phylum = ");
-            qb.push_bind(taxon_name);
-        }
-        "kingdom" => {
-            qb.push("kingdom = ");
-            qb.push_bind(taxon_name);
-        }
-        _ => {
-            qb.push("scientific_name = ");
-            qb.push_bind(taxon_name);
-        }
-    }
+    let column = match rank_lower {
+        "species" | "subspecies" | "variety" => "t.species",
+        "genus" => "t.genus",
+        "family" => "t.family",
+        "order" => "t.\"order\"",
+        "class" => "t.class",
+        "phylum" => "t.phylum",
+        "kingdom" => "t.kingdom",
+        _ => "t.scientific_name",
+    };
+    qb.push("uri IN (SELECT ci.occurrence_uri FROM community_ids ci JOIN taxa t ON t.taxon_key = ci.accepted_taxon_key WHERE ");
+    qb.push(column);
+    qb.push(" = ");
+    qb.push_bind(taxon_name);
+    qb.push(")");
 }

--- a/crates/observing-db/src/taxa.rs
+++ b/crates/observing-db/src/taxa.rs
@@ -90,6 +90,12 @@ pub async fn get_by_name(
 /// Insert or refresh a batch of taxa rows. Conflicting `taxon_key` rows are
 /// updated in place so concurrent resolves of the same name are safe and a
 /// re-fetch overwrites stale ancestry data.
+///
+/// Dedupes the input by `taxon_key` (last entry wins) before issuing the
+/// INSERT. Postgres rejects `ON CONFLICT DO UPDATE` when the same target
+/// row appears twice in the values list, and GBIF's match payload often
+/// includes the target taxon as both the `usage` and the tail of the
+/// `classification` chain.
 pub async fn upsert_many(
     executor: impl sqlx::PgExecutor<'_>,
     rows: &[TaxonRow],
@@ -97,6 +103,13 @@ pub async fn upsert_many(
     if rows.is_empty() {
         return Ok(());
     }
+
+    let mut by_key: std::collections::HashMap<i64, &TaxonRow> =
+        std::collections::HashMap::with_capacity(rows.len());
+    for row in rows {
+        by_key.insert(row.taxon_key, row);
+    }
+    let deduped: Vec<&TaxonRow> = by_key.into_values().collect();
 
     let mut qb = QueryBuilder::<Postgres>::new(
         r#"INSERT INTO taxa (
@@ -108,7 +121,7 @@ pub async fn upsert_many(
             vernacular_name, extinct, fetched_at, source
         ) "#,
     );
-    qb.push_values(rows, |mut b, row| {
+    qb.push_values(&deduped, |mut b, row| {
         b.push_bind(row.taxon_key)
             .push_bind(&row.scientific_name)
             .push_bind(&row.authorship)


### PR DESCRIPTION
## Summary

Closes #426 and #440. Routes taxon-rank filters through the consensus identification's resolved taxon instead of the submitter's denormalized columns on `occurrences`.

- New migration rebuilds the `community_ids` matview to expose `accepted_taxon_key` and reduces it to one row per occurrence (the winning vote).
- `feeds.rs` filter helpers (`get_explore_feed` kingdom filter; `get_occurrences_by_taxon` and `count_occurrences_by_taxon` rank filters) now subquery `community_ids → taxa` so kingdom/phylum/…/species filters match canonical Linnaean ancestry.
- `admin.rs` known-table list updated for the new column.

## Why this fixes the bugs

`/explore?kingdom=Plantae` and `/taxon/Plantae/Ficaria-verna` were filtering against `occurrences.kingdom` / `occurrences.genus`, which submitters routinely leave blank. The community ID always has a resolved `accepted_taxon_key` (after the resolver runs), and joining to `taxa` exposes its full ancestry — so a Ficaria verna observation with `kingdom=NULL` on the occurrence row now matches `kingdom=Plantae` because the consensus taxon's `t.kingdom = 'Plantae'`.

## Deployment order

Requires `cargo run --bin resolve_taxa` to have populated `accepted_taxon_key` on existing identifications before this migration applies in prod. Otherwise filter pages return empty during the gap. Stacked on top of #446 (resolve-taxa background worker).

## Test plan

- [x] `cargo check --workspace`
- [x] `cargo test --workspace`
- [x] `cargo clippy --workspace --tests -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [ ] Verify `/explore?kingdom=Plantae` returns plant observations after migration + resolve_taxa run
- [ ] Verify `/taxon/Plantae/Ficaria-verna` shows recent observations
- [ ] Verify higher-rank pages (e.g. `/taxon/Family/Ranunculaceae`) populate