### PR TITLE
ci(tap-ingester): inherit upstream Tap's stdio for observability

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,7 @@ jobs:
             --cpu=1 \
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime \
+            --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,TAP_INHERIT_STDIO=1 \
             --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
             --min-instances=1 \
             --max-instances=1 \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,7 +519,6 @@ jobs:
             --cpu=1 \
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-<<<<<<< HEAD
             --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,TAP_MAX_DB_CONNS=5,TAP_INHERIT_STDIO=1 \
             --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
             --min-instances=1 \


### PR DESCRIPTION
## Summary
- `tapped::TapProcess` defaults the spawned Go `tap` binary's stdio to `/dev/null` (see `crates/tap-ingester/src/main.rs:144`). Echo's request logs and any GORM errors from the embedded process are completely invisible in Cloud Run.
- That's why we couldn't see *why* the dashboard's `tap-stats` panel was reporting intermittent `failed to get repo count` and `failed to get outbox buffer size` 500s — the upstream handler wraps the underlying error with a generic 500 string, and there was no stderr to compare against.
- The Rust process already gates this behind `TAP_INHERIT_STDIO`. Setting it on the production deploy means the next intermittent upstream failure has visible context.

Companion PRs: #514, #515, #516.

## Test plan
- [ ] After merge & deploy, hit `https://ingester.observ.ing/` and watch Cloud Run logs — Tap's own log lines should now appear alongside `tap_ingester` logs.