### PR TITLE
feat(observation): hide lat/lon inputs behind a toggle

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -7,9 +7,13 @@ import {
   Stack,
   InputAdornment,
   Slider,
+  Button,
+  Collapse,
   useTheme,
 } from "@mui/material";
 import SearchIcon from "@mui/icons-material/Search";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { darkMapFilter, mapContainerSx } from "./mapStyle";
@@ -64,6 +68,7 @@ export function LocationPicker({
   const [isSearching, setIsSearching] = useState(false);
   const [latInput, setLatInput] = useState(latitude?.toFixed(6) ?? "");
   const [lngInput, setLngInput] = useState(longitude?.toFixed(6) ?? "");
+  const [showCoordinates, setShowCoordinates] = useState(false);
   const theme = useTheme();
 
   const updateMarker = useCallback(
@@ -302,24 +307,34 @@ export function LocationPicker({
         ref={mapContainer}
         sx={[mapContainerSx, theme.palette.mode === "dark" && darkMapFilter]}
       />
-      <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
-        <TextField
-          size="small"
-          label="Latitude"
-          value={latInput}
-          onChange={(e) => handleLatChange(e.target.value)}
-          slotProps={{ htmlInput: { inputMode: "decimal" } }}
-          sx={{ flex: 1 }}
-        />
-        <TextField
-          size="small"
-          label="Longitude"
-          value={lngInput}
-          onChange={(e) => handleLngChange(e.target.value)}
-          slotProps={{ htmlInput: { inputMode: "decimal" } }}
-          sx={{ flex: 1 }}
-        />
-      </Stack>
+      <Button
+        size="small"
+        onClick={() => setShowCoordinates((v) => !v)}
+        endIcon={showCoordinates ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        sx={{ mt: 1, textTransform: "none", color: "text.secondary" }}
+      >
+        {showCoordinates ? "Hide coordinates" : "Enter coordinates manually"}
+      </Button>
+      <Collapse in={showCoordinates}>
+        <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+          <TextField
+            size="small"
+            label="Latitude"
+            value={latInput}
+            onChange={(e) => handleLatChange(e.target.value)}
+            slotProps={{ htmlInput: { inputMode: "decimal" } }}
+            sx={{ flex: 1 }}
+          />
+          <TextField
+            size="small"
+            label="Longitude"
+            value={lngInput}
+            onChange={(e) => handleLngChange(e.target.value)}
+            slotProps={{ htmlInput: { inputMode: "decimal" } }}
+            sx={{ flex: 1 }}
+          />
+        </Stack>
+      </Collapse>
       <Typography
         variant="caption"
         sx={{
@@ -328,7 +343,7 @@ export function LocationPicker({
           mt: 0.5,
         }}
       >
-        Search, click map, or enter coordinates
+        Search or click the map to set a location
       </Typography>
       {onUncertaintyChange && (
         <Box sx={{ mt: 2 }}>

--- a/tests/auto-identification.spec.ts
+++ b/tests/auto-identification.spec.ts
@@ -1,5 +1,5 @@
 import { test as authTest, expect as authExpect } from "./fixtures/mock-auth";
-import { openUploadModal } from "./helpers/navigation";
+import { openUploadModal, revealCoordinateInputs } from "./helpers/navigation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 import {
   mockOwnObservationFeed,
@@ -72,6 +72,7 @@ authTest.describe("Auto-Identification on Upload", () => {
       await authExpect(option).toBeVisible();
       await option.click();
 
+      await revealCoordinateInputs(page);
       const latInput = page.getByLabel("Latitude");
       await latInput.scrollIntoViewIfNeeded();
       await latInput.fill("37.7749");

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "@playwright/test";
 import { test as authTest, getTestUser } from "./fixtures/auth";
-import { openUploadModal } from "./helpers/navigation";
+import { openUploadModal, revealCoordinateInputs } from "./helpers/navigation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 
 /**
@@ -34,6 +34,7 @@ authTest.describe("E2E CRUD flow", () => {
       await expect(option).toBeVisible();
       await option.click();
 
+      await revealCoordinateInputs(page);
       const latInput = page.getByLabel("Latitude");
       await latInput.scrollIntoViewIfNeeded();
       await latInput.fill("37.7749");
@@ -73,6 +74,7 @@ authTest.describe("E2E CRUD flow", () => {
       // removed from the occurrence schema, and lat/lng are always present
       // on existing records — so this exercises the PUT round-trip without
       // depending on optional fields.
+      await revealCoordinateInputs(page);
       const latInput = page.getByLabel("Latitude");
       await latInput.scrollIntoViewIfNeeded();
       await latInput.fill("37.8000");

--- a/tests/helpers/navigation.ts
+++ b/tests/helpers/navigation.ts
@@ -18,3 +18,14 @@ export async function openUploadModal(page: Page) {
   // Wait for the modal content to actually render instead of a fixed delay
   await page.getByLabel(/Taxon/i).waitFor({ state: "visible", timeout: 10_000 });
 }
+
+/**
+ * Expands the collapsed manual-coordinate inputs in LocationPicker so that
+ * the Latitude/Longitude TextFields become accessible.
+ */
+export async function revealCoordinateInputs(page: Page) {
+  const toggle = page.getByRole("button", { name: "Enter coordinates manually" });
+  await toggle.scrollIntoViewIfNeeded();
+  await toggle.click();
+  await page.getByLabel("Latitude").waitFor({ state: "visible", timeout: 5_000 });
+}

--- a/tests/upload.spec.ts
+++ b/tests/upload.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { test as authTest, expect as authExpect, getTestUser } from "./fixtures/mock-auth";
-import { openUploadModal } from "./helpers/navigation";
+import { openUploadModal, revealCoordinateInputs } from "./helpers/navigation";
 import { mockOwnObservationFeed } from "./helpers/mock-observation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 
@@ -129,6 +129,7 @@ authTest.describe("Upload Modal - Logged In", () => {
     }
 
     // Set location via coordinate inputs
+    await revealCoordinateInputs(page);
     const latInput = page.getByLabel("Latitude");
     await latInput.scrollIntoViewIfNeeded();
     await latInput.fill("37.7749");
@@ -223,6 +224,7 @@ authTest.describe("Upload Modal - Logged In", () => {
         .catch(() => {});
 
       // Set location via coordinate inputs
+      await revealCoordinateInputs(page);
       const latInput = page.getByLabel("Latitude");
       await latInput.scrollIntoViewIfNeeded();
       await latInput.fill("37.7749");


### PR DESCRIPTION
## Summary
- Hides the Latitude/Longitude TextFields in `LocationPicker` behind an "Enter coordinates manually" toggle that expands a `Collapse`.
- Reduces vertical space taken by the new observation modal, since most users set location via search or map click.

Closes #415

## Test plan
- [ ] Open the new observation modal — coordinate fields are hidden by default
- [ ] Click "Enter coordinates manually" — fields expand; values reflect current marker
- [ ] Edit values manually — map marker updates as before
- [ ] Click the map / search a place — marker moves and (when toggle expanded) inputs update