### PR TITLE
feat(explore): show observations even when location/eventDate is null

### DIFF
--- a/.sqlx/query-25c520cc353d597aba224da8fe2ead8b114d8646499c7e34918976d924d2cab0.json
+++ b/.sqlx/query-25c520cc353d597aba224da8fe2ead8b114d8646499c7e34918976d924d2cab0.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date as \"event_date!\",\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            ST_Distance(location, ST_SetSRID(ST_MakePoint($2, $1), 4326)::geography) as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE ST_DWithin(\n            location,\n            ST_SetSRID(ST_MakePoint($2, $1), 4326)::geography,\n            $3\n        )\n        AND did != ALL($6)\n        AND event_date IS NOT NULL\n        ORDER BY distance_meters\n        LIMIT $4 OFFSET $5\n        ",
+  "query": "\n            SELECT\n                uri, cid, did, scientific_name,\n                event_date,\n                ST_Y(location::geometry) as latitude,\n                ST_X(location::geometry) as longitude,\n                coordinate_uncertainty_meters,\n                associated_media, recorded_by,\n                taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                created_at,\n                NULL::float8 as distance_meters,\n                NULL::text as source\n            FROM occurrences\n            WHERE did != ALL($2)\n            ORDER BY created_at DESC\n            LIMIT $1\n            ",
   "describe": {
     "columns": [
       {
@@ -25,17 +25,17 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date!",
+        "name": "event_date",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 5,
-        "name": "latitude!",
+        "name": "latitude",
         "type_info": "Float8"
       },
       {
         "ordinal": 6,
-        "name": "longitude!",
+        "name": "longitude",
         "type_info": "Float8"
       },
       {
@@ -111,10 +111,6 @@
     ],
     "parameters": {
       "Left": [
-        "Float8",
-        "Float8",
-        "Float8",
-        "Int8",
         "Int8",
         "TextArray"
       ]
@@ -143,5 +139,5 @@
       null
     ]
   },
-  "hash": "1897b04e47eade3764a988dafccb700631df09adf3d9eb6e4146ad6d774edd3a"
+  "hash": "25c520cc353d597aba224da8fe2ead8b114d8646499c7e34918976d924d2cab0"
 }

--- a/.sqlx/query-55e21c5cd9741166c798a2d8b43816de86a2652bccb58700ea30d7421bede2a6.json
+++ b/.sqlx/query-55e21c5cd9741166c798a2d8b43816de86a2652bccb58700ea30d7421bede2a6.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date as \"event_date!\",\n                    ST_Y(location::geometry) as \"latitude!\",\n                    ST_X(location::geometry) as \"longitude!\",\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1 AND created_at < ($3::text)::timestamptz\n                AND location IS NOT NULL\n                AND event_date IS NOT NULL\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
+  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date,\n            ST_Y(location::geometry) as latitude,\n            ST_X(location::geometry) as longitude,\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            NULL::float8 as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE uri = $1\n        ",
   "describe": {
     "columns": [
       {
@@ -25,17 +25,17 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date!",
+        "name": "event_date",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 5,
-        "name": "latitude!",
+        "name": "latitude",
         "type_info": "Float8"
       },
       {
         "ordinal": 6,
-        "name": "longitude!",
+        "name": "longitude",
         "type_info": "Float8"
       },
       {
@@ -111,8 +111,6 @@
     ],
     "parameters": {
       "Left": [
-        "Text",
-        "Int8",
         "Text"
       ]
     },
@@ -140,5 +138,5 @@
       null
     ]
   },
-  "hash": "4b8f33746ef5a58c14dde69546d8293b0202affbd923ba8a2f4d40874dc4850e"
+  "hash": "55e21c5cd9741166c798a2d8b43816de86a2652bccb58700ea30d7421bede2a6"
 }

