### PR TITLE
chore(deps): bump fast-uri to 3.1.2 (GHSA-q3j6-qgpj-74h6)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6522,9 +6522,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- `fast-uri <= 3.1.0` is flagged by `npm audit` as a high-severity path-traversal vulnerability ([GHSA-q3j6-qgpj-74h6](https://github.com/advisories/GHSA-q3j6-qgpj-74h6)). Currently failing the `frontend-audit` CI job.
- Transitive dep of `ajv`. `npm audit fix` cleanly resolves it to 3.1.2 with only lockfile churn.

## Test plan
- [ ] `frontend-audit` CI job passes
- [ ] All other CI jobs remain green