### PR TITLE
fix(identification): break Community ID label onto its own line

### DIFF
--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -117,6 +117,7 @@ export function IdentificationPanel({
             variant="caption"
             sx={{
               color: "text.secondary",
+              display: "block",
             }}
           >
             Community ID


### PR DESCRIPTION
## Summary
- The "Community ID" caption in `IdentificationPanel` rendered as inline `<span>` and the adjacent `TaxonLink` rendered as inline `<a>`, so they shared a line.
- Set the caption to `display: block` so the taxon name renders below the label.

## Test plan
- [ ] Log in, open an observation, confirm "Community ID" label sits above the taxon name in the identification panel.