### PR TITLE
feat(tap-ingester): ledger of records that failed to persist

### DIFF
--- a/.sqlx/query-4113abc24e07f5cbed82734ac3621696bc726c7055d00e30d016ea75a2828b10.json
+++ b/.sqlx/query-4113abc24e07f5cbed82734ac3621696bc726c7055d00e30d016ea75a2828b10.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        INSERT INTO failed_records (\n            uri, collection, did, cid, action, record_json, last_error\n        ) VALUES (\n            $1, $2, $3, $4, $5, $6, $7\n        )\n        ON CONFLICT (uri) DO UPDATE SET\n            collection      = EXCLUDED.collection,\n            did             = EXCLUDED.did,\n            cid             = EXCLUDED.cid,\n            action          = EXCLUDED.action,\n            record_json     = EXCLUDED.record_json,\n            last_error      = EXCLUDED.last_error,\n            attempts        = failed_records.attempts + 1,\n            last_attempt_at = NOW()\n        ",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Text",
+        "Jsonb",
+        "Text"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "4113abc24e07f5cbed82734ac3621696bc726c7055d00e30d016ea75a2828b10"
+}

--- a/crates/observing-db/migrations/20260509120000_failed_records.sql
+++ b/crates/observing-db/migrations/20260509120000_failed_records.sql
@@ -1,0 +1,34 @@
+-- Ledger of records that the ingester couldn't persist on the first try.
+--
+-- Populated from tap-ingester's main loop when `process_record` returns
+-- Err and the cross-repo resolver did NOT trigger a new `/repos/add`
+-- (i.e. we've decided to ack and drop). Without this ledger those
+-- failures are visible only as a stats counter and a tracing line; the
+-- actual records are gone the moment the WS event is acked. The table
+-- captures enough state to either replay the upsert later (record_json
+-- preserves the original payload) or just observe the drop pattern.
+--
+-- Lives in `ingester` schema alongside the other ingester-owned tables;
+-- ALTER DEFAULT PRIVILEGES from 20260428000001 grants ingester_runtime
+-- full CRUD and appview_runtime SELECT automatically.
+--
+-- Idempotent (CREATE IF NOT EXISTS).
+
+CREATE TABLE IF NOT EXISTS ingester.failed_records (
+    uri               TEXT        PRIMARY KEY,
+    collection        TEXT        NOT NULL,
+    did               TEXT        NOT NULL,
+    cid               TEXT,
+    action            TEXT        NOT NULL,
+    record_json       JSONB,
+    last_error        TEXT        NOT NULL,
+    attempts          INTEGER     NOT NULL DEFAULT 1,
+    first_attempt_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_attempt_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS failed_records_collection_idx
+    ON ingester.failed_records (collection);
+
+CREATE INDEX IF NOT EXISTS failed_records_last_attempt_idx
+    ON ingester.failed_records (last_attempt_at DESC);

--- a/crates/observing-db/src/failed_records.rs
+++ b/crates/observing-db/src/failed_records.rs
@@ -1,0 +1,65 @@
+//! Ledger of records the ingester couldn't persist on the first try.
+//!
+//! See migration `20260509120000_failed_records.sql` for the table
+//! shape and motivation. The ledger is write-through from
+//! tap-ingester's main loop: a row exists ⇔ at least one ack-and-drop
+//! happened for that URI. A subsequent successful upsert for the same
+//! URI does NOT auto-clear the ledger row — entries can become stale
+//! once redelivery succeeds, and an explicit cleanup pass (or admin
+//! tool) prunes them. That keeps the hot write path one query instead
+//! of two.
+//!
+//! `record_json` is stored as JSONB so a future replay job can iterate
+//! the ledger and call the appropriate `processing::*_from_json` +
+//! `upsert` directly without going back to the firehose.
+
+use serde_json::Value;
+
+/// Inputs for [`record`]. Borrowed so callers don't have to clone the
+/// firehose payload just to log a failure.
+pub struct FailedRecord<'a> {
+    pub uri: &'a str,
+    pub collection: &'a str,
+    pub did: &'a str,
+    pub cid: Option<&'a str>,
+    pub action: &'a str,
+    pub record_json: Option<&'a Value>,
+    pub error: &'a str,
+}
+
+/// Upsert a failure into the ledger. On a repeat failure for the same
+/// URI, bumps `attempts` and refreshes `last_attempt_at` / `last_error`
+/// without touching `first_attempt_at`.
+pub async fn record(
+    executor: impl sqlx::PgExecutor<'_>,
+    p: FailedRecord<'_>,
+) -> Result<(), sqlx::Error> {
+    sqlx::query!(
+        r#"
+        INSERT INTO failed_records (
+            uri, collection, did, cid, action, record_json, last_error
+        ) VALUES (
+            $1, $2, $3, $4, $5, $6, $7
+        )
+        ON CONFLICT (uri) DO UPDATE SET
+            collection      = EXCLUDED.collection,
+            did             = EXCLUDED.did,
+            cid             = EXCLUDED.cid,
+            action          = EXCLUDED.action,
+            record_json     = EXCLUDED.record_json,
+            last_error      = EXCLUDED.last_error,
+            attempts        = failed_records.attempts + 1,
+            last_attempt_at = NOW()
+        "#,
+        p.uri,
+        p.collection,
+        p.did,
+        p.cid,
+        p.action,
+        p.record_json,
+        p.error,
+    )
+    .execute(executor)
+    .await?;
+    Ok(())
+}

--- a/crates/observing-db/src/lib.rs
+++ b/crates/observing-db/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod admin;
 pub mod comments;
 pub mod community_ids;
+pub mod failed_records;
 pub mod feeds;
 pub mod identifications;
 pub mod interactions;

--- a/crates/tap-ingester/src/database.rs
+++ b/crates/tap-ingester/src/database.rs
@@ -259,4 +259,16 @@ impl Database {
         observing_db::likes::delete(&self.pool, uri).await?;
         Ok(())
     }
+
+    /// Append (or bump) a row in `ingester.failed_records` describing a
+    /// record we've decided to drop after `process_record` returned
+    /// `Err`. Idempotent: repeat failures for the same URI bump
+    /// `attempts` and refresh `last_attempt_at`/`last_error`.
+    pub async fn record_failure<'a>(
+        &self,
+        params: observing_db::failed_records::FailedRecord<'a>,
+    ) -> Result<()> {
+        observing_db::failed_records::record(&self.pool, params).await?;
+        Ok(())
+    }
 }

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -47,6 +47,7 @@ use chrono::Utc;
 use clap::Parser;
 use dashboard::DashboardState;
 use database::Database;
+use observing_db::failed_records::FailedRecord;
 use serde_json::Value;
 use server::{ServerState, SharedState};
 use subject_resolver::SubjectResolver;
@@ -161,23 +162,41 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     while let Ok(received) = channel.recv().await {
         let mut should_ack = true;
         if let Event::Record(record) = &received.event {
-            if process_record(&db, record, &state).await.is_err() {
+            if let Err(err) = process_record(&db, record, &state).await {
                 // process_record already logged + bumped stats.errors.
                 // Reactively ask the resolver for the subject DID; if it
                 // *added* a new DID to Tap, suppress this event's ack so
                 // Tap redelivers after the foreign repo backfills.
                 // Otherwise (subject already tracked, no subject, or
-                // resolver couldn't add), ack and move on — looping on
-                // unresolvable records would saturate the queue.
-                let added_new_did = match record_json(record) {
-                    Some(json) => subject_resolver
-                        .ensure_subject_tracked(&json)
-                        .await
-                        .is_some(),
+                // resolver couldn't add), record the drop in
+                // `ingester.failed_records` so the loss is observable
+                // and a future replay job can re-attempt — then ack and
+                // move on. Looping on unresolvable records would
+                // saturate the queue.
+                let json = record_json(record);
+                let added_new_did = match json.as_ref() {
+                    Some(j) => subject_resolver.ensure_subject_tracked(j).await.is_some(),
                     None => false,
                 };
                 if added_new_did {
                     should_ack = false;
+                } else {
+                    let uri = format_uri(record);
+                    let err_str = err.to_string();
+                    if let Err(ledger_err) = db
+                        .record_failure(FailedRecord {
+                            uri: &uri,
+                            collection: record.collection.as_str(),
+                            did: &record.did,
+                            cid: record.cid.as_deref(),
+                            action: action_to_str(record.action),
+                            record_json: json.as_ref(),
+                            error: &err_str,
+                        })
+                        .await
+                    {
+                        warn!(%uri, error = %ledger_err, "failed_records ledger write failed");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- New `ingester.failed_records` table (uri PK, JSONB record body, attempts counter, first/last-attempt timestamps) — captures every record `process_record` couldn't write.
- `observing_db::failed_records::record()` upsert: ON CONFLICT bumps `attempts` and refreshes `last_attempt_at`/`last_error` without losing `first_attempt_at`.
- tap-ingester writes a row on every dropped record before the existing ack. Ledger write failures are warned but never propagated — observability can't block ingest.

## Why
Today, when `process_record` errors (FK violation against an untracked subject DID, parse failure, transient DB hiccup), the ingester logs, bumps the errors stat, and acks. The dropped record is gone the moment the ack lands — invisible to operators and unreplayable.

The ledger keeps the original payload in `record_json` so a future replay job can iterate the table and call `processing::*_from_json` + `upsert` directly, without going back to the firehose.

## Pairs with #464
Once cross-repo resolution lands, the ledger write moves into the no-resolver-retry branch (`if added_new_did { ... } else { record_failure(...) }`), so only records we've truly given up on hit the table; resolver-triggered retries don't pollute it.

## Deferred (not in this PR)
- Auto-clear on successful redelivery (cheaper as a periodic prune than an extra DELETE per upsert)
- Replay job + admin endpoints
- Dashboard counter for ledger size / oldest entry

## Test plan
- [x] `cargo build -p tap-ingester -p observing-db` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test -p tap-ingester -p observing-db` — 14 passed
- [x] `cargo sqlx prepare --workspace --check` passes (CI-equivalent)
- [x] Migration runs cleanly against local DB
- [ ] Verify failed_records row appears when an identification with an untracked subject DID flows through prod tap-ingester