### PR TITLE
feat(transparency): populate cost data and move link into Docs

### DIFF
--- a/frontend/src/components/docs/DocsPage.tsx
+++ b/frontend/src/components/docs/DocsPage.tsx
@@ -1,6 +1,6 @@
 import { Link as RouterLink } from "react-router-dom";
 import { Box, Container, Typography, Paper, Stack } from "@mui/material";
-import { Schema, AutoStories, GitHub, ChevronRight } from "@mui/icons-material";
+import { Schema, AutoStories, GitHub, AccountBalance, ChevronRight } from "@mui/icons-material";
 import { usePageTitle } from "../../hooks/usePageTitle";
 
 interface DocLink {
@@ -17,6 +17,12 @@ const links: DocLink[] = [
     description: "AT Protocol record schemas that define how data is stored.",
     icon: <Schema />,
     to: "/lexicons",
+  },
+  {
+    label: "Transparency",
+    description: "Monthly Google Cloud hosting costs for Observ.ing.",
+    icon: <AccountBalance />,
+    to: "/transparency",
   },
   {
     label: "Storybook",

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,7 +10,7 @@ import {
   Divider,
   Typography,
 } from "@mui/material";
-import { AccountBalance, Login, Logout, MenuBook } from "@mui/icons-material";
+import { Login, Logout, MenuBook } from "@mui/icons-material";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
@@ -113,19 +113,6 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
                 <MenuBook fontSize="small" />
               </ListItemIcon>
               <ListItemText primary="Docs" />
-            </ListItemButton>
-          </ListItem>
-          <ListItem disablePadding>
-            <ListItemButton
-              component={Link}
-              to="/transparency"
-              onClick={onMobileClose}
-              sx={{ borderRadius: 2 }}
-            >
-              <ListItemIcon sx={{ minWidth: 40 }}>
-                <AccountBalance fontSize="small" />
-              </ListItemIcon>
-              <ListItemText primary="Transparency" />
             </ListItemButton>
           </ListItem>
         </List>

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -20,15 +20,7 @@ import {
   Divider,
   alpha,
 } from "@mui/material";
-import {
-  AccountBalance,
-  Person,
-  Login,
-  Logout,
-  MenuBook,
-  Settings,
-  Menu as MenuIcon,
-} from "@mui/icons-material";
+import { Person, Login, Logout, MenuBook, Settings, Menu as MenuIcon } from "@mui/icons-material";
 import { getDisplayName } from "../../lib/utils";
 import logoSvg from "../../assets/logo.svg";
 import { useNavigation } from "../../hooks/useNavigation";
@@ -151,18 +143,11 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
 
           <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 0.5, md: 1.5 } }}>
             {!isMobile && (
-              <>
-                <Tooltip title="Docs">
-                  <IconButton component={Link} to="/docs" color="inherit">
-                    <MenuBook />
-                  </IconButton>
-                </Tooltip>
-                <Tooltip title="Transparency">
-                  <IconButton component={Link} to="/transparency" color="inherit">
-                    <AccountBalance />
-                  </IconButton>
-                </Tooltip>
-              </>
+              <Tooltip title="Docs">
+                <IconButton component={Link} to="/docs" color="inherit">
+                  <MenuBook />
+                </IconButton>
+              </Tooltip>
             )}
 
             {notificationItem && (

--- a/frontend/src/data/transparency.json
+++ b/frontend/src/data/transparency.json
@@ -1,5 +1,8 @@
 {
   "currency": "USD",
   "notes": "Monthly Google Cloud Platform hosting costs for Observ.ing. Numbers are updated manually after each month closes.",
-  "months": []
+  "months": [
+    { "month": "2026-04", "cost": 43.53 },
+    { "month": "2026-03", "cost": 0.29 }
+  ]
 }


### PR DESCRIPTION
Follow-up to #497.

## Summary
- Populates `transparency.json` with March/April 2026 hosting cost figures pulled from the GCP billing export BigQuery table. Numbers are gross (pre-credit) so the page reflects underlying usage rather than `$0` after Free Tier / promotional credits.
- Moves the Transparency entry out of the desktop top bar (`AccountBalance` icon) and mobile sidebar into the `/docs` page as a tile alongside Lexicons and Storybook — a better home for low-traffic reference content.

## Test plan
- [ ] Visit `/transparency` — table shows April 2026 ($43.53) and March 2026 ($0.29), total $43.82
- [ ] Visit `/docs` — Transparency tile is present, links to `/transparency`
- [ ] Desktop top bar no longer shows the `AccountBalance` icon
- [ ] Mobile sidebar no longer shows the Transparency entry under Docs
- [ ] `npm run fmt:check`, `npx oxlint`, `npx tsc --noEmit`, `npm run check:stories` all pass