### PR TITLE
feat(ingester): accept occurrences without inline location or eventDate

### DIFF
--- a/.sqlx/query-1897b04e47eade3764a988dafccb700631df09adf3d9eb6e4146ad6d774edd3a.json
+++ b/.sqlx/query-1897b04e47eade3764a988dafccb700631df09adf3d9eb6e4146ad6d774edd3a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    uri, cid, did, scientific_name, event_date,\n                    ST_Y(location::geometry) as \"latitude!\",\n                    ST_X(location::geometry) as \"longitude!\",\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1 AND created_at < ($3::text)::timestamptz\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
+  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date as \"event_date!\",\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            ST_Distance(location, ST_SetSRID(ST_MakePoint($2, $1), 4326)::geography) as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE ST_DWithin(\n            location,\n            ST_SetSRID(ST_MakePoint($2, $1), 4326)::geography,\n            $3\n        )\n        AND did != ALL($6)\n        AND event_date IS NOT NULL\n        ORDER BY distance_meters\n        LIMIT $4 OFFSET $5\n        ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date",
+        "name": "event_date!",
         "type_info": "Timestamptz"
       },
       {
@@ -111,9 +111,12 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
+        "Float8",
+        "Float8",
+        "Float8",
         "Int8",
-        "Text"
+        "Int8",
+        "TextArray"
       ]
     },
     "nullable": [
@@ -121,7 +124,7 @@
       false,
       false,
       true,
-      false,
+      true,
       null,
       null,
       true,
@@ -140,5 +143,5 @@
       null
     ]
   },
-  "hash": "6303277f7f28430084de599a7ecd35e4583de823b270cf7b0befee8a3a2087a0"
+  "hash": "1897b04e47eade3764a988dafccb700631df09adf3d9eb6e4146ad6d774edd3a"
 }

--- a/.sqlx/query-4b8f33746ef5a58c14dde69546d8293b0202affbd923ba8a2f4d40874dc4850e.json
+++ b/.sqlx/query-4b8f33746ef5a58c14dde69546d8293b0202affbd923ba8a2f4d40874dc4850e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did, scientific_name, event_date,\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            NULL::float8 as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE uri = $1\n        ",
+  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date as \"event_date!\",\n                    ST_Y(location::geometry) as \"latitude!\",\n                    ST_X(location::geometry) as \"longitude!\",\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1 AND created_at < ($3::text)::timestamptz\n                AND location IS NOT NULL\n                AND event_date IS NOT NULL\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date",
+        "name": "event_date!",
         "type_info": "Timestamptz"
       },
       {
@@ -111,6 +111,8 @@
     ],
     "parameters": {
       "Left": [
+        "Text",
+        "Int8",
         "Text"
       ]
     },
@@ -119,7 +121,7 @@
       false,
       false,
       true,
-      false,
+      true,
       null,
       null,
       true,
@@ -138,5 +140,5 @@
       null
     ]
   },
-  "hash": "027221eae91c91c3830f5d532ce56d1e9990fc31dcb1673bb17e962859609d0f"
+  "hash": "4b8f33746ef5a58c14dde69546d8293b0202affbd923ba8a2f4d40874dc4850e"
 }

--- a/.sqlx/query-4c34df635d14e5cdac904c0ea27312c0ad17270782111516780e8ee1f927f127.json
+++ b/.sqlx/query-4c34df635d14e5cdac904c0ea27312c0ad17270782111516780e8ee1f927f127.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    uri, cid, did, scientific_name, event_date,\n                    ST_Y(location::geometry) as \"latitude!\",\n                    ST_X(location::geometry) as \"longitude!\",\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
+  "query": "\n            SELECT\n                uri, cid, did, scientific_name,\n                event_date as \"event_date!\",\n                ST_Y(location::geometry) as \"latitude!\",\n                ST_X(location::geometry) as \"longitude!\",\n                coordinate_uncertainty_meters,\n                associated_media, recorded_by,\n                taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                created_at,\n                NULL::float8 as distance_meters,\n                NULL::text as source\n            FROM occurrences\n            WHERE created_at < ($2::text)::timestamptz\n            AND did != ALL($3)\n            AND location IS NOT NULL\n            AND event_date IS NOT NULL\n            ORDER BY created_at DESC\n            LIMIT $1\n            ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date",
+        "name": "event_date!",
         "type_info": "Timestamptz"
       },
       {
@@ -111,8 +111,9 @@
     ],
     "parameters": {
       "Left": [
+        "Int8",
         "Text",
-        "Int8"
+        "TextArray"
       ]
     },
     "nullable": [
@@ -120,7 +121,7 @@
       false,
       false,
       true,
-      false,
+      true,
       null,
       null,
       true,
@@ -139,5 +140,5 @@
       null
     ]
   },
