### PR TITLE
feat(transparency): break monthly costs down by GCP service

### DIFF
--- a/frontend/src/components/transparency/TransparencyPage.tsx
+++ b/frontend/src/components/transparency/TransparencyPage.tsx
@@ -14,15 +14,20 @@ import {
 import { usePageTitle } from "../../hooks/usePageTitle";
 import transparencyData from "../../data/transparency.json";
 
-interface MonthCost {
-  month: string;
+interface ServiceCost {
+  name: string;
   cost: number;
+}
+
+interface MonthEntry {
+  month: string;
+  services: ServiceCost[];
 }
 
 interface TransparencyData {
   currency: string;
   notes: string;
-  months: MonthCost[];
+  months: MonthEntry[];
 }
 
 const data: TransparencyData = transparencyData;
@@ -59,12 +64,27 @@ export function TransparencyPage() {
     currency: data.currency,
   }).format;
 
-  const total = data.months.reduce((sum, m) => sum + m.cost, 0);
+  const serviceTotals = new Map<string, number>();
+  for (const month of data.months) {
+    for (const s of month.services) {
+      serviceTotals.set(s.name, (serviceTotals.get(s.name) ?? 0) + s.cost);
+    }
+  }
+  const services = [...serviceTotals.keys()].sort((a, b) => {
+    const diff = (serviceTotals.get(b) ?? 0) - (serviceTotals.get(a) ?? 0);
+    return diff !== 0 ? diff : a.localeCompare(b);
+  });
+
   const sortedMonths = [...data.months].sort((a, b) => b.month.localeCompare(a.month));
+
+  const costFor = (m: MonthEntry, name: string) =>
+    m.services.find((s) => s.name === name)?.cost ?? 0;
+  const monthTotal = (m: MonthEntry) => m.services.reduce((sum, s) => sum + s.cost, 0);
+  const grandTotal = sortedMonths.reduce((sum, m) => sum + monthTotal(m), 0);
 
   return (
     <Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
-      <Container maxWidth="sm" sx={{ py: 3 }}>
+      <Container maxWidth="md" sx={{ py: 3 }}>
         <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
           Transparency
         </Typography>
@@ -85,22 +105,39 @@ export function TransparencyPage() {
                 <TableHead>
                   <TableRow>
                     <TableCell>Month</TableCell>
-                    <TableCell align="right">Cost</TableCell>
+                    {services.map((s) => (
+                      <TableCell key={s} align="right">
+                        {s}
+                      </TableCell>
+                    ))}
+                    <TableCell align="right">Total</TableCell>
                   </TableRow>
                 </TableHead>
                 <TableBody>
                   {sortedMonths.map((m) => (
                     <TableRow key={m.month}>
                       <TableCell>{formatMonth(m.month)}</TableCell>
-                      <TableCell align="right">{formatCurrency(m.cost)}</TableCell>
+                      {services.map((s) => (
+                        <TableCell key={s} align="right">
+                          {formatCurrency(costFor(m, s))}
+                        </TableCell>
+                      ))}
+                      <TableCell align="right" sx={{ fontWeight: 600 }}>
+                        {formatCurrency(monthTotal(m))}
+                      </TableCell>
                     </TableRow>
                   ))}
                 </TableBody>
                 <TableFooter>
                   <TableRow>
                     <TableCell sx={{ fontWeight: 600 }}>Total</TableCell>
+                    {services.map((s) => (
+                      <TableCell key={s} align="right" sx={{ fontWeight: 600 }}>
+                        {formatCurrency(serviceTotals.get(s) ?? 0)}
+                      </TableCell>
+                    ))}
                     <TableCell align="right" sx={{ fontWeight: 600 }}>
-                      {formatCurrency(total)}
+                      {formatCurrency(grandTotal)}
                     </TableCell>
                   </TableRow>
                 </TableFooter>

--- a/frontend/src/data/transparency.json
+++ b/frontend/src/data/transparency.json
@@ -1,8 +1,27 @@
 {
   "currency": "USD",
-  "notes": "Monthly Google Cloud Platform hosting costs for Observ.ing. Numbers are updated manually after each month closes.",
+  "notes": "Monthly Google Cloud Platform hosting costs for Observ.ing, broken down by service. Figures are gross (before Free Tier and promotional credits) and are updated manually after each month closes.",
   "months": [
-    { "month": "2026-04", "cost": 43.53 },
-    { "month": "2026-03", "cost": 0.29 }
+    {
+      "month": "2026-04",
+      "services": [
+        { "name": "Cloud Run", "cost": 36.8 },
+        { "name": "Artifact Registry", "cost": 13.93 },
+        { "name": "Cloud SQL", "cost": 4.36 },
+        { "name": "Cloud Logging", "cost": 0 },
+        { "name": "Secret Manager", "cost": 0 }
+      ]
+    },
+    {
+      "month": "2026-03",
+      "services": [
+        { "name": "Cloud SQL", "cost": 0.14 },
+        { "name": "Cloud Run", "cost": 0.13 },
+        { "name": "Artifact Registry", "cost": 0.01 },
+        { "name": "Cloud Logging", "cost": 0 },
+        { "name": "Invoice", "cost": 0 },
+        { "name": "Secret Manager", "cost": 0 }
+      ]
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- Replaces the single per-month cost figure with a pivot: months as rows, GCP services as columns, plus row totals (Total column) and column totals (Total row).
- Service columns are dynamically derived from the data and ordered by lifetime spend descending, then alphabetically as a tiebreaker — so dominant services (Cloud Run, Artifact Registry, Cloud SQL) surface first; zero-cost services sit on the right.
- Cost figures refreshed from the BigQuery billing export. April 2026 reads higher than the previous snapshot ($55.09 vs $43.53 gross) because more mid-month usage has flushed into the export since.
- Container widened from `maxWidth="sm"` to `maxWidth="md"` to accommodate the additional columns; `TableContainer` still provides horizontal scroll on narrow viewports.

## Test plan
- [ ] `/transparency` — pivot renders with one row per month, services as columns, totals row + total column visible
- [ ] April 2026 row sums to $55.09; March 2026 row sums to $0.28; grand total reads $55.37
- [ ] Service columns ordered Cloud Run → Artifact Registry → Cloud SQL → (Cloud Logging, Invoice, Secret Manager alphabetical, all $0.00)
- [ ] `npm run fmt:check`, `npx oxlint frontend/src`, `npx tsc --noEmit`, `npm run check:stories` all pass