### PR TITLE
refactor(UploadModal): use AbortController for taxon validation

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -131,16 +131,19 @@ export function UploadModal() {
     // Resolve the existing taxon name back to a TaxaResult so the form
     // shows "Existing taxon" instead of incorrectly flagging it as new.
     if (!existingName) return undefined;
-    let cancelled = false;
-    void validateTaxon(existingName, existingKingdom || undefined).then((result) => {
-      if (cancelled) return;
-      if (result?.valid && result.taxon) {
-        setMatchedTaxon(result.taxon);
-      }
-    });
-    return () => {
-      cancelled = true;
-    };
+    const controller = new AbortController();
+    validateTaxon(existingName, existingKingdom || undefined, controller.signal)
+      .then((result) => {
+        if (controller.signal.aborted) return;
+        if (result?.valid && result.taxon) {
+          setMatchedTaxon(result.taxon);
+        }
+      })
+      .catch(() => {
+        // Silent — fetch was aborted or failed; the unmatched-name UI is the
+        // safe default.
+      });
+    return () => controller.abort();
   }, [isOpen, currentLocation, editingObservation]);
 
   const resetForm = () => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -211,10 +211,11 @@ export async function searchTaxa(query: string): Promise<TaxaResult[]> {
 export async function validateTaxon(
   name: string,
   kingdom?: string,
+  signal?: AbortSignal,
 ): Promise<ValidateResponse | null> {
   const params = new URLSearchParams({ name });
   if (kingdom) params.set("kingdom", kingdom);
-  const response = await fetch(`${API_BASE}/api/taxa/validate?${params}`);
+  const response = await fetch(`${API_BASE}/api/taxa/validate?${params}`, signal ? { signal } : {});
   if (!response.ok) return null;
   return response.json();
 }


### PR DESCRIPTION
## Summary
- Replace the closed-over `cancelled` boolean in the editing effect with an `AbortController`.
- Add an optional `signal?: AbortSignal` parameter to `validateTaxon` and forward it to `fetch()` — now an unmount or effect rerun actually aborts the in-flight HTTP request.
- Existing callers (tests) don't pass a signal — that's fine since the parameter is optional.

Adds a silent `.catch` for the new AbortError path; the unmatched-name fallback UI is the safe default if the request was aborted before completion.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run fmt:check`
- [x] `npm run lint` (0 errors)