### PR TITLE
fix(tap-ingester): run failed-records dashboard queries sequentially

### DIFF
--- a/crates/tap-ingester/src/dashboard.rs
+++ b/crates/tap-ingester/src/dashboard.rs
@@ -190,10 +190,11 @@ async fn failed_records_handler(State(s): State<DashboardState>) -> Json<FailedR
             error: Some("database pool not yet initialized".to_string()),
         });
     };
-    let (items_res, total_res) = tokio::join!(
-        failed_records::list_recent(pool, 50),
-        failed_records::count_total(pool),
-    );
+    // Run sequentially rather than `tokio::join!` so we only hold one
+    // pool connection at a time. Under Cloud SQL connection pressure the
+    // parallel acquire was reliably timing out on the second query.
+    let items_res = failed_records::list_recent(pool, 50).await;
+    let total_res = failed_records::count_total(pool).await;
 
     let mut error = None;
     let items = match items_res {


### PR DESCRIPTION
## Summary
- `/api/failed-records` was racing `list_recent` and `count_total` via `tokio::join!`. The parallel acquire saturated the pool budget under Cloud SQL pressure and the second query reliably timed out at the 5s `acquire_timeout`.
- Logs show a steady cadence of `failed_records count query failed | pool timed out while waiting for an open connection` warnings (once a minute, matching backgrounded-tab `setInterval` throttling).
- Run the two queries sequentially so we only hold one pool connection at a time. The endpoint isn't hot enough for the small added latency to matter.

## Test plan
- [ ] `cargo build -p tap-ingester` (done locally)
- [ ] After deploy, watch `failed_records count query failed` warnings drop off in Cloud Run logs
- [ ] Dashboard's Failed records panel continues to render total + items