### PR TITLE
feat(tap-ingester): surface parse failures in ledger + dashboard

### DIFF
--- a/.sqlx/query-440b0e267b51b2735bb100bfede0a18874f1c021ffb39eb8a692ce58f573c6b7.json
+++ b/.sqlx/query-440b0e267b51b2735bb100bfede0a18874f1c021ffb39eb8a692ce58f573c6b7.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "SELECT COUNT(*) as \"count!\" FROM ingester.failed_records",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "count!",
+        "type_info": "Int8"
+      }
+    ],
+    "parameters": {
+      "Left": []
+    },
+    "nullable": [
+      null
+    ]
+  },
+  "hash": "440b0e267b51b2735bb100bfede0a18874f1c021ffb39eb8a692ce58f573c6b7"
+}

--- a/.sqlx/query-53b682bc34a8cae18fba78c0ae6f6e51ac2d1484f9075cdaebdc42cc4bf31418.json
+++ b/.sqlx/query-53b682bc34a8cae18fba78c0ae6f6e51ac2d1484f9075cdaebdc42cc4bf31418.json
@@ -1,0 +1,64 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT\n            uri,\n            collection,\n            did,\n            action,\n            last_error,\n            attempts,\n            first_attempt_at as \"first_attempt_at: DateTime<Utc>\",\n            last_attempt_at  as \"last_attempt_at: DateTime<Utc>\"\n        FROM ingester.failed_records\n        ORDER BY last_attempt_at DESC\n        LIMIT $1\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uri",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 1,
+        "name": "collection",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 2,
+        "name": "did",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 3,
+        "name": "action",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 4,
+        "name": "last_error",
+        "type_info": "Text"
+      },
+      {
+        "ordinal": 5,
+        "name": "attempts",
+        "type_info": "Int4"
+      },
+      {
+        "ordinal": 6,
+        "name": "first_attempt_at: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      },
+      {
+        "ordinal": 7,
+        "name": "last_attempt_at: DateTime<Utc>",
+        "type_info": "Timestamptz"
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "53b682bc34a8cae18fba78c0ae6f6e51ac2d1484f9075cdaebdc42cc4bf31418"
+}

--- a/crates/observing-db/src/failed_records.rs
+++ b/crates/observing-db/src/failed_records.rs
@@ -13,6 +13,7 @@
 //! the ledger and call the appropriate `processing::*_from_json` +
 //! `upsert` directly without going back to the firehose.
 
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 
 /// Inputs for [`record`]. Borrowed so callers don't have to clone the
@@ -62,4 +63,55 @@ pub async fn record(
     .execute(executor)
     .await?;
     Ok(())
+}
+
+/// One row from `ingester.failed_records`, trimmed for dashboard display.
+/// Omits `record_json` (potentially large) — fetch the full row separately
+/// if a replay tool needs it.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct FailedRecordRow {
+    pub uri: String,
+    pub collection: String,
+    pub did: String,
+    pub action: String,
+    pub last_error: String,
+    pub attempts: i32,
+    pub first_attempt_at: DateTime<Utc>,
+    pub last_attempt_at: DateTime<Utc>,
+}
+
+/// Most recently re-attempted failures, newest first. Backed by the
+/// `failed_records_last_attempt_idx` index.
+pub async fn list_recent(
+    executor: impl sqlx::PgExecutor<'_>,
+    limit: i64,
+) -> Result<Vec<FailedRecordRow>, sqlx::Error> {
+    sqlx::query_as!(
+        FailedRecordRow,
+        r#"
+        SELECT
+            uri,
+            collection,
+            did,
+            action,
+            last_error,
+            attempts,
+            first_attempt_at as "first_attempt_at: DateTime<Utc>",
+            last_attempt_at  as "last_attempt_at: DateTime<Utc>"
+        FROM ingester.failed_records
+        ORDER BY last_attempt_at DESC
+        LIMIT $1
+        "#,
+        limit,
+    )
+    .fetch_all(executor)
+    .await
+}
+
+/// Total number of distinct URIs in the failure ledger.
+pub async fn count_total(executor: impl sqlx::PgExecutor<'_>) -> Result<i64, sqlx::Error> {
+    let row = sqlx::query!(r#"SELECT COUNT(*) as "count!" FROM ingester.failed_records"#)
+        .fetch_one(executor)
+        .await?;
+    Ok(row.count)
 }

--- a/crates/tap-ingester/src/dashboard.rs
+++ b/crates/tap-ingester/src/dashboard.rs
@@ -7,12 +7,14 @@
 //! ingester's own counters on a single HTML page.
 //!
 //! Routes:
-//!   GET /                  Combined HTML dashboard.
-//!   GET /health            Cloud Run liveness probe (JSON).
-//!   GET /api/stats         Ingester counters (JSON).
-//!   GET /api/tap-stats     Tap state — repo/record/buffer counts and
-//!                          cursors, fetched from the embedded Tap on
-//!                          loopback (JSON).
+//!   GET /                    Combined HTML dashboard.
+//!   GET /health              Cloud Run liveness probe (JSON).
+//!   GET /api/stats           Ingester counters (JSON).
+//!   GET /api/tap-stats       Tap state — repo/record/buffer counts and
+//!                            cursors, fetched from the embedded Tap on
+//!                            loopback (JSON).
+//!   GET /api/failed-records  Recent rows from `ingester.failed_records`
+//!                            (JSON) for the dashboard's failures panel.
 
 use crate::{
     server::SharedState,
@@ -24,11 +26,14 @@ use axum::{
     routing::get,
     Router,
 };
+use observing_db::failed_records;
 use serde::Serialize;
+use sqlx::postgres::PgPool;
 use std::sync::Arc;
 use tapped::TapClient;
 use tokio::sync::OnceCell;
 use tower_http::cors::CorsLayer;
+use tracing::warn;
 
 /// Shared by all dashboard routes.
 ///
@@ -41,6 +46,11 @@ use tower_http::cors::CorsLayer;
 pub struct DashboardState {
     pub ingester: SharedState,
     pub tap: Arc<OnceCell<TapClient>>,
+    /// Connected after `Database::connect` returns in `main`. Same
+    /// late-init pattern as `tap`: the HTTP server comes up first so
+    /// the Cloud Run TCP startup probe passes, and `/api/failed-records`
+    /// reports "not yet initialized" until the pool lands.
+    pub pool: Arc<OnceCell<PgPool>>,
 }
 
 pub fn router(state: DashboardState) -> Router {
@@ -49,6 +59,7 @@ pub fn router(state: DashboardState) -> Router {
         .route("/health", get(health))
         .route("/api/stats", get(stats))
         .route("/api/tap-stats", get(tap_stats))
+        .route("/api/failed-records", get(failed_records_handler))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -161,6 +172,58 @@ async fn tap_stats(State(s): State<DashboardState>) -> Json<TapStatsResponse> {
     })
 }
 
+#[derive(Serialize)]
+struct FailedRecordsResponse {
+    total: Option<i64>,
+    items: Vec<failed_records::FailedRecordRow>,
+    /// Populated when the ledger query failed; the dashboard renders this
+    /// instead of 500-ing the whole page. `total` and `items` may still be
+    /// partially set if one query succeeded and the other didn't.
+    error: Option<String>,
+}
+
+async fn failed_records_handler(State(s): State<DashboardState>) -> Json<FailedRecordsResponse> {
+    let Some(pool) = s.pool.get() else {
+        return Json(FailedRecordsResponse {
+            total: None,
+            items: Vec::new(),
+            error: Some("database pool not yet initialized".to_string()),
+        });
+    };
+    let (items_res, total_res) = tokio::join!(
+        failed_records::list_recent(pool, 50),
+        failed_records::count_total(pool),
+    );
+
+    let mut error = None;
+    let items = match items_res {
+        Ok(rows) => rows,
+        Err(e) => {
+            warn!(error = %e, "failed_records list query failed");
+            error = Some(format!("list: {e}"));
+            Vec::new()
+        }
+    };
+    let total = match total_res {
+        Ok(n) => Some(n),
+        Err(e) => {
+            warn!(error = %e, "failed_records count query failed");
+            // Concatenate so a list error doesn't hide a count error.
+            error = Some(match error {
+                Some(prev) => format!("{prev}; count: {e}"),
+                None => format!("count: {e}"),
+            });
+            None
+        }
+    };
+
+    Json(FailedRecordsResponse {
+        total,
+        items,
+        error,
+    })
+}
+
 async fn dashboard() -> Html<&'static str> {
     Html(DASHBOARD_HTML)
 }
@@ -212,6 +275,10 @@ const DASHBOARD_HTML: &str = r#"<!DOCTYPE html>
   <h2>Recent events</h2>
   <div id="recent-events">No events yet...</div>
 
+  <h2>Failed records <span id="failed-total" style="font-weight: normal; color: #888;"></span></h2>
+  <div id="failed-records-error" class="errors"></div>
+  <div id="failed-records">Loading...</div>
+
   <script>
     function formatDuration(seconds) {
       const h = Math.floor(seconds / 3600);
@@ -230,11 +297,21 @@ const DASHBOARD_HTML: &str = r#"<!DOCTYPE html>
       return s == null || s === '' ? '-' : s;
     }
 
+    function escapeHtml(s) {
+      return String(s)
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+    }
+
     async function refresh() {
       try {
-        const [stats, tap] = await Promise.all([
+        const [stats, tap, failed] = await Promise.all([
           fetch('/api/stats').then(r => r.json()),
           fetch('/api/tap-stats').then(r => r.json()),
+          fetch('/api/failed-records').then(r => r.json()),
         ]);
 
         const statusEl = document.getElementById('status');
@@ -262,8 +339,34 @@ const DASHBOARD_HTML: &str = r#"<!DOCTYPE html>
           eventsEl.textContent = 'No events yet...';
         } else {
           eventsEl.innerHTML = stats.recentEvents.map(e =>
-            '<div class="event">' + new Date(e.time).toLocaleTimeString() + ' [' + e.type + '] ' + e.action + ' ' + e.uri + '</div>'
+            '<div class="event">' + new Date(e.time).toLocaleTimeString() + ' [' + escapeHtml(e.type) + '] ' + escapeHtml(e.action) + ' ' + escapeHtml(e.uri) + '</div>'
           ).join('');
+        }
+
+        const totalEl = document.getElementById('failed-total');
+        totalEl.textContent = failed.total != null ? '(' + fmtNum(failed.total) + ' total)' : '';
+        document.getElementById('failed-records-error').textContent = failed.error || '';
+        const failedEl = document.getElementById('failed-records');
+        if (!failed.items || failed.items.length === 0) {
+          failedEl.textContent = failed.error ? '' : 'No failed records.';
+        } else {
+          const rows = failed.items.map(r =>
+            '<tr>' +
+              '<td>' + new Date(r.last_attempt_at).toLocaleString() + '</td>' +
+              '<td>' + fmtNum(r.attempts) + '</td>' +
+              '<td>' + escapeHtml(r.collection) + '</td>' +
+              '<td>' + escapeHtml(r.action) + '</td>' +
+              '<td style="word-break: break-all;">' + escapeHtml(r.uri) + '</td>' +
+              '<td class="err">' + escapeHtml(r.last_error) + '</td>' +
+            '</tr>'
+          ).join('');
+          failedEl.innerHTML =
+            '<table style="width: 100%;">' +
+              '<thead><tr>' +
+                '<th>Last attempt</th><th>Attempts</th><th>Collection</th><th>Action</th><th>URI</th><th>Error</th>' +
+              '</tr></thead>' +
+              '<tbody>' + rows + '</tbody>' +
+            '</table>';
         }
       } catch (err) {
         const statusEl = document.getElementById('status');

--- a/crates/tap-ingester/src/database.rs
+++ b/crates/tap-ingester/src/database.rs
@@ -5,7 +5,7 @@
 //! scalar params (did, uri, cid, time, record JSON) rather than a
 //! firehose-coupled `CommitInfo` struct.
 
-use crate::error::Result;
+use crate::error::{IngesterError, Result};
 use crate::media_resolver::MediaResolver;
 use chrono::{DateTime, Utc};
 use observing_db::processing;
@@ -46,14 +46,18 @@ async fn notify_occurrence_owner(
     }
 }
 
-/// Run a `processing::*_from_json` call, returning `Ok(())` with a warning on parse failure.
-macro_rules! process_or_warn {
+/// Run a `processing::*_from_json` call, returning `Err(Processing)` on parse failure.
+///
+/// The main loop's failure path catches this, checks the subject resolver,
+/// and writes to `ingester.failed_records` if there's no cross-repo
+/// dependency to resolve — so schema/format mismatches stay observable
+/// instead of being silently warned-and-acked.
+macro_rules! process_or_fail {
     ($uri:expr, $method:ident, $label:literal, $($arg:expr),* $(,)?) => {
         match processing::$method($($arg),*) {
             Ok(p) => p,
             Err(e) => {
-                warn!(uri = %$uri, error = %e, "Failed to process {} record", $label);
-                return Ok(());
+                return Err(IngesterError::Processing(format!("{}: {}", $label, e)));
             }
         }
     };
@@ -80,6 +84,11 @@ impl Database {
         })
     }
 
+    /// Pool handle for read-only consumers (dashboard `/api/failed-records`).
+    pub fn pool(&self) -> &PgPool {
+        &self.pool
+    }
+
     pub async fn upsert_occurrence(
         &self,
         did: &str,
@@ -90,7 +99,7 @@ impl Database {
     ) -> Result<()> {
         debug!("Upserting occurrence: {}", uri);
 
-        let mut parsed = process_or_warn!(
+        let mut parsed = process_or_fail!(
             uri,
             occurrence_from_json,
             "occurrence",
@@ -143,7 +152,7 @@ impl Database {
     ) -> Result<()> {
         debug!("Upserting identification: {}", uri);
 
-        let params = process_or_warn!(
+        let params = process_or_fail!(
             uri,
             identification_from_json,
             "identification",
@@ -175,7 +184,7 @@ impl Database {
     ) -> Result<()> {
         debug!("Upserting comment: {}", uri);
 
-        let params = process_or_warn!(
+        let params = process_or_fail!(
             uri,
             comment_from_json,
             "comment",
@@ -207,7 +216,7 @@ impl Database {
     ) -> Result<()> {
         debug!("Upserting interaction: {}", uri);
 
-        let params = process_or_warn!(
+        let params = process_or_fail!(
             uri,
             interaction_from_json,
             "interaction",
@@ -238,7 +247,7 @@ impl Database {
     ) -> Result<()> {
         debug!("Upserting like: {}", uri);
 
-        let params = process_or_warn!(
+        let params = process_or_fail!(
             uri,
             like_from_json,
             "like",

--- a/crates/tap-ingester/src/error.rs
+++ b/crates/tap-ingester/src/error.rs
@@ -7,6 +7,12 @@ pub enum IngesterError {
     Database(Box<sqlx::Error>),
     Decode(String),
     Config(String),
+    /// Record could not be parsed into its lexicon type or is missing
+    /// fields the ingester treats as required (e.g. coordinates,
+    /// eventDate on an occurrence). Surfaced to the main loop so the
+    /// drop lands in `ingester.failed_records` instead of being
+    /// silently warned-and-acked.
+    Processing(String),
 }
 
 impl fmt::Display for IngesterError {
@@ -15,6 +21,7 @@ impl fmt::Display for IngesterError {
             IngesterError::Database(err) => write!(f, "Database error: {}", err),
             IngesterError::Decode(msg) => write!(f, "Decode error: {}", msg),
             IngesterError::Config(msg) => write!(f, "Configuration error: {}", msg),
+            IngesterError::Processing(msg) => write!(f, "Processing error: {}", msg),
         }
     }
 }

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -90,10 +90,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // until the cell is populated.
     let tap_cell: Arc<tokio::sync::OnceCell<TapClient>> = Arc::new(tokio::sync::OnceCell::new());
 
+    // Same late-init pattern for the DB pool: HTTP server up first so
+    // Cloud Run TCP startup probe passes, then `Database::connect` below
+    // sets this cell so `/api/failed-records` can query the ledger.
+    let pool_cell: Arc<tokio::sync::OnceCell<sqlx::postgres::PgPool>> =
+        Arc::new(tokio::sync::OnceCell::new());
+
     // Spawn HTTP server immediately so Cloud Run TCP startup probe passes.
     let dash_state = DashboardState {
         ingester: state.clone(),
         tap: tap_cell.clone(),
+        pool: pool_cell.clone(),
     };
     tokio::spawn(async move {
         if let Err(e) = serve_http(dash_state, port).await {
@@ -102,6 +109,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     });
 
     let db = Database::connect(&database_url).await?;
+    pool_cell.set(db.pool().clone()).ok();
 
     // Bring up Tap. If TAP_URL is set we treat it as already running;
     // otherwise spawn the bundled binary as a child process. The


### PR DESCRIPTION
## Summary

- Stop silently dropping records the ingester can't parse: `process_or_warn!` (now `process_or_fail!`) returns `Err(IngesterError::Processing(...))` instead of `Ok(())`, so the existing main-loop failure path writes them to `ingester.failed_records` and bumps the stats counter.
- Add a "Failed records" panel to the dashboard backed by a new `GET /api/failed-records` endpoint (50 most recent rows + total count). Pool plumbed into `DashboardState` via the same late-init `OnceCell` pattern already used for the Tap client.
- HTML-escape user-controlled fields in the existing "Recent events" list while touching the same JS.

## Motivation

While investigating why `at://did:plc:jt6xegjm6ba2lt34aztyi2mn/bio.lexicons.temp.v0-1.occurrence/3mmfezfhhi42x` (`kueda.net`) didn't ingest, traced it to an occurrence with no inline `eventDate` / `decimalLatitude` / `decimalLongitude` — those live on a parent `bio.lexicons.temp.v0-1.survey` record (a lexicon we don't support yet). `processing::occurrence_from_json` returned `InvalidField("missing valid coordinates")`, which the macro silently swallowed. With this change the next redelivery of that record will show up in the dashboard with `last_error: "occurrence: invalid field: missing valid coordinates"`.

Doesn't fix the underlying feature gap (survey-aware ingestion), but makes the gap observable instead of invisible.

## Test plan

- [ ] `cargo build -p tap-ingester` (already done locally; .sqlx cache regenerated)
- [ ] `cargo test -p tap-ingester` — 21/21 pass locally
- [ ] Deploy to dev, hit `https://ingester.observ.ing/` and confirm the new "Failed records" section renders
- [ ] Confirm `/api/failed-records` returns `{total, items, error}` shape
- [ ] After deploy, watch for kueda.net's `3mmfezfhhi42x` (and similar survey-bound occurrences) appearing in the panel on next Tap redelivery