### PR TITLE
fix(e2e): use Account menu button as login indicator

### DIFF
--- a/tests/auth.setup.ts
+++ b/tests/auth.setup.ts
@@ -60,8 +60,12 @@ setup("authenticate via Bluesky OAuth", async ({ page }) => {
   // 8. Wait for redirect back to our app
   await page.waitForURL(/127\.0\.0\.1/, { timeout: 30000 });
 
-  // 9. Verify we're authenticated — the sidebar should show the test user
-  await expect(page.getByText(`@${handle}`).first()).toBeVisible({ timeout: 10000 });
+  // 9. Verify we're authenticated — the avatar/menu button is the only
+  // login indicator reliably rendered post-OAuth. `@handle` only appears
+  // inside the (closed) account-menu popover, so checking it here is racy.
+  await expect(page.getByRole("button", { name: "Account menu" })).toBeVisible({
+    timeout: 10000,
+  });
 
   // 10. Fetch user info from /oauth/me
   const userInfo = await page.evaluate(async () => {

--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "@playwright/test";
-import { test as authTest, getTestUser } from "./fixtures/auth";
+import { test as authTest } from "./fixtures/auth";
 import { openUploadModal } from "./helpers/navigation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 
@@ -13,11 +13,15 @@ authTest.describe("E2E CRUD flow", () => {
   let occurrenceUri: string | null = null;
 
   authTest("create, identify, and delete an occurrence", async ({ authenticatedPage: page }) => {
-    const user = getTestUser();
-
-    // Step 1: verify signed in
+    // Step 1: verify signed in. The avatar/menu button is the only login
+    // indicator that's reliably rendered on `/` regardless of feed state —
+    // `@handle` only appears inside the closed account-menu popover or on
+    // observation cards owned by the user, so it disappears whenever the
+    // home feed has none of the test user's observations.
     await page.goto("/");
-    await expect(page.getByText(`@${user.handle}`).first()).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("button", { name: "Account menu" })).toBeVisible({
+      timeout: 10000,
+    });
 
     // Step 2: create occurrence
     await authTest.step("create occurrence", async () => {


### PR DESCRIPTION
## Summary
The post-login assertion in `tests/e2e.spec.ts:20` and `tests/auth.setup.ts:64` was checking for `@\${user.handle}` text on `/`, but since #240 (sidebar → top-bar migration) the handle is only rendered:
- inside the **closed** account-menu popover (not in the DOM until clicked) — `TopBar.tsx:224`
- on the user's own profile page — `ProfileView.tsx:153`
- on observation cards in the home feed, when the user owns visible observations — `FeedItem.tsx:50`

When the test user's home feed renders none of their observations (e.g. when previous runs' cleanup succeeded), the @handle text doesn't exist anywhere visible and the assertion fails. This is the source of the intermittent e2e failures on \`main\` (~10% of recent runs).

## Fix
The avatar button has \`aria-label=\"Account menu\"\` and is rendered unconditionally when \`user\` is truthy (\`TopBar.tsx:172-180\`), so it's a stable login indicator across all routes.

\`\`\`ts
// before
await expect(page.getByText(\`@\${user.handle}\`).first()).toBeVisible({ timeout: 10000 });
// after
await expect(page.getByRole(\"button\", { name: \"Account menu\" })).toBeVisible({ timeout: 10000 });
\`\`\`

## Evidence
Failed run #25587258550 attached the page snapshot at the moment of failure. The DOM contained the Settings link and Account menu button (so the user was logged in), but \`<main>\` was empty (feed not yet populated) — and \`@testobserving.bsky.social\` appeared nowhere in the rendered tree.

## Test plan
- [ ] Re-run e2e on this PR; expect the assertion to pass deterministically.
- [ ] No other tests reference the @handle text post-login, so no other call sites to update.