### PR TITLE
style: drop r#""# where no embedded quote needs escaping

### DIFF
--- a/crates/axum-admin/src/lib.rs
+++ b/crates/axum-admin/src/lib.rs
@@ -141,12 +141,12 @@ struct TableSchema {
 
 async fn introspect(pool: &PgPool, schema: &str, table: &str) -> Result<TableSchema, sqlx::Error> {
     let columns = sqlx::query_as::<_, (String, String, String)>(
-        r#"
+        r"
         SELECT column_name, data_type, is_nullable
         FROM information_schema.columns
         WHERE table_schema = $1 AND table_name = $2
         ORDER BY ordinal_position
-        "#,
+        ",
     )
     .bind(schema)
     .bind(table)
@@ -165,13 +165,13 @@ async fn introspect(pool: &PgPool, schema: &str, table: &str) -> Result<TableSch
     // session search_path.
     let qualified = format!("{}.{}", quote_ident(schema), quote_ident(table));
     let primary_key: Option<(String,)> = sqlx::query_as(
-        r#"
+        r"
         SELECT a.attname::text
         FROM   pg_index i
         JOIN   pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey)
         WHERE  i.indrelid = ($1::text)::regclass AND i.indisprimary
         LIMIT  1
-        "#,
+        ",
     )
     .bind(&qualified)
     .fetch_optional(pool)

--- a/crates/wikidata-client/src/lib.rs
+++ b/crates/wikidata-client/src/lib.rs
@@ -126,10 +126,10 @@ impl WikidataClient {
             .join(" ");
 
         let query = format!(
-            r#"SELECT ?external_id ?item WHERE {{
+            r"SELECT ?external_id ?item WHERE {{
     VALUES ?external_id {{ {values} }} .
     ?item wdt:{property} ?external_id .
-}}"#,
+}}",
         );
 
         let bindings = match self.sparql_query(&query).await {
@@ -185,11 +185,11 @@ impl WikidataClient {
             .join(" ");
 
         let query = format!(
-            r#"SELECT ?external_id (SAMPLE(?image) AS ?image) WHERE {{
+            r"SELECT ?external_id (SAMPLE(?image) AS ?image) WHERE {{
     VALUES ?external_id {{ {values} }} .
     ?item wdt:{property} ?external_id .
     OPTIONAL {{ ?item wdt:P18 ?image }} .
-}} GROUP BY ?external_id"#,
+}} GROUP BY ?external_id",
         );
 
         let bindings = match self.sparql_query(&query).await {


### PR DESCRIPTION
## Summary
- Four raw-string literals (two SPARQL queries in `wikidata-client`, two SQL queries in `axum-admin`) used `r#"..."#` even though their bodies contained no `"` to escape.
- Drop the hashes — the embedded `{values}` quotes are inserted at format-time, not at lex-time, so they don't require the raw-string escape.

The HTML raw strings in `axum-admin` still need the hashes (they contain `href="…"`), so those are left alone.

## Test plan
- [x] `cargo build -p wikidata-client -p axum-admin`
- [x] `cargo test -p wikidata-client -p axum-admin`
- [x] `cargo fmt --check`