### PR TITLE
refactor(useDebouncedTaxaSearch): pass searchTaxa directly

### DIFF
--- a/frontend/src/hooks/useDebouncedTaxaSearch.ts
+++ b/frontend/src/hooks/useDebouncedTaxaSearch.ts
@@ -1,4 +1,3 @@
-import { useCallback } from "react";
 import { searchTaxa } from "../services/api";
 import type { TaxaResult } from "../services/types";
 import { MAX_AUTOCOMPLETE_RESULTS } from "../lib/utils";
@@ -10,13 +9,12 @@ import { useAutocomplete } from "./useAutocomplete";
  * every keystroke.
  */
 export function useDebouncedTaxaSearch(debounceMs = 300) {
-  const searchFn = useCallback((query: string) => searchTaxa(query), []);
   const {
     options: suggestions,
     handleSearch: search,
     clearOptions: clearSuggestions,
   } = useAutocomplete<TaxaResult>({
-    searchFn,
+    searchFn: searchTaxa,
     filterResults: (results) => results.slice(0, MAX_AUTOCOMPLETE_RESULTS),
     debounceMs,
   });


### PR DESCRIPTION
## Summary
- `useDebouncedTaxaSearch` wrapped `searchTaxa` in a no-op `useCallback`. Drop the wrapper and the now-unused `useCallback` import — same simplification as the earlier `TaxaAutocomplete` cleanup in #483.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run fmt:check`
- [x] `npm run lint` (0 errors)