### PR TITLE
feat(spike): Tap shadow consumer for AT Protocol sync evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4736,6 +4736,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap-client"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "futures-util",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+]
+
+[[package]]
+name = "tap-shadow"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "reqwest 0.13.3",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tap-client",
+ "tokio",
+ "tracing",
+ "tracing-stackdriver",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/observing-ingester/src/database.rs
+++ b/crates/observing-ingester/src/database.rs
@@ -72,7 +72,7 @@ macro_rules! process_or_warn {
 
 /// Database connection and operations
 pub struct Database {
-    pool: PgPool,
+    pub(crate) pool: PgPool,
     media_resolver: MediaResolver,
 }
 

--- a/crates/observing-ingester/src/main.rs
+++ b/crates/observing-ingester/src/main.rs
@@ -7,6 +7,7 @@ mod database;
 mod error;
 mod media_resolver;
 mod server;
+mod spike_log;
 mod types;
 
 use crate::database::Database;
@@ -149,6 +150,9 @@ async fn main() -> Result<()> {
                 let collection = commit.collection.as_str();
                 if !enabled_collections.contains(collection) {
                     continue;
+                }
+                if spike_log::enabled() {
+                    spike_log::log_jetstream_commit(&db.pool, &commit).await;
                 }
                 let action = commit.operation.clone();
                 let uri = commit.uri.clone();

--- a/crates/observing-ingester/src/spike_log.rs
+++ b/crates/observing-ingester/src/spike_log.rs
@@ -1,0 +1,34 @@
+//! Tap spike: optional dual-source event log.
+//!
+//! When the env var `SPIKE_LOG_EVENTS=1` is set at startup, the ingester
+//! writes one row to `tap_spike.event_log` per Jetstream commit it receives,
+//! tagged `source = 'jetstream'`. The tap-shadow consumer writes parallel
+//! rows tagged `source = 'tap'`. The schema lives in
+//! `scripts/tap-spike-schema.sql`. Drop the schema to disable cleanly.
+
+use jetstream_client::CommitInfo;
+use sqlx::PgPool;
+use tracing::warn;
+
+pub fn enabled() -> bool {
+    std::env::var("SPIKE_LOG_EVENTS").map(|v| v == "1").unwrap_or(false)
+}
+
+pub async fn log_jetstream_commit(pool: &PgPool, commit: &CommitInfo) {
+    let cid = (!commit.cid.is_empty()).then_some(commit.cid.as_str());
+    if let Err(e) = sqlx::query(
+        "INSERT INTO tap_spike.event_log
+            (source, did, collection, rkey, cid, action, live, tap_event_id)
+         VALUES ('jetstream', $1, $2, $3, $4, $5, NULL, NULL)",
+    )
+    .bind(&commit.did)
+    .bind(&commit.collection)
+    .bind(&commit.rkey)
+    .bind(cid)
+    .bind(&commit.operation)
+    .execute(pool)
+    .await
+    {
+        warn!(error = %e, "spike event_log insert failed");
+    }
+}

--- a/crates/tap-client/Cargo.toml
+++ b/crates/tap-client/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "tap-client"
+version = "0.1.0"
+edition = "2021"
+description = "AT Protocol Tap WebSocket client (spike)"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# Async runtime
+tokio = { workspace = true }
+
+# WebSocket
+tokio-tungstenite = { version = "0.29", features = ["native-tls"] }
+futures-util = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+
+# HTTP basic auth header (used only when admin password is set)
+base64 = "0.22"

--- a/crates/tap-client/examples/print_events.rs
+++ b/crates/tap-client/examples/print_events.rs
@@ -1,0 +1,83 @@
+//! Connect to a local Tap, print the first N events, ack each, then exit.
+//!
+//! Usage: `cargo run -p tap-client --example print_events -- [--count 10] [--url ws://...]`
+
+use std::env;
+use std::time::Duration;
+use tap_client::{TapConfig, TapEvent, TapSubscription};
+use tokio::sync::mpsc;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args: Vec<String> = env::args().collect();
+    let mut url = "ws://localhost:2480/channel".to_string();
+    let mut count: usize = 10;
+    let mut i = 1;
+    while i < args.len() {
+        match args[i].as_str() {
+            "--url" => {
+                url = args[i + 1].clone();
+                i += 2;
+            }
+            "--count" => {
+                count = args[i + 1].parse()?;
+                i += 2;
+            }
+            other => return Err(format!("unknown arg: {}", other).into()),
+        }
+    }
+
+    let (event_tx, mut event_rx) = mpsc::channel(64);
+    let (mut sub, ack) = TapSubscription::new(
+        TapConfig {
+            url,
+            admin_password: env::var("TAP_ADMIN_PASSWORD").ok(),
+        },
+        event_tx,
+    );
+
+    let sub_handle = tokio::spawn(async move { sub.run().await });
+
+    let mut received = 0usize;
+    let timeout = tokio::time::sleep(Duration::from_secs(30));
+    tokio::pin!(timeout);
+
+    loop {
+        tokio::select! {
+            evt = event_rx.recv() => {
+                let Some(evt) = evt else { break };
+                match &evt {
+                    TapEvent::Connected => println!("[connected]"),
+                    TapEvent::Disconnected => println!("[disconnected]"),
+                    TapEvent::Error(e) => println!("[error] {}", e),
+                    TapEvent::Identity(i) => {
+                        println!("identity id={} {} ({}, status={})", i.id, i.did, i.handle, i.status);
+                    }
+                    TapEvent::Record(r) => {
+                        println!(
+                            "record  id={} live={} {} {} {} cid={}",
+                            r.id, r.live, r.action, r.collection, r.rkey,
+                            r.cid.as_deref().unwrap_or("-")
+                        );
+                    }
+                }
+                if let Some(id) = evt.id() {
+                    ack.ack(id).await?;
+                    received += 1;
+                    if received >= count {
+                        println!("[done] received {} events; closing", received);
+                        break;
+                    }
+                }
+            }
+            _ = &mut timeout => {
+                println!("[timeout] received {}/{} events in 30s", received, count);
+                break;
+            }
+        }
+    }
+
+    drop(ack);
+    let _ = sub_handle.await;
+    Ok(())
+}

--- a/crates/tap-client/src/error.rs
+++ b/crates/tap-client/src/error.rs
@@ -1,0 +1,66 @@
+//! Error types for the Tap client
+
+use std::fmt;
+
+#[derive(Debug)]
+pub enum TapError {
+    WebSocket(Box<tokio_tungstenite::tungstenite::Error>),
+    JsonParse(String),
+    InvalidEventType(String),
+    MaxReconnectAttempts,
+    ConnectionClosed,
+    AckChannelClosed,
+}
+
+impl fmt::Display for TapError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TapError::WebSocket(err) => write!(f, "WebSocket error: {}", err),
+            TapError::JsonParse(msg) => write!(f, "JSON parse error: {}", msg),
+            TapError::InvalidEventType(t) => write!(f, "unknown Tap event type: {}", t),
+            TapError::MaxReconnectAttempts => write!(f, "Max reconnection attempts reached"),
+            TapError::ConnectionClosed => write!(f, "Connection closed"),
+            TapError::AckChannelClosed => write!(f, "Ack channel closed before connection"),
+        }
+    }
+}
+
+impl std::error::Error for TapError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            TapError::WebSocket(err) => Some(err.as_ref()),
+            _ => None,
+        }
+    }
+}
+
+impl From<tokio_tungstenite::tungstenite::Error> for TapError {
+    fn from(err: tokio_tungstenite::tungstenite::Error) -> Self {
+        TapError::WebSocket(Box::new(err))
+    }
+}
+
+impl From<serde_json::Error> for TapError {
+    fn from(err: serde_json::Error) -> Self {
+        TapError::JsonParse(err.to_string())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, TapError>;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_invalid_event_type_display() {
+        let err = TapError::InvalidEventType("commit".to_string());
+        assert_eq!(format!("{}", err), "unknown Tap event type: commit");
+    }
+
+    #[test]
+    fn test_ack_channel_closed_display() {
+        let err = TapError::AckChannelClosed;
+        assert_eq!(format!("{}", err), "Ack channel closed before connection");
+    }
+}

--- a/crates/tap-client/src/event.rs
+++ b/crates/tap-client/src/event.rs
@@ -1,0 +1,231 @@
+//! Event types emitted by the Tap subscription
+//!
+//! Wire format reference:
+//! https://github.com/bluesky-social/indigo/blob/main/cmd/tap/types.go (`MarshallableEvt`)
+//!
+//! Each frame from the server is JSON of the shape:
+//! ```json
+//! {"id": <u64>, "type": "record" | "identity",
+//!  "record": {...}      // when type == "record"
+//!  "identity": {...}    // when type == "identity"
+//! }
+//! ```
+
+use serde::{Deserialize, Serialize};
+
+/// Events emitted by the Tap subscription to the consumer.
+#[derive(Debug, Clone)]
+pub enum TapEvent {
+    Record(RecordEvent),
+    Identity(IdentityEvent),
+    Connected,
+    Disconnected,
+    Error(String),
+}
+
+impl TapEvent {
+    /// Outer event id, used for acknowledgement. `None` for lifecycle events.
+    pub fn id(&self) -> Option<u64> {
+        match self {
+            TapEvent::Record(e) => Some(e.id),
+            TapEvent::Identity(e) => Some(e.id),
+            _ => None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordEvent {
+    pub id: u64,
+    pub live: bool,
+    pub did: String,
+    pub rev: String,
+    pub collection: String,
+    pub rkey: String,
+    pub action: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub record: Option<serde_json::Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cid: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct IdentityEvent {
+    pub id: u64,
+    pub did: String,
+    pub handle: String,
+    pub is_active: bool,
+    pub status: String,
+}
+
+/// Wire frame: outer envelope with the event id and a payload for one of the
+/// known event types.
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireFrame {
+    pub id: u64,
+    #[serde(rename = "type")]
+    pub kind: String,
+    pub record: Option<WireRecord>,
+    pub identity: Option<WireIdentity>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireRecord {
+    pub live: bool,
+    pub did: String,
+    pub rev: String,
+    pub collection: String,
+    pub rkey: String,
+    pub action: String,
+    pub record: Option<serde_json::Value>,
+    pub cid: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct WireIdentity {
+    pub did: String,
+    pub handle: String,
+    pub is_active: bool,
+    pub status: String,
+}
+
+impl WireFrame {
+    /// Convert a parsed wire frame into the public event type, returning
+    /// `None` for unknown event types.
+    pub(crate) fn into_event(self) -> Option<TapEvent> {
+        match self.kind.as_str() {
+            "record" => self.record.map(|r| {
+                TapEvent::Record(RecordEvent {
+                    id: self.id,
+                    live: r.live,
+                    did: r.did,
+                    rev: r.rev,
+                    collection: r.collection,
+                    rkey: r.rkey,
+                    action: r.action,
+                    record: r.record,
+                    cid: r.cid,
+                })
+            }),
+            "identity" => self.identity.map(|i| {
+                TapEvent::Identity(IdentityEvent {
+                    id: self.id,
+                    did: i.did,
+                    handle: i.handle,
+                    is_active: i.is_active,
+                    status: i.status,
+                })
+            }),
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Captured live from Tap during Phase 1 sanity check (Phase 1 fixture).
+    const FIXTURE_RECORD: &str = r#"{
+        "id": 4,
+        "type": "record",
+        "record": {
+            "live": false,
+            "did": "did:plc:vozr2os4b4sxrxr6opde5js5",
+            "rev": "3mkkilda2bz24",
+            "collection": "bio.lexicons.temp.v0-1.identification",
+            "rkey": "3mkkilda2bz24",
+            "action": "create",
+            "cid": "bafyreig3hdmup5zzyxwb6qhwoesnwnhbesxxpt7ajv5mnydsyscv7wio2e",
+            "record": {
+                "$type": "bio.lexicons.temp.v0-1.identification",
+                "createdAt": "2026-04-15T12:00:00.000Z",
+                "isAgreement": true,
+                "occurrence": "at://did:plc:abc/bio.lexicons.temp.v0-1.occurrence/3xyz",
+                "scientificName": "Quercus alba"
+            }
+        }
+    }"#;
+
+    const FIXTURE_IDENTITY: &str = r#"{
+        "id": 1,
+        "type": "identity",
+        "identity": {
+            "did": "did:plc:jh6n3ntljfhhtr4jbvrm3k5b",
+            "handle": "testobserving.bsky.social",
+            "is_active": true,
+            "status": "active"
+        }
+    }"#;
+
+    #[test]
+    fn parses_record_frame() {
+        let frame: WireFrame = serde_json::from_str(FIXTURE_RECORD).unwrap();
+        let evt = frame.into_event().unwrap();
+        let r = match evt {
+            TapEvent::Record(r) => r,
+            _ => panic!("expected record"),
+        };
+        assert_eq!(r.id, 4);
+        assert_eq!(r.collection, "bio.lexicons.temp.v0-1.identification");
+        assert_eq!(r.action, "create");
+        assert!(!r.live);
+        assert_eq!(r.cid.as_deref(), Some("bafyreig3hdmup5zzyxwb6qhwoesnwnhbesxxpt7ajv5mnydsyscv7wio2e"));
+        let body = r.record.as_ref().unwrap();
+        assert_eq!(body["scientificName"], "Quercus alba");
+    }
+
+    #[test]
+    fn parses_identity_frame() {
+        let frame: WireFrame = serde_json::from_str(FIXTURE_IDENTITY).unwrap();
+        let evt = frame.into_event().unwrap();
+        let i = match evt {
+            TapEvent::Identity(i) => i,
+            _ => panic!("expected identity"),
+        };
+        assert_eq!(i.id, 1);
+        assert_eq!(i.handle, "testobserving.bsky.social");
+        assert!(i.is_active);
+        assert_eq!(i.status, "active");
+    }
+
+    #[test]
+    fn delete_record_has_no_body() {
+        let json = r#"{
+            "id": 99,
+            "type": "record",
+            "record": {
+                "live": true,
+                "did": "did:plc:abc",
+                "rev": "rev1",
+                "collection": "bio.lexicons.temp.v0-1.occurrence",
+                "rkey": "rk",
+                "action": "delete"
+            }
+        }"#;
+        let frame: WireFrame = serde_json::from_str(json).unwrap();
+        let r = match frame.into_event().unwrap() {
+            TapEvent::Record(r) => r,
+            _ => panic!(),
+        };
+        assert_eq!(r.action, "delete");
+        assert!(r.record.is_none());
+        assert!(r.cid.is_none());
+    }
+
+    #[test]
+    fn unknown_type_yields_none() {
+        let json = r#"{"id":1,"type":"weird"}"#;
+        let frame: WireFrame = serde_json::from_str(json).unwrap();
+        assert!(frame.into_event().is_none());
+    }
+
+    #[test]
+    fn event_id_returns_outer_id() {
+        let frame: WireFrame = serde_json::from_str(FIXTURE_RECORD).unwrap();
+        let evt = frame.into_event().unwrap();
+        assert_eq!(evt.id(), Some(4));
+
+        assert_eq!(TapEvent::Connected.id(), None);
+    }
+}

--- a/crates/tap-client/src/lib.rs
+++ b/crates/tap-client/src/lib.rs
@@ -1,0 +1,13 @@
+//! AT Protocol Tap WebSocket Client (spike)
+//!
+//! Connects to a [Tap](https://github.com/bluesky-social/indigo/tree/main/cmd/tap)
+//! instance and consumes events from its `/channel` endpoint, including the
+//! ack handshake required for at-least-once delivery.
+
+pub mod error;
+pub mod event;
+pub mod subscription;
+
+pub use error::{Result, TapError};
+pub use event::{IdentityEvent, RecordEvent, TapEvent};
+pub use subscription::{AckSender, TapConfig, TapSubscription};

--- a/crates/tap-client/src/subscription.rs
+++ b/crates/tap-client/src/subscription.rs
@@ -1,0 +1,246 @@
+//! Tap WebSocket subscription with ack handshake.
+//!
+//! Connects to a Tap instance's `/channel` endpoint (default `ws://localhost:2480/channel`),
+//! reads JSON event frames, and forwards them to the consumer's mpsc. The consumer
+//! acks each event by sending its id on the [`AckSender`] returned from [`TapSubscription::new`].
+//!
+//! Reconnects on disconnect with exponential backoff, mirroring `jetstream-client`.
+
+use crate::error::{Result, TapError};
+use crate::event::{TapEvent, WireFrame};
+use base64::{engine::general_purpose::STANDARD as B64, Engine as _};
+use futures_util::{SinkExt, StreamExt};
+use serde::Serialize;
+use std::time::Duration;
+use tokio::sync::mpsc;
+use tokio_tungstenite::{
+    connect_async,
+    tungstenite::{client::IntoClientRequest, Message},
+};
+use tracing::{debug, error, info, warn};
+
+const DEFAULT_URL: &str = "ws://localhost:2480/channel";
+const MAX_RECONNECT_ATTEMPTS: u32 = 10;
+const INITIAL_RECONNECT_DELAY: Duration = Duration::from_secs(1);
+const ACK_CHANNEL_CAPACITY: usize = 1024;
+
+/// Configuration for the Tap subscription.
+pub struct TapConfig {
+    /// Full WebSocket URL, e.g. `ws://localhost:2480/channel`.
+    pub url: String,
+    /// Optional admin password if Tap is configured with `TAP_ADMIN_PASSWORD`.
+    pub admin_password: Option<String>,
+}
+
+impl Default for TapConfig {
+    fn default() -> Self {
+        Self {
+            url: DEFAULT_URL.to_string(),
+            admin_password: None,
+        }
+    }
+}
+
+/// Handle returned alongside the subscription that the consumer uses to
+/// acknowledge processed events.
+#[derive(Clone)]
+pub struct AckSender {
+    tx: mpsc::Sender<u64>,
+}
+
+impl AckSender {
+    /// Acknowledge an event by id. Errors only if the subscription has been
+    /// dropped or its connection has terminated.
+    pub async fn ack(&self, id: u64) -> Result<()> {
+        self.tx
+            .send(id)
+            .await
+            .map_err(|_| TapError::AckChannelClosed)
+    }
+}
+
+#[derive(Serialize)]
+struct AckMessage<'a> {
+    #[serde(rename = "type")]
+    kind: &'a str,
+    id: u64,
+}
+
+pub struct TapSubscription {
+    config: TapConfig,
+    event_tx: mpsc::Sender<TapEvent>,
+    ack_rx: mpsc::Receiver<u64>,
+}
+
+impl TapSubscription {
+    /// Build a subscription. Returns the subscription itself plus an
+    /// [`AckSender`] cloneable handle the consumer uses to ack events.
+    pub fn new(
+        config: TapConfig,
+        event_tx: mpsc::Sender<TapEvent>,
+    ) -> (Self, AckSender) {
+        let (ack_tx, ack_rx) = mpsc::channel(ACK_CHANNEL_CAPACITY);
+        (
+            Self {
+                config,
+                event_tx,
+                ack_rx,
+            },
+            AckSender { tx: ack_tx },
+        )
+    }
+
+    /// Run the subscription until the ack sender is dropped or the maximum
+    /// reconnect attempts are exhausted.
+    pub async fn run(&mut self) -> Result<()> {
+        let mut reconnect_attempts = 0;
+
+        loop {
+            match self.connect_and_stream().await {
+                Ok(()) => {
+                    info!("Tap connection closed cleanly");
+                    return Ok(());
+                }
+                Err(e) => {
+                    error!("Tap error: {}", e);
+                    if let Err(send_err) = self
+                        .event_tx
+                        .send(TapEvent::Error(e.to_string()))
+                        .await
+                    {
+                        warn!(error = %send_err, "Failed to send error event to consumer");
+                    }
+
+                    reconnect_attempts += 1;
+                    if reconnect_attempts >= MAX_RECONNECT_ATTEMPTS {
+                        return Err(TapError::MaxReconnectAttempts);
+                    }
+                    let delay = INITIAL_RECONNECT_DELAY * 2u32.pow(reconnect_attempts - 1);
+                    warn!(
+                        "Reconnecting in {:?} (attempt {}/{})",
+                        delay, reconnect_attempts, MAX_RECONNECT_ATTEMPTS
+                    );
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    async fn connect_and_stream(&mut self) -> Result<()> {
+        info!("Connecting to Tap: {}", self.config.url);
+
+        let mut request = self
+            .config
+            .url
+            .as_str()
+            .into_client_request()
+            .map_err(|e| TapError::JsonParse(format!("invalid Tap url: {}", e)))?;
+        if let Some(password) = self.config.admin_password.as_ref() {
+            let auth = format!("admin:{}", password);
+            let encoded = B64.encode(auth.as_bytes());
+            request.headers_mut().insert(
+                "Authorization",
+                format!("Basic {}", encoded).parse().map_err(|_| {
+                    TapError::JsonParse("invalid admin password header value".to_string())
+                })?,
+            );
+        }
+
+        let (ws_stream, _) = connect_async(request).await?;
+        let (mut write, mut read) = ws_stream.split();
+
+        if let Err(e) = self.event_tx.send(TapEvent::Connected).await {
+            warn!(error = %e, "Failed to send connected event to consumer");
+        }
+        info!("Tap connection established");
+
+        loop {
+            tokio::select! {
+                msg = read.next() => {
+                    match msg {
+                        Some(Ok(Message::Text(text))) => {
+                            if let Err(e) = self.handle_text(&text).await {
+                                debug!("Error processing message: {}", e);
+                            }
+                        }
+                        Some(Ok(Message::Close(_))) | None => {
+                            info!("Tap WebSocket closed by server");
+                            let _ = self.event_tx.send(TapEvent::Disconnected).await;
+                            return Ok(());
+                        }
+                        Some(Ok(_)) => {
+                            // Ignore binary, ping, pong frames.
+                        }
+                        Some(Err(e)) => {
+                            error!("WebSocket read error: {}", e);
+                            let _ = self.event_tx.send(TapEvent::Disconnected).await;
+                            return Err(e.into());
+                        }
+                    }
+                }
+                ack_id = self.ack_rx.recv() => {
+                    let Some(id) = ack_id else {
+                        info!("Ack channel closed, shutting down subscription");
+                        let _ = write.send(Message::Close(None)).await;
+                        return Ok(());
+                    };
+                    let payload = serde_json::to_string(&AckMessage { kind: "ack", id })?;
+                    if let Err(e) = write.send(Message::Text(payload.into())).await {
+                        error!("Failed to send ack for id={}: {}", id, e);
+                        return Err(e.into());
+                    }
+                    debug!("acked id={}", id);
+                }
+            }
+        }
+    }
+
+    async fn handle_text(&self, text: &str) -> Result<()> {
+        let frame: WireFrame = serde_json::from_str(text)?;
+        let kind = frame.kind.clone();
+        if let Some(evt) = frame.into_event() {
+            if let Err(e) = self.event_tx.send(evt).await {
+                warn!(error = %e, "consumer dropped event channel");
+            }
+        } else {
+            return Err(TapError::InvalidEventType(kind));
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_default() {
+        let c = TapConfig::default();
+        assert_eq!(c.url, DEFAULT_URL);
+        assert!(c.admin_password.is_none());
+    }
+
+    #[test]
+    fn ack_message_serializes_correctly() {
+        let ack = AckMessage { kind: "ack", id: 42 };
+        let s = serde_json::to_string(&ack).unwrap();
+        assert_eq!(s, r#"{"type":"ack","id":42}"#);
+    }
+
+    #[tokio::test]
+    async fn ack_sender_send_ok() {
+        let (event_tx, _event_rx) = mpsc::channel(10);
+        let (_sub, ack) = TapSubscription::new(TapConfig::default(), event_tx);
+        // The receiver lives in `_sub`, so this should succeed.
+        ack.ack(7).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn ack_sender_send_after_drop_errors() {
+        let (event_tx, _event_rx) = mpsc::channel(10);
+        let (sub, ack) = TapSubscription::new(TapConfig::default(), event_tx);
+        drop(sub);
+        let err = ack.ack(7).await.unwrap_err();
+        assert!(matches!(err, TapError::AckChannelClosed));
+    }
+}

--- a/crates/tap-shadow/Cargo.toml
+++ b/crates/tap-shadow/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "tap-shadow"
+version = "0.1.0"
+edition = "2021"
+description = "Tap spike: shadow consumer that writes to tap_spike.event_log"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+tap-client = { path = "../tap-client" }
+tokio = { workspace = true }
+sqlx = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-stackdriver = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/tap-shadow/src/main.rs
+++ b/crates/tap-shadow/src/main.rs
@@ -1,0 +1,178 @@
+//! Tap spike: shadow consumer that connects to a Tap instance, writes every
+//! event into `tap_spike.event_log`, and acks. Runs alongside the existing
+//! Jetstream ingester (which also writes to `event_log` when SPIKE_LOG_EVENTS=1)
+//! so we can diff coverage during the observation window.
+//!
+//! Apply scripts/tap-spike-schema.sql before starting.
+//!
+//! Env vars:
+//!   DATABASE_URL          Postgres connection string (required)
+//!   TAP_URL               WebSocket URL (default ws://localhost:2480/channel)
+//!   TAP_HTTP_URL          HTTP base for /repos/add (default http://localhost:2480)
+//!   TAP_ADMIN_PASSWORD    Optional Basic auth password
+//!   BOOTSTRAP_OAUTH       If "1", read oauth_sessions and POST /repos/add at startup
+
+use std::env;
+use std::time::Duration;
+
+use clap::Parser;
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use tap_client::{TapConfig, TapEvent, TapSubscription};
+use tokio::sync::mpsc;
+use tracing::{error, info, warn};
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+#[derive(Parser)]
+#[command(about = "Tap spike: shadow consumer writing to tap_spike.event_log")]
+struct Cli {
+    /// Bootstrap repos via POST /repos/add from appview.oauth_sessions on startup.
+    #[arg(long, env = "BOOTSTRAP_OAUTH")]
+    bootstrap_oauth: bool,
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    tracing_subscriber::registry()
+        .with(EnvFilter::from_default_env().add_directive("tap_shadow=info".parse()?))
+        .with(tracing_stackdriver::layer())
+        .init();
+
+    let cli = Cli::parse();
+    let database_url = env::var("DATABASE_URL")?;
+    let tap_url = env::var("TAP_URL").unwrap_or_else(|_| "ws://localhost:2480/channel".to_string());
+    let tap_http = env::var("TAP_HTTP_URL").unwrap_or_else(|_| "http://localhost:2480".to_string());
+    let admin_password = env::var("TAP_ADMIN_PASSWORD").ok();
+
+    info!("connecting to database");
+    let pool = PgPoolOptions::new()
+        .max_connections(4)
+        .connect(&database_url)
+        .await?;
+
+    sanity_check_schema(&pool).await?;
+
+    if cli.bootstrap_oauth {
+        if let Err(e) = bootstrap_from_oauth(&pool, &tap_http, admin_password.as_deref()).await {
+            warn!("bootstrap_from_oauth failed: {}", e);
+        }
+    }
+
+    let (event_tx, mut event_rx) = mpsc::channel(256);
+    let (mut sub, ack) = TapSubscription::new(
+        TapConfig {
+            url: tap_url.clone(),
+            admin_password,
+        },
+        event_tx,
+    );
+
+    let sub_handle = tokio::spawn(async move {
+        if let Err(e) = sub.run().await {
+            error!("tap subscription error: {}", e);
+        }
+    });
+
+    let mut count = 0u64;
+    while let Some(evt) = event_rx.recv().await {
+        match &evt {
+            TapEvent::Connected => info!("tap connected"),
+            TapEvent::Disconnected => warn!("tap disconnected"),
+            TapEvent::Error(e) => warn!("tap error: {}", e),
+            TapEvent::Identity(i) => {
+                // Identity events are ack-only — nothing to log to event_log.
+                info!(did = %i.did, handle = %i.handle, status = %i.status, "identity");
+            }
+            TapEvent::Record(r) => {
+                if let Err(e) = sqlx::query(
+                    "INSERT INTO tap_spike.event_log
+                        (source, did, collection, rkey, cid, action, live, tap_event_id)
+                     VALUES ('tap', $1, $2, $3, $4, $5, $6, $7)",
+                )
+                .bind(&r.did)
+                .bind(&r.collection)
+                .bind(&r.rkey)
+                .bind(r.cid.as_deref())
+                .bind(&r.action)
+                .bind(r.live)
+                .bind(r.id as i64)
+                .execute(&pool)
+                .await
+                {
+                    error!("event_log insert failed for id={}: {}", r.id, e);
+                    // Don't ack on insert failure — let Tap redeliver.
+                    continue;
+                }
+
+                count += 1;
+                if count % 100 == 0 {
+                    info!(count, "events written");
+                }
+            }
+        }
+        if let Some(id) = evt.id() {
+            if let Err(e) = ack.ack(id).await {
+                error!("ack failed for id={}: {}", id, e);
+                break;
+            }
+        }
+    }
+
+    drop(ack);
+    let _ = sub_handle.await;
+    Ok(())
+}
+
+async fn sanity_check_schema(pool: &PgPool) -> Result<(), sqlx::Error> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS (
+             SELECT 1 FROM information_schema.tables
+             WHERE table_schema = 'tap_spike' AND table_name = 'event_log'
+         )",
+    )
+    .fetch_one(pool)
+    .await?;
+    if !exists {
+        return Err(sqlx::Error::Configuration(
+            "tap_spike.event_log not found — run scripts/tap-spike-schema.sql first".into(),
+        ));
+    }
+    Ok(())
+}
+
+async fn bootstrap_from_oauth(
+    pool: &PgPool,
+    tap_http: &str,
+    admin_password: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // appview.oauth_sessions stores the DID in the `key` column.
+    let dids: Vec<String> = sqlx::query_scalar("SELECT DISTINCT key FROM appview.oauth_sessions")
+        .fetch_all(pool)
+        .await?;
+    if dids.is_empty() {
+        info!("oauth_sessions empty, nothing to bootstrap");
+        return Ok(());
+    }
+    info!(count = dids.len(), "bootstrapping repos via /repos/add");
+
+    let client = reqwest::Client::builder()
+        .timeout(Duration::from_secs(30))
+        .build()?;
+    let mut req = client
+        .post(format!("{}/repos/add", tap_http.trim_end_matches('/')))
+        .json(&serde_json::json!({ "dids": dids }));
+    if let Some(pw) = admin_password {
+        req = req.basic_auth("admin", Some(pw));
+    }
+    let resp = req.send().await?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "/repos/add returned {}: {}",
+            resp.status(),
+            resp.text().await.unwrap_or_default()
+        )
+        .into());
+    }
+    info!("bootstrap complete");
+    Ok(())
+}

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -44,3 +44,28 @@ processes:
         port: 3005
         path: /health
       initial_delay_seconds: 10
+
+  # Spike: AT Proto Tap sync utility — see docs/architecture.md notes.
+  # Signal collection is `bio.lexicons.temp.v0-1.occurrence`; users who only make
+  # identifications (no occurrences) won't be auto-discovered by Tap and would
+  # need to be added via POST /repos/add.
+  tap:
+    disabled: true
+    command: |
+      docker run --rm --init --name observing-tap \
+        -p 2480:2480 \
+        -v "$PWD/cache/tap:/data" \
+        -e TAP_DATABASE_URL=sqlite:///data/tap.db \
+        -e TAP_SIGNAL_COLLECTION=bio.lexicons.temp.v0-1.occurrence \
+        -e TAP_COLLECTION_FILTERS=bio.lexicons.temp.v0-1.occurrence,bio.lexicons.temp.v0-1.identification,ing.observ.temp.comment,ing.observ.temp.interaction,ing.observ.temp.like \
+        -e TAP_NO_REPLAY=true \
+        -e TAP_DISABLE_ACKS=true \
+        -e TAP_LOG_LEVEL=info \
+        ghcr.io/bluesky-social/indigo/tap:latest
+    readiness_probe:
+      http_get:
+        host: localhost
+        port: 2480
+        path: /health
+      initial_delay_seconds: 5
+      period_seconds: 5

--- a/scripts/tap-spike-analysis.sql
+++ b/scripts/tap-spike-analysis.sql
@@ -1,0 +1,122 @@
+-- Tap spike: post-observation analysis queries.
+--
+-- Run after both `tap-shadow` and the patched ingester (SPIKE_LOG_EVENTS=1)
+-- have run in parallel for 24-72 hours.
+--
+-- Reset the table before the observation window:
+--   psql "$DATABASE_URL" -c 'TRUNCATE tap_spike.event_log;'
+
+\timing on
+
+----------------------------------------------------------------------
+-- Headline numbers
+----------------------------------------------------------------------
+
+SELECT source, COUNT(*) AS rows, MIN(received_at) AS first, MAX(received_at) AS last
+FROM tap_spike.event_log
+GROUP BY source
+ORDER BY source;
+
+----------------------------------------------------------------------
+-- 1. Coverage delta
+--    For each (did, collection, rkey, cid) tuple, was it seen by tap,
+--    jetstream, or both? "tap-only" is the headline win; "jetstream-only"
+--    is the risk we'd take by switching.
+----------------------------------------------------------------------
+
+WITH per_record AS (
+    SELECT did, collection, rkey, cid,
+           bool_or(source = 'tap')        AS seen_by_tap,
+           bool_or(source = 'jetstream')  AS seen_by_jetstream
+    FROM tap_spike.event_log
+    GROUP BY did, collection, rkey, cid
+)
+SELECT
+    CASE
+        WHEN seen_by_tap AND seen_by_jetstream THEN 'both'
+        WHEN seen_by_tap                       THEN 'tap-only'
+        WHEN seen_by_jetstream                 THEN 'jetstream-only'
+    END AS bucket,
+    COUNT(*) AS records
+FROM per_record
+GROUP BY 1
+ORDER BY 1;
+
+----------------------------------------------------------------------
+-- 2. Repo discovery
+--    DIDs Tap surfaced via collection-signal that are NOT in the
+--    appview.oauth_sessions set the existing `--all` backfill is
+--    bounded by. This is the headline product gap the spike tests.
+----------------------------------------------------------------------
+
+-- NOTE: appview.oauth_sessions stores the DID in the `key` column, not `did`.
+SELECT DISTINCT e.did
+FROM tap_spike.event_log e
+LEFT JOIN appview.oauth_sessions s ON s.key = e.did
+WHERE e.source = 'tap'
+  AND s.key IS NULL
+ORDER BY e.did;
+
+-- ...and the inverse: DIDs in oauth_sessions that Tap did NOT surface
+-- (these are users who logged in but apparently have no occurrence
+-- records — Tap's signal collection wouldn't pick them up).
+
+SELECT s.key AS did
+FROM appview.oauth_sessions s
+LEFT JOIN (SELECT DISTINCT did FROM tap_spike.event_log WHERE source = 'tap') t
+       ON t.did = s.key
+WHERE t.did IS NULL
+ORDER BY s.key;
+
+----------------------------------------------------------------------
+-- 3. Latency
+--    For records seen by both, how much earlier did one source land
+--    than the other. (`live=true` only — backfill latency from Tap is
+--    inherently larger and not comparable to firehose latency.)
+----------------------------------------------------------------------
+
+WITH first_seen AS (
+    SELECT did, collection, rkey,
+           MIN(received_at) FILTER (WHERE source = 'tap'       AND live IS TRUE) AS tap_at,
+           MIN(received_at) FILTER (WHERE source = 'jetstream')                  AS jet_at
+    FROM tap_spike.event_log
+    GROUP BY did, collection, rkey
+    HAVING COUNT(DISTINCT source) = 2
+)
+SELECT
+    COUNT(*)                                                  AS overlapping_records,
+    AVG(EXTRACT(EPOCH FROM (tap_at - jet_at)))                AS avg_tap_minus_jet_secs,
+    PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (tap_at - jet_at))) AS p50,
+    PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (tap_at - jet_at))) AS p95
+FROM first_seen
+WHERE tap_at IS NOT NULL AND jet_at IS NOT NULL;
+
+----------------------------------------------------------------------
+-- 4. Backfill behavior
+--    For each repo Tap is tracking, how many backfill (live=false)
+--    vs live (live=true) events did we see. Confirms backfill ran
+--    and live cutover happened.
+----------------------------------------------------------------------
+
+SELECT did,
+       COUNT(*) FILTER (WHERE live IS FALSE) AS backfill_events,
+       COUNT(*) FILTER (WHERE live IS TRUE)  AS live_events
+FROM tap_spike.event_log
+WHERE source = 'tap'
+GROUP BY did
+ORDER BY backfill_events DESC, live_events DESC;
+
+----------------------------------------------------------------------
+-- 5. Duplicate / redelivery rate (sanity check)
+--    Tap promises at-least-once. How often did a (did, collection,
+--    rkey, cid) appear more than once per source?
+----------------------------------------------------------------------
+
+SELECT source, AVG(n)::numeric(10,2) AS avg_redelivery, MAX(n) AS max_redelivery
+FROM (
+    SELECT source, did, collection, rkey, cid, COUNT(*) AS n
+    FROM tap_spike.event_log
+    GROUP BY source, did, collection, rkey, cid
+) per_record
+GROUP BY source
+ORDER BY source;

--- a/scripts/tap-spike-schema.sql
+++ b/scripts/tap-spike-schema.sql
@@ -1,0 +1,32 @@
+-- Tap spike: shadow event log written by both the Jetstream ingester and
+-- the tap-shadow consumer in parallel. See docs notes from the Tap spike.
+--
+-- Apply once before starting either process:
+--   psql "$DATABASE_URL" -f scripts/tap-spike-schema.sql
+--
+-- Drop after the spike concludes:
+--   psql "$DATABASE_URL" -c 'DROP SCHEMA tap_spike CASCADE;'
+
+CREATE SCHEMA IF NOT EXISTS tap_spike;
+
+CREATE TABLE IF NOT EXISTS tap_spike.event_log (
+    id            BIGSERIAL PRIMARY KEY,
+    source        TEXT        NOT NULL,                   -- 'tap' | 'jetstream'
+    did           TEXT        NOT NULL,
+    collection    TEXT        NOT NULL,
+    rkey          TEXT        NOT NULL,
+    cid           TEXT,                                   -- null for delete
+    action        TEXT        NOT NULL,                   -- create | update | delete
+    live          BOOLEAN,                                -- tap only; null for jetstream
+    received_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+    tap_event_id  BIGINT                                  -- tap only, for debugging
+);
+
+CREATE INDEX IF NOT EXISTS event_log_source_did_idx
+    ON tap_spike.event_log (source, did);
+
+CREATE INDEX IF NOT EXISTS event_log_uri_idx
+    ON tap_spike.event_log (did, collection, rkey);
+
+CREATE INDEX IF NOT EXISTS event_log_received_at_idx
+    ON tap_spike.event_log (received_at);


### PR DESCRIPTION
## Summary

Spike to evaluate replacing the current Jetstream client with [bluesky-social/indigo `tap`](https://github.com/bluesky-social/indigo/tree/main/cmd/tap). Adds a parallel ingest path that runs alongside the existing one so we can diff coverage in production-like data over an observation window. **Not for merge** — artifacts exist to gather data, then the schema and crates either get promoted to a real integration or dropped.

- `crates/tap-client`: WebSocket client with ack handshake. Mirrors `jetstream-client`'s shape; returns an `AckSender` alongside the subscription so consumers can ack after handler success.
- `crates/tap-shadow`: consumer that writes each Tap event to `tap_spike.event_log`. Optional `--bootstrap-oauth` POSTs DIDs from `appview.oauth_sessions` to `/repos/add` to close the identifier-only-DIDs gap inherent to collection-signal mode.
- `observing-ingester`: gated by `SPIKE_LOG_EVENTS=1`. Off by default — no production behavior change. When on, writes a parallel `source='jetstream'` row to the same `event_log` table for each commit it would have processed anyway.
- `scripts/tap-spike-{schema,analysis}.sql`: schema setup + the five queries we'll run after the observation window (coverage delta, repo discovery, latency, backfill behavior, redelivery rate).
- `process-compose.yaml`: `tap` Docker entry, `disabled: true` so it doesn't auto-start.

Smoke test in branch comments confirmed: tap-shadow drained Tap's 530-event backfill into `event_log` correctly with acks, schema accepts both sources, all five analysis queries parse and execute. Preliminary finding (smoke data only): 1 of 3 Tap-discovered repos (`jackallard.net`) is not in `oauth_sessions` — already a hint that collection-signal mode finds users the existing `--all` backfill cannot reach.

Cleanup if we decide not to proceed: `DROP SCHEMA tap_spike CASCADE;` + stop/remove the Tap container. No production code path touches the schema when `SPIKE_LOG_EVENTS` is unset.

## Production candidate: `atproto-tap`

If the spike says go, the in-tree `tap-client` crate should be replaced with [`atproto-tap`](https://crates.io/crates/atproto-tap) (ngerakines, v0.14.5). It covers everything we built (WS + ack + reconnect) plus a `TapClient` management API that subsumes our hand-rolled `/repos/add` bootstrap. Blockers to confirm before adopting: MSRV (it requires Rust 1.90 + edition 2024 — verify against `rust-toolchain.toml`) and bus factor (single maintainer, low download count). Alternative: [`tapped`](https://crates.io/crates/tapped) (lib-only, slightly smaller surface).

## Test plan

- [x] `cargo build -p tap-client -p tap-shadow -p observing-ingester` clean
- [x] `cargo test -p tap-client` — 11/11 pass (event deserialization fixtures, ack wire format, ack-channel-closed)
- [x] Local smoke: Tap container + tap-shadow + ingester (`SPIKE_LOG_EVENTS=1`) running in parallel; `event_log` populated with `source='tap'` rows; synthetic INSERT confirms schema accepts `source='jetstream'`
- [x] `psql -f scripts/tap-spike-analysis.sql` runs end-to-end against a populated `event_log`
- [ ] Observation window: 24-72h with both paths writing, then run analysis queries and write the go/no-go memo
- [ ] If the memo says "go": replace the spike crates with a real integration (production ack handling, signature verification path, deployment story, `atproto-tap` dep evaluation)
- [ ] If the memo says "no": revert this commit + `DROP SCHEMA tap_spike CASCADE;`