### PR TITLE
feat(deploy): tap-ingester Cloud Run service with embedded Tap

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,12 @@ jobs:
       REGISTRY: us-central1-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/observing
     strategy:
       matrix:
-        service: [appview, ingester, species-id, migrate]
+        service:
+          - observing-appview
+          - observing-ingester
+          - observing-species-id
+          - observing-migrate
+          - tap-ingester
     steps:
       - uses: actions/checkout@v4
 
@@ -415,15 +420,15 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          build-args: SERVICE=observing-${{ matrix.service }}
+          build-args: SERVICE=${{ matrix.service }}
           push: true
-          tags: ${{ env.REGISTRY }}/observing-${{ matrix.service }}:latest
+          tags: ${{ env.REGISTRY }}/${{ matrix.service }}:latest
           cache-from: |
             type=gha,scope=${{ matrix.service }}
-            type=registry,ref=${{ env.REGISTRY }}/observing-${{ matrix.service }}:buildcache
+            type=registry,ref=${{ env.REGISTRY }}/${{ matrix.service }}:buildcache
           cache-to: |
             type=gha,mode=max,scope=${{ matrix.service }}
-            type=registry,ref=${{ env.REGISTRY }}/observing-${{ matrix.service }}:buildcache,mode=max
+            type=registry,ref=${{ env.REGISTRY }}/${{ matrix.service }}:buildcache,mode=max
 
   deploy:
     runs-on: ubuntu-latest
@@ -488,6 +493,25 @@ jobs:
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
             --set-env-vars=RUST_LOG=observing_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe \
+            --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
+            --min-instances=1 \
+            --max-instances=1 \
+            --timeout=3600
+
+      # Side-by-side with observing-ingester during the verification window.
+      # Bundles its own `tap` binary spawned as a child process; SQLite state
+      # at /data/tap.db is instance-ephemeral (Tap re-discovers + re-backfills
+      # on instance restart, which is fine for current scale).
+      - name: Deploy tap-ingester
+        run: |
+          gcloud run deploy tap-ingester \
+            --image=$REGISTRY/tap-ingester:latest \
+            --region=$REGION \
+            --allow-unauthenticated \
+            --cpu=1 \
+            --memory=2Gi \
+            --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
+            --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime \
             --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
             --min-instances=1 \
             --max-instances=1 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,12 @@
 # automatically but its output is only copied into the final image
 # when SERVICE=observing-appview.
 #
+# For tap-ingester, the `tap` binary from bluesky-social/indigo is built
+# in a Go stage and bundled into the runtime image; tapped::TapProcess
+# spawns it as a child process at runtime.
+#
 # Supported SERVICE values:
-#   observing-appview, observing-ingester, observing-species-id, observing-migrate
+#   observing-appview, observing-ingester, observing-species-id, observing-migrate, tap-ingester
 
 ARG SERVICE=observing-appview
 
@@ -76,6 +80,31 @@ ARG SERVICE
 RUN cargo build --release -p ${SERVICE}
 
 # ---------------------------------------------------------------------------
+# Stage: tap-build – build the upstream `tap` Go binary (only used by
+# the tap-ingester runtime, but Docker BuildKit prunes unused stages so
+# this is free for other services).
+# ---------------------------------------------------------------------------
+FROM golang:1.26-bookworm AS tap-build
+
+# Pinned to indigo main as of 2026-04-28. Bump deliberately when upstream
+# tap or its event format changes.
+ARG INDIGO_REV=ce62b8fce9e01434213a69cb251852b2c9436cb9
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+        ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+RUN git init . \
+    && git remote add origin https://github.com/bluesky-social/indigo.git \
+    && git fetch --depth 1 origin ${INDIGO_REV} \
+    && git checkout FETCH_HEAD
+
+ENV GODEBUG=netdns=go
+RUN go build -tags timetzdata -o /tap ./cmd/tap
+
+# ---------------------------------------------------------------------------
 # Stage: runtime-base – shared runtime setup
 # ---------------------------------------------------------------------------
 FROM debian:bookworm-slim AS runtime-base
@@ -112,6 +141,24 @@ ENV RUST_LOG=observing_ingester=info
 ENV PORT=8080
 EXPOSE 8080
 CMD ["/app/observing-ingester"]
