### PR TITLE
fix(tap-ingester): widen DB pool acquire timeout from 5s to 30s

### DIFF
--- a/crates/tap-ingester/src/database.rs
+++ b/crates/tap-ingester/src/database.rs
@@ -73,7 +73,12 @@ impl Database {
         info!("Connecting to database...");
         let pool = PgPoolOptions::new()
             .max_connections(10)
-            .acquire_timeout(std::time::Duration::from_secs(5))
+            // 5s was too tight against the shared Cloud SQL instance — the
+            // dashboard's read-path acquires were reliably timing out under
+            // even mild connection contention. 30s gives the pool room to
+            // wait through a transient spike without surfacing a user-visible
+            // failure.
+            .acquire_timeout(std::time::Duration::from_secs(30))
             .idle_timeout(Some(std::time::Duration::from_secs(300)))
             .connect(database_url)
             .await?;


### PR DESCRIPTION
## Summary
- The dashboard's read-path queries were intermittently failing with `pool timed out while waiting for an open connection` against the shared `db-f1-micro` Cloud SQL instance.
- Root cause is connection budget pressure: the embedded Tap process defaults to a pool of 32, the ingester adds 10, and the Cloud SQL instance only permits ~25 connections. New connection establishment under that pressure regularly exceeded the 5s `acquire_timeout`.
- 30s gives the pool room to ride out a transient spike before turning into a user-visible failure on the dashboard.

Companion fixes (separate PRs): #514 (run failed-records queries sequentially) and CI env-var changes to cap Tap's pool / enable upstream-tap stderr.

## Test plan
- [ ] `cargo build -p tap-ingester` (done locally)
- [ ] After deploy, dashboard `failed_records count query failed` warnings drop off in Cloud Run logs