### PR TITLE
style: inline format! args across non-generated code

### DIFF
--- a/crates/atproto-blob-resolver/src/error.rs
+++ b/crates/atproto-blob-resolver/src/error.rs
@@ -41,16 +41,13 @@ mod tests {
     #[test]
     fn test_did_resolution_error_display() {
         let err = BlobResolverError::DidResolution("invalid DID format".to_string());
-        assert_eq!(
-            format!("{}", err),
-            "DID resolution error: invalid DID format"
-        );
+        assert_eq!(format!("{err}"), "DID resolution error: invalid DID format");
     }
 
     #[test]
     fn test_error_is_debug() {
         let err = BlobResolverError::DidResolution("test".to_string());
-        let debug_str = format!("{:?}", err);
+        let debug_str = format!("{err:?}");
         assert!(debug_str.contains("DidResolution"));
     }
 }

--- a/crates/file-blob-cache/src/cache.rs
+++ b/crates/file-blob-cache/src/cache.rs
@@ -53,7 +53,7 @@ impl BlobCache {
     /// Generate a cache key from DID and CID
     pub fn cache_key(did: &str, cid: &str) -> String {
         let mut hasher = Sha256::new();
-        hasher.update(format!("{}:{}", did, cid).as_bytes());
+        hasher.update(format!("{did}:{cid}").as_bytes());
         hex::encode(hasher.finalize())
     }
 

--- a/crates/nominatim-client/src/client.rs
+++ b/crates/nominatim-client/src/client.rs
@@ -65,7 +65,7 @@ impl NominatimClient {
         }
 
         // Round to 6 decimal places for cache key (~0.1m precision)
-        let cache_key = format!("{:.6},{:.6}", latitude, longitude);
+        let cache_key = format!("{latitude:.6},{longitude:.6}");
 
         // Check cache
         if let Some(cached) = self.cache.get(&cache_key).await {

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -272,7 +272,7 @@ async fn vite_proxy(
         .path_and_query()
         .map(|pq| pq.as_str())
         .unwrap_or("/");
-    let target_url = format!("{}{}", vite_base_url, path_query);
+    let target_url = format!("{vite_base_url}{path_query}");
 
     let method = reqwest::Method::from_bytes(req.method().as_str().as_bytes())
         .unwrap_or(reqwest::Method::GET);

--- a/crates/observing-appview/src/taxonomy/gbif.rs
+++ b/crates/observing-appview/src/taxonomy/gbif.rs
@@ -141,7 +141,7 @@ fn build_taxon_path(scientific_name: &str, rank: &str, kingdom: Option<&str>) ->
         return scientific_name.to_string();
     }
     match kingdom {
-        Some(k) => format!("{}/{}", k, scientific_name),
+        Some(k) => format!("{k}/{scientific_name}"),
         None => scientific_name.to_string(),
     }
 }

--- a/crates/tap-ingester/src/error.rs
+++ b/crates/tap-ingester/src/error.rs
@@ -68,7 +68,7 @@ mod tests {
     fn test_config_error_display() {
         let err = IngesterError::Config("missing DATABASE_URL".to_string());
         assert_eq!(
-            format!("{}", err),
+            format!("{err}"),
             "Configuration error: missing DATABASE_URL"
         );
     }
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn test_error_is_debug() {
         let err = IngesterError::Decode("x".to_string());
-        let debug_str = format!("{:?}", err);
+        let debug_str = format!("{err:?}");
         assert!(debug_str.contains("Decode"));
     }
 }

--- a/crates/wikidata-client/src/lib.rs
+++ b/crates/wikidata-client/src/lib.rs
@@ -121,7 +121,7 @@ impl WikidataClient {
 
         let values: String = ids
             .iter()
-            .map(|id| format!("\"{}\"", id))
+            .map(|id| format!("\"{id}\""))
             .collect::<Vec<_>>()
             .join(" ");
 
@@ -180,7 +180,7 @@ impl WikidataClient {
 
         let values: String = ids
             .iter()
-            .map(|id| format!("\"{}\"", id))
+            .map(|id| format!("\"{id}\""))
             .collect::<Vec<_>>()
             .join(" ");
 
@@ -231,7 +231,7 @@ impl Default for WikidataClient {
 /// ```
 pub fn to_thumbnail_url(file_url: &str, width: u32) -> String {
     if file_url.contains("Special:FilePath/") {
-        format!("{}?width={}", file_url, width)
+        format!("{file_url}?width={width}")
     } else {
         file_url.to_string()
     }


### PR DESCRIPTION
## Summary
Apply `clippy::uninlined_format_args` cleanup at the eight workspace sites where the format argument is a single identifier (so `format!("...{x}...")` is a direct substitution, no extra `let` needed):

- `atproto-blob-resolver/src/error.rs` (2 sites, test)
- `file-blob-cache/src/cache.rs`
- `nominatim-client/src/client.rs`
- `tap-ingester/src/error.rs` (2 sites, test)
- `observing-appview/src/main.rs`
- `observing-appview/src/taxonomy/gbif.rs`
- `wikidata-client/src/lib.rs` (3 sites — the SPARQL `VALUES` builders + `to_thumbnail_url`)

Skipped sites where the argument is a function call or method chain (e.g. `axum-admin`'s `quote_ident(...)`, `observing-db`'s `.to_lowercase()`): inlining those would require an extra `let`-binding, defeating the cleanup.

## Test plan
- [x] `cargo build --workspace`
- [x] `cargo test --workspace` — all suites pass
- [x] `cargo fmt --check`