--- a/.sqlx/query-6a3a73c649d6c23699979c7f4cd88bcd9f76a6b16ebaa93e14711da7c44bd3ad.json
+++ b/.sqlx/query-6a3a73c649d6c23699979c7f4cd88bcd9f76a6b16ebaa93e14711da7c44bd3ad.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                uri, cid, did, scientific_name,\n                event_date as \"event_date!\",\n                ST_Y(location::geometry) as \"latitude!\",\n                ST_X(location::geometry) as \"longitude!\",\n                coordinate_uncertainty_meters,\n                associated_media, recorded_by,\n                taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                created_at,\n                NULL::float8 as distance_meters,\n                NULL::text as source\n            FROM occurrences\n            WHERE did != ALL($2)\n            AND location IS NOT NULL\n            AND event_date IS NOT NULL\n            ORDER BY created_at DESC\n            LIMIT $1\n            ",
+  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date,\n                    ST_Y(location::geometry) as latitude,\n                    ST_X(location::geometry) as longitude,\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
   "describe": {
     "columns": [
       {
@@ -25,17 +25,17 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date!",
+        "name": "event_date",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 5,
-        "name": "latitude!",
+        "name": "latitude",
         "type_info": "Float8"
       },
       {
         "ordinal": 6,
-        "name": "longitude!",
+        "name": "longitude",
         "type_info": "Float8"
       },
       {
@@ -111,8 +111,8 @@
     ],
     "parameters": {
       "Left": [
-        "Int8",
-        "TextArray"
+        "Text",
+        "Int8"
       ]
     },
     "nullable": [
@@ -139,5 +139,5 @@
       null
     ]
   },
-  "hash": "90d6ae7395615a276e3229f17e146204affaad0218bccf07848f1203cf98985f"
+  "hash": "6a3a73c649d6c23699979c7f4cd88bcd9f76a6b16ebaa93e14711da7c44bd3ad"
 }

--- a/.sqlx/query-8581ab35005155f6a02cb6d14030fe89b76225da5ab403f19579764ee1b46262.json
+++ b/.sqlx/query-8581ab35005155f6a02cb6d14030fe89b76225da5ab403f19579764ee1b46262.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date as \"event_date!\",\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            NULL::float8 as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE uri = $1\n          AND location IS NOT NULL\n          AND event_date IS NOT NULL\n        ",
+  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date,\n                    ST_Y(location::geometry) as latitude,\n                    ST_X(location::geometry) as longitude,\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1 AND created_at < ($3::text)::timestamptz\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
   "describe": {
     "columns": [
       {
@@ -25,17 +25,17 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date!",
+        "name": "event_date",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 5,
-        "name": "latitude!",
+        "name": "latitude",
         "type_info": "Float8"
       },
       {
         "ordinal": 6,
-        "name": "longitude!",
+        "name": "longitude",
         "type_info": "Float8"
       },
       {
@@ -111,6 +111,8 @@
     ],
     "parameters": {
       "Left": [
+        "Text",
+        "Int8",
         "Text"
       ]
     },
@@ -138,5 +140,5 @@
       null
     ]
   },
-  "hash": "f146ea310ae9fded89f65f652363eda1a977371c4e48864e08a505e088eda02a"
+  "hash": "8581ab35005155f6a02cb6d14030fe89b76225da5ab403f19579764ee1b46262"
 }

--- a/.sqlx/query-bd8e6f609aac49a1afcb690a275d88532a2eb0688348ef731214453943546719.json
+++ b/.sqlx/query-bd8e6f609aac49a1afcb690a275d88532a2eb0688348ef731214453943546719.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date as \"event_date!\",\n                    ST_Y(location::geometry) as \"latitude!\",\n                    ST_X(location::geometry) as \"longitude!\",\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1\n                AND location IS NOT NULL\n                AND event_date IS NOT NULL\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
+  "query": "\n            SELECT\n                uri, cid, did, scientific_name,\n                event_date,\n                ST_Y(location::geometry) as latitude,\n                ST_X(location::geometry) as longitude,\n                coordinate_uncertainty_meters,\n                associated_media, recorded_by,\n                taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                created_at,\n                NULL::float8 as distance_meters,\n                NULL::text as source\n            FROM occurrences\n            WHERE created_at < ($2::text)::timestamptz\n            AND did != ALL($3)\n            ORDER BY created_at DESC\n            LIMIT $1\n            ",
   "describe": {
     "columns": [
       {
@@ -25,17 +25,17 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date!",
+        "name": "event_date",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 5,
-        "name": "latitude!",
+        "name": "latitude",
         "type_info": "Float8"
       },
       {
         "ordinal": 6,
-        "name": "longitude!",
+        "name": "longitude",
         "type_info": "Float8"
       },
       {
@@ -111,8 +111,9 @@
     ],
     "parameters": {
       "Left": [
+        "Int8",
         "Text",
-        "Int8"
+        "TextArray"
       ]
     },
     "nullable": [
@@ -139,5 +140,5 @@
       null
     ]
   },
-  "hash": "f1e8befb63e08273954a01301e2c87fede7340c690b56281e003aba441db6a64"
+  "hash": "bd8e6f609aac49a1afcb690a275d88532a2eb0688348ef731214453943546719"
 }

