### PR TITLE
feat(tap-ingester): side-by-side ingester sourced from Tap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2297,7 +2297,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.29.0",
  "tracing",
 ]
 
@@ -4749,6 +4749,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
+name = "tap-ingester"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "clap",
+ "jetstream-client",
+ "observing-db",
+ "observing-ingester",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "tapped",
+ "tokio",
+ "tracing",
+ "tracing-stackdriver",
+ "tracing-subscriber",
+]
+
+[[package]]
+name = "tapped"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6950da6dbc404bec88b6f8d39f6062bd46e7efdadbaeeb5a79d9d08a7937c394"
+dependencies = [
+ "base64",
+ "futures-util",
+ "libc",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-tungstenite 0.28.0",
+ "tracing",
+ "tungstenite 0.28.0",
+ "url",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4936,6 +4975,22 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
+dependencies = [
+ "futures-util",
+ "log",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
@@ -4945,7 +5000,7 @@ dependencies = [
  "native-tls",
  "tokio",
  "tokio-native-tls",
- "tungstenite",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -5151,6 +5206,25 @@ dependencies = [
 
 [[package]]
 name = "tungstenite"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "rustls",
+ "rustls-pki-types",
+ "sha1",
+ "thiserror 2.0.18",
+ "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
@@ -5328,6 +5402,7 @@ dependencies = [
  "idna",
  "percent-encoding",
  "serde",
+ "serde_derive",
 ]
 
 [[package]]
@@ -5335,6 +5410,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf-8"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
 name = "utf8-zero"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,9 @@ tower = "0.5"
 # HTTP client
 reqwest = { version = "0.13", features = ["json"] }
 
+# AT Protocol Tap sync utility wrapper
+tapped = "0.3"
+
 # Database
 sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgres", "chrono"] }
 

--- a/crates/observing-ingester/Cargo.toml
+++ b/crates/observing-ingester/Cargo.toml
@@ -58,6 +58,10 @@ urlencoding = { workspace = true }
 [dev-dependencies]
 tower = { workspace = true, features = ["util"] }
 
+[lib]
+name = "observing_ingester"
+path = "src/lib.rs"
+
 [[bin]]
 name = "observing-ingester"
 path = "src/main.rs"

--- a/crates/tap-ingester/Cargo.toml
+++ b/crates/tap-ingester/Cargo.toml
@@ -1,0 +1,46 @@
+[package]
+name = "tap-ingester"
+version = "0.1.0"
+edition = "2021"
+description = "AT Protocol ingester sourced from a Tap (indigo cmd/tap) instance"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# Tap client wrapper — handles WebSocket + ack handshake + reconnection.
+tapped = { workspace = true }
+
+# Reuse the existing record dispatcher, media resolver, types, and HTTP server.
+observing-ingester = { path = "../observing-ingester" }
+
+# Database write path — same processing module observing-ingester uses.
+observing-db = { path = "../observing-db", features = ["processing"] }
+
+# Database::upsert_* methods on the shared crate take &CommitInfo. tap-ingester
+# constructs a CommitInfo from each tapped::RecordEvent. That coupling will go
+# away when PR-C decommissions observing-ingester.
+jetstream-client = { path = "../jetstream-client" }
+
+# Async runtime
+tokio = { workspace = true }
+
+# Database
+sqlx = { workspace = true }
+
+# Serialization
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# Logging
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+tracing-stackdriver = { workspace = true }
+
+# Time
+chrono = { workspace = true }
+
+# CLI
+clap = { version = "4", features = ["derive", "env"] }
+
+[[bin]]
+name = "tap-ingester"
+path = "src/main.rs"

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -1,0 +1,225 @@
+//! AT Protocol ingester sourced from a Tap (indigo cmd/tap) instance.
+//!
+//! Connects to an externally-running Tap over WebSocket, ack-mode, and writes
+//! events into the same `ingester` schema observing-ingester uses. Idempotent
+//! upserts on `(uri, cid)` mean both ingesters can run side-by-side during
+//! the verification window without colliding.
+//!
+//! Required env vars:
+//!   DATABASE_URL          Postgres connection string
+//!   TAP_URL               Base URL of the Tap HTTP API (e.g. http://localhost:2480)
+//!
+//! Optional env vars:
+//!   TAP_ADMIN_PASSWORD    Tap basic auth password (if Tap was started with one)
+//!   PORT                  HTTP server port (default 8080)
+
+use std::sync::Arc;
+
+use chrono::Utc;
+use clap::Parser;
+use jetstream_client::CommitInfo;
+use observing_ingester::{
+    server::{start_server, ServerState, SharedState},
+    types::{
+        RecentEvent, COMMENT_COLLECTION, IDENTIFICATION_COLLECTION, INTERACTION_COLLECTION,
+        LIKE_COLLECTION, OCCURRENCE_COLLECTION,
+    },
+    Database,
+};
+use tapped::{Event, RecordAction, RecordEvent, TapClient};
+use tokio::sync::RwLock;
+use tracing::{error, info, warn};
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+#[derive(Parser)]
+#[command(about = "Observ.ing AT Protocol Tap-sourced ingester")]
+struct Cli {}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let _cli = Cli::parse();
+
+    let env_filter =
+        EnvFilter::from_default_env().add_directive("tap_ingester=info".parse()?);
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_stackdriver::layer())
+        .init();
+
+    info!("Starting Observ.ing tap-ingester...");
+
+    let database_url = std::env::var("DATABASE_URL")?;
+    let tap_url = std::env::var("TAP_URL").unwrap_or_else(|_| "http://localhost:2480".to_string());
+    let port: u16 = std::env::var("PORT")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(8080);
+
+    let state: SharedState = Arc::new(RwLock::new(ServerState::new()));
+
+    // Spawn HTTP server immediately so Cloud Run health checks pass.
+    let http_state = state.clone();
+    tokio::spawn(async move {
+        if let Err(e) = start_server(http_state, port).await {
+            error!("HTTP server error: {}", e);
+        }
+    });
+
+    let db = Database::connect(&database_url).await?;
+
+    let tap = match std::env::var("TAP_ADMIN_PASSWORD") {
+        Ok(pw) => TapClient::with_auth(&tap_url, pw)?,
+        Err(_) => TapClient::new(&tap_url)?,
+    };
+
+    info!(tap_url = %tap_url, "connecting to tap channel");
+    let mut channel = tap.channel().await?;
+    state.write().await.connected = true;
+    info!("tap channel connected");
+
+    while let Ok(received) = channel.recv().await {
+        let mut should_ack = true;
+        match &received.event {
+            Event::Identity(_) => {
+                // Identity events don't write to ingester schema — observing-ingester
+                // doesn't process them either. Ack and move on.
+            }
+            Event::Record(record) => {
+                if let Err(e) = process_record(&db, record, &state).await {
+                    error!(uri = %format_uri(record), "process_record failed: {}", e);
+                    state.write().await.stats.errors += 1;
+                    // Skip ack so Tap redelivers after retry-timeout. tapped's
+                    // AckGuard is private, so leaking the ReceivedEvent is the
+                    // only way to suppress the auto-ack-on-drop.
+                    should_ack = false;
+                }
+            }
+            // tapped::Event is #[non_exhaustive]; ignore future variants.
+            _ => {}
+        }
+        if should_ack {
+            drop(received);
+        } else {
+            std::mem::forget(received);
+        }
+    }
+
+    state.write().await.connected = false;
+    warn!("tap channel closed");
+    Ok(())
+}
+
+async fn process_record(
+    db: &Database,
+    record: &RecordEvent,
+    state: &SharedState,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let collection = record.collection.as_str();
+    let action = action_to_str(record.action);
+
+    let event_type = match collection {
+        OCCURRENCE_COLLECTION => "occurrence",
+        IDENTIFICATION_COLLECTION => "identification",
+        COMMENT_COLLECTION => "comment",
+        INTERACTION_COLLECTION => "interaction",
+        LIKE_COLLECTION => "like",
+        _ => return Ok(()),
+    };
+
+    let uri = format_uri(record);
+
+    let result = if matches!(record.action, RecordAction::Delete) {
+        match collection {
+            OCCURRENCE_COLLECTION => db.delete_occurrence(&uri).await,
+            IDENTIFICATION_COLLECTION => db.delete_identification(&uri).await,
+            COMMENT_COLLECTION => db.delete_comment(&uri).await,
+            INTERACTION_COLLECTION => db.delete_interaction(&uri).await,
+            LIKE_COLLECTION => db.delete_like(&uri).await,
+            _ => unreachable!(),
+        }
+    } else {
+        let commit = build_commit(record, &uri)?;
+
+        // Like records are filtered to occurrence-subjects only — same predicate
+        // as observing-ingester.
+        if collection == LIKE_COLLECTION {
+            let is_occurrence_like = commit
+                .record
+                .as_ref()
+                .and_then(|r| r.get("subject"))
+                .and_then(|s| s.get("uri"))
+                .and_then(|u| u.as_str())
+                .is_some_and(|uri| uri.contains(OCCURRENCE_COLLECTION));
+            if !is_occurrence_like {
+                return Ok(());
+            }
+        }
+
+        match collection {
+            OCCURRENCE_COLLECTION => db.upsert_occurrence(&commit).await,
+            IDENTIFICATION_COLLECTION => db.upsert_identification(&commit).await,
+            COMMENT_COLLECTION => db.upsert_comment(&commit).await,
+            INTERACTION_COLLECTION => db.upsert_interaction(&commit).await,
+            LIKE_COLLECTION => db.upsert_like(&commit).await,
+            _ => unreachable!(),
+        }
+    };
+
+    let mut s = state.write().await;
+    if let Err(e) = result {
+        error!(%uri, error = %e, "{} {} failed", event_type, action);
+        s.stats.errors += 1;
+    } else {
+        match event_type {
+            "occurrence" => s.stats.occurrences += 1,
+            "identification" => s.stats.identifications += 1,
+            "comment" => s.stats.comments += 1,
+            "interaction" => s.stats.interactions += 1,
+            "like" => s.stats.likes += 1,
+            _ => {}
+        }
+        s.add_recent_event(RecentEvent {
+            event_type: event_type.to_string(),
+            action: action.to_string(),
+            uri,
+            time: Utc::now(),
+        });
+    }
+    Ok(())
+}
+
+/// Tap delivers events without a per-event timestamp; observing-db's
+/// processing module needs *some* time, and falls back to `record.createdAt`
+/// when present. Receipt time matches the firehose delivery semantics
+/// observing-ingester uses, so we pass that.
+fn build_commit(record: &RecordEvent, uri: &str) -> Result<CommitInfo, Box<dyn std::error::Error>> {
+    let record_json = match record.record_as_str() {
+        Some(s) => Some(serde_json::from_str(s)?),
+        None => None,
+    };
+    Ok(CommitInfo {
+        did: record.did.clone(),
+        collection: record.collection.clone(),
+        rkey: record.rkey.clone(),
+        uri: uri.to_string(),
+        cid: record.cid.clone().unwrap_or_default(),
+        operation: action_to_str(record.action).to_string(),
+        seq: 0,
+        time: Utc::now(),
+        record: record_json,
+    })
+}
+
+fn format_uri(record: &RecordEvent) -> String {
+    format!("at://{}/{}/{}", record.did, record.collection, record.rkey)
+}
+
+fn action_to_str(action: RecordAction) -> &'static str {
+    match action {
+        RecordAction::Create => "create",
+        RecordAction::Update => "update",
+        RecordAction::Delete => "delete",
+        // RecordAction is #[non_exhaustive]; future variants treated as no-op upserts.
+        _ => "unknown",
+    }
+}

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -39,8 +39,7 @@ struct Cli {}
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let _cli = Cli::parse();
 
-    let env_filter =
-        EnvFilter::from_default_env().add_directive("tap_ingester=info".parse()?);
+    let env_filter = EnvFilter::from_default_env().add_directive("tap_ingester=info".parse()?);
     tracing_subscriber::registry()
         .with(env_filter)
         .with(tracing_stackdriver::layer())


### PR DESCRIPTION
## Summary

Adds `tap-ingester`, a parallel ingest binary that consumes events from a [Tap](https://github.com/bluesky-social/indigo/tree/main/cmd/tap) instance via [`tapped`](https://crates.io/crates/tapped). Same destination tables as `observing-ingester`, idempotent upserts on `(uri, cid)`, so both can run in production simultaneously during a verification window before the eventual decommission of the Jetstream path.

This is **PR-B** in a three-step migration. PR-A was the spike (#461, closed). PR-C will be the decommission: cross-repo dependency resolution, then delete `observing-ingester`, `jetstream-client`, and the FK-blind portions of `bin/backfill.rs`.

### What's in this PR
- `crates/tap-ingester`: new binary. Reuses `observing_ingester`'s lib face (`Database`, `media_resolver`, `types`, HTTP server) so dispatch logic and media resolution stay in one place.
- `crates/observing-ingester/Cargo.toml`: adds `[lib]` section. The lib was already declared in `src/lib.rs`; this just makes Cargo pick it up. Bin behavior unchanged.
- `Cargo.toml`: adds `tapped = "0.3"` to workspace deps.

### Library choice: `tapped` not `atproto-tap`
`atproto-tap` (the more popular crate, ngerakines) pulls in a crates.io `atproto-identity ^0.14.5` that name-collides with our local `crates/atproto-identity`. `tapped` (thombles) has no such conflict, supports the same WebSocket+ack+reconnect surface, and adds `TapClient::with_auth` / `client.channel()` for management API + event stream.

### Cross-repo identifications: known gap (inherited)
The smoke test (see commit body) showed 515 of 528 backfill identifications failing the `identifications_subject_uri_fkey` constraint because they reference occurrences on DIDs Tap isn't tracking. This is the **same gap `observing-ingester` has on its live firehose path** — production today bridges it by running `bin/backfill.rs --all` to seed cross-repo occurrences before live ingest. `tap-ingester` ships with the same operational model. PR-C will introduce lazy `/repos/add` on subject reference (or equivalent) to remove the dependency.

### Error handling: `mem::forget` on the ack guard
`tapped::ReceivedEvent` auto-acks on `Drop` and exposes no public way to suppress this. On record-processing failure tap-ingester `mem::forget`s the ReceivedEvent so Tap can redeliver after `retry-timeout`. Worth filing upstream for a clean `received.skip_ack()` API.

## Test plan

- [x] `cargo build -p tap-ingester` clean
- [x] Smoke test against local Tap + dev DB: backfill drained, occurrences (14 attempted → 17 in DB via idempotent upsert), likes (1), same-repo identifications (13) all wrote successfully. Cross-repo identifications failed FK as expected.
- [ ] **Verification window in production**: deploy `tap-ingester` as a separate Cloud Run service alongside the existing `observing-ingester`. Run for several days. Compare row counts and timing between the two paths. Watch for FK constraint violations in `tap-ingester` logs that don't also appear in `observing-ingester`.
- [ ] **Cloud Run deployment story**: `cloudbuild.yaml` needs a `tap-ingester` service entry. Tap itself needs to run as its own Cloud Run service (Postgres state, `TAP_ADMIN_PASSWORD` set, signal-collection mode for `bio.lexicons.temp.v0-1.occurrence`). Deferring to a follow-up commit on this branch before flipping to ready-for-review.
- [ ] PR-C: lazy `/repos/add` on cross-repo subject reference, then delete `observing-ingester` + `jetstream-client` once production parity confirmed.