### PR TITLE
feat(transparency): add page showing monthly hosting costs

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -26,6 +26,7 @@ import { LexiconView } from "./components/lexicon/LexiconView";
 import { DocsPage } from "./components/docs/DocsPage";
 import { NotificationsPage } from "./components/notifications/NotificationsPage";
 import { SettingsPage } from "./components/settings/SettingsPage";
+import { TransparencyPage } from "./components/transparency/TransparencyPage";
 import "./styles/global.css";
 
 function AppContent() {
@@ -132,6 +133,7 @@ function AppContent() {
           <Route path="/lexicons" element={<LexiconView />} />
           <Route path="/docs" element={<DocsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
+          <Route path="/transparency" element={<TransparencyPage />} />
           <Route path="*" element={<NotFound />} />
         </Routes>
       </Box>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Divider,
   Typography,
 } from "@mui/material";
-import { Login, Logout, MenuBook } from "@mui/icons-material";
+import { AccountBalance, Login, Logout, MenuBook } from "@mui/icons-material";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
@@ -113,6 +113,19 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
                 <MenuBook fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Docs" />
+            </ListItemButton>
+          </ListItem>
+          <ListItem disablePadding>
+            <ListItemButton
+              component={Link}
+              to="/transparency"
+              onClick={onMobileClose}
+              sx={{ borderRadius: 2 }}
+            >
+              <ListItemIcon sx={{ minWidth: 40 }}>
+                <AccountBalance fontSize="small" />
+              </ListItemIcon>
+              <ListItemText primary="Transparency" />
             </ListItemButton>
           </ListItem>
         </List>

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -20,7 +20,15 @@ import {
   Divider,
   alpha,
 } from "@mui/material";
-import { Person, Login, Logout, MenuBook, Settings, Menu as MenuIcon } from "@mui/icons-material";
+import {
+  AccountBalance,
+  Person,
+  Login,
+  Logout,
+  MenuBook,
+  Settings,
+  Menu as MenuIcon,
+} from "@mui/icons-material";
 import { getDisplayName } from "../../lib/utils";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
@@ -143,11 +151,18 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
 
           <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 0.5, md: 1.5 } }}>
             {!isMobile && (
-              <Tooltip title="Docs">
-                <IconButton component={Link} to="/docs" color="inherit">
-                  <MenuBook />
-                </IconButton>
-              </Tooltip>
+              <>
+                <Tooltip title="Docs">
+                  <IconButton component={Link} to="/docs" color="inherit">
+                    <MenuBook />
+                  </IconButton>
+                </Tooltip>
+                <Tooltip title="Transparency">
+                  <IconButton component={Link} to="/transparency" color="inherit">
+                    <AccountBalance />
+                  </IconButton>
+                </Tooltip>
+              </>
             )}
 
             {notificationItem && (

--- a/frontend/src/components/transparency/TransparencyPage.stories.tsx
+++ b/frontend/src/components/transparency/TransparencyPage.stories.tsx
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TransparencyPage } from "./TransparencyPage";
+
+const meta = {
+  title: "Transparency/TransparencyPage",
+  component: TransparencyPage,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof TransparencyPage>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/src/components/transparency/TransparencyPage.tsx
+++ b/frontend/src/components/transparency/TransparencyPage.tsx
@@ -1,0 +1,114 @@
+import {
+  Box,
+  Container,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableFooter,
+  TableHead,
+  TableRow,
+  Typography,
+} from "@mui/material";
+import { usePageTitle } from "../../hooks/usePageTitle";
+import transparencyData from "../../data/transparency.json";
+
+interface MonthCost {
+  month: string;
+  cost: number;
+}
+
+interface TransparencyData {
+  currency: string;
+  notes: string;
+  months: MonthCost[];
+}
+
+const data: TransparencyData = transparencyData;
+
+const MONTH_NAMES = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December",
+];
+
+function formatMonth(value: string): string {
+  const [yearStr, monthStr] = value.split("-");
+  const monthIdx = Number(monthStr) - 1;
+  if (!yearStr || Number.isNaN(monthIdx) || monthIdx < 0 || monthIdx > 11) {
+    return value;
+  }
+  return `${MONTH_NAMES[monthIdx]} ${yearStr}`;
+}
+
+export function TransparencyPage() {
+  usePageTitle("Transparency");
+
+  const formatCurrency = new Intl.NumberFormat(undefined, {
+    style: "currency",
+    currency: data.currency,
+  }).format;
+
+  const total = data.months.reduce((sum, m) => sum + m.cost, 0);
+  const sortedMonths = [...data.months].sort((a, b) => b.month.localeCompare(a.month));
+
+  return (
+    <Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
+      <Container maxWidth="sm" sx={{ py: 3 }}>
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+          Transparency
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>
+          {data.notes}
+        </Typography>
+
+        <Paper variant="outlined" sx={{ borderRadius: 2 }}>
+          {sortedMonths.length === 0 ? (
+            <Box sx={{ p: 3 }}>
+              <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                No cost data has been recorded yet.
+              </Typography>
+            </Box>
+          ) : (
+            <TableContainer>
+              <Table size="small">
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Month</TableCell>
+                    <TableCell align="right">Cost</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {sortedMonths.map((m) => (
+                    <TableRow key={m.month}>
+                      <TableCell>{formatMonth(m.month)}</TableCell>
+                      <TableCell align="right">{formatCurrency(m.cost)}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+                <TableFooter>
+                  <TableRow>
+                    <TableCell sx={{ fontWeight: 600 }}>Total</TableCell>
+                    <TableCell align="right" sx={{ fontWeight: 600 }}>
+                      {formatCurrency(total)}
+                    </TableCell>
+                  </TableRow>
+                </TableFooter>
+              </Table>
+            </TableContainer>
+          )}
+        </Paper>
+      </Container>
+    </Box>
+  );
+}

--- a/frontend/src/data/transparency.json
+++ b/frontend/src/data/transparency.json
@@ -1,0 +1,5 @@
+{
+  "currency": "USD",
+  "notes": "Monthly Google Cloud Platform hosting costs for Observ.ing. Numbers are updated manually after each month closes.",
+  "months": []
+}


### PR DESCRIPTION
## Summary
- Adds a public `/transparency` page that renders monthly Google Cloud hosting costs from a committed `frontend/src/data/transparency.json`.
- Reachable from the Docs/Settings cluster: `AccountBalance` icon in the desktop top bar and an entry under Docs in the mobile sidebar.
- JSON is currently empty pending the first BigQuery billing-export table; the page renders an empty-state message until rows are added.
- No backend changes, no new dependencies — purely frontend.

## Test plan
- [ ] Visit `/transparency` — confirm heading, notes paragraph, and the empty-state message ("No cost data has been recorded yet.")
- [ ] Add a row to `transparency.json` (e.g. `{ "month": "2026-04", "cost": 18.93 }`) and confirm it renders in the table with currency formatting and updates the total
- [ ] Months sorted newest-first
- [ ] Page reachable from `AccountBalance` icon in desktop top bar
- [ ] Page reachable from the bottom section of the mobile sidebar
- [ ] Page accessible while logged out
- [ ] \`npm run fmt:check\`, \`npx oxlint\`, \`npx tsc --noEmit\`, \`npm run check:stories\` all pass

Closes #450