--- a/.sqlx/query-e611a0eec458dc9f59d13e99eb6ac827383166b37b4f8f538d36542f3593ff7e.json
+++ b/.sqlx/query-e611a0eec458dc9f59d13e99eb6ac827383166b37b4f8f538d36542f3593ff7e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date as \"event_date!\",\n            ST_Y(location::geometry) as \"latitude!\",\n            ST_X(location::geometry) as \"longitude!\",\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            NULL::float8 as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE location && ST_MakeEnvelope($1, $2, $3, $4, 4326)::geography\n        AND did != ALL($6)\n        AND event_date IS NOT NULL\n        LIMIT $5\n        ",
+  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date,\n            ST_Y(location::geometry) as latitude,\n            ST_X(location::geometry) as longitude,\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            ST_Distance(location, ST_SetSRID(ST_MakePoint($2, $1), 4326)::geography) as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE ST_DWithin(\n            location,\n            ST_SetSRID(ST_MakePoint($2, $1), 4326)::geography,\n            $3\n        )\n        AND did != ALL($6)\n        ORDER BY distance_meters\n        LIMIT $4 OFFSET $5\n        ",
   "describe": {
     "columns": [
       {
@@ -25,17 +25,17 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date!",
+        "name": "event_date",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 5,
-        "name": "latitude!",
+        "name": "latitude",
         "type_info": "Float8"
       },
       {
         "ordinal": 6,
-        "name": "longitude!",
+        "name": "longitude",
         "type_info": "Float8"
       },
       {
@@ -114,7 +114,7 @@
         "Float8",
         "Float8",
         "Float8",
-        "Float8",
+        "Int8",
         "Int8",
         "TextArray"
       ]
@@ -143,5 +143,5 @@
       null
     ]
   },
-  "hash": "d5ad1343fd64f0353911457463a390d7a0dadbc8aafa673b313bf9b22266c028"
+  "hash": "e611a0eec458dc9f59d13e99eb6ac827383166b37b4f8f538d36542f3593ff7e"
 }

--- a/.sqlx/query-f5774b8d2c1c5b603e5972d590027a2f657e5cb624d8237a12e864967bf7069e.json
+++ b/.sqlx/query-f5774b8d2c1c5b603e5972d590027a2f657e5cb624d8237a12e864967bf7069e.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n            SELECT\n                uri, cid, did, scientific_name,\n                event_date as \"event_date!\",\n                ST_Y(location::geometry) as \"latitude!\",\n                ST_X(location::geometry) as \"longitude!\",\n                coordinate_uncertainty_meters,\n                associated_media, recorded_by,\n                taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                created_at,\n                NULL::float8 as distance_meters,\n                NULL::text as source\n            FROM occurrences\n            WHERE created_at < ($2::text)::timestamptz\n            AND did != ALL($3)\n            AND location IS NOT NULL\n            AND event_date IS NOT NULL\n            ORDER BY created_at DESC\n            LIMIT $1\n            ",
+  "query": "\n        SELECT\n            uri, cid, did, scientific_name,\n            event_date,\n            ST_Y(location::geometry) as latitude,\n            ST_X(location::geometry) as longitude,\n            coordinate_uncertainty_meters,\n            associated_media, recorded_by,\n            taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n            created_at,\n            NULL::float8 as distance_meters,\n            NULL::text as source\n        FROM occurrences\n        WHERE location && ST_MakeEnvelope($1, $2, $3, $4, 4326)::geography\n        AND did != ALL($6)\n        LIMIT $5\n        ",
   "describe": {
     "columns": [
       {
@@ -25,17 +25,17 @@
       },
       {
         "ordinal": 4,
-        "name": "event_date!",
+        "name": "event_date",
         "type_info": "Timestamptz"
       },
       {
         "ordinal": 5,
-        "name": "latitude!",
+        "name": "latitude",
         "type_info": "Float8"
       },
       {
         "ordinal": 6,
-        "name": "longitude!",
+        "name": "longitude",
         "type_info": "Float8"
       },
       {
@@ -111,8 +111,11 @@
     ],
     "parameters": {
       "Left": [
+        "Float8",
+        "Float8",
+        "Float8",
+        "Float8",
         "Int8",
-        "Text",
         "TextArray"
       ]
     },
@@ -140,5 +143,5 @@
       null
     ]
   },
