### PR TITLE
feat(tap-ingester): cross-repo dependency resolution

### DIFF
--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -38,6 +38,7 @@ mod database;
 mod error;
 mod media_resolver;
 mod server;
+mod subject_resolver;
 mod types;
 
 use std::sync::Arc;
@@ -48,6 +49,7 @@ use dashboard::DashboardState;
 use database::Database;
 use serde_json::Value;
 use server::{ServerState, SharedState};
+use subject_resolver::SubjectResolver;
 use tapped::{Event, LogLevel, RecordAction, RecordEvent, TapClient, TapConfig, TapProcess};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
@@ -144,29 +146,51 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // (we run this once), so .ok() the result.
     tap_cell.set(tap.clone()).ok();
 
+    // Resolver for cross-repo subject DIDs: when an identification/comment/
+    // like references an occurrence on a DID Tap isn't tracking, the
+    // resolver POSTs `/repos/add` and we suppress the ack so Tap redelivers
+    // the record after backfill. De-dupes per-process so we don't
+    // hammer `/repos/add` for the same DID.
+    let subject_resolver = SubjectResolver::new(tap.clone());
+
     info!("connecting to tap channel");
     let mut channel = tap.channel().await?;
     state.write().await.connected = true;
     info!("tap channel connected");
 
     while let Ok(received) = channel.recv().await {
+        let mut should_ack = true;
         if let Event::Record(record) = &received.event {
-            if let Err(e) = process_record(&db, record, &state).await {
-                // Drop FK-failing or otherwise-bad records on the floor —
-                // ack and move on. Skipping the ack and waiting for Tap
-                // to redeliver only works if there's a path for the
-                // record to eventually succeed; with no cross-repo
-                // resolver in this crate yet, identifications referencing
-                // occurrences on untracked DIDs would loop forever and
-                // saturate the queue ahead of records that *would*
-                // succeed. Cross-repo recovery is tracked separately.
-                error!(uri = %format_uri(record), "process_record failed: {}", e);
-                state.write().await.stats.errors += 1;
+            if process_record(&db, record, &state).await.is_err() {
+                // process_record already logged + bumped stats.errors.
+                // Reactively ask the resolver for the subject DID; if it
+                // *added* a new DID to Tap, suppress this event's ack so
+                // Tap redelivers after the foreign repo backfills.
+                // Otherwise (subject already tracked, no subject, or
+                // resolver couldn't add), ack and move on — looping on
+                // unresolvable records would saturate the queue.
+                let added_new_did = match record_json(record) {
+                    Some(json) => subject_resolver
+                        .ensure_subject_tracked(&json)
+                        .await
+                        .is_some(),
+                    None => false,
+                };
+                if added_new_did {
+                    should_ack = false;
+                }
             }
         }
         // Identity events and any future #[non_exhaustive] tapped::Event
-        // variants are dropped (ack via Drop) without further handling.
-        drop(received);
+        // variants ack via Drop without further handling.
+        if should_ack {
+            drop(received);
+        } else {
+            // Skip auto-ack so Tap redelivers after retry-timeout. tapped's
+            // AckGuard is private, so leaking the ReceivedEvent is the only
+            // way to suppress the auto-ack-on-drop.
+            std::mem::forget(received);
+        }
     }
 
     state.write().await.connected = false;

--- a/crates/tap-ingester/src/subject_resolver.rs
+++ b/crates/tap-ingester/src/subject_resolver.rs
@@ -1,0 +1,169 @@
+//! Cross-repo dependency resolution.
+//!
+//! When tap-ingester processes an identification/comment/like/interaction
+//! that references an occurrence on a DID Tap isn't tracking, the
+//! subject's DID is added to Tap via `/repos/add`. The current event is
+//! then mem::forget'd by the caller so it isn't acked; Tap redelivers
+//! after retry-timeout, and by then the foreign repo's occurrences have
+//! been backfilled (within the per-repo ordering guarantee).
+//!
+//! De-duplication is per-process: a `HashSet` of attempted DIDs prevents
+//! repeatedly POSTing the same DID. On process restart the set resets,
+//! but Tap's repo-tracking is durable in its SQLite/Postgres state, so
+//! a redelivered request is a no-op (Tap dedupes by DID).
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use serde_json::Value;
+use tapped::TapClient;
+use tokio::sync::Mutex;
+use tracing::{info, warn};
+
+#[derive(Clone)]
+pub struct SubjectResolver {
+    tap: TapClient,
+    attempted: Arc<Mutex<HashSet<String>>>,
+}
+
+impl SubjectResolver {
+    pub fn new(tap: TapClient) -> Self {
+        Self {
+            tap,
+            attempted: Arc::new(Mutex::new(HashSet::new())),
+        }
+    }
+
+    /// If the record carries a strongRef subject (`record.occurrence` for
+    /// identifications/interactions, `record.subject` for comments/likes),
+    /// extract the DID and ensure Tap is tracking that repo. Idempotent:
+    /// each DID is `/repos/add`-ed at most once per process lifetime.
+    /// Returns the DID added, or `None` if there was nothing to do.
+    pub async fn ensure_subject_tracked(&self, record: &Value) -> Option<String> {
+        let subject_did = extract_subject_did(record)?;
+
+        {
+            let mut attempted = self.attempted.lock().await;
+            if attempted.contains(&subject_did) {
+                return None;
+            }
+            attempted.insert(subject_did.clone());
+        }
+
+        match self.tap.add_repos(std::slice::from_ref(&subject_did)).await {
+            Ok(_) => {
+                info!(did = %subject_did, "added subject DID to Tap tracking");
+                Some(subject_did)
+            }
+            Err(e) => {
+                warn!(did = %subject_did, error = %e, "/repos/add failed");
+                // Allow a later event to retry.
+                self.attempted.lock().await.remove(&subject_did);
+                None
+            }
+        }
+    }
+}
+
+/// Find a strongRef-shaped subject in the record (under either `occurrence`
+/// or `subject`) and return the DID portion of its `uri`.
+fn extract_subject_did(record: &Value) -> Option<String> {
+    let uri = record
+        .get("occurrence")
+        .and_then(|r| r.get("uri"))
+        .or_else(|| record.get("subject").and_then(|r| r.get("uri")))
+        .and_then(|u| u.as_str())?;
+    let stripped = uri.strip_prefix("at://")?;
+    let did = stripped.split('/').next()?;
+    if did.is_empty() {
+        return None;
+    }
+    Some(did.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn identification_uses_occurrence_field() {
+        let record = json!({
+            "$type": "bio.lexicons.temp.v0-1.identification",
+            "occurrence": {
+                "uri": "at://did:plc:foo123/bio.lexicons.temp.v0-1.occurrence/3xyz",
+                "cid": "bafy..."
+            },
+            "scientificName": "Quercus alba"
+        });
+        assert_eq!(
+            extract_subject_did(&record).as_deref(),
+            Some("did:plc:foo123")
+        );
+    }
+
+    #[test]
+    fn comment_uses_subject_field() {
+        let record = json!({
+            "$type": "ing.observ.temp.comment",
+            "subject": {
+                "uri": "at://did:plc:bar456/bio.lexicons.temp.v0-1.occurrence/abc",
+                "cid": "bafy..."
+            },
+            "body": "Nice find!"
+        });
+        assert_eq!(
+            extract_subject_did(&record).as_deref(),
+            Some("did:plc:bar456")
+        );
+    }
+
+    #[test]
+    fn like_uses_subject_field() {
+        let record = json!({
+            "$type": "ing.observ.temp.like",
+            "subject": {
+                "uri": "at://did:plc:baz789/bio.lexicons.temp.v0-1.occurrence/xyz",
+                "cid": "bafy..."
+            }
+        });
+        assert_eq!(
+            extract_subject_did(&record).as_deref(),
+            Some("did:plc:baz789")
+        );
+    }
+
+    #[test]
+    fn interaction_uses_occurrence_field() {
+        let record = json!({
+            "$type": "ing.observ.temp.interaction",
+            "occurrence": {
+                "uri": "at://did:plc:qux/bio.lexicons.temp.v0-1.occurrence/i",
+                "cid": "bafy..."
+            }
+        });
+        assert_eq!(extract_subject_did(&record).as_deref(), Some("did:plc:qux"));
+    }
+
+    #[test]
+    fn occurrence_record_has_no_subject() {
+        let record = json!({
+            "$type": "bio.lexicons.temp.v0-1.occurrence",
+            "scientificName": "Quercus alba",
+            "eventDate": "2026-04-15"
+        });
+        assert!(extract_subject_did(&record).is_none());
+    }
+
+    #[test]
+    fn malformed_uri_returns_none() {
+        let record = json!({"subject": {"uri": "not-an-at-uri"}});
+        assert!(extract_subject_did(&record).is_none());
+    }
+
+    #[test]
+    fn empty_did_returns_none() {
+        let record = json!({"subject": {"uri": "at:///collection/rkey"}});
+        assert!(extract_subject_did(&record).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

Closes the cross-repo gap inherited from `observing-ingester`: when an identification/comment/like/interaction references an occurrence on a DID Tap isn't tracking, the foreign DID is now POSTed to `/repos/add` so Tap backfills its occurrences, and the current event is held back so it's redelivered after Tap's `retry-timeout`.

**Stacked on #463** (the deploy PR). Rebase to main once that lands.

- `subject_resolver.rs`: extracts the DID from a record's strongRef (`occurrence` for identifications/interactions, `subject` for comments/likes), calls `TapClient::add_repos` once per (process lifetime, DID) — `HashSet` dedupe so high-error-rate workloads don't hammer the API. 7 unit tests cover the field-shape matrix and edge cases.
- **Bug fix in `main.rs`**: the previous PR's `process_record` swallowed Database errors and returned `Ok(())`, so the outer loop's error handler (ack-skip + retry) never ran. With it now propagating, both the resolver call and `mem::forget` actually fire.
- **Bounded retry**: `mem::forget` the `ReceivedEvent` only when the resolver actually added a new DID. Records pointing at deleted occurrences (or anything else permanently unresolvable) are acked on first failure, matching `observing-ingester`'s log-and-continue behavior. No infinite loops on data-quality issues.

## Smoke test

Local Tap + tap-ingester against the dev DB. The test dataset is dominated by testobserving's identifications, ~530 of which reference occurrences that have been deleted from PDS — a real-world data-quality case.

|                  | Before resolver (PR #462) | With infinite retry | With bounded retry (this PR) |
|------------------|---------------------------|---------------------|------------------------------|
| `/repos/add` calls | 0 | 1 (no-op, same-DID) | 1 (no-op, same-DID) |
| Errors @ 4min    | 528 | 2120 | 531 |
| Plateau?         | Yes (acked first try) | No (kept growing) | Yes |
| Records written  | 14 occ / 13 ident / 1 like | same | same |

For the dataset of interest (real cross-DID identifications between observ.ing users), the resolver path works as designed: when it sees a previously-untracked DID, it adds it, suppresses the ack so Tap redelivers, and the redelivered event finds the FK target after Tap finishes backfilling. Locally we couldn't exercise that path because all the failing identifications point at testobserving's own DID (a data quirk, not a code issue). Production data should hit the cross-DID path and resolve.

## What's still TODO

- **Verification window in production** (PR #463 deploy + this resolver) before flipping to ready-for-review and starting on the decommission step.
- **Decommission**: delete `crates/observing-ingester` + `crates/jetstream-client` + the FK-blind portions of `bin/backfill.rs`. Becomes its own PR after verification confirms parity.

## Test plan

- [x] `cargo test -p tap-ingester` — 7 new tests pass (field-shape extraction matrix)
- [x] `cargo clippy -p tap-ingester -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Local smoke: resolver fires on FK errors, dedupes correctly, no infinite retry
- [ ] CI green
- [ ] Deploy + verification window proves cross-DID path works on production data