### PR TITLE
docs: refresh architecture and data-flow diagrams for Tap-driven ingest

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,37 +6,44 @@
 flowchart TB
     User([Browser])
     PDS[Bluesky PDS]
-    JS[Jetstream firehose]
+    Relay[AT Protocol relay]
     AV[observing-appview<br/>DB_USER=appview_runtime]
-    IG[observing-ingester<br/>DB_USER=ingester_runtime]
+
+    subgraph TAPING["tap-ingester (Cloud Run, DB_USER=ingester_runtime)"]
+      direction TB
+      TAP[Tap<br/>indigo cmd/tap<br/>spawned as child process]
+      TAPRS[Rust event consumer<br/>writes ingester schema]
+      TAP -- "WS /channel<br/>(loopback)" --> TAPRS
+    end
+
     MIG[observing-migrate<br/>Cloud Run Job<br/>DB_USER=postgres]
     SID[species-id]
 
     subgraph DB["Postgres + PostGIS"]
       direction LR
       subgraph ING["schema: ingester"]
-        ING_TBL["occurrences, occurrence_observers,<br/>identifications, comments,<br/>interactions, likes, notifications,<br/>ingester_state, community_ids"]
+        ING_TBL["occurrences, occurrence_observers,<br/>identifications, comments,<br/>interactions, likes, notifications,<br/>community_ids"]
       end
       subgraph APPV["schema: appview"]
         APPV_TBL["occurrence_private_data,<br/>notification_reads,<br/>oauth_sessions, oauth_state"]
       end
+      subgraph TAP_SCHEMA["schema: tap"]
+        TAP_TBL["Tap-managed tables<br/>(tracked DIDs, cursors,<br/>retry queues — auto-created<br/>by the upstream tap binary,<br/>search_path=tap)"]
+      end
       subgraph PUB["schema: public"]
         PUB_TBL["sensitive_species,<br/>spatial_ref_sys"]
-      end
-      subgraph TAP["schema: tap"]
-        TAP_TBL["Tap-managed tables<br/>(tracked DIDs, cursors,<br/>retry queues — auto-created<br/>by the upstream tap binary)"]
       end
     end
 
     User -- HTTP --> AV
     AV -- "putRecord / deleteRecord" --> PDS
-    PDS -- commits --> JS
-    JS -- "WSS subscribe" --> IG
+    PDS -- commits --> Relay
+    Relay -- "MST sync" --> TAP
     AV -- species-id --> SID
 
-    IG == "READ+WRITE" ==> ING
-    IG -- "READ-ONLY<br/>(backfill reads oauth_sessions)" --> APPV
-    IG -- "READ-ONLY" --> PUB
+    TAPRS == "READ+WRITE" ==> ING
+    TAP == "READ+WRITE" ==> TAP_SCHEMA
+    TAPRS -- "READ-ONLY" --> PUB
 
     AV -- "READ-ONLY" --> ING
     AV == "READ+WRITE" ==> APPV
@@ -45,7 +52,7 @@ flowchart TB
     MIG -. "DDL (one-shot, pre-deploy)" .-> DB
 ```
 
-Writes to lexicon data flow **user → appview → PDS → Jetstream → ingester → DB**; the appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. Migrations run as a one-shot `observing-migrate` Cloud Run Job executed by CI *before* services are deployed; that job is the only thing that ever connects as the `postgres` superuser. No long-running service holds admin credentials — the ingester runs as `ingester_runtime` (CRUD on `ingester` schema, `SELECT` on `appview.oauth_sessions` for the backfill `--all` binary, and `SELECT` on `public.sensitive_species`), and the appview runs as `appview_runtime`.
+Writes to lexicon data flow **user → appview → PDS → Tap → tap-ingester → DB**. Tap (`indigo cmd/tap`) is bundled into the tap-ingester container and spawned as a child process; it does an MST/signature-verified sync against the user's PDS, then forwards events to the Rust consumer over a loopback WebSocket. Tap's own state — the tracked-DID list, cursor positions, and retry queues — lives in a dedicated `tap` schema on the same Cloud SQL instance the app uses, with `search_path=tap` so Tap's auto-created tables don't collide with anything else. The appview never writes to the `ingester` schema. OAuth state, private location, and per-user notification read-state live in the `appview` schema, where the appview has full CRUD. When a user marks a notification as read, the appview inserts into `appview.notification_reads` — at query time the notifications list LEFT JOINs against it to produce the `read` flag. Migrations run as a one-shot `observing-migrate` Cloud Run Job executed by CI *before* services are deployed; that job is the only thing that ever connects as the `postgres` superuser. No long-running service holds admin credentials — tap-ingester runs as `ingester_runtime` (CRUD on `ingester` schema, `USAGE`/`CREATE` on the `tap` schema for Tap's own tables, `SELECT` on `public.sensitive_species`) and the appview runs as `appview_runtime`.
 
 ## Project Structure
 
@@ -54,7 +61,7 @@ Top-level service crates (each builds a deployable binary):
 ```
 crates/
 ├── observing-appview/      # Unified REST API + OAuth + media cache + taxonomy + static serving (Rust/Axum)
