### PR TITLE
perf: borrow-deserialize in two more JSON->struct sites

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -291,7 +291,7 @@ pub async fn update_occurrence(
         for (i, blob) in existing_blobs.iter().enumerate() {
             let blob_cid = blob.image.ref_.cid();
             if retained_cids.iter().any(|cid| cid == blob_cid) {
-                match serde_json::from_value::<StrongRef>(existing_media_refs[i].clone()) {
+                match StrongRef::deserialize(&existing_media_refs[i]) {
                     Ok(strong_ref) => media_refs.push(strong_ref),
                     Err(e) => {
                         warn!(error = %e, "Failed to parse existing strong ref; dropping");

--- a/crates/observing-db/src/types.rs
+++ b/crates/observing-db/src/types.rs
@@ -88,7 +88,7 @@ impl OccurrenceRow {
     pub fn blob_entries(&self) -> Vec<BlobEntry> {
         self.associated_media
             .as_ref()
-            .and_then(|v| serde_json::from_value::<Vec<BlobEntry>>(v.clone()).ok())
+            .and_then(|v| Vec::<BlobEntry>::deserialize(v).ok())
             .unwrap_or_default()
     }
 }


### PR DESCRIPTION
## Summary
Follow-up to #484. Two more sites where `serde_json::from_value(v.clone())` can become `T::deserialize(&v)`:

- **`OccurrenceRow::blob_entries`** (`observing-db/src/types.rs`) — runs on every SELECT that includes `associated_media`.
- **Existing-strong-ref parse loop** in `observing-appview/.../routes/occurrences/write.rs` — runs per retained blob on each occurrence update.

`&serde_json::Value` already implements `Deserializer`, so the clones were just dead weight.

## Test plan
- [x] `cargo build -p observing-db -p observing-appview`
- [x] `cargo test -p observing-db -p observing-appview` (53 + 36 passed)
- [x] `cargo fmt --check`