-  "hash": "83611b7293a72db66cbe19b0517fc6c17d73118c8ccc2eeaccfe99be75537f4b"
+  "hash": "4c34df635d14e5cdac904c0ea27312c0ad17270782111516780e8ee1f927f127"
 }

--- a/.sqlx/query-90d6ae7395615a276e3229f17e146204affaad0218bccf07848f1203cf98985f.json
+++ b/.sqlx/query-90d6ae7395615a276e3229f17e146204affaad0218bccf07848f1203cf98985f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did, scientific_name, event_date,\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            ST_Distance(location, ST_SetSRID(ST_MakePoint($2, $1), 4326)::geography) as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE ST_DWithin(\n            location,\n            ST_SetSRID(ST_MakePoint($2, $1), 4326)::geography,\n            $3\n        )\n        AND did != ALL($6)\n        ORDER BY distance_meters\n        LIMIT $4 OFFSET $5\n        ",
+  "query": "\n            SELECT\n                uri, cid, did, scientific_name,\n                event_date as \"event_date!\",\n                ST_Y(location::geometry) as \"latitude!\",\n                ST_X(location::geometry) as \"longitude!\",\n                coordinate_uncertainty_meters,\n                associated_media, recorded_by,\n                taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                created_at,\n                NULL::float8 as distance_meters,\n                NULL::text as source\n            FROM occurrences\n            WHERE did != ALL($2)\n            AND location IS NOT NULL\n            AND event_date IS NOT NULL\n            ORDER BY created_at DESC\n            LIMIT $1\n            ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date",
+        "name": "event_date!",
         "type_info": "Timestamptz"
       },
       {
@@ -111,10 +111,6 @@
     ],
     "parameters": {
       "Left": [
-        "Float8",
-        "Float8",
-        "Float8",
-        "Int8",
         "Int8",
         "TextArray"
       ]
@@ -124,7 +120,7 @@
       false,
       false,
       true,
-      false,
+      true,
       null,
       null,
       true,
@@ -143,5 +139,5 @@
       null
     ]
   },
-  "hash": "9d519a1bf205420f989ee3d90fdf14c5014e7a99f5220e04e0ba03fa3cb32a17"
+  "hash": "90d6ae7395615a276e3229f17e146204affaad0218bccf07848f1203cf98985f"
 }

--- a/.sqlx/query-d5ad1343fd64f0353911457463a390d7a0dadbc8aafa673b313bf9b22266c028.json
+++ b/.sqlx/query-d5ad1343fd64f0353911457463a390d7a0dadbc8aafa673b313bf9b22266c028.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did, scientific_name, event_date,\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            NULL::float8 as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE location && ST_MakeEnvelope($1, $2, $3, $4, 4326)::geography\n        AND did != ALL($6)\n        LIMIT $5\n        ",
+  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date as \"event_date!\",\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            NULL::float8 as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE location && ST_MakeEnvelope($1, $2, $3, $4, 4326)::geography\n        AND did != ALL($6)\n        AND event_date IS NOT NULL\n        LIMIT $5\n        ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date",
+        "name": "event_date!",
         "type_info": "Timestamptz"
       },
       {
@@ -124,7 +124,7 @@
       false,
       false,
       true,
-      false,
+      true,
       null,
       null,
       true,
@@ -143,5 +143,5 @@
       null
     ]
   },
-  "hash": "846ecb890880c6d45c77eed9f854de79b93c7992ae9a1159468fc2afd9afd768"
+  "hash": "d5ad1343fd64f0353911457463a390d7a0dadbc8aafa673b313bf9b22266c028"
 }

