### PR TITLE
feat(tap-ingester): reverse-proxy embedded Tap admin UI under /tap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4752,11 +4752,13 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 name = "tap-ingester"
 version = "0.1.0"
 dependencies = [
+ "axum",
  "chrono",
  "clap",
  "jetstream-client",
  "observing-db",
  "observing-ingester",
+ "reqwest 0.13.3",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/tap-ingester/Cargo.toml
+++ b/crates/tap-ingester/Cargo.toml
@@ -23,6 +23,10 @@ jetstream-client = { path = "../jetstream-client" }
 # Async runtime
 tokio = { workspace = true }
 
+# HTTP server (proxy route to embedded Tap admin) + HTTP client (proxy upstream)
+axum = { workspace = true }
+reqwest = { workspace = true }
+
 # Database
 sqlx = { workspace = true }
 

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -25,20 +25,31 @@
 //!                         `sqlite:///data/tap.db`. /data is the Dockerfile
 //!                         work dir; on Cloud Run it's instance-ephemeral.
 //!   PORT                  HTTP server port (default 8080).
+//!
+//! HTTP routes:
+//!   /                     Stats dashboard (occurrences, identifications, etc.).
+//!   /health, /api/stats   Cloud Run health check + JSON stats feed.
+//!   /tap, /tap/*          Reverse proxy to the embedded Tap admin UI on
+//!                         127.0.0.1:2480. Auth headers pass through; Tap's
+//!                         TAP_ADMIN_PASSWORD is the gate.
+
+mod tap_proxy;
 
 use std::sync::Arc;
 
+use axum::routing::any;
 use chrono::Utc;
 use clap::Parser;
 use jetstream_client::CommitInfo;
 use observing_ingester::{
-    server::{start_server, ServerState, SharedState},
+    server::{create_router, ServerState, SharedState},
     types::{
         RecentEvent, COMMENT_COLLECTION, IDENTIFICATION_COLLECTION, INTERACTION_COLLECTION,
         LIKE_COLLECTION, OCCURRENCE_COLLECTION,
     },
     Database,
 };
+use tap_proxy::TapProxy;
 use tapped::{Event, LogLevel, RecordAction, RecordEvent, TapClient, TapConfig, TapProcess};
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
@@ -68,10 +79,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let state: SharedState = Arc::new(RwLock::new(ServerState::new()));
 
+    // Tap admin reverse-proxy target. When TAP_URL is set we point at it;
+    // otherwise the embedded Tap binds to localhost on its default port.
+    let tap_admin_url =
+        std::env::var("TAP_URL").unwrap_or_else(|_| "http://127.0.0.1:2480".to_string());
+
     // Spawn HTTP server immediately so Cloud Run health checks pass.
     let http_state = state.clone();
+    let tap_proxy_state = TapProxy::new(tap_admin_url);
     tokio::spawn(async move {
-        if let Err(e) = start_server(http_state, port).await {
+        if let Err(e) = serve_http(http_state, tap_proxy_state, port).await {
             error!("HTTP server error: {}", e);
         }
     });
@@ -151,6 +168,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     warn!("tap channel closed");
     // _process drops here, sending SIGTERM to the embedded Tap.
     Ok(())
+}
+
+/// Compose the dashboard router (from observing-ingester) with the /tap/*
+/// reverse proxy and serve the result. The proxy routes use their own
+/// `TapProxy` state, so we build them as a sub-router and nest it.
+async fn serve_http(state: SharedState, proxy: TapProxy, port: u16) -> std::io::Result<()> {
+    let proxy_router = axum::Router::new()
+        .route("/", any(tap_proxy::proxy_root))
+        .route("/{*path}", any(tap_proxy::proxy))
+        .with_state(proxy);
+    let router = create_router(state).nest("/tap", proxy_router);
+    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
+    info!("Starting HTTP server on {}", addr);
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, router).await
 }
 
 /// Build a Postgres connection string from either DATABASE_URL directly

