### PR TITLE
chore(deps): switch gbif-api git pin to crates.io `gbif` 0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1471,9 +1471,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "gbif-api"
+name = "gbif"
 version = "0.1.0"
-source = "git+https://github.com/observ-ing/rust-gbif.git?rev=f5e1008ed83f917260d0a81e10f4760348852f6b#f5e1008ed83f917260d0a81e10f4760348852f6b"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01cdd058b7ba599b2fa16d97ab5877d6e52f81fe04b832851dc94a111ffce6cc"
 dependencies = [
  "base64",
  "bytes",
@@ -2863,7 +2864,7 @@ dependencies = [
  "chrono",
  "file-blob-cache",
  "futures",
- "gbif-api",
+ "gbif",
  "hickory-resolver",
  "jacquard-common",
  "moka",
@@ -2988,7 +2989,7 @@ name = "observing-taxonomy-gbif"
 version = "0.1.0"
 dependencies = [
  "chrono",
- "gbif-api",
+ "gbif",
  "observing-db",
  "reqwest 0.13.3",
  "serde",

--- a/crates/observing-appview/Cargo.toml
+++ b/crates/observing-appview/Cargo.toml
@@ -13,7 +13,7 @@ nominatim-client = { path = "../nominatim-client" }
 observing-lexicons = { path = "../observing-lexicons" }
 at-uri-parser = { path = "../at-uri-parser" }
 # Taxonomy resolver (formerly observing-taxonomy)
-gbif-api = { git = "https://github.com/observ-ing/rust-gbif.git", rev = "f5e1008ed83f917260d0a81e10f4760348852f6b" }
+gbif = "0.1"
 wikidata-client = { path = "../wikidata-client" }
 # Media cache (formerly observing-media-proxy)
 atproto-blob-resolver = { path = "../atproto-blob-resolver" }

--- a/crates/observing-appview/src/taxonomy/gbif.rs
+++ b/crates/observing-appview/src/taxonomy/gbif.rs
@@ -1,6 +1,6 @@
 //! GBIF-based taxonomy client with caching.
 //!
-//! Wraps the generated `gbif_api::checklistbank::Client` (from rust-gbif) with
+//! Wraps the generated `gbif::checklistbank::Client` (from rust-gbif) with
 //! an appview-shaped facade: 404→`Ok(None)`, an [`IucnCategory`] enum + parser,
 //! a [`GbifError`] alias for the generated progenitor error, conversion to the
 //! TS-bound [`TaxonResult`]/[`TaxonDetail`] shapes, and a moka cache.
@@ -10,14 +10,14 @@ use crate::taxonomy_client::{
     ConservationStatus, TaxonAncestor, TaxonDescription, TaxonDetail, TaxonMedia, TaxonReference,
     TaxonResult, ValidateResponse,
 };
-use gbif_api::checklistbank::{
+use gbif::checklistbank::{
     types::{
         DiagnosticsMatchType, NameUsage, NameUsageMatch, NameUsageMediaObject,
         NameUsageSearchResult, RankedName, Status, Usage,
     },
     Client as GbifChecklistbankClient, Error as GbifClientError,
 };
-use gbif_api::Uuid;
+use gbif::Uuid;
 use moka::future::Cache;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::Duration;
@@ -892,7 +892,7 @@ fn pick_vernacular_name(item: &NameUsageSearchResult) -> Option<String> {
     // The serialized form of `VernacularNameLanguage::Eng` is "eng"; we
     // compare via a serde round-trip so we don't depend on the enum's
     // identifier munging.
-    fn lang_str(v: &gbif_api::checklistbank::types::VernacularName) -> Option<String> {
+    fn lang_str(v: &gbif::checklistbank::types::VernacularName) -> Option<String> {
         v.language.as_ref().and_then(rank_to_string)
     }
 

--- a/crates/observing-taxonomy-gbif/Cargo.toml
+++ b/crates/observing-taxonomy-gbif/Cargo.toml
@@ -6,7 +6,7 @@ description = "GBIF-backed TaxonomyUpstream impl for observing-db's resolver"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-gbif-api = { git = "https://github.com/observ-ing/rust-gbif.git", rev = "f5e1008ed83f917260d0a81e10f4760348852f6b" }
+gbif = "0.1"
 observing-db = { path = "../observing-db" }
 chrono = { workspace = true }
 reqwest = { workspace = true }

--- a/crates/observing-taxonomy-gbif/src/lib.rs
+++ b/crates/observing-taxonomy-gbif/src/lib.rs
@@ -13,7 +13,7 @@
 //! response, so wiring this up is a follow-up.
 
 use chrono::Utc;
-use gbif_api::checklistbank::{
+use gbif::checklistbank::{
     types::{NameUsageMatch, RankedName, Usage},
     Client as GbifClient,
 };


### PR DESCRIPTION
Follow-up to #452. The upstream crate was renamed from `gbif-api` to `gbif` and re-published under the new name (https://crates.io/crates/gbif 0.1.0). The previously-published `gbif-api` 0.1.0 was removed from crates.io.

This PR follows along:
- `gbif-api = { git = ... }` → `gbif = "0.1"` in both consumer Cargo.tomls (`observing-appview`, `observing-taxonomy-gbif`)
- All `gbif_api::*` paths → `gbif::*` (4 files)

## Test plan
- [x] `cargo build` — green
- [x] `cargo test -p observing-appview --bins` — 53 passed
- [x] `cargo test -p observing-taxonomy-gbif --lib` — 5 passed
- [x] `cargo fmt --all -- --check` — clean