--- a/.sqlx/query-f146ea310ae9fded89f65f652363eda1a977371c4e48864e08a505e088eda02a.json
+++ b/.sqlx/query-f146ea310ae9fded89f65f652363eda1a977371c4e48864e08a505e088eda02a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                uri, cid, did, scientific_name, event_date,\n                ST_Y(location::geometry) as \"latitude!\",\n                ST_X(location::geometry) as \"longitude!\",\n                coordinate_uncertainty_meters,\n                associated_media, recorded_by,\n                taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                created_at,\n                NULL::float8 as distance_meters,\n                NULL::text as source\n            FROM occurrences\n            WHERE created_at < ($2::text)::timestamptz\n            AND did != ALL($3)\n            ORDER BY created_at DESC\n            LIMIT $1\n            ",
+  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date as \"event_date!\",\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            NULL::float8 as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE uri = $1\n          AND location IS NOT NULL\n          AND event_date IS NOT NULL\n        ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date",
+        "name": "event_date!",
         "type_info": "Timestamptz"
       },
       {
@@ -111,9 +111,7 @@
     ],
     "parameters": {
       "Left": [
-        "Int8",
-        "Text",
-        "TextArray"
+        "Text"
       ]
     },
     "nullable": [
@@ -121,7 +119,7 @@
       false,
       false,
       true,
-      false,
+      true,
       null,
       null,
       true,
@@ -140,5 +138,5 @@
       null
     ]
   },
-  "hash": "2699a09377ce25feceba44e901a2b1917ff21de54599ee70f8abed27bc35be0a"
+  "hash": "f146ea310ae9fded89f65f652363eda1a977371c4e48864e08a505e088eda02a"
 }

--- a/.sqlx/query-f1e8befb63e08273954a01301e2c87fede7340c690b56281e003aba441db6a64.json
+++ b/.sqlx/query-f1e8befb63e08273954a01301e2c87fede7340c690b56281e003aba441db6a64.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                uri, cid, did, scientific_name, event_date,\n                ST_Y(location::geometry) as \"latitude!\",\n                ST_X(location::geometry) as \"longitude!\",\n                coordinate_uncertainty_meters,\n                associated_media, recorded_by,\n                taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                created_at,\n                NULL::float8 as distance_meters,\n                NULL::text as source\n            FROM occurrences\n            WHERE did != ALL($2)\n            ORDER BY created_at DESC\n            LIMIT $1\n            ",
+  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date as \"event_date!\",\n                    ST_Y(location::geometry) as \"latitude!\",\n                    ST_X(location::geometry) as \"longitude!\",\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1\n                AND location IS NOT NULL\n                AND event_date IS NOT NULL\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
   "describe": {
     "columns": [
       {
@@ -25,7 +25,7 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date",
+        "name": "event_date!",
         "type_info": "Timestamptz"
       },
       {
@@ -111,8 +111,8 @@
     ],
     "parameters": {
       "Left": [
-        "Int8",
-        "TextArray"
+        "Text",
+        "Int8"
       ]
     },
     "nullable": [
@@ -120,7 +120,7 @@
       false,
       false,
       true,
-      false,
+      true,
       null,
       null,
       true,
@@ -139,5 +139,5 @@
       null
     ]
   },
-  "hash": "f652da74676f8279daf28d4212eeeb6a1645baa9312500e38e49a9020f0a9e09"
+  "hash": "f1e8befb63e08273954a01301e2c87fede7340c690b56281e003aba441db6a64"
 }

