### PR TITLE
fix(observation-edit): fit map to uncertainty radius on load

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -17,7 +17,13 @@ import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { darkMapFilter, mapContainerSx } from "./mapStyle";
-import { MAP_MARKER_COLOR, addUncertaintyLayers, createCircleGeoJSON, createMap } from "./mapUtils";
+import {
+  MAP_MARKER_COLOR,
+  addUncertaintyLayers,
+  createCircleGeoJSON,
+  createMap,
+  getRadiusBounds,
+} from "./mapUtils";
 
 interface LocationPickerProps {
   latitude: number | null;
@@ -179,7 +185,16 @@ export function LocationPicker({
 
       addUncertaintyLayers(mapInstance);
 
-      if (latitude && longitude) updateMarker(longitude, latitude);
+      if (latitude && longitude) {
+        updateMarker(longitude, latitude);
+        if (uncertaintyMeters > 0) {
+          mapInstance.fitBounds(getRadiusBounds(latitude, longitude, uncertaintyMeters), {
+            padding: 40,
+            maxZoom: 18,
+            animate: false,
+          });
+        }
+      }
     });
 
     mapInstance.on("click", (e) => {


### PR DESCRIPTION
## Summary
- When editing an observation, the map now auto-fits to the coordinate-uncertainty circle on load instead of using a hardcoded zoom level — users no longer have to manually zoom out to see the full radius.
- Mirrors the existing `fitBounds` pattern in `LocationMap.tsx` (the read-only view).

Closes #422

## Test plan
- [ ] Open the edit-observation modal for an observation with a small radius (e.g. 50 m) — map should zoom in to frame the circle.
- [ ] Open the edit-observation modal for an observation with a large radius (e.g. 50 km) — map should zoom out to fit the circle.
- [ ] Open the edit-observation modal for an observation with no coordinates — map behaves as before (world view at zoom 1).
- [ ] Adjust the uncertainty slider after load — the circle resizes but the map view does not re-fit (intentional; refit is "on load" only).