### PR TITLE
chore(deps): bump @babel/plugin-transform-modules-systemjs (GHSA-fv7c-fp4j-7gwp)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1102,9 +1102,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
## Summary
- New high-severity advisory [GHSA-fv7c-fp4j-7gwp](https://github.com/advisories/GHSA-fv7c-fp4j-7gwp) on `@babel/plugin-transform-modules-systemjs` (7.12.0–7.29.0). Currently failing `frontend-audit` on every PR.
- `npm audit fix` resolves to 7.29.4 with only lockfile churn.

## Test plan
- [ ] `frontend-audit` passes
- [ ] Other CI jobs remain green