### PR TITLE
fix(IdentificationPanel): label suggest-ID input as "Taxon Name"

### DIFF
--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -92,7 +92,7 @@ export function IdentificationPanel({
     e.preventDefault();
 
     if (!taxonName.trim()) {
-      dispatch(addToast({ message: "Please enter a species name", type: "error" }));
+      dispatch(addToast({ message: "Please enter a taxon name", type: "error" }));
       return;
     }
 
@@ -177,6 +177,7 @@ export function IdentificationPanel({
                   }
                 }}
                 onMatchChange={setMatchedTaxon}
+                label="Taxon Name"
                 size="small"
                 margin="none"
                 bottomContent={

--- a/tests/identification.spec.ts
+++ b/tests/identification.spec.ts
@@ -57,7 +57,7 @@ authTest.describe("Identification - Logged In", () => {
       await authExpect(suggestBtn).toBeVisible({ timeout: 10000 });
       await suggestBtn.click();
 
-      await authExpect(page.getByLabel("Species Name")).toBeVisible({
+      await authExpect(page.getByLabel("Taxon Name")).toBeVisible({
         timeout: 10000,
       });
     },
@@ -84,8 +84,8 @@ authTest.describe("Identification - Logged In", () => {
       await authExpect(suggestBtn).toBeVisible({ timeout: 10000 });
       await suggestBtn.click();
 
-      const speciesInput = page.getByLabel("Species Name");
-      await speciesInput.fill("Quercus rubra");
+      const taxonInput = page.getByLabel("Taxon Name");
+      await taxonInput.fill("Quercus rubra");
 
       const postRequest = page.waitForRequest(
         (req: Request) => req.method() === "POST" && req.url().includes("/api/identifications"),
@@ -105,9 +105,9 @@ authTest.describe("Identification - Logged In", () => {
     });
     await authExpect(suggestBtn).toBeVisible({ timeout: 10000 });
     await suggestBtn.click();
-    await authExpect(page.getByLabel("Species Name")).toBeVisible();
+    await authExpect(page.getByLabel("Taxon Name")).toBeVisible();
 
     await page.getByRole("button", { name: "Cancel" }).click();
-    await authExpect(page.getByLabel("Species Name")).not.toBeVisible();
+    await authExpect(page.getByLabel("Taxon Name")).not.toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary
- Closes #418
- Rename the input label on the observation page's Suggest ID form from "Species Name" to "Taxon Name" and update the matching empty-input error toast
- Scoped override on the call site — `TaxaAutocompleteView`'s default label is unchanged so other call sites are unaffected

## Test plan
- [ ] Open an observation, click "Suggest Different ID", confirm the input is labeled "Taxon Name"
- [ ] Submit the form empty and confirm the toast reads "Please enter a taxon name"