+
+# ---------------------------------------------------------------------------
+# Stage: runtime for tap-ingester
+# Bundles the upstream `tap` binary so tapped::TapProcess can spawn it
+# as a child process. The /data directory holds the SQLite cursor/state
+# database; on Cloud Run it lives on the ephemeral instance filesystem.
+# Losing it on instance restart is fine — Tap re-discovers and re-backfills.
+# ---------------------------------------------------------------------------
+FROM runtime-base AS runtime-tap-ingester
+
+COPY --from=builder /app/target/release/tap-ingester /app/tap-ingester
+COPY --from=tap-build /tap /usr/local/bin/tap
+
+RUN mkdir -p /data
+ENV RUST_LOG=tap_ingester=info
+ENV PORT=8080
+EXPOSE 8080
+CMD ["/app/tap-ingester"]
 
 # ---------------------------------------------------------------------------
 # Stage: runtime for migrate (one-shot Cloud Run Job)

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -1,17 +1,30 @@
 //! AT Protocol ingester sourced from a Tap (indigo cmd/tap) instance.
 //!
-//! Connects to an externally-running Tap over WebSocket, ack-mode, and writes
-//! events into the same `ingester` schema observing-ingester uses. Idempotent
-//! upserts on `(uri, cid)` mean both ingesters can run side-by-side during
-//! the verification window without colliding.
+//! Two modes:
+//! - **Spawn-inline (default):** uses `tapped::TapProcess::spawn_default` to
+//!   launch the bundled `tap` binary as a child process, then talks to it
+//!   over WebSocket on localhost. The image's Dockerfile puts `tap` on
+//!   PATH; production deploy targets this mode.
+//! - **Connect-existing:** if `TAP_URL` is set, skip spawning and connect
+//!   to an existing Tap instance. Useful for local dev where Tap is
+//!   already running in Docker.
 //!
-//! Required env vars:
-//!   DATABASE_URL          Postgres connection string
-//!   TAP_URL               Base URL of the Tap HTTP API (e.g. http://localhost:2480)
+//! Writes events into the same `ingester` schema observing-ingester uses.
+//! Idempotent upserts on `(uri, cid)` mean both ingesters can run
+//! side-by-side during the verification window without colliding.
+//!
+//! Required env vars (one of):
+//!   DATABASE_URL          Postgres connection string, OR
+//!   DB_HOST + DB_NAME + DB_USER + DB_PASSWORD   (Cloud SQL socket style)
 //!
 //! Optional env vars:
-//!   TAP_ADMIN_PASSWORD    Tap basic auth password (if Tap was started with one)
-//!   PORT                  HTTP server port (default 8080)
+//!   TAP_URL               If set, skip spawning Tap and connect to this URL.
+//!   TAP_ADMIN_PASSWORD    Basic auth password (passed to spawned Tap or used
+//!                         when connecting to an existing one).
+//!   TAP_DATABASE_URL      Backing DB for the embedded Tap. Default
+//!                         `sqlite:///data/tap.db`. /data is the Dockerfile
+//!                         work dir; on Cloud Run it's instance-ephemeral.
+//!   PORT                  HTTP server port (default 8080).
 
 use std::sync::Arc;
 
@@ -26,7 +39,7 @@ use observing_ingester::{
     },
     Database,
 };
-use tapped::{Event, RecordAction, RecordEvent, TapClient};
+use tapped::{Event, LogLevel, RecordAction, RecordEvent, TapClient, TapConfig, TapProcess};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -47,8 +60,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     info!("Starting Observ.ing tap-ingester...");
 
-    let database_url = std::env::var("DATABASE_URL")?;
-    let tap_url = std::env::var("TAP_URL").unwrap_or_else(|_| "http://localhost:2480".to_string());
+    let database_url = resolve_database_url()?;
     let port: u16 = std::env::var("PORT")
         .ok()
         .and_then(|s| s.parse().ok())
@@ -66,12 +78,44 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let db = Database::connect(&database_url).await?;
 
