### PR TITLE
ci: pin sqlx-cli to 0.8.6 to match rust-toolchain 1.93

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -247,11 +247,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: sqlx-cli
           # Pinned: sqlx-cli 0.9.0 requires rustc >=1.94; we pin to 1.93
           # in rust-toolchain.toml. Workspace uses sqlx 0.8.x, so 0.8.6
           # matches. Bump in lockstep when the toolchain pin moves.
-          version: 0.8.6
+          tool: sqlx-cli@0.8.6
           no-default-features: true
           features: postgres
       - run: cargo sqlx prepare --workspace --check
@@ -310,9 +309,8 @@ jobs:
       - run: npm ci
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
-          tool: sqlx-cli
           # See rust-sqlx job above for rationale on the version pin.
-          version: 0.8.6
+          tool: sqlx-cli@0.8.6
           no-default-features: true
           features: postgres
       - name: Run database migrations and seed

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -248,6 +248,10 @@ jobs:
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: sqlx-cli
+          # Pinned: sqlx-cli 0.9.0 requires rustc >=1.94; we pin to 1.93
+          # in rust-toolchain.toml. Workspace uses sqlx 0.8.x, so 0.8.6
+          # matches. Bump in lockstep when the toolchain pin moves.
+          version: 0.8.6
           no-default-features: true
           features: postgres
       - run: cargo sqlx prepare --workspace --check
@@ -307,6 +311,8 @@ jobs:
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
           tool: sqlx-cli
+          # See rust-sqlx job above for rationale on the version pin.
+          version: 0.8.6
           no-default-features: true
           features: postgres
       - name: Run database migrations and seed


### PR DESCRIPTION
## Summary

Pin `sqlx-cli` to `0.8.6` in both the `rust-sqlx` and `e2e` jobs.

## Why

`sqlx-cli 0.9.0` was published to crates.io and now requires `rustc >= 1.94`, but `rust-toolchain.toml` pins the project to `channel = "1.93"`. Both jobs install `sqlx-cli` unpinned via `taiki-e/cache-cargo-install-action`, so every PR opened today fails with:

> error: cannot install package `sqlx-cli 0.9.0`, it requires rustc 1.94.0 or newer, while the currently active rustc version is 1.93.1

The workspace uses `sqlx = "0.8"`, so `sqlx-cli 0.8.6` (latest 0.8.x) is the natural match. Bump in lockstep when the toolchain pin moves.

## Test plan

- [ ] CI on this PR passes both `rust-sqlx` and `e2e` (which was the previously-failing surface).