### PR TITLE
refactor(App): poll unread count via async/await

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,12 +49,15 @@ function AppContent() {
       setUnreadCount(0);
       return;
     }
-    const poll = () => {
-      fetchUnreadCount()
-        .then((data) => setUnreadCount(data.count))
-        .catch(() => {});
+    const poll = async () => {
+      try {
+        const data = await fetchUnreadCount();
+        setUnreadCount(data.count);
+      } catch {
+        // Silent — count is best-effort.
+      }
     };
-    poll();
+    void poll();
     intervalRef.current = setInterval(poll, 30_000);
     return () => {
       if (intervalRef.current) clearInterval(intervalRef.current);


### PR DESCRIPTION
## Summary
- Convert `fetchUnreadCount().then(...).catch(...)` in the unread-count polling effect to an `async`/`await` `try/catch`.
- Silent-on-error behaviour is preserved (the catch was already a no-op — kept it explicit since the count is best-effort).

Originally scoped to also cover `AdminPage.tsx`, but that file was removed in #476.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run fmt:check`
- [x] `npm run lint` (0 errors)