### PR TITLE
ci(tap-ingester): cap embedded Tap's Postgres pool at 5 connections

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
             --cpu=1 \
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime \
+            --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,TAP_MAX_DB_CONNS=5 \
             --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
             --min-instances=1 \
             --max-instances=1 \


### PR DESCRIPTION
## Summary
- The embedded `tap` Go process defaults to `max-db-conn=32` (per indigo's `cmd/tap/main.go`) and shares the `db-f1-micro` Cloud SQL instance with the rest of the services.
- f1-micro's default `max_connections` is roughly 25, so Tap alone is over-budget. Combined with the ingester (10) and appview (default 10), Cloud SQL is regularly saturated and acquires time out across services.
- Set `TAP_MAX_DB_CONNS=5` — current workload is tiny (~7 tracked repos, sub-thousand records), so 5 is plenty and leaves real headroom.

The `tapped` crate already forwards this env var to the Go process (`config.rs` `push_env!(self.max_db_conns, "TAP_MAX_DB_CONNS", string)`), so no code change is needed.

Companion fixes (separate PRs): #514 (sequential failed-records queries), #515 (widen acquire timeout), and a follow-up to enable upstream Tap's stderr so we can see its errors.

## Test plan
- [ ] Deploy via main and confirm tap-ingester revision starts cleanly
- [ ] After deploy: `gcloud sql instances describe observing-db ...` shows lower active-connection counts during steady-state
- [ ] No new `connection refused` errors from any service against `observing-db`