### PR TITLE
fix(observation): make community ID taxon clickable

### DIFF
--- a/frontend/src/components/identification/IdentificationPanel.stories.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.stories.tsx
@@ -28,6 +28,8 @@ export const Default: Story = {
       uri: OAK_OBSERVATION.uri,
       cid: OAK_OBSERVATION.cid,
       scientificName: "Quercus robur",
+      kingdom: "Plantae",
+      rank: "species",
     },
   },
 };
@@ -38,6 +40,8 @@ export const WithImage: Story = {
       uri: OAK_OBSERVATION.uri,
       cid: OAK_OBSERVATION.cid,
       scientificName: "Quercus robur",
+      kingdom: "Plantae",
+      rank: "species",
     },
     imageUrl: OAK_OBSERVATION.images[0] ?? "",
     latitude: 51.5074,

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -8,7 +8,7 @@ import type { TaxaResult } from "../../services/types";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { VisualIdCards } from "./VisualIdCards";
 import { useVisualId } from "../../hooks/useVisualId";
-import { shouldItalicizeTaxonName } from "../common/TaxonLink";
+import { TaxonLink } from "../common/TaxonLink";
 import { useAppDispatch } from "../../store";
 import { addToast } from "../../store/uiSlice";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
@@ -19,6 +19,8 @@ interface IdentificationPanelProps {
     cid: string;
     scientificName?: string | undefined;
     communityId?: string | undefined;
+    kingdom?: string | undefined;
+    rank?: string | undefined;
   };
   /** Full URL of the observation's primary image, for visual ID matching */
   imageUrl?: string | undefined;
@@ -119,14 +121,7 @@ export function IdentificationPanel({
           >
             Community ID
           </Typography>
-          <Typography
-            sx={{
-              fontStyle: shouldItalicizeTaxonName(currentId) ? "italic" : "normal",
-              color: "primary.main",
-            }}
-          >
-            {currentId}
-          </Typography>
+          <TaxonLink name={currentId} kingdom={observation.kingdom} rank={observation.rank} />
         </Box>
       </Stack>
       <Stack

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -513,6 +513,8 @@ export function ObservationDetail() {
                         cid: observation.cid,
                         scientificName: taxonomy?.scientificName,
                         communityId: observation.communityId,
+                        kingdom: taxonomy?.kingdom,
+                        rank: taxonomy?.rank,
                       }}
                       imageUrl={
                         observation.images[0] != null


### PR DESCRIPTION
## Summary
- Render the Community ID name in `IdentificationPanel` with `TaxonLink` instead of a plain `Typography`, so it navigates to the taxon page like the species header and identification history rows already do.
- Thread `kingdom` and `rank` from `effectiveTaxonomy` through `ObservationDetail` → `IdentificationPanel` so the link has the info it needs to build a URL (it falls back to plain text if kingdom is unknown).
- Storybook fixtures updated to include kingdom/rank so the link is exercised visually.

Closes #417

## Test plan
- [ ] Open an observation detail page with a community ID — the name under "Community ID" is a link and routes to the taxon page.
- [ ] Storybook `Identification/IdentificationPanel` Default and WithImage stories show a clickable taxon name; Unidentified story still renders plain text.