### PR TITLE
refactor: drop redundant memoization wrappers

### DIFF
--- a/frontend/src/components/common/TaxaAutocomplete.tsx
+++ b/frontend/src/components/common/TaxaAutocomplete.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type ReactNode } from "react";
+import { type ReactNode } from "react";
 import { searchTaxa } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { useAutocomplete } from "../../hooks/useAutocomplete";
@@ -23,9 +23,8 @@ interface TaxaAutocompleteProps {
 }
 
 export function TaxaAutocomplete(props: TaxaAutocompleteProps) {
-  const searchFn = useCallback((query: string) => searchTaxa(query), []);
   const { options, loading, handleSearch, clearOptions } = useAutocomplete<TaxaResult>({
-    searchFn,
+    searchFn: searchTaxa,
     filterResults: (results) => results.slice(0, MAX_AUTOCOMPLETE_RESULTS),
   });
 

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -77,8 +77,9 @@ export function TaxonExplorer() {
 
   usePageTitle(taxon?.scientificName || "Taxon");
 
-  // Wikidata thumbnail for hero image
-  const heroNames = useMemo(() => (taxon ? [taxon.scientificName] : []), [taxon]);
+  // Wikidata thumbnail for hero image. useWikidataThumbnails keys its effect
+  // on names.join("|"), so reference identity of the array doesn't matter.
+  const heroNames = taxon ? [taxon.scientificName] : [];
   const heroThumbnails = useWikidataThumbnails(heroNames, 44);
 
   const heroUrl = useMemo(() => {


### PR DESCRIPTION
## Summary
- `TaxaAutocomplete`: pass `searchTaxa` directly. The `useCallback` was wrapping it in an arrow that re-implemented the same `(query) => Promise<T[]>` signature.
- `TaxonExplorer`: `heroNames` was wrapped in `useMemo`, but the only consumer (`useWikidataThumbnails`) keys its effect on `names.join("|")`, not array reference identity.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run fmt:check`
- [x] `npm run lint` (0 errors)