### PR TITLE
refactor(useWikidataThumbnails): silence exhaustive-deps with explanatory disable

### DIFF
--- a/frontend/src/hooks/useWikidataThumbnails.ts
+++ b/frontend/src/hooks/useWikidataThumbnails.ts
@@ -53,6 +53,9 @@ export function useWikidataThumbnails(names: string[], size: number = 48): Map<s
     });
 
     return () => controller.abort();
+    // names.join("|") captures the identity of the array's contents; listing
+    // `names` itself would re-fire every render on fresh array literals.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [names.join("|"), size]);
 
   return thumbnails;


### PR DESCRIPTION
## Summary
- The effect was keyed off `[names.join("|"), size]`. oxlint's exhaustive-deps rule flagged this three times (complex expression, missing `names`, missing `names.length`), but the rule is wrong here — the joined string genuinely captures the array's contents.
- Listing `names` directly would re-fire every render on fresh array literals from callers, so the join is doing real work.
- Rather than mask the join with a `useRef` + mid-render write, just acknowledge the rule with an inline `eslint-disable-next-line react-hooks/exhaustive-deps` plus a comment explaining why. Matches the existing convention in `useVisualId.ts`.
- Clears 3 of the 6 pre-existing oxlint warnings (same warning count as the prior approach, less code).

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run fmt:check`
- [x] `npm run lint` (4 warnings remaining, down from 6; 0 errors)