### PR TITLE
fix(pwa): exclude /admin from service worker navigateFallback

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -17,7 +17,7 @@ export default defineConfig({
       manifest: false,
       workbox: {
         navigateFallback: "/index.html",
-        navigateFallbackDenylist: [/^\/api/, /^\/oauth/, /^\/media/],
+        navigateFallbackDenylist: [/^\/api/, /^\/oauth/, /^\/media/, /^\/admin/],
         globPatterns: ["**/*.{js,css,html,ico,png,svg,webmanifest}"],
         cleanupOutdatedCaches: true,
         // Bumped from default 2 MiB so the current bundle precaches.


### PR DESCRIPTION
## Summary
The PWA service worker's \`navigateFallback: \"/index.html\"\` was intercepting navigations to admin routes and serving the cached SPA shell instead of letting requests through to the appview. Hard refresh worked (bypasses SW) but normal refresh didn't.

The \`navigateFallbackDenylist\` already excludes \`/api\`, \`/oauth\`, \`/media\`. Just adding \`/admin\` alongside them.

## Why this matters now
Without this, the new \`/admin/browse\` HTML page (added in #457) is invisible on a soft refresh — the SW returns the cached SPA shell. Same issue would apply to any future server-rendered route.

## Test plan
- [ ] After deploy, soft-refresh \`https://observ.ing/admin/browse\` — should show the admin page (or 401 if not logged in), not the SPA shell.
- [ ] \`/api/*\`, \`/oauth/*\`, \`/media/*\` continue to behave as before (already excluded).