### PR TITLE
test(api): cover validateTaxon wrapper

### DIFF
--- a/frontend/src/services/api.test.ts
+++ b/frontend/src/services/api.test.ts
@@ -371,6 +371,95 @@ describe("api", () => {
     });
   });
 
+  describe("validateTaxon", () => {
+    it("returns the validate response when the name resolves", async () => {
+      const mockResponse = {
+        valid: true,
+        matchedName: "Quercus alba",
+        taxon: { id: 1, name: "Quercus alba" },
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await api.validateTaxon("Quercus alba");
+
+      expect(result).toEqual(mockResponse);
+      expect(mockFetch).toHaveBeenCalledWith("/api/taxa/validate?name=Quercus+alba");
+    });
+
+    it("includes kingdom hint when provided", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      await api.validateTaxon("Pinus", "Plantae");
+
+      expect(mockFetch).toHaveBeenCalledWith("/api/taxa/validate?name=Pinus&kingdom=Plantae");
+    });
+
+    it("omits kingdom param when not provided", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      await api.validateTaxon("Pinus");
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("kingdom");
+    });
+
+    it("omits kingdom param when explicitly empty", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ valid: true }),
+      });
+
+      await api.validateTaxon("Pinus", "");
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).not.toContain("kingdom");
+    });
+
+    it("encodes special characters in the name", async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({ valid: false }),
+      });
+
+      await api.validateTaxon("Genus species & subsp.");
+
+      const calledUrl = mockFetch.mock.calls[0][0] as string;
+      expect(calledUrl).toBe("/api/taxa/validate?name=Genus+species+%26+subsp.");
+    });
+
+    it("returns null on a non-ok response", async () => {
+      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+
+      const result = await api.validateTaxon("Quercus alba");
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the response body even when valid is false", async () => {
+      const mockResponse = {
+        valid: false,
+        suggestions: [{ id: 2, name: "Quercus rubra" }],
+      };
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockResponse),
+      });
+
+      const result = await api.validateTaxon("Quercus albu");
+
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
   describe("submitObservation", () => {
     it("submits occurrence data", async () => {
       mockFetch.mockResolvedValue({


### PR DESCRIPTION
## Summary

- Stacked on top of #434 to add unit tests for the new `validateTaxon` helper in `services/api.ts`.
- 7 cases: URL construction with/without kingdom, kingdom omitted when undefined or empty, special-character encoding in `name`, `null` on non-ok responses, and pass-through of `valid: false` bodies.
- No coverage added for the `UploadModal` `useEffect` rehydration path — that file has no existing component test harness.

## Test plan

- [x] `npx vitest run frontend/src/services/api.test.ts -t "validateTaxon"` — 7 passed