--- a/crates/tap-ingester/src/tap_proxy.rs
+++ b/crates/tap-ingester/src/tap_proxy.rs
@@ -1,0 +1,126 @@
+//! Reverse proxy from tap-ingester's HTTP server to the embedded Tap admin UI.
+//!
+//! Tap binds to `127.0.0.1:2480` inside the Cloud Run container, which means
+//! its admin surface is unreachable from the public internet. Cloud Run only
+//! exposes a single port (the ingester's), and there's no SSH/exec story for
+//! Cloud Run instances. Mounting Tap's UI underneath `/tap/*` on the ingester
+//! is the only practical way to inspect repo lists, pause channels, or trigger
+//! manual `/repos/add` calls from outside the container.
+//!
+//! Auth: requests are forwarded as-is. Tap's existing Basic auth (gated by
+//! `TAP_ADMIN_PASSWORD`) is the only check — the proxy itself adds none. Don't
+//! deploy without `TAP_ADMIN_PASSWORD` set in production.
+
+use axum::{
+    body::Body,
+    extract::{Path, Request, State},
+    http::{HeaderMap, HeaderName, HeaderValue, StatusCode},
+    response::Response,
+};
+use reqwest::Client;
+use std::str::FromStr;
+use tracing::warn;
+
+#[derive(Clone)]
+pub struct TapProxy {
+    upstream: String,
+    client: Client,
+}
+
+impl TapProxy {
+    pub fn new(upstream: impl Into<String>) -> Self {
+        let upstream = upstream.into().trim_end_matches('/').to_string();
+        Self {
+            upstream,
+            client: Client::new(),
+        }
+    }
+}
+
+/// Hop-by-hop headers that must not be forwarded across a proxy boundary.
+/// (RFC 9110 §7.6.1.) `host` is also stripped because reqwest sets its own.
+fn is_hop_header(name: &str) -> bool {
+    matches!(
+        name,
+        "connection"
+            | "keep-alive"
+            | "proxy-authenticate"
+            | "proxy-authorization"
+            | "te"
+            | "trailers"
+            | "transfer-encoding"
+            | "upgrade"
+            | "host"
+            | "content-length"
+    )
+}
+
+fn copy_headers(src: &HeaderMap, dst: &mut HeaderMap) {
+    for (name, value) in src.iter() {
+        if is_hop_header(name.as_str()) {
+            continue;
+        }
+        dst.insert(name.clone(), value.clone());
+    }
+}
+
+pub async fn proxy(
+    State(proxy): State<TapProxy>,
+    Path(path): Path<String>,
+    req: Request<Body>,
+) -> Result<Response, StatusCode> {
+    let method = req.method().clone();
+    let headers = req.headers().clone();
+    let query = req
+        .uri()
+        .query()
+        .map(|q| format!("?{q}"))
+        .unwrap_or_default();
+    let body_bytes = axum::body::to_bytes(req.into_body(), usize::MAX)
+        .await
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    let target = format!("{}/{}{}", proxy.upstream, path, query);
+    let upstream_method =
+        reqwest::Method::from_str(method.as_str()).map_err(|_| StatusCode::BAD_REQUEST)?;
+    let mut builder = proxy.client.request(upstream_method, &target);
+    let mut forwarded = HeaderMap::new();
+    copy_headers(&headers, &mut forwarded);
+    builder = builder.headers(forwarded).body(body_bytes.to_vec());
+
+    let resp = match builder.send().await {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(target = %target, error = %e, "tap proxy upstream request failed");
+            return Err(StatusCode::BAD_GATEWAY);
+        }
+    };
+
+    let status = resp.status();
+    let mut out = Response::builder().status(status.as_u16());
+    if let Some(headers_mut) = out.headers_mut() {
+        for (name, value) in resp.headers().iter() {
+            if is_hop_header(name.as_str()) {
+                continue;
+            }
+            if let (Ok(n), Ok(v)) = (
+                HeaderName::from_bytes(name.as_str().as_bytes()),
+                HeaderValue::from_bytes(value.as_bytes()),
+            ) {
+                headers_mut.insert(n, v);
+            }
+        }
+    }
+    let bytes = resp.bytes().await.map_err(|_| StatusCode::BAD_GATEWAY)?;
+    out.body(Body::from(bytes))
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)
+}
+
+/// Convenience: bare `/tap` (no trailing path) — Tap's UI lives at the root,
+/// so we forward to upstream `/`.
+pub async fn proxy_root(
+    State(state): State<TapProxy>,
+    req: Request<Body>,
+) -> Result<Response, StatusCode> {
+    proxy(State(state), Path(String::new()), req).await
+}


### PR DESCRIPTION
## Summary

Mounts the embedded Tap admin UI under `/tap/*` on the tap-ingester service so it's reachable in production. Tap binds to `127.0.0.1:2480` inside the Cloud Run container — without this proxy, its repo list, `/repos/add` endpoint, and channel state are unreachable from outside the instance (Cloud Run exposes only the ingester's port; no exec/SSH).

## Auth model

Requests are forwarded as-is. Tap's existing Basic auth — gated by `TAP_ADMIN_PASSWORD` — is the only check. The proxy itself adds no auth, so:

- **Keep `TAP_ADMIN_PASSWORD` set in production.** Without it, anyone reaching the public Cloud Run URL could mutate Tap state.
- Hop-by-hop headers (`connection`, `keep-alive`, `transfer-encoding`, `upgrade`, `host`, `content-length`, plus the proxy-* / TE / trailers set from RFC 9110 §7.6.1) are stripped on both directions.
- All HTTP methods are forwarded — including POST for `/repos/add`. If we want read-only later, that's a one-line `axum::routing::any` → `axum::routing::get` change.

## Files

- `crates/tap-ingester/src/tap_proxy.rs` (new) — reqwest-backed forwarding handler, hop-by-hop header stripping, `TapProxy` state struct.
- `crates/tap-ingester/src/main.rs` — adds `mod tap_proxy`, computes `tap_admin_url` (TAP_URL env var or `http://127.0.0.1:2480`), replaces the `start_server` call with a `serve_http` helper that nests the proxy router under `/tap` on top of `observing_ingester::server::create_router`.
- `crates/tap-ingester/Cargo.toml` — direct deps on workspace `axum` and `reqwest` (already pulled in transitively; this just makes the use-site honest).

## Test plan

- [x] `cargo build -p tap-ingester` clean
- [x] `cargo clippy -p tap-ingester --all-targets -- -D warnings` clean
- [x] `cargo test -p tap-ingester` clean
- [x] `cargo fmt` clean
- [ ] CI green
- [ ] After deploy, hit `https://tap-ingester-...run.app/tap/` in a browser — Basic auth prompt should come from Tap; entering `TAP_ADMIN_PASSWORD` should land on Tap's admin UI.