### PR TITLE
refactor(TaxonLink): drop deprecated, never-passed taxonId prop

### DIFF
--- a/frontend/src/components/common/TaxonLink.tsx
+++ b/frontend/src/components/common/TaxonLink.tsx
@@ -19,8 +19,6 @@ export function shouldItalicizeTaxonName(name: string, rank?: string): boolean {
 export interface TaxonLinkProps {
   /** The taxon name to display */
   name: string;
-  /** @deprecated Use kingdom prop instead. GBIF taxon ID (e.g., "gbif:3084746") for direct linking */
-  taxonId?: string | undefined;
   /** Kingdom for building the taxon URL (e.g., "Plantae", "Animalia") */
   kingdom?: string | undefined;
   /** Taxonomic rank (e.g., "species", "genus", "family") */
@@ -39,7 +37,6 @@ export interface TaxonLinkProps {
  */
 export function TaxonLink({
   name,
-  taxonId,
   kingdom,
   rank,
   variant = "text",


### PR DESCRIPTION
## Summary
- `taxonId` on `TaxonLink` was marked `@deprecated` and is not passed by any caller (`grep -rn 'taxonId'` only hits this file and unrelated API types).
- Drop it from both the props interface and the destructuring. Clears one of the six pre-existing `oxlint` warnings (no-unused-vars).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run fmt:check`
- [x] `npm run lint` (5 warnings now, down from 6; 0 errors)