### PR TITLE
feat(docs): add /docs page consolidating reference links

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -23,6 +23,7 @@ import { NotFound } from "./components/common/NotFound";
 import { OfflineBanner } from "./components/common/OfflineBanner";
 import { UpdatePrompt } from "./components/common/UpdatePrompt";
 import { LexiconView } from "./components/lexicon/LexiconView";
+import { DocsPage } from "./components/docs/DocsPage";
 import { NotificationsPage } from "./components/notifications/NotificationsPage";
 import { SettingsPage } from "./components/settings/SettingsPage";
 import { AdminPage } from "./components/admin/AdminPage";
@@ -125,6 +126,7 @@ function AppContent() {
           <Route path="/taxon/:kingdom/:name" element={<TaxonExplorer />} />
           <Route path="/taxon/:id" element={<TaxonExplorer />} />
           <Route path="/lexicons" element={<LexiconView />} />
+          <Route path="/docs" element={<DocsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
           <Route path="/admin" element={<AdminPage />} />
           <Route path="/admin/collections/:nsid" element={<CollectionDetailPage />} />

--- a/frontend/src/components/docs/DocsPage.stories.tsx
+++ b/frontend/src/components/docs/DocsPage.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DocsPage } from "./DocsPage";
+
+const meta = {
+  title: "Docs/DocsPage",
+  component: DocsPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof DocsPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/src/components/docs/DocsPage.tsx
+++ b/frontend/src/components/docs/DocsPage.tsx
@@ -1,0 +1,91 @@
+import { Link as RouterLink } from "react-router-dom";
+import { Box, Container, Typography, Paper, Stack } from "@mui/material";
+import { Schema, AutoStories, GitHub, ChevronRight } from "@mui/icons-material";
+import { usePageTitle } from "../../hooks/usePageTitle";
+
+interface DocLink {
+  label: string;
+  description: string;
+  icon: React.ReactNode;
+  to?: string;
+  href?: string;
+}
+
+const links: DocLink[] = [
+  {
+    label: "Lexicons",
+    description: "AT Protocol record schemas that define how data is stored.",
+    icon: <Schema />,
+    to: "/lexicons",
+  },
+  {
+    label: "Storybook",
+    description: "Interactive component library and UI documentation.",
+    icon: <AutoStories />,
+    href: "https://storybook.observ.ing",
+  },
+  {
+    label: "Source Code",
+    description: "Browse the project on GitHub.",
+    icon: <GitHub />,
+    href: "https://github.com/observ-ing/core",
+  },
+];
+
+export function DocsPage() {
+  usePageTitle("Docs");
+
+  return (
+    <Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
+      <Container maxWidth="sm" sx={{ py: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+          Docs
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>
+          Reference material and resources for Observ.ing.
+        </Typography>
+
+        <Stack spacing={1.5}>
+          {links.map((link) => {
+            const linkProps = link.to
+              ? { component: RouterLink, to: link.to }
+              : {
+                  component: "a" as const,
+                  href: link.href,
+                  target: "_blank",
+                  rel: "noopener noreferrer",
+                };
+            return (
+              <Paper
+                key={link.label}
+                variant="outlined"
+                {...linkProps}
+                sx={{
+                  p: 2,
+                  borderRadius: 2,
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 2,
+                  textDecoration: "none",
+                  color: "text.primary",
+                  "&:hover": { bgcolor: "action.hover", borderColor: "primary.main" },
+                }}
+              >
+                <Box sx={{ color: "primary.main", display: "flex" }}>{link.icon}</Box>
+                <Box sx={{ flex: 1, minWidth: 0 }}>
+                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                    {link.label}
+                  </Typography>
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                    {link.description}
+                  </Typography>
+                </Box>
+                <ChevronRight sx={{ color: "text.secondary" }} />
+              </Paper>
+            );
+          })}
+        </Stack>
+      </Container>
+    </Box>
+  );
+}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Divider,
   Typography,
 } from "@mui/material";
-import { Login, Logout, GitHub, Schema } from "@mui/icons-material";
+import { Login, Logout, MenuBook } from "@mui/icons-material";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
@@ -105,28 +105,14 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
           <ListItem disablePadding>
             <ListItemButton
               component={Link}
-              to="/lexicons"
+              to="/docs"
               onClick={onMobileClose}
               sx={{ borderRadius: 2 }}
             >
               <ListItemIcon sx={{ minWidth: 40 }}>
-                <Schema fontSize="small" />
+                <MenuBook fontSize="small" />
               </ListItemIcon>
-              <ListItemText primary="Lexicons" />
-            </ListItemButton>
-          </ListItem>
-          <ListItem disablePadding>
-            <ListItemButton
-              component="a"
-              href="https://github.com/observ-ing/core"
-              target="_blank"
-              rel="noopener noreferrer"
-              sx={{ borderRadius: 2 }}
-            >
-              <ListItemIcon sx={{ minWidth: 40 }}>
-                <GitHub fontSize="small" />
-              </ListItemIcon>
-              <ListItemText primary="Source Code" />
+              <ListItemText primary="Docs" />
             </ListItemButton>
           </ListItem>
         </List>

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -20,15 +20,7 @@ import {
   Divider,
   alpha,
 } from "@mui/material";
-import {
-  Person,
-  Login,
-  Logout,
-  GitHub,
-  Schema,
-  Settings,
-  Menu as MenuIcon,
-} from "@mui/icons-material";
+import { Person, Login, Logout, MenuBook, Settings, Menu as MenuIcon } from "@mui/icons-material";
 import { getDisplayName } from "../../lib/utils";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
@@ -151,24 +143,11 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
 
           <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 0.5, md: 1.5 } }}>
             {!isMobile && (
-              <>
-                <Tooltip title="Lexicons">
-                  <IconButton component={Link} to="/lexicons" color="inherit">
-                    <Schema />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="Source Code">
-                  <IconButton
-                    component="a"
-                    href="https://github.com/observ-ing/core"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    color="inherit"
-                  >
-                    <GitHub />
-                  </IconButton>
-                </Tooltip>
-              </>
+              <Tooltip title="Docs">
+                <IconButton component={Link} to="/docs" color="inherit">
+                  <MenuBook />
+                </IconButton>
+              </Tooltip>
             )}
 
             {notificationItem && (


### PR DESCRIPTION
## Summary
- New `/docs` page with cards linking to Lexicons, Storybook (`https://storybook.observ.ing`), and the GitHub repo
- Replaced the Lexicons + Source Code icon buttons in `TopBar` with a single Docs link (`MenuBook` icon)
- Replaced the Lexicons + Source Code rows in the `Sidebar` bottom section with a single Docs row

## Test plan
- [ ] `npm run build` succeeds
- [ ] Navbar shows the Docs icon (desktop) and Docs entry (mobile sidebar)
- [ ] `/docs` renders three working links — Lexicons (internal route), Storybook (new tab), GitHub (new tab)