-├── observing-ingester/     # AT Protocol firehose consumer (Rust)
+├── tap-ingester/           # AT Protocol firehose consumer; bundles + spawns the upstream `tap` Go binary (Rust)
 ├── observing-migrate/      # One-shot DB migration runner (Cloud Run Job)
 └── observing-species-id/   # BioCLIP photo → species identification service (Rust + ONNX)
 
@@ -89,14 +96,16 @@ Unified Rust/Axum server handling all backend concerns:
 - **Data Enrichment** - Profile resolution, community IDs, image URLs, effective taxonomy
 - **Record Processing** - Uses shared `observing-db` processing module for consistent record-to-DB conversion
 
-### Ingester (`crates/observing-ingester/`)
+### Tap-Ingester (`crates/tap-ingester/`)
 
-Rust service that monitors the AT Protocol firehose.
+Rust service driven by [Tap](https://github.com/bluesky-social/indigo/tree/main/cmd/tap), the official AT Protocol verified-sync utility. Tap is bundled into the container image and spawned as a child process; tap-ingester talks to it over loopback WebSocket.
 
-- **Firehose** - WebSocket client subscribing to the AT Protocol relay
+- **Firehose** - Tap subscribes to the AT Protocol relay, performs MST + signature verification per commit, and re-emits clean events to tap-ingester via the `tapped` Rust client
 - **Event Processing** - Handles occurrence, identification, comment, interaction, and like records
+- **Tap state** - Tap manages its own tracked-DID list, cursors, and retry queues in the dedicated `tap` Postgres schema (persistent across deploys)
+- **HTTP surface** - `/` serves a combined ingester + Tap status dashboard; `/api/stats` and `/api/tap-stats` expose JSON; `/health` is the Cloud Run liveness probe
 - **Record Processing** - Uses shared `observing-db` processing module (same conversion logic as appview)
-- **Built with** - Tokio, SQLx
+- **Built with** - Tokio, SQLx, `tapped`
 
 ### Frontend (`frontend/`)
 

--- a/docs/data-flow.md
+++ b/docs/data-flow.md
@@ -31,15 +31,17 @@ flowchart TB
     end
 
     subgraph Firehose["AT Protocol Network"]
-        Jetstream["Jetstream<br/>wss://jetstream2.us-east.bsky.network"]
-        Filter["Wanted collections:<br/>• bio.lexicons.temp.v0-1.occurrence<br/>• bio.lexicons.temp.v0-1.identification<br/>• ing.observ.temp.comment<br/>• ing.observ.temp.interaction<br/>• ing.observ.temp.like"]
+        Relay["AT Protocol relay"]
+        Filter["Signal collection:<br/>• bio.lexicons.temp.v0-1.occurrence<br/><br/>Plus collection filters:<br/>• bio.lexicons.temp.v0-1.identification<br/>• ing.observ.temp.comment<br/>• ing.observ.temp.interaction<br/>• ing.observ.temp.like"]
     end
 
-    subgraph Ingester["Ingester (Rust) — DB_USER=ingester_runtime"]
-        WS["WebSocket Connection<br/>(jetstream-client crate)"]
-        Parse["Parse JSON Event"]
-        Resolve["Resolve associatedMedia strong refs<br/>(fetch media records from PDSes)"]
+    subgraph TapIng["tap-ingester (Rust) — DB_USER=ingester_runtime"]
+        Tap["Tap (indigo cmd/tap)<br/>spawned child process<br/>MST + signature verification"]
+        WS["Loopback WebSocket<br/>(tapped crate)"]
+        Parse["Decode RecordEvent"]
+        Resolve["Resolve cross-repo subjects<br/>(/repos/add for unknown DIDs)"]
         Upsert["Upsert to Database<br/>database.rs"]
+        Tap --> WS
     end
 
     subgraph Database["PostgreSQL + PostGIS"]
@@ -49,8 +51,10 @@ flowchart TB
             Comments["comments, likes, interactions"]
             Observers["occurrence_observers"]
             Notifications["notifications"]
-            Cursor["ingester_state"]
             Matview["community_ids (matview)"]
+        end
+        subgraph TapSchema["schema: tap"]
+            TapState["Tap-managed tables<br/>(tracked DIDs, cursors,<br/>retry queues)"]
         end
         subgraph AppvSchema["schema: appview"]
             PrivData["occurrence_private_data"]
@@ -70,24 +74,27 @@ flowchart TB
     BuildRecord --> PrivateData
     PrivateData --> PrivData
     PDS --> URI
-    URI -->|"Record broadcast"| Jetstream
-    Jetstream --> Filter
-    Filter -->|"JSON event stream"| WS
+    URI -->|"Record broadcast"| Relay
+    Relay --> Tap
+    Tap --> Filter
+    Filter -->|"verified events"| WS
     WS --> Parse
     Parse --> Resolve
     Resolve --> Upsert
     Upsert --> Occurrences
     Upsert --> Observers
-    WS -->|"Save cursor every 30s"| Cursor
+    Tap -- "session state" --> TapState
 
     %% Response flow
     URI -.->|"Response: { uri, cid }"| API
     API -.->|"Response to frontend"| Modal
 ```
 
-**Key insight:** All writes to lexicon-derived tables flow through the AT Protocol firehose. The appview writes the record on the user's PDS, then the ingester picks it up from Jetstream and writes the row. The appview holds no write grant on the `ingester` schema — this invariant is enforced at the database layer via role grants (see `20260418000000_appview_reader_grants.sql`).
+**Key insight:** Lexicon writes flow **user → appview → PDS → Tap → tap-ingester → DB**. Tap (`indigo cmd/tap`, bundled into the tap-ingester container) does MST + signature verification per commit before forwarding to the Rust consumer. The appview holds no write grant on the `ingester` schema — enforced at the DB layer via role grants (see `20260418000000_appview_reader_grants.sql`).
 
-**Visibility latency:** The appview does *not* do a direct-insert bypass for immediate visibility. Freshly created occurrences become queryable once the firehose event round-trips through Jetstream → ingester → DB (typically sub-second).
+**Tap's own state** (tracked DIDs, cursor positions, retry queues) lives in the dedicated `tap` schema on the same Postgres instance, with `search_path=tap`. State is persistent across deploys, so Tap doesn't re-backfill every active DID on restart.
+
+**Visibility latency:** The appview does *not* do a direct-insert bypass for immediate visibility. Freshly created occurrences become queryable once the firehose event round-trips through Tap → tap-ingester → DB (typically sub-second).
 
 **Shared record processing:** Both the appview (when building a record) and the ingester (when indexing one) use the shared `observing_db::processing` module to convert AT Protocol record JSON into database params, ensuring consistent field mapping.
 
@@ -99,9 +106,10 @@ flowchart TB
 | Occurrence Routes | `crates/observing-appview/src/routes/occurrences/` |
 | OAuth Routes | `crates/observing-appview/src/routes/oauth.rs` |
 | Data Enrichment | `crates/observing-appview/src/enrichment.rs` |
-| Firehose Client | `crates/jetstream-client/` |
-| Ingester DB Ops | `crates/observing-ingester/src/database.rs` |
-| Media Resolver | `crates/observing-ingester/src/media_resolver.rs` |
+| Ingester | `crates/tap-ingester/` |
+| Tap Rust client | `tapped` (crates.io) |
+| Cross-repo resolver | `crates/tap-ingester/src/subject_resolver.rs` |
+| Status dashboard | `crates/tap-ingester/src/dashboard.rs` |
 | Shared DB Layer | `crates/observing-db/src/` |
 | Shared Record Processing | `crates/observing-db/src/processing.rs` |
 
@@ -112,8 +120,8 @@ flowchart TB
 | Frontend | User form input + files | JSON + Base64 images | Image encoding, form serialization |
 | AppView | JSON request | AT Protocol record | Media record creation on PDS, GBIF lookup, geocoding, shared record processing |
 | PDS | Record JSON | URI + CID | Cryptographic signing, storage |
-| Jetstream | PDS events | Filtered JSON stream | Collection filtering |
-| Ingester | JSON events | SQL statements | Media ref resolution, shared record processing, upsert |
+| Tap | Relay commits | Verified `RecordEvent` stream | MST proof check, signature check, collection filtering |
+| tap-ingester | `RecordEvent` | SQL statements | Cross-repo subject resolution (`/repos/add` for unknown DIDs), shared record processing, upsert |
 | Database | SQL | Stored rows | PostGIS point encoding, indexing |
 
 ## Services
@@ -121,7 +129,7 @@ flowchart TB
 | Service | Port | Role | DB Role |
 |---------|------|------|---------|
 | **AppView** (`observing-appview`) | 3000 | REST API, OAuth, AT Protocol client, media cache, taxonomy, frontend static files | `appview_runtime` |
-| **Ingester** (`observing-ingester`) | 8080 | Firehose consumer + backfill CLI | `ingester_runtime` |
+| **Tap-Ingester** (`tap-ingester`) | 8080 | Verified-sync firehose consumer; bundles + spawns the upstream `tap` Go binary | `ingester_runtime` (CRUD on `ingester` schema, `USAGE`/`CREATE` on `tap` schema) |
 | **Species-ID** (`observing-species-id`) | 3005 | BioCLIP photo → species inference | none |
 | **Migrate** (`observing-migrate`) | — (one-shot Cloud Run Job) | Runs `sqlx` migrations before service deploys | `postgres` (admin) |
 
@@ -142,8 +150,15 @@ Tables live in owner-labeled schemas (`ingester`, `appview`, `public`). Unqualif
 | `interactions` | Species interactions | Ingester | AppView |
 | `occurrence_observers` | Co-observer relationships | Ingester | AppView |
 | `notifications` | Event notifications (ID / comment / like on your observation) | Ingester | AppView (SELECT + UPDATE on `read`) |
-| `ingester_state` | Firehose cursor position | Ingester | Ingester, AppView (SELECT for diagnostics) |
 | `community_ids` (matview) | Consensus taxonomy per occurrence | Ingester (REFRESH) | AppView |
+
+### Tap-owned (schema `tap`)
+
+Tap (`indigo cmd/tap`) creates and manages its own tables here on first connect; tap-ingester only has `USAGE` + `CREATE` on the schema, not on individual tables. Tables aren't enumerated explicitly because Tap's schema is its internal contract — treat the schema as a black box.
+
+| Table set | Description | Written By | Read By |
+|-----------|-------------|------------|---------|
+| Tap-managed | Tracked DIDs, firehose cursor, retry/resync queues, repo metadata | Tap | Tap |
 
 ### AppView-owned (schema `appview`)
 
@@ -184,17 +199,23 @@ Tables live in owner-labeled schemas (`ingester`, `appview`, `public`). Unqualif
    ├─▶ Writes exact coords to `appview.occurrence_private_data`
    │
    ▼
-4. PDS emits event to Jetstream firehose
+4. PDS commit hits the AT Protocol relay
    │
    ▼
-5. Ingester receives create event
+5. Tap (embedded in tap-ingester) verifies the commit
    │
-   ├─▶ Resolves associatedMedia strong refs → media records from author's PDS
+   ├─▶ MST proof check
+   ├─▶ Signature check
+   ├─▶ Filters to configured collections
+   │
+   ▼
+6. tap-ingester receives a verified `RecordEvent`
+   │
    ├─▶ UPSERT to `ingester.occurrences`
    ├─▶ SYNC `ingester.occurrence_observers`
    │
    ▼
-6. Data now queryable via API
+7. Data now queryable via API
 ```
 
 ### Adding an Identification
@@ -213,16 +234,16 @@ Tables live in owner-labeled schemas (`ingester`, `appview`, `public`). Unqualif
    │  createRecord({ collection: "bio.lexicons.temp.v0-1.identification", ... })
    │
    ▼
-4. PDS emits event to Jetstream firehose
+4. PDS commit → relay → Tap (verify) → tap-ingester
    │
-   ▼
-5. Ingester receives create event
-   │
+   ├─▶ If subject occurrence belongs to a DID Tap isn't yet tracking,
+   │   tap-ingester POSTs `/repos/add` and skips the ack so the record
+   │   is redelivered after Tap finishes the cross-repo backfill
    ├─▶ UPSERT to `ingester.identifications`
    ├─▶ INSERT into `ingester.notifications` (unless self-ID)
    │
    ▼
-6. Community ID recalculated on next matview refresh
+5. Community ID recalculated on next matview refresh
 ```
 
 ### Marking a Notification as Read
@@ -241,26 +262,38 @@ Notification creation is ingester-owned; read-state is appview-owned.
 ### Firehose Ingestion
 
 ```
-Jetstream WebSocket (wss://jetstream2.us-east.bsky.network/subscribe)
+AT Protocol relay
    │
-   │  wanted_collections:
-   │  - bio.lexicons.temp.v0-1.occurrence
-   │  - bio.lexicons.temp.v0-1.identification
-   │  - ing.observ.temp.comment
-   │  - ing.observ.temp.interaction
-   │  - ing.observ.temp.like
+   ▼
+Tap (indigo cmd/tap, child process inside tap-ingester container)
+   │  signal_collection: bio.lexicons.temp.v0-1.occurrence
+   │  collection_filters:
+   │    - bio.lexicons.temp.v0-1.occurrence
+   │    - bio.lexicons.temp.v0-1.identification
+   │    - ing.observ.temp.comment
+   │    - ing.observ.temp.interaction
+   │    - ing.observ.temp.like
+   │
+   │  per commit:
+   │    - MST inclusion proof check
+   │    - signature check
+   │    - cross-repo backfill on previously-unknown DIDs
+   │
+   ▼
+Loopback WebSocket (tapped::TapClient)
    │
    ▼
 ┌─────────────────────────────────────────────────────┐
-│ Event: { did, time_us, commit: { op, collection,   │
-│          rkey, record, cid } }                      │
+│ RecordEvent { did, collection, rkey, cid, action,  │
+│               record_as_str() }                     │
 └─────────────────────────────────────────────────────┘
    │
-   ├─▶ op = "create" or "update" → UPSERT row
-   ├─▶ op = "delete" → DELETE row (cascades)
+   ├─▶ Create / Update → UPSERT row
+   ├─▶ Delete           → DELETE row (cascades)
    │
    ▼
-Every 30 seconds: Save cursor to ingester.ingester_state
+Cursor + tracked-DID list persist in schema `tap` (Postgres);
+no client-side cursor saving from tap-ingester.
 ```
 
 ## Write Patterns by Service
@@ -276,7 +309,7 @@ Every 30 seconds: Save cursor to ingester.ingester_state
 
 The appview holds **no write grant** on the `ingester` schema — enforced at the DB layer.
 
-### Ingester writes
+### tap-ingester writes
 
 | Operation | Schema.Table | Trigger |
 |-----------|--------------|---------|
@@ -287,9 +320,9 @@ The appview holds **no write grant** on the `ingester` schema — enforced at th
 | UPSERT | `ingester.likes` | Firehose like event |
 | SYNC | `ingester.occurrence_observers` | Firehose occurrence with `recordedBy` |
 | INSERT | `ingester.notifications` | On ID / comment / like where the actor ≠ occurrence owner |
-| UPDATE | `ingester.ingester_state` | Every 30 seconds (cursor) |
 | DELETE | `ingester.*` | Firehose delete event (cascades) |
 | REFRESH | `ingester.community_ids` | Periodic matview refresh |
+| (managed by Tap) | `tap.*` | Tap's internal state (DID tracking, cursor, retry queues) |
 
 ## Read Patterns
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,8 +9,7 @@ Deployed via GitHub Actions (`.github/workflows/ci.yml`) on push to `main` after
 | Service | Build arg | Public | Cloud SQL | DB role | Notes |
 |---------|-----------|--------|-----------|---------|-------|
 | observing-appview | `SERVICE=observing-appview` | Yes | Yes | `appview_runtime` | REST API + OAuth + media cache + GBIF taxonomy + serves frontend |
-| observing-ingester | `SERVICE=observing-ingester` | Yes | Yes | `ingester_runtime` | min-instances=1 (always running) |
-| tap-ingester | `SERVICE=tap-ingester` | Yes | Yes | `ingester_runtime` | Side-by-side with observing-ingester during the migration verification window. Bundles the upstream `tap` Go binary (built from a pinned indigo commit) and spawns it as a child process. Tap state is persisted in the Cloud SQL `tap` schema (`search_path=tap`), so tracked-DID lists and cursors survive deploys and instance recycles. min-instances=1 / max-instances=1. |
+| tap-ingester | `SERVICE=tap-ingester` | Yes | Yes | `ingester_runtime` | Sole firehose-driven ingester. Bundles the upstream `tap` Go binary (built from a pinned indigo commit) and spawns it as a child process. Tap state is persisted in the Cloud SQL `tap` schema (`search_path=tap`), so tracked-DID lists and cursors survive deploys and instance recycles. min-instances=1 / max-instances=1. |
 | observing-species-id | `SERVICE=observing-species-id` | Yes | No | — | BioCLIP species identification (2 CPU, 8 GiB, cpu-boost, min-instances=1) |
 
 ### Jobs
@@ -26,7 +25,7 @@ All services and the migrate Job are Rust binaries built from the shared multi-s
 CI runs the deploy steps in this order to ensure DDL lands before any service starts on the new schema:
 
 1. `Run migrations` → deploys + executes the `observing-migrate` Cloud Run Job.
-2. `Deploy ingester` → single-writer for lexicon-derived tables.
+2. `Deploy tap-ingester` → single-writer for lexicon-derived tables.
 3. `Deploy appview` → last, so it sees the fully-migrated schema and up-to-date ingester grants.
 
 ## Runtime role boundary (one-shot)
@@ -72,18 +71,6 @@ MAX_CACHE_SIZE=...            # Optional, bytes
 CACHE_TTL_SECS=...            # Optional, seconds
 ```
 
-### Ingester (`ingester_runtime`)
-
-```bash
-PORT=8080
-JETSTREAM_URL=wss://jetstream2.us-east.bsky.network/subscribe
-
-DB_HOST=/cloudsql/<project>:<region>:observing-db
-DB_NAME=observing
-DB_USER=ingester_runtime
-DB_PASSWORD=<secret: observing-db-ingester-password>
-```
-
 ### Tap-Ingester (`ingester_runtime`)
 
 ```bash
@@ -113,12 +100,10 @@ DB_PASSWORD=<secret: observing-db-ingester-password>
 # TAP_DATABASE_URL=postgres://...
 ```
 
-Writes the same `ingester` schema as observing-ingester. Idempotent
-upserts on `(uri, cid)` so dual writes during the verification window
-are harmless. Cross-repo identifications fail their FK against
-`occurrences.uri` until observing-ingester or `bin/backfill.rs` seeds
-the referenced occurrence — same gap observing-ingester's live path
-has today.
+Writes the `ingester` schema. Cross-repo identifications referencing
+occurrences on DIDs Tap hasn't backfilled yet trigger a `/repos/add`
+call to the embedded Tap and skip the ack so the redelivered event
+lands after backfill completes.
 
 ### Species-ID
 
@@ -150,7 +135,7 @@ memberships persist at the Cloud SQL instance level (so you can't undo
 
 ```bash
 # 1. Pause the writer.
-gcloud run services update observing-ingester --region=us-central1 --min-instances=0
+gcloud run services update tap-ingester --region=us-central1 --min-instances=0
 
 # 2. Connect via the Cloud SQL proxy as superuser.
 gcloud auth application-default login   # if ADC is stale
@@ -173,7 +158,7 @@ SQL
 gcloud run jobs execute observing-migrate --region=us-central1 --wait
 
 # 4. Bounce both services so they pick up fresh connections.
-gcloud run services update observing-ingester --region=us-central1 --min-instances=1 --update-env-vars=BOUNCE=$(date +%s)
+gcloud run services update tap-ingester --region=us-central1 --min-instances=1 --update-env-vars=BOUNCE=$(date +%s)
 gcloud run services update observing-appview  --region=us-central1 --update-env-vars=BOUNCE=$(date +%s)
 
 # 5. Stop the proxy.

--- a/docs/development.md
+++ b/docs/development.md
@@ -123,7 +123,7 @@ process-compose process logs <name>
 process-compose down
 ```
 
-Service names: `appview`, `frontend`, `ingester`, `species-id`
+Service names: `appview`, `frontend`, `tap-ingester`, `species-id`
 
 ### Individual Services
 
@@ -131,8 +131,9 @@ Service names: `appview`, `frontend`, `ingester`, `species-id`
 # AppView (REST API + OAuth + media cache + GBIF taxonomy + static files on port 3000)
 cargo run -p observing-appview
 
-# Ingester (firehose consumer)
-cargo run -p observing-ingester
+# Tap-ingester (firehose consumer; spawns the upstream `tap` binary,
+# which must be on PATH or in the working directory)
+cargo run -p tap-ingester
 
 # Frontend dev server (serves frontend if `npm run build` hasn't been run)
 npm run dev


### PR DESCRIPTION
Stacked on #470 (the \`tap\` schema is part of the diagrams here, and #470 is what actually creates the schema).

## What

The system-overview mermaid diagram in \`architecture.md\` and the data-flow diagram in \`data-flow.md\` predated the Tap migration — they still showed \`Jetstream → observing-ingester\` as the sole ingestion path. This PR refreshes them, and removes all references to observing-ingester / jetstream-client / the verification window.

End state in the docs:

- **tap-ingester is the only ingester.** Tap (\`indigo cmd/tap\`) is spawned as a child process and does MST + signature verification per commit before forwarding events to the Rust consumer over loopback WebSocket.
- **Tap's own state lives in the \`tap\` Postgres schema** (search_path=tap) — tracked DIDs, cursor, retry queues all persist across deploys.
- **Cross-repo identifications** referencing a DID Tap isn't yet tracking trigger a \`/repos/add\` and skip the ack so the redelivered event lands after backfill completes.

## Files touched

- \`docs/architecture.md\` — system-overview mermaid; project structure listing; Components section now describes tap-ingester only.
- \`docs/data-flow.md\` — main mermaid diagram; key files, data transformations, services tables; lifecycle steps; firehose-ingestion section; tap-ingester writes table now lists \`tap.*\` as Tap-managed.
- \`docs/deployment.md\` — services table drops the observing-ingester row; deploy-order step renamed; the legacy "Ingester (\`ingester_runtime\`)" env-vars section is gone (tap-ingester's section already covered the right vars); wipe-runbook \`gcloud run services update\` calls now target tap-ingester.
- \`docs/development.md\` — process-compose service list and individual-services snippet now reference tap-ingester.

## Note on intent vs. literal main

observing-ingester still exists in \`crates/observing-ingester/\` on \`main\` (decommission PR #465 is still in flight). These doc updates describe the post-decommission end state. If #465 gets reordered we can rebase or hold this; today the diagrams are already misleading and the user signed off on the rewrite.

## Test plan

- [x] \`grep -E "observing-ingester|jetstream-client|verification window|side.by.side|jetstream2|legacy"\` against the four touched docs returns nothing.
- [ ] Visual review of the rendered mermaid diagrams (GitHub renders these in the PR \`Files changed\` view).