-  "hash": "4c34df635d14e5cdac904c0ea27312c0ad17270782111516780e8ee1f927f127"
+  "hash": "f5774b8d2c1c5b603e5972d590027a2f657e5cb624d8237a12e864967bf7069e"
 }

--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -23,8 +23,15 @@ pub struct OccurrenceResponse {
     pub effective_taxonomy: Option<EffectiveTaxonomy>,
     #[ts(type = "number")]
     pub identification_count: i64,
-    pub event_date: String,
-    pub location: LocationResponse,
+    /// NULL on survey-based occurrences whose `eventDate` lives on the
+    /// referenced survey record we don't yet ingest. The explore page
+    /// renders a placeholder rather than dropping the observation.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub event_date: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    #[ts(optional)]
+    pub location: Option<LocationResponse>,
     pub images: Vec<OccurrenceImage>,
     pub created_at: String,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -255,11 +262,16 @@ pub async fn enrich_occurrences(
             community_id,
             effective_taxonomy,
             identification_count,
-            event_date: row.event_date.to_rfc3339(),
-            location: LocationResponse {
-                latitude: row.latitude,
-                longitude: row.longitude,
-                uncertainty_meters: row.coordinate_uncertainty_meters,
+            event_date: row.event_date.map(|d| d.to_rfc3339()),
+            // Coordinates come from ST_X/ST_Y(location) — both are NULL
+            // together when the column is NULL, so checking one suffices.
+            location: match (row.latitude, row.longitude) {
+                (Some(latitude), Some(longitude)) => Some(LocationResponse {
+                    latitude,
+                    longitude,
+                    uncertainty_meters: row.coordinate_uncertainty_meters,
+                }),
+                _ => None,
             },
             images,
             created_at: row.created_at.to_rfc3339(),
@@ -419,9 +431,9 @@ mod tests {
             cid: "cid".into(),
             did: "did:plc:test".into(),
             scientific_name: None,
-            event_date: Utc::now(),
-            latitude: 0.0,
-            longitude: 0.0,
+            event_date: Some(Utc::now()),
+            latitude: Some(0.0),
+            longitude: Some(0.0),
             coordinate_uncertainty_meters: None,
             associated_media: media,
             recorded_by: None,

--- a/crates/observing-appview/src/responses.rs
+++ b/crates/observing-appview/src/responses.rs
@@ -128,7 +128,8 @@ pub struct GeoJsonPoint {
 #[serde(rename_all = "camelCase")]
 pub struct GeoJsonProperties {
     pub uri: String,
-    pub event_date: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub event_date: Option<String>,
 }
 
 #[derive(Serialize)]

--- a/crates/observing-appview/src/routes/occurrences/read.rs
+++ b/crates/observing-appview/src/routes/occurrences/read.rs
@@ -210,18 +210,25 @@ pub async fn get_geojson(
     )
     .await?;
 
+    // Bbox query already excludes rows without `location` (the `&&`
+    // operator returns NULL there), so an unwrap here would be safe —
+    // but the row type is Option<f64>, so filter to be explicit and
+    // skip any row whose coords are somehow missing.
     let features: Vec<GeoJsonFeature> = rows
         .iter()
-        .map(|row| GeoJsonFeature {
-            feature_type: "Feature",
-            geometry: GeoJsonPoint {
-                geometry_type: "Point",
-                coordinates: [row.longitude, row.latitude],
-            },
-            properties: GeoJsonProperties {
-                uri: row.uri.clone(),
-                event_date: row.event_date.to_rfc3339(),
-            },
+        .filter_map(|row| {
+            let (lng, lat) = (row.longitude?, row.latitude?);
+            Some(GeoJsonFeature {
+                feature_type: "Feature",
+                geometry: GeoJsonPoint {
+                    geometry_type: "Point",
+                    coordinates: [lng, lat],
+                },
+                properties: GeoJsonProperties {
+                    uri: row.uri.clone(),
+                    event_date: row.event_date.map(|d| d.to_rfc3339()),
+                },
+            })
         })
         .collect();
 

--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -14,10 +14,7 @@ pub async fn get_explore_feed(
     let mut qb = QueryBuilder::<Postgres>::new(concat!(
         "SELECT ",
         occurrence_columns!(),
-        // Skip rows missing the fields downstream callers assume are present
-        // (survey-based occurrences land with NULL location/event_date until
-        // proper survey resolution backfills them).
-        " FROM occurrences WHERE location IS NOT NULL AND event_date IS NOT NULL"
+        " FROM occurrences WHERE TRUE"
     ));
 
     if !hidden_dids.is_empty() {
@@ -74,17 +71,13 @@ pub async fn get_profile_feed(
     let limit = options.limit.unwrap_or(20);
     let feed_type = options.feed_type.as_ref().cloned().unwrap_or_default();
 
-    // Get counts. Observations count matches what feeds expose, so it
-    // filters incomplete (NULL location/event_date) rows the same way.
     let counts_row: (i64, i64, i64) = sqlx::query_as(
         r#"
         SELECT
-            (SELECT COUNT(*) FROM occurrences
-             WHERE did = $1 AND location IS NOT NULL AND event_date IS NOT NULL),
+            (SELECT COUNT(*) FROM occurrences WHERE did = $1),
             (SELECT COUNT(*) FROM identifications WHERE did = $1),
             (SELECT COUNT(DISTINCT (scientific_name, kingdom)) FROM occurrences
-             WHERE did = $1 AND scientific_name IS NOT NULL
-               AND location IS NOT NULL AND event_date IS NOT NULL)
+             WHERE did = $1 AND scientific_name IS NOT NULL)
         "#,
     )
     .bind(did)
@@ -110,9 +103,9 @@ pub async fn get_profile_feed(
                 r#"
                 SELECT
                     uri, cid, did, scientific_name,
-                    event_date as "event_date!",
-                    ST_Y(location::geometry) as "latitude!",
-                    ST_X(location::geometry) as "longitude!",
+                    event_date,
+                    ST_Y(location::geometry) as latitude,
+                    ST_X(location::geometry) as longitude,
                     coordinate_uncertainty_meters,
                     associated_media, recorded_by,
                     taxon_id, taxon_rank, kingdom, phylum, class, "order" as order_, family, genus,
@@ -121,8 +114,6 @@ pub async fn get_profile_feed(
                     NULL::text as source
                 FROM occurrences
                 WHERE did = $1 AND created_at < ($3::text)::timestamptz
-                AND location IS NOT NULL
-                AND event_date IS NOT NULL
                 ORDER BY created_at DESC
                 LIMIT $2
                 "#,
@@ -138,9 +129,9 @@ pub async fn get_profile_feed(
                 r#"
                 SELECT
                     uri, cid, did, scientific_name,
-                    event_date as "event_date!",
-                    ST_Y(location::geometry) as "latitude!",
-                    ST_X(location::geometry) as "longitude!",
+                    event_date,
+                    ST_Y(location::geometry) as latitude,
+                    ST_X(location::geometry) as longitude,
                     coordinate_uncertainty_meters,
                     associated_media, recorded_by,
                     taxon_id, taxon_rank, kingdom, phylum, class, "order" as order_, family, genus,
@@ -149,8 +140,6 @@ pub async fn get_profile_feed(
                     NULL::text as source
                 FROM occurrences
                 WHERE did = $1
-                AND location IS NOT NULL
-                AND event_date IS NOT NULL
                 ORDER BY created_at DESC
                 LIMIT $2
                 "#,
@@ -224,10 +213,7 @@ pub async fn get_home_feed(
     let mut qb = QueryBuilder::<Postgres>::new(concat!(
         "SELECT ",
         occurrence_columns!(),
-        // Skip rows missing the fields downstream callers assume are present
-        // (survey-based occurrences land with NULL location/event_date until
-        // proper survey resolution backfills them).
-        " FROM occurrences WHERE location IS NOT NULL AND event_date IS NOT NULL"
+        " FROM occurrences WHERE TRUE"
     ));
 
     if !hidden_dids.is_empty() {
@@ -265,7 +251,7 @@ pub async fn get_occurrences_by_taxon(
     let mut qb = QueryBuilder::<Postgres>::new(concat!(
         "SELECT ",
         occurrence_columns!(),
-        " FROM occurrences WHERE location IS NOT NULL AND event_date IS NOT NULL AND "
+        " FROM occurrences WHERE "
     ));
 
     push_consensus_rank_filter(&mut qb, &rank_lower, taxon_name);
@@ -306,9 +292,7 @@ pub async fn count_occurrences_by_taxon(
 ) -> Result<i64, sqlx::Error> {
     let rank_lower = taxon_rank.to_lowercase();
 
-    let mut qb = QueryBuilder::<Postgres>::new(
-        "SELECT COUNT(*) FROM occurrences WHERE location IS NOT NULL AND event_date IS NOT NULL AND ",
-    );
+    let mut qb = QueryBuilder::<Postgres>::new("SELECT COUNT(*) FROM occurrences WHERE ");
 
     push_consensus_rank_filter(&mut qb, &rank_lower, taxon_name);
 

--- a/crates/observing-db/src/occurrences.rs
+++ b/crates/observing-db/src/occurrences.rs
@@ -96,9 +96,9 @@ pub async fn get(
         r#"
         SELECT
             uri, cid, did, scientific_name,
-            event_date as "event_date!",
-            ST_Y(location::geometry) as "latitude!",
-            ST_X(location::geometry) as "longitude!",
+            event_date,
+            ST_Y(location::geometry) as latitude,
+            ST_X(location::geometry) as longitude,
             coordinate_uncertainty_meters,
             associated_media, recorded_by,
             taxon_id, taxon_rank, kingdom, phylum, class, "order" as order_, family, genus,
@@ -107,8 +107,6 @@ pub async fn get(
             NULL::text as source
         FROM occurrences
         WHERE uri = $1
-          AND location IS NOT NULL
-          AND event_date IS NOT NULL
         "#,
         uri,
     )
@@ -131,9 +129,9 @@ pub async fn get_nearby(
         r#"
         SELECT
             uri, cid, did, scientific_name,
-            event_date as "event_date!",
-            ST_Y(location::geometry) as "latitude!",
-            ST_X(location::geometry) as "longitude!",
+            event_date,
+            ST_Y(location::geometry) as latitude,
+            ST_X(location::geometry) as longitude,
             coordinate_uncertainty_meters,
             associated_media, recorded_by,
             taxon_id, taxon_rank, kingdom, phylum, class, "order" as order_, family, genus,
@@ -147,7 +145,6 @@ pub async fn get_nearby(
             $3
         )
         AND did != ALL($6)
-        AND event_date IS NOT NULL
         ORDER BY distance_meters
         LIMIT $4 OFFSET $5
         "#,
@@ -177,9 +174,9 @@ pub async fn get_by_bounding_box(
         r#"
         SELECT
             uri, cid, did, scientific_name,
-            event_date as "event_date!",
-            ST_Y(location::geometry) as "latitude!",
-            ST_X(location::geometry) as "longitude!",
+            event_date,
+            ST_Y(location::geometry) as latitude,
+            ST_X(location::geometry) as longitude,
             coordinate_uncertainty_meters,
             associated_media, recorded_by,
             taxon_id, taxon_rank, kingdom, phylum, class, "order" as order_, family, genus,
@@ -189,7 +186,6 @@ pub async fn get_by_bounding_box(
         FROM occurrences
         WHERE location && ST_MakeEnvelope($1, $2, $3, $4, 4326)::geography
         AND did != ALL($6)
-        AND event_date IS NOT NULL
         LIMIT $5
         "#,
         min_lng,
@@ -216,9 +212,9 @@ pub async fn get_feed(
             r#"
             SELECT
                 uri, cid, did, scientific_name,
-                event_date as "event_date!",
-                ST_Y(location::geometry) as "latitude!",
-                ST_X(location::geometry) as "longitude!",
+                event_date,
+                ST_Y(location::geometry) as latitude,
+                ST_X(location::geometry) as longitude,
                 coordinate_uncertainty_meters,
                 associated_media, recorded_by,
                 taxon_id, taxon_rank, kingdom, phylum, class, "order" as order_, family, genus,
@@ -228,8 +224,6 @@ pub async fn get_feed(
             FROM occurrences
             WHERE created_at < ($2::text)::timestamptz
             AND did != ALL($3)
-            AND location IS NOT NULL
-            AND event_date IS NOT NULL
             ORDER BY created_at DESC
             LIMIT $1
             "#,
@@ -245,9 +239,9 @@ pub async fn get_feed(
             r#"
             SELECT
                 uri, cid, did, scientific_name,
-                event_date as "event_date!",
-                ST_Y(location::geometry) as "latitude!",
-                ST_X(location::geometry) as "longitude!",
+                event_date,
+                ST_Y(location::geometry) as latitude,
+                ST_X(location::geometry) as longitude,
                 coordinate_uncertainty_meters,
                 associated_media, recorded_by,
                 taxon_id, taxon_rank, kingdom, phylum, class, "order" as order_, family, genus,
@@ -256,8 +250,6 @@ pub async fn get_feed(
                 NULL::text as source
             FROM occurrences
             WHERE did != ALL($2)
-            AND location IS NOT NULL
-            AND event_date IS NOT NULL
             ORDER BY created_at DESC
             LIMIT $1
             "#,

--- a/crates/observing-db/src/types.rs
+++ b/crates/observing-db/src/types.rs
@@ -60,9 +60,12 @@ pub struct OccurrenceRow {
     pub cid: String,
     pub did: String,
     pub scientific_name: Option<String>,
-    pub event_date: DateTime<Utc>,
-    pub latitude: f64,
-    pub longitude: f64,
+    /// NULL on survey-based occurrences whose `eventDate` lives on the
+    /// referenced `bio.lexicons.temp.v0-1.survey` record we don't yet
+    /// ingest. Surfaced as-is so the explore page can still display the row.
+    pub event_date: Option<DateTime<Utc>>,
+    pub latitude: Option<f64>,
+    pub longitude: Option<f64>,
     pub coordinate_uncertainty_meters: Option<i32>,
     pub associated_media: Option<serde_json::Value>,
     pub recorded_by: Option<String>,

--- a/frontend/src/bindings/Occurrence.ts
+++ b/frontend/src/bindings/Occurrence.ts
@@ -14,8 +14,13 @@ export type Occurrence = {
   communityId?: string;
   effectiveTaxonomy?: EffectiveTaxonomy;
   identificationCount: number;
-  eventDate: string;
-  location: Location;
+  /**
+   * NULL on survey-based occurrences whose `eventDate` lives on the
+   * referenced survey record we don't yet ingest. The explore page
+   * renders a placeholder rather than dropping the observation.
+   */
+  eventDate?: string;
+  location?: Location;
   images: Array<OccurrenceImage>;
   createdAt: string;
   likeCount?: number;

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -440,7 +440,7 @@ export function ObservationDetail() {
               </ListItemIcon>
               <ListItemText
                 primary="Observed"
-                secondary={formatDate(observation.eventDate)}
+                secondary={observation.eventDate ? formatDate(observation.eventDate) : "—"}
                 slotProps={{
                   primary: { variant: "caption", color: "text.secondary" },
                   secondary: { variant: "body1", color: "text.primary" },
@@ -455,22 +455,26 @@ export function ObservationDetail() {
               <ListItemText
                 primary="Coordinates"
                 secondary={
-                  <>
-                    {observation.location.latitude.toFixed(5)},{" "}
-                    {observation.location.longitude.toFixed(5)}
-                    {observation.location.uncertaintyMeters && (
-                      <Typography
-                        component="span"
-                        variant="body2"
-                        sx={{
-                          color: "text.disabled",
-                        }}
-                      >
-                        {" "}
-                        (±{observation.location.uncertaintyMeters}m)
-                      </Typography>
-                    )}
-                  </>
+                  observation.location ? (
+                    <>
+                      {observation.location.latitude.toFixed(5)},{" "}
+                      {observation.location.longitude.toFixed(5)}
+                      {observation.location.uncertaintyMeters && (
+                        <Typography
+                          component="span"
+                          variant="body2"
+                          sx={{
+                            color: "text.disabled",
+                          }}
+                        >
+                          {" "}
+                          (±{observation.location.uncertaintyMeters}m)
+                        </Typography>
+                      )}
+                    </>
+                  ) : (
+                    "—"
+                  )
                 }
                 slotProps={{
                   primary: { variant: "caption", color: "text.secondary" },
@@ -482,13 +486,15 @@ export function ObservationDetail() {
                 }}
               />
             </ListItem>
-            <Box sx={{ ml: 4.5, mb: 1 }}>
-              <LocationMap
-                latitude={observation.location.latitude}
-                longitude={observation.location.longitude}
-                uncertaintyMeters={observation.location.uncertaintyMeters}
-              />
-            </Box>
+            {observation.location && (
+              <Box sx={{ ml: 4.5, mb: 1 }}>
+                <LocationMap
+                  latitude={observation.location.latitude}
+                  longitude={observation.location.longitude}
+                  uncertaintyMeters={observation.location.uncertaintyMeters}
+                />
+              </Box>
+            )}
           </List>
 
           <Box sx={{ mt: 3 }}>


### PR DESCRIPTION
## Summary

Reverses the read-side `IS NOT NULL` filters from #511. Survey-based occurrences (72 currently in prod, more incoming) land with NULL `location`/`event_date` because the data lives on a referenced `bio.lexicons.temp.v0-1.survey` record we don't yet ingest. Hiding them entirely was a stopgap; this change surfaces them as undated/unlocated rows in /explore, /home, and profile feeds so users can see their identifications instead of having the observations vanish.

## Changes

**Backend**
- `OccurrenceRow.event_date/latitude/longitude` → `Option` (`types.rs`)
- Drop `WHERE event_date IS NOT NULL AND location IS NOT NULL` from `get`, `get_feed` (occurrences.rs), `get_explore_feed`, `get_home_feed`, `get_profile_feed`, `get_occurrences_by_taxon`, `count_occurrences_by_taxon`, and the profile counts query (feeds.rs).
- Drop `as "event_date!"`/`"latitude!"`/`"longitude!"` non-null assertions; `OccurrenceRow` now carries the Option types directly.
- Keep implicit exclusion on `get_nearby` / `get_by_bounding_box` — PostGIS `&&` / `ST_DWithin` return NULL on NULL geometry, so locationless rows can't appear in spatial queries by definition.
- `OccurrenceResponse.event_date` → `Option<String>`, `OccurrenceResponse.location` → `Option<LocationResponse>` (`enrichment.rs`).
- `GeoJsonProperties.event_date` → `Option<String>` (`responses.rs`) since bbox results may now carry undated points.
- Regenerated sqlx cache.

**Frontend**
- `Occurrence` TS binding regenerated: `eventDate?`, `location?`.
- `ObservationDetail.tsx`: renders `"—"` for missing date or coordinates; hides the embedded map when location is null.
- `UploadModal.tsx` already guarded both fields (`if (editingObservation.eventDate)` / `if (editingObservation.location)`) — no change needed.

## What still hides rows

- Spatial map queries (`/api/occurrences/geojson`, "nearby"): unchanged. No coords → no pin, by definition.
- Filter panels that filter by date range: rows with NULL `event_date` won't satisfy `event_date >= X`, so explicit date filters still exclude them. Felt right — if a user picks a date, undated rows shouldn't appear.

## Test plan

- [x] `cargo check --workspace`, `cargo test --workspace --all-features` (177 tests pass)
- [x] `npm run lint` (no new warnings)
- [x] `npx tsc --noEmit` (only pre-existing storybook env errors)
- [ ] After deploy: verify the 72 backfilled occurrences (`did:plc:govo6vltxigqf6hmap7uq3u7`, `did:plc:jt6xegjm6ba2lt34aztyi2mn`, `did:plc:q63fhp2lll2hvlgj7bgo724r`) appear in https://observ.ing/explore with "—" date placeholder.
- [ ] Open one of the affected observation detail pages — coordinates row reads "—", embedded map is hidden, identifications list renders normally.