### PR TITLE
test(e2e): split Agree-button race into API poll + tight DOM check

### DIFF
--- a/tests/e2e.spec.ts
+++ b/tests/e2e.spec.ts
@@ -1,7 +1,22 @@
-import { expect } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 import { test as authTest } from "./fixtures/auth";
 import { openUploadModal, revealCoordinateInputs } from "./helpers/navigation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
+
+async function waitForOccurrenceIndexed(page: Page, uri: string, timeoutMs = 30_000) {
+  const encoded = encodeURIComponent(uri);
+  const deadline = Date.now() + timeoutMs;
+  let lastStatus: number | null = null;
+  while (Date.now() < deadline) {
+    const resp = await page.request.get(`/api/occurrences/${encoded}`);
+    lastStatus = resp.status();
+    if (lastStatus === 200) return;
+    await page.waitForTimeout(500);
+  }
+  throw new Error(
+    `occurrence ${uri} was not indexed within ${timeoutMs}ms (last status ${lastStatus})`,
+  );
+}
 
 /**
  * End-to-end CRUD test against a live Bluesky PDS.
@@ -52,10 +67,22 @@ authTest.describe("E2E CRUD flow", () => {
       occurrenceUri = `at://${did}/bio.lexicons.temp.v0-1.occurrence/${rkey}`;
     });
 
-    // Step 3: add identification
+    // Step 3: add identification.
+    //
+    // The `Agree` button only renders once the occurrence row exists in
+    // appview's Postgres — i.e. after the firehose → ingester → DB write
+    // round-trip completes. Waiting on a button that depends on that
+    // pipeline conflates "ingester wrote" with "DOM rerendered," and the
+    // single 10s `toBeVisible` was racy under CI load (issue #467).
+    //
+    // Split the wait: poll the appview API until the occurrence is
+    // indexed (generous budget — that's where the real wait lives), then
+    // assert button visibility with a tight DOM-only timeout. Next time
+    // this flakes, the failure mode tells us which half is slow.
     await authTest.step("add identification", async () => {
+      await waitForOccurrenceIndexed(page, occurrenceUri!);
       const agreeBtn = page.getByRole("button", { name: "Agree" });
-      await expect(agreeBtn).toBeVisible({ timeout: 10000 });
+      await expect(agreeBtn).toBeVisible({ timeout: 5_000 });
       const idDone = page.waitForResponse(
         (resp) => resp.request().method() === "POST" && resp.url().includes("/api/identifications"),
         { timeout: 15_000 },


### PR DESCRIPTION
Investigates #467.

## What's flaking

\`tests/e2e.spec.ts:15:3\` ‹ E2E CRUD flow › create, identify, and delete an occurrence › intermittently fails on:

\`\`\`
Locator: getByRole('button', { name: 'Agree' })
> 58 |       await expect(agreeBtn).toBeVisible({ timeout: 10000 });
\`\`\`

The button only appears after the firehose → ingester → Postgres write round-trip completes. The 10s budget conflates "ingester wrote" with "DOM rerendered," and under CI load the firehose pipeline occasionally exceeds 10s.

## Change

Add \`waitForOccurrenceIndexed(page, uri)\` that polls \`GET /api/occurrences/:uri\` for a 200, with a 30s budget. Call it before the Agree-button visibility check. Drop the visibility check to a tight 5s — purely DOM, no DB write in the budget.

## Why this is the right shape (vs. just bumping the timeout)

1. **Diagnostic.** Next time this fails, the error tells us *which half* was slow:
   - Helper throws → ingester→DB pipeline didn't finish in 30s (real systems issue)
   - 5s DOM expect fails → row was indexed but the page didn't rerender (frontend issue)
2. **Honest budget.** The current 10s is implicitly waiting on a multi-service pipeline; making that explicit forces us to think about whether 30s is really what we want here.
3. **No behavior change in the happy path.** Test still creates, agrees, edits, deletes the same way.

## Test plan

- [x] \`oxfmt\` clean
- [x] \`oxlint\` clean (no new warnings on the changed file)
- [ ] CI run — primary signal. If e2e is green, that's the test passing once; flake confirmation needs a few clean runs.
- [ ] Watch for failure mode if it does flake — helper-thrown vs. DOM-expect tells us next move.