-    let tap = match std::env::var("TAP_ADMIN_PASSWORD") {
-        Ok(pw) => TapClient::with_auth(&tap_url, pw)?,
-        Err(_) => TapClient::new(&tap_url)?,
+    // Bring up Tap. If TAP_URL is set we treat it as already running;
+    // otherwise spawn the bundled binary as a child process. The
+    // _process handle keeps the spawned Tap alive for the lifetime of
+    // this binary (kill_on_drop).
+    let admin_password = std::env::var("TAP_ADMIN_PASSWORD").ok();
+    let (_process, tap) = match std::env::var("TAP_URL") {
+        Ok(url) => {
+            info!(tap_url = %url, "TAP_URL set, connecting to existing Tap");
+            let client = match admin_password {
+                Some(pw) => TapClient::with_auth(&url, pw)?,
+                None => TapClient::new(&url)?,
+            };
+            (None, client)
+        }
+        Err(_) => {
+            info!("spawning embedded tap process");
+            let mut builder = TapConfig::builder()
+                .database_url(
+                    std::env::var("TAP_DATABASE_URL")
+                        .unwrap_or_else(|_| "sqlite:///data/tap.db".to_string()),
+                )
+                .signal_collection(OCCURRENCE_COLLECTION)
+                .collection_filter(OCCURRENCE_COLLECTION)
+                .collection_filter(IDENTIFICATION_COLLECTION)
+                .collection_filter(COMMENT_COLLECTION)
+                .collection_filter(INTERACTION_COLLECTION)
+                .collection_filter(LIKE_COLLECTION)
+                .log_level(LogLevel::Info);
+            if let Some(pw) = admin_password.as_deref() {
+                builder = builder.admin_password(pw.to_string());
+            }
+            let process = TapProcess::spawn_default(builder.build()).await?;
+            let client = process.client()?;
+            (Some(process), client)
+        }
     };
 
-    info!(tap_url = %tap_url, "connecting to tap channel");
+    info!("connecting to tap channel");
     let mut channel = tap.channel().await?;
     state.write().await.connected = true;
     info!("tap channel connected");
@@ -105,7 +149,35 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     state.write().await.connected = false;
     warn!("tap channel closed");
+    // _process drops here, sending SIGTERM to the embedded Tap.
     Ok(())
+}
+
+/// Build a Postgres connection string from either DATABASE_URL directly
+/// or the DB_HOST/DB_NAME/DB_USER/DB_PASSWORD bundle observing-ingester
+/// uses for Cloud SQL socket connections.
+fn resolve_database_url() -> Result<String, Box<dyn std::error::Error>> {
+    if let Ok(url) = std::env::var("DATABASE_URL") {
+        return Ok(url);
+    }
+    let host = std::env::var("DB_HOST")
+        .map_err(|_| "DATABASE_URL or DB_HOST environment variable is required".to_string())?;
+    let name = std::env::var("DB_NAME").unwrap_or_else(|_| "observing".to_string());
+    let user = std::env::var("DB_USER").unwrap_or_else(|_| "postgres".to_string());
+    let password = std::env::var("DB_PASSWORD").unwrap_or_default();
+
+    if host.starts_with("/cloudsql/") {
+        Ok(format!(
+            "postgresql://{}:{}@localhost/{}?host={}",
+            user, password, name, host
+        ))
+    } else {
+        let port = std::env::var("DB_PORT").unwrap_or_else(|_| "5432".to_string());
+        Ok(format!(
+            "postgresql://{}:{}@{}:{}/{}",
+            user, password, host, port, name
+        ))
+    }
 }
 
 async fn process_record(

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,6 +10,7 @@ Deployed via GitHub Actions (`.github/workflows/ci.yml`) on push to `main` after
 |---------|-----------|--------|-----------|---------|-------|
 | observing-appview | `SERVICE=observing-appview` | Yes | Yes | `appview_runtime` | REST API + OAuth + media cache + GBIF taxonomy + serves frontend |
 | observing-ingester | `SERVICE=observing-ingester` | Yes | Yes | `ingester_runtime` | min-instances=1 (always running) |
+| tap-ingester | `SERVICE=tap-ingester` | Yes | Yes | `ingester_runtime` | Side-by-side with observing-ingester during the migration verification window. Bundles the upstream `tap` Go binary (built from a pinned indigo commit) and spawns it as a child process. SQLite state at `/data/tap.db` is instance-ephemeral. min-instances=1 / max-instances=1. |
 | observing-species-id | `SERVICE=observing-species-id` | Yes | No | — | BioCLIP species identification (2 CPU, 8 GiB, cpu-boost, min-instances=1) |
 
 ### Jobs
@@ -82,6 +83,34 @@ DB_NAME=observing
 DB_USER=ingester_runtime
 DB_PASSWORD=<secret: observing-db-ingester-password>
 ```
+
+### Tap-Ingester (`ingester_runtime`)
+
+```bash
+PORT=8080
+
+DB_HOST=/cloudsql/<project>:<region>:observing-db
+DB_NAME=observing
+DB_USER=ingester_runtime
+DB_PASSWORD=<secret: observing-db-ingester-password>
+
+# Optional: connect to an external Tap rather than spawning the bundled
+# binary. Unset in production; useful for local dev when running Tap in
+# Docker separately.
+# TAP_URL=http://localhost:2480
+# TAP_ADMIN_PASSWORD=<secret>
+
+# Optional: backing DB for the embedded Tap. Defaults to
+# `sqlite:///data/tap.db` (instance-ephemeral).
+# TAP_DATABASE_URL=postgres://...
+```
+
+Writes the same `ingester` schema as observing-ingester. Idempotent
+upserts on `(uri, cid)` so dual writes during the verification window
+are harmless. Cross-repo identifications fail their FK against
+`occurrences.uri` until observing-ingester or `bin/backfill.rs` seeds
+the referenced occurrence — same gap observing-ingester's live path
+has today.
 
 ### Species-ID
 


### PR DESCRIPTION
## Summary

Wires up the production deploy for `tap-ingester` (added in #462). One Cloud Run service, one image, one process tree: the Rust binary launches the upstream `tap` Go binary as a child via `tapped::TapProcess::spawn_default`. No separate Tap service to operate, no second deploy step, no separate secrets.

- `Dockerfile`: new `tap-build` stage builds `tap` from a pinned indigo commit (`ce62b8f`); new `runtime-tap-ingester` stage bundles it at `/usr/local/bin/tap`.
- `tap-ingester/main.rs`: spawn-or-connect. Unset `TAP_URL` → spawn embedded; set → connect to existing (preserves the local-dev path against a Docker-running Tap). Adds the `DB_HOST`/`DB_NAME`/`DB_USER`/`DB_PASSWORD` fallback for Cloud SQL socket connections.
- `ci.yml`: build matrix entries are now full service names (drops the implicit `observing-` prefix); adds `tap-ingester` to the matrix and a `Deploy tap-ingester` step modeled on the existing ingester deploy. Same DB role (`ingester_runtime`), same min/max-instances=1.
- `docs/deployment.md`: services table row + env var section.

### Trade-offs

- **Single instance, ephemeral state.** Tap's SQLite DB lives at `/data/tap.db` on the Cloud Run instance. On restart Tap re-discovers and re-backfills (~seconds at current scale). Splitting into a separate Tap service with persistent Postgres state is a follow-up if observ.ing grows past what a single SQLite-on-tmpfs Tap can handle.
- **Cost.** `min-instances=1` on tap-ingester adds a second always-on instance during the verification window. PR-C decommissions either tap-ingester or observing-ingester depending on what the production data shows, so this overlap is bounded.
- **`max-instances=1`** to avoid two embedded Taps both subscribing to the firehose (each would establish its own outbox; data wouldn't corrupt but resync work would double).

### Indigo pin

`tap-build` checks out `ce62b8fce9e01434213a69cb251852b2c9436cb9` (indigo main as of 2026-04-28). Bump deliberately when upstream tap or its event format changes; rebuild is a single CI run.

## Test plan

- [x] `cargo build -p tap-ingester` clean
- [x] `cargo clippy -p tap-ingester -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `docker build --build-arg SERVICE=tap-ingester` builds the image (Go stage builds tap from pinned commit, Rust stage builds tap-ingester, runtime stage bundles both)
- [x] Container smoke against local Postgres: spawned embedded Tap, drained 543-event backfill, wrote 14 occurrences + 13 identifications + 1 like; cross-repo identifications hit the expected FK gap
- [ ] CI green
- [ ] Deploy succeeds; tap-ingester instance reaches `/health`; logs show `spawning embedded tap process` followed by `tap channel connected`
- [ ] Verification window: side-by-side row counts in `ingester` schema, identification FK errors only on cross-repo records, no other surprises
- [ ] PR-C: cross-repo dependency resolution + decommission observing-ingester + jetstream-client