### PR TITLE
style(atproto-identity): nest or-patterns in did syntax check

### DIFF
--- a/crates/atproto-identity/src/did.rs
+++ b/crates/atproto-identity/src/did.rs
@@ -152,7 +152,7 @@ fn validate_did_syntax(s: &str) -> Result<(), DidParseError> {
         return Err(DidParseError::InvalidCharacter);
     }
     match s.as_bytes().last() {
-        Some(b':') | Some(b'-') => Err(DidParseError::InvalidTrailingCharacter),
+        Some(b':' | b'-') => Err(DidParseError::InvalidTrailingCharacter),
         _ => Ok(()),
     }
 }


### PR DESCRIPTION
## Summary
- `Some(b':') | Some(b'-')` → `Some(b':' | b'-')` in the DID trailing-separator check.
- Pure refactor; same semantics, slightly more idiomatic.

## Test plan
- [x] `cargo test -p atproto-identity` (13 passed)