### PR TITLE
feat(tap-ingester): persist Tap state in Postgres `tap` schema

### DIFF
--- a/crates/observing-db/migrations/20260509100000_tap_schema.sql
+++ b/crates/observing-db/migrations/20260509100000_tap_schema.sql
@@ -1,0 +1,28 @@
+-- Tap's persistent state (tracked DIDs, cursors, retry queues) lives in
+-- its own `tap` schema, separate from observ.ing's app tables. This
+-- replaces the per-instance ephemeral SQLite at /data/tap.db, where
+-- every Cloud Run revision lost Tap's tracked-DID list and forced a
+-- full repo backfill on each deploy.
+--
+-- tap-ingester connects with `?options=-c search_path=tap`, so Tap's
+-- unqualified CREATE TABLE statements land here. The schema is
+-- owned by postgres but ingester_runtime has CREATE on it, so the
+-- tables Tap creates end up owned by ingester_runtime with full
+-- privileges (postgres can no longer GRANT on or operate on objects
+-- owned by ingester_runtime — see the comment in 20260428000001 —
+-- which is fine since Tap is the only thing reading or writing here).
+--
+-- Idempotent. The grants block no-ops where `ingester_runtime`
+-- doesn't exist (local/CI).
+
+CREATE SCHEMA IF NOT EXISTS tap;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ingester_runtime') THEN
+        RAISE NOTICE 'ingester_runtime role not found; skipping tap-schema grants (expected on local/CI)';
+        RETURN;
+    END IF;
+    EXECUTE 'GRANT USAGE, CREATE ON SCHEMA tap TO ingester_runtime';
+END
+$$;

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -21,9 +21,14 @@
 //!   TAP_URL               If set, skip spawning Tap and connect to this URL.
 //!   TAP_ADMIN_PASSWORD    Basic auth password (passed to spawned Tap or used
 //!                         when connecting to an existing one).
-//!   TAP_DATABASE_URL      Backing DB for the embedded Tap. Default
-//!                         `sqlite:///data/tap.db`. /data is the Dockerfile
-//!                         work dir; on Cloud Run it's instance-ephemeral.
+//!   TAP_DATABASE_URL      Backing DB for the embedded Tap. If unset and
+//!                         DB_HOST is set (production), tap-ingester
+//!                         derives a Postgres URL from the same DB_*
+//!                         vars used for the app database, with
+//!                         `search_path=tap` so Tap's tables land in
+//!                         their own schema. If neither is set,
+//!                         falls back to `sqlite:///data/tap.db`
+//!                         (instance-ephemeral on Cloud Run).
 //!   PORT                  HTTP server port (default 8080).
 //!
 //! HTTP routes (see `dashboard` module for handlers):
@@ -113,10 +118,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Err(_) => {
             info!("spawning embedded tap process");
             let mut builder = TapConfig::builder()
-                .database_url(
-                    std::env::var("TAP_DATABASE_URL")
-                        .unwrap_or_else(|_| "sqlite:///data/tap.db".to_string()),
-                )
+                .database_url(resolve_tap_database_url())
                 .signal_collection(OCCURRENCE_COLLECTION)
                 .collection_filter(OCCURRENCE_COLLECTION)
                 .collection_filter(IDENTIFICATION_COLLECTION)
@@ -182,6 +184,43 @@ async fn serve_http(state: DashboardState, port: u16) -> std::io::Result<()> {
     info!("Starting HTTP server on {}", addr);
     let listener = tokio::net::TcpListener::bind(addr).await?;
     axum::serve(listener, router).await
+}
+
+/// Backing DB URL for the embedded Tap.
+///
+/// Precedence:
+/// 1. `TAP_DATABASE_URL` if set — explicit override (e.g. local dev
+///    pointing at a separate sqlite file).
+/// 2. `DB_HOST` set → derive a Postgres URL from the same env vars
+///    `resolve_database_url` uses for the app DB, plus
+///    `options=-c search_path=tap` so Tap's tables land in the `tap`
+///    schema instead of `public`. This is the production path.
+/// 3. Fallback `sqlite:///data/tap.db` — instance-ephemeral, only
+///    relevant when nothing about Postgres is configured (early local
+///    dev with just `DATABASE_URL`).
+fn resolve_tap_database_url() -> String {
+    if let Ok(url) = std::env::var("TAP_DATABASE_URL") {
+        return url;
+    }
+    let Ok(host) = std::env::var("DB_HOST") else {
+        return "sqlite:///data/tap.db".to_string();
+    };
+    let name = std::env::var("DB_NAME").unwrap_or_else(|_| "observing".to_string());
+    let user = std::env::var("DB_USER").unwrap_or_else(|_| "postgres".to_string());
+    let password = std::env::var("DB_PASSWORD").unwrap_or_default();
+    // `-csearch_path%3Dtap` is libpq's `options` form, URL-encoded:
+    // `-c search_path=tap`. Standard pg drivers (including the one Tap
+    // links) honor it on session start.
+    if host.starts_with("/cloudsql/") {
+        format!(
+            "postgresql://{user}:{password}@localhost/{name}?host={host}&options=-c%20search_path%3Dtap"
+        )
+    } else {
+        let port = std::env::var("DB_PORT").unwrap_or_else(|_| "5432".to_string());
+        format!(
+            "postgresql://{user}:{password}@{host}:{port}/{name}?options=-c%20search_path%3Dtap"
+        )
+    }
 }
 
 /// Build a Postgres connection string from either DATABASE_URL directly

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -23,6 +23,9 @@ flowchart TB
       subgraph PUB["schema: public"]
         PUB_TBL["sensitive_species,<br/>spatial_ref_sys"]
       end
+      subgraph TAP["schema: tap"]
+        TAP_TBL["Tap-managed tables<br/>(tracked DIDs, cursors,<br/>retry queues — auto-created<br/>by the upstream tap binary)"]
+      end
     end
 
     User -- HTTP --> AV

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,7 @@ Deployed via GitHub Actions (`.github/workflows/ci.yml`) on push to `main` after
 |---------|-----------|--------|-----------|---------|-------|
 | observing-appview | `SERVICE=observing-appview` | Yes | Yes | `appview_runtime` | REST API + OAuth + media cache + GBIF taxonomy + serves frontend |
 | observing-ingester | `SERVICE=observing-ingester` | Yes | Yes | `ingester_runtime` | min-instances=1 (always running) |
-| tap-ingester | `SERVICE=tap-ingester` | Yes | Yes | `ingester_runtime` | Side-by-side with observing-ingester during the migration verification window. Bundles the upstream `tap` Go binary (built from a pinned indigo commit) and spawns it as a child process. SQLite state at `/data/tap.db` is instance-ephemeral. min-instances=1 / max-instances=1. |
+| tap-ingester | `SERVICE=tap-ingester` | Yes | Yes | `ingester_runtime` | Side-by-side with observing-ingester during the migration verification window. Bundles the upstream `tap` Go binary (built from a pinned indigo commit) and spawns it as a child process. Tap state is persisted in the Cloud SQL `tap` schema (`search_path=tap`), so tracked-DID lists and cursors survive deploys and instance recycles. min-instances=1 / max-instances=1. |
 | observing-species-id | `SERVICE=observing-species-id` | Yes | No | — | BioCLIP species identification (2 CPU, 8 GiB, cpu-boost, min-instances=1) |
 
 ### Jobs
@@ -100,8 +100,16 @@ DB_PASSWORD=<secret: observing-db-ingester-password>
 # TAP_URL=http://localhost:2480
 # TAP_ADMIN_PASSWORD=<secret>
 
-# Optional: backing DB for the embedded Tap. Defaults to
-# `sqlite:///data/tap.db` (instance-ephemeral).
+# Optional: backing DB for the embedded Tap.
+#
+# When unset (the production default), tap-ingester derives a Postgres
+# URL from the same DB_HOST/DB_NAME/DB_USER/DB_PASSWORD vars used for
+# the app DB and appends `options=-c search_path=tap`, so Tap's tables
+# land in the dedicated `tap` schema. State persists across deploys.
+#
+# When neither TAP_DATABASE_URL nor DB_HOST is set, falls back to
+# `sqlite:///data/tap.db` (instance-ephemeral). Set explicitly to
+# override either default.
 # TAP_DATABASE_URL=postgres://...
 ```
 
@@ -153,6 +161,7 @@ PGPASSWORD=$(python3 -c "import urllib.parse,sys; print(urllib.parse.urlparse(sy
 BEGIN;
 DROP SCHEMA IF EXISTS appview CASCADE;
 DROP SCHEMA IF EXISTS ingester CASCADE;
+DROP SCHEMA IF EXISTS tap CASCADE;
 DROP SCHEMA IF EXISTS public CASCADE;
 CREATE SCHEMA public;
 GRANT ALL ON SCHEMA public TO postgres;


### PR DESCRIPTION
## Why

Tap currently keeps its tracked-DID list, cursors, and retry queues in SQLite at \`/data/tap.db\` — instance-ephemeral on Cloud Run. Every deploy lands on a fresh instance with empty Tap state, so Tap re-discovers each active DID via the firehose signal and re-backfills their full repos against their PDSes. Idempotent \`(uri, cid)\` upserts make this safe, but it's wasted bandwidth/time that scales with tracked DIDs.

## Change

Move Tap onto the same Cloud SQL instance, in a dedicated \`tap\` schema:

- **New migration** \`20260509100000_tap_schema.sql\` — \`CREATE SCHEMA tap\` + \`GRANT USAGE, CREATE ON SCHEMA tap TO ingester_runtime\`. Idempotent; no-ops on local/CI where \`ingester_runtime\` doesn't exist.
- **\`resolve_tap_database_url()\`** — precedence: explicit \`TAP_DATABASE_URL\` > derived from \`DB_*\` (with \`?options=-c%20search_path%3Dtap\`) > \`sqlite:///data/tap.db\` fallback.
- **Tap creates its own tables.** They end up owned by \`ingester_runtime\` (which has \`CREATE\` on the schema), which is intentional — postgres can no longer \`GRANT\` on objects owned by runtime roles after \#334 revoked \`cloudsqlsuperuser\`. Tap is the only thing reading or writing this schema, so single-owner is fine.
- **Docs.** Updated \`docs/deployment.md\` (env-var section + wipe runbook now drops \`tap\`) and \`docs/architecture.md\` (added \`tap\` schema to the diagram).

## Migration cost on this deploy

This deploy itself still pays one backfill — Tap loses the SQLite file and starts fresh against the new Postgres schema. After that, deploys are cheap.

## Risks

- **Search-path quirks.** Tap's Go binary uses pgx; pgx honors the \`options=-c\` libpq form. If for some reason it doesn't, Tap will try to \`CREATE TABLE\` in \`public\`, which \`ingester_runtime\` doesn't have \`CREATE\` on — loud failure (permission denied), not silent table creation in the wrong schema. Confirmed locally: cargo build/clippy/test/fmt all clean. Live test on the staging deploy will confirm pgx+search_path works as expected.
- **Cloud SQL load.** Tap's writes go to Cloud SQL instead of local SQLite. Tap state ops are tiny (cursor advances, occasional retry-queue updates). Negligible.

## Test plan

- [x] \`cargo build --workspace\` clean
- [x] \`cargo clippy -p tap-ingester --all-targets -- -D warnings\` clean
- [x] \`cargo test -p tap-ingester\` clean
- [x] \`cargo fmt\` clean
- [ ] CI: \`rust-sqlx\` job runs the migration against a real Postgres
- [ ] Post-deploy: verify \`/api/tap-stats\` reports non-zero counts and a non-null firehose cursor; confirm \`SELECT tablename FROM pg_tables WHERE schemaname='tap'\` returns Tap's tables.
- [ ] Trigger a redeploy and confirm \`recordCount\` and \`repoCount\` don't reset.