--- a/crates/observing-db/migrations/20260522000000_optional_occurrence_location.sql
+++ b/crates/observing-db/migrations/20260522000000_optional_occurrence_location.sql
@@ -1,0 +1,15 @@
+-- The bio.lexicons.temp.v0-1.occurrence lexicon marks decimalLatitude,
+-- decimalLongitude, and eventDate as optional (no `required` array in
+-- the schema). Survey-based records carry those values on a referenced
+-- bio.lexicons.temp.v0-1.survey record via `eventID`, so the occurrence
+-- itself has no inline coordinates or date.
+--
+-- The ingester was rejecting these records (silent drop pre-#508, then
+-- failed_records entries post-#508) which in turn caused FK violations
+-- when their identifications arrived. Allow NULL so the ledger drains
+-- and identifications can land. Read queries in the appview filter
+-- incomplete rows out (`WHERE location IS NOT NULL AND event_date IS NOT NULL`)
+-- so the API contract is unchanged until proper survey support lands.
+
+ALTER TABLE occurrences ALTER COLUMN location DROP NOT NULL;
+ALTER TABLE occurrences ALTER COLUMN event_date DROP NOT NULL;

--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -14,7 +14,10 @@ pub async fn get_explore_feed(
     let mut qb = QueryBuilder::<Postgres>::new(concat!(
         "SELECT ",
         occurrence_columns!(),
-        " FROM occurrences WHERE TRUE"
+        // Skip rows missing the fields downstream callers assume are present
+        // (survey-based occurrences land with NULL location/event_date until
+        // proper survey resolution backfills them).
+        " FROM occurrences WHERE location IS NOT NULL AND event_date IS NOT NULL"
     ));
 
     if !hidden_dids.is_empty() {
@@ -71,14 +74,17 @@ pub async fn get_profile_feed(
     let limit = options.limit.unwrap_or(20);
     let feed_type = options.feed_type.as_ref().cloned().unwrap_or_default();
 
-    // Get counts
+    // Get counts. Observations count matches what feeds expose, so it
+    // filters incomplete (NULL location/event_date) rows the same way.
     let counts_row: (i64, i64, i64) = sqlx::query_as(
         r#"
         SELECT
-            (SELECT COUNT(*) FROM occurrences WHERE did = $1),
+            (SELECT COUNT(*) FROM occurrences
+             WHERE did = $1 AND location IS NOT NULL AND event_date IS NOT NULL),
             (SELECT COUNT(*) FROM identifications WHERE did = $1),
             (SELECT COUNT(DISTINCT (scientific_name, kingdom)) FROM occurrences
-             WHERE did = $1 AND scientific_name IS NOT NULL)
+             WHERE did = $1 AND scientific_name IS NOT NULL
+               AND location IS NOT NULL AND event_date IS NOT NULL)
         "#,
     )
     .bind(did)
@@ -103,7 +109,8 @@ pub async fn get_profile_feed(
                 OccurrenceRow,
                 r#"
                 SELECT
-                    uri, cid, did, scientific_name, event_date,
+                    uri, cid, did, scientific_name,
+                    event_date as "event_date!",
                     ST_Y(location::geometry) as "latitude!",
                     ST_X(location::geometry) as "longitude!",
                     coordinate_uncertainty_meters,
@@ -114,6 +121,8 @@ pub async fn get_profile_feed(
                     NULL::text as source
                 FROM occurrences
                 WHERE did = $1 AND created_at < ($3::text)::timestamptz
+                AND location IS NOT NULL
+                AND event_date IS NOT NULL
                 ORDER BY created_at DESC
                 LIMIT $2
                 "#,
@@ -128,7 +137,8 @@ pub async fn get_profile_feed(
                 OccurrenceRow,
                 r#"
                 SELECT
-                    uri, cid, did, scientific_name, event_date,
+                    uri, cid, did, scientific_name,
+                    event_date as "event_date!",
                     ST_Y(location::geometry) as "latitude!",
                     ST_X(location::geometry) as "longitude!",
                     coordinate_uncertainty_meters,
@@ -139,6 +149,8 @@ pub async fn get_profile_feed(
                     NULL::text as source
                 FROM occurrences
                 WHERE did = $1
+                AND location IS NOT NULL
+                AND event_date IS NOT NULL
                 ORDER BY created_at DESC
                 LIMIT $2
                 "#,
@@ -212,7 +224,10 @@ pub async fn get_home_feed(
     let mut qb = QueryBuilder::<Postgres>::new(concat!(
         "SELECT ",
         occurrence_columns!(),
-        " FROM occurrences WHERE TRUE"
+        // Skip rows missing the fields downstream callers assume are present
+        // (survey-based occurrences land with NULL location/event_date until
+        // proper survey resolution backfills them).
+        " FROM occurrences WHERE location IS NOT NULL AND event_date IS NOT NULL"
     ));
 
     if !hidden_dids.is_empty() {
@@ -250,7 +265,7 @@ pub async fn get_occurrences_by_taxon(
     let mut qb = QueryBuilder::<Postgres>::new(concat!(
         "SELECT ",
         occurrence_columns!(),
-        " FROM occurrences WHERE "
+        " FROM occurrences WHERE location IS NOT NULL AND event_date IS NOT NULL AND "
     ));
 
     push_consensus_rank_filter(&mut qb, &rank_lower, taxon_name);
@@ -291,7 +306,9 @@ pub async fn count_occurrences_by_taxon(
 ) -> Result<i64, sqlx::Error> {
     let rank_lower = taxon_rank.to_lowercase();
 
-    let mut qb = QueryBuilder::<Postgres>::new("SELECT COUNT(*) FROM occurrences WHERE ");
+    let mut qb = QueryBuilder::<Postgres>::new(
+        "SELECT COUNT(*) FROM occurrences WHERE location IS NOT NULL AND event_date IS NOT NULL AND ",
+    );
 
     push_consensus_rank_filter(&mut qb, &rank_lower, taxon_name);
 

--- a/crates/observing-db/src/occurrences.rs
+++ b/crates/observing-db/src/occurrences.rs
@@ -59,9 +59,12 @@ pub async fn upsert(
         p.cid,
         p.did,
         p.scientific_name as _,
-        p.event_date,
-        p.longitude,
-        p.latitude,
+        p.event_date as _,
+        // ST_MakePoint is STRICT, so a NULL coord propagates through to a
+        // NULL location column — that's how survey-based occurrences land
+        // with NULL geometry until proper survey resolution fills them in.
+        p.longitude as _,
+        p.latitude as _,
         p.coordinate_uncertainty_meters as _,
         p.associated_media as _,
         p.recorded_by as _,
@@ -92,7 +95,8 @@ pub async fn get(
         OccurrenceRow,
         r#"
         SELECT
-            uri, cid, did, scientific_name, event_date,
+            uri, cid, did, scientific_name,
+            event_date as "event_date!",
             ST_Y(location::geometry) as "latitude!",
             ST_X(location::geometry) as "longitude!",
             coordinate_uncertainty_meters,
@@ -103,6 +107,8 @@ pub async fn get(
             NULL::text as source
         FROM occurrences
         WHERE uri = $1
+          AND location IS NOT NULL
+          AND event_date IS NOT NULL
         "#,
         uri,
     )
@@ -124,7 +130,8 @@ pub async fn get_nearby(
         OccurrenceRow,
         r#"
         SELECT
-            uri, cid, did, scientific_name, event_date,
+            uri, cid, did, scientific_name,
+            event_date as "event_date!",
             ST_Y(location::geometry) as "latitude!",
             ST_X(location::geometry) as "longitude!",
             coordinate_uncertainty_meters,
@@ -140,6 +147,7 @@ pub async fn get_nearby(
             $3
         )
         AND did != ALL($6)
+        AND event_date IS NOT NULL
         ORDER BY distance_meters
         LIMIT $4 OFFSET $5
         "#,
@@ -168,7 +176,8 @@ pub async fn get_by_bounding_box(
         OccurrenceRow,
         r#"
         SELECT
-            uri, cid, did, scientific_name, event_date,
+            uri, cid, did, scientific_name,
+            event_date as "event_date!",
             ST_Y(location::geometry) as "latitude!",
             ST_X(location::geometry) as "longitude!",
             coordinate_uncertainty_meters,
@@ -180,6 +189,7 @@ pub async fn get_by_bounding_box(
         FROM occurrences
         WHERE location && ST_MakeEnvelope($1, $2, $3, $4, 4326)::geography
         AND did != ALL($6)
+        AND event_date IS NOT NULL
         LIMIT $5
         "#,
         min_lng,
@@ -205,7 +215,8 @@ pub async fn get_feed(
             OccurrenceRow,
             r#"
             SELECT
-                uri, cid, did, scientific_name, event_date,
+                uri, cid, did, scientific_name,
+                event_date as "event_date!",
                 ST_Y(location::geometry) as "latitude!",
                 ST_X(location::geometry) as "longitude!",
                 coordinate_uncertainty_meters,
@@ -217,6 +228,8 @@ pub async fn get_feed(
             FROM occurrences
             WHERE created_at < ($2::text)::timestamptz
             AND did != ALL($3)
+            AND location IS NOT NULL
+            AND event_date IS NOT NULL
             ORDER BY created_at DESC
             LIMIT $1
             "#,
@@ -231,7 +244,8 @@ pub async fn get_feed(
             OccurrenceRow,
             r#"
             SELECT
-                uri, cid, did, scientific_name, event_date,
+                uri, cid, did, scientific_name,
+                event_date as "event_date!",
                 ST_Y(location::geometry) as "latitude!",
                 ST_X(location::geometry) as "longitude!",
                 coordinate_uncertainty_meters,
@@ -242,6 +256,8 @@ pub async fn get_feed(
                 NULL::text as source
             FROM occurrences
             WHERE did != ALL($2)
+            AND location IS NOT NULL
+            AND event_date IS NOT NULL
             ORDER BY created_at DESC
             LIMIT $1
             "#,

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -111,13 +111,12 @@ pub fn occurrence_from_json(
         })
         .and_then(|s| s.parse::<f64>().ok());
 
-    let (lat, lng) = match (lat, lng) {
-        (Some(lat), Some(lng)) => (lat, lng),
-        _ => {
-            return Err(ProcessingError::InvalidField(
-                "missing valid coordinates".into(),
-            ))
-        }
+    // Both coordinates must be present together to mean anything; mixing
+    // one with NULL would silently misplace the point at the equator or
+    // prime meridian.
+    let coords = match (lat, lng) {
+        (Some(lat), Some(lng)) => Some((lat, lng)),
+        _ => None,
     };
 
     let event_date = record
@@ -130,8 +129,7 @@ pub fn occurrence_from_json(
                 .get("eventDate")
                 .and_then(|v| v.as_str())
                 .and_then(parse_datetime)
-        })
-        .ok_or_else(|| ProcessingError::InvalidField("missing valid eventDate".into()))?;
+        });
 
     // Extension fields: read from raw JSON (not part of bio.lexicons.temp.v0-1.occurrence schema)
     let created_at = record_json
@@ -161,8 +159,8 @@ pub fn occurrence_from_json(
             did,
             scientific_name: None,
             event_date,
-            longitude: lng,
-            latitude: lat,
+            longitude: coords.map(|(_, lng)| lng),
+            latitude: coords.map(|(lat, _)| lat),
             coordinate_uncertainty_meters: record
                 .coordinate_uncertainty_in_meters
                 .or_else(|| {
@@ -864,5 +862,35 @@ mod tests {
             "missing createdAt must fall back to the firehose commit time, \
              not event_date — otherwise feeds sort by observation date"
         );
+    }
+
+    /// Survey-based occurrences carry no inline coordinates or eventDate —
+    /// those live on the linked bio.lexicons.temp.v0-1.survey record. The
+    /// occurrence lexicon marks those fields optional, so the parser must
+    /// accept the record and let the database persist NULLs instead of
+    /// rejecting it (which previously caused identifications to FK-violate).
+    #[test]
+    fn test_occurrence_from_json_accepts_survey_based_record() {
+        let record = serde_json::json!({
+            "$type": "bio.lexicons.temp.v0-1.occurrence",
+            "eventID": "at://did:plc:author/bio.lexicons.temp.v0-1.survey/3xyz",
+            "taxonID": "https://www.inaturalist.org/taxa/63962",
+            "organismQuantity": "1",
+            "organismQuantityType": "individual-count"
+            // no decimalLatitude/decimalLongitude/eventDate
+        });
+
+        let parsed = occurrence_from_json(
+            &record,
+            "at://did:plc:author/bio.lexicons.temp.v0-1.occurrence/xyz".into(),
+            "bafyreioccurrence".into(),
+            "did:plc:author".into(),
+            Utc::now(),
+        )
+        .expect("survey-based occurrence must parse with NULL location/event_date");
+
+        assert!(parsed.params.latitude.is_none());
+        assert!(parsed.params.longitude.is_none());
+        assert!(parsed.params.event_date.is_none());
     }
 }

--- a/crates/observing-db/src/types.rs
+++ b/crates/observing-db/src/types.rs
@@ -217,16 +217,23 @@ pub struct UserPreferencesRow {
     pub updated_at: DateTime<Utc>,
 }
 
-/// Parameters for upserting an occurrence
+/// Parameters for upserting an occurrence.
+///
+/// `event_date`, `longitude`, and `latitude` are optional because the
+/// underlying lexicon (bio.lexicons.temp.v0-1.occurrence) lists them as
+/// optional. Survey-based records carry these on a separate
+/// bio.lexicons.temp.v0-1.survey record referenced by `eventID`. Read
+/// queries in the appview filter incomplete rows out so callers still
+/// see fully-populated occurrences.
 #[derive(Debug, Clone)]
 pub struct UpsertOccurrenceParams {
     pub uri: String,
     pub cid: String,
     pub did: String,
     pub scientific_name: Option<String>,
-    pub event_date: DateTime<Utc>,
-    pub longitude: f64,
-    pub latitude: f64,
+    pub event_date: Option<DateTime<Utc>>,
+    pub longitude: Option<f64>,
+    pub latitude: Option<f64>,
     pub coordinate_uncertainty_meters: Option<i32>,
     pub associated_media: Option<serde_json::Value>,
     pub recorded_by: Option<String>,


### PR DESCRIPTION
## Summary

Fixes the FK-violation flood visible in https://ingester.observ.ing/ Failed records panel. All 72 entries were identifications referencing occurrences that the ingester rejected for missing inline `decimalLatitude` / `decimalLongitude` / `eventDate` — fields the [bio.lexicons.temp.v0-1.occurrence](https://github.com/lexicons-bio/lexicons.bio/blob/main/lexicons/bio/lexicons/temp/v0-1/occurrence.json) lexicon marks as **optional** (no `required` array).

Survey-based records carry those values on a referenced `bio.lexicons.temp.v0-1.survey` via `eventID`. Until proper survey resolution lands and backfills the missing fields, we accept the occurrence with NULL location/event_date so its identifications can land too.

### Changes

- **Migration** (`20260522000000_optional_occurrence_location.sql`): drops NOT NULL on `occurrences.location` and `event_date`.
- **Parser** (`processing::occurrence_from_json`): stops returning `InvalidField` when coordinates / eventDate are missing — emits `None` instead. Coordinates are still treated as "both or neither" so we never mix a real coord with NULL.
- **Upsert** (`occurrences::upsert`): binds coords as nullable. `ST_MakePoint` is STRICT, so a NULL coord propagates through to a NULL `location` column naturally.
- **Read queries** (occurrences.rs `get`/`get_nearby`/`get_by_bounding_box`/`get_feed`; feeds.rs all query paths + counts): add `WHERE location IS NOT NULL AND event_date IS NOT NULL` so the appview API contract is unchanged — callers continue to see only fully-populated occurrences.

### Out of scope (deliberate)

- Full survey support (Rust type + `surveys` table + parser that pulls eventDate/coords from the linked survey). This unblocks ingest first; the survey lookup can land separately.

## Test plan

- [x] `cargo test --workspace --all-features` — 37 obs-db tests pass, including new `test_occurrence_from_json_accepts_survey_based_record`
- [x] `cargo sqlx prepare --workspace` — cache regenerated
- [ ] After deploy, verify https://ingester.observ.ing/ Failed records stops growing for the two known DIDs (`did:plc:govo6vltxigqf6hmap7uq3u7`, `did:plc:jt6xegjm6ba2lt34aztyi2mn`) and the new identifications start landing once Tap redelivers
- [ ] Spot-check the appview feed for one of those DIDs — incomplete occurrences should not appear