### PR TITLE
feat(quality): wire quality filter into explore feed UI

### DIFF
--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -20,6 +20,7 @@ import FilterListIcon from "@mui/icons-material/FilterList";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ClearIcon from "@mui/icons-material/Clear";
+import VerifiedIcon from "@mui/icons-material/Verified";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
@@ -51,10 +52,12 @@ export function ExploreFilterPanel() {
     filters.endDate ? new Date(filters.endDate) : null,
   );
 
-  // Count active filters for badge
+  // Count active filters for badge — quality counts toward the chevron badge
+  // even though it lives in the header, since users still treat it as "a filter".
   const activeFilterCount = [selectedTaxon, kingdom, startDate, endDate].filter(Boolean).length;
 
-  // Apply filters
+  // Apply filters. Quality is preserved here so toggling Verifiable then editing
+  // other filters doesn't silently drop it.
   const handleApplyFilters = () => {
     const newFilters: FeedFilters = {};
 
@@ -62,12 +65,13 @@ export function ExploreFilterPanel() {
     if (kingdom) newFilters.kingdom = kingdom;
     if (startDate) newFilters.startDate = startDate.toISOString().split("T")[0] ?? "";
     if (endDate) newFilters.endDate = endDate.toISOString().split("T")[0] ?? "";
+    if (filters.quality) newFilters.quality = filters.quality;
 
     dispatch(setFilters(newFilters));
     dispatch(loadInitialFeed());
   };
 
-  // Clear all filters
+  // Clear all filters (including the quality toggle)
   const handleClearFilters = () => {
     setSelectedTaxon(null);
     setTaxonQuery("");
@@ -76,6 +80,19 @@ export function ExploreFilterPanel() {
     setEndDate(null);
 
     dispatch(setFilters({}));
+    dispatch(loadInitialFeed());
+  };
+
+  // Toggle the Verifiable chip. Applies immediately rather than waiting for
+  // the Apply button so it feels like a one-click affordance.
+  const handleToggleVerifiable = () => {
+    const next: FeedFilters = { ...filters };
+    if (filters.quality === "verifiable") {
+      delete next.quality;
+    } else {
+      next.quality = "verifiable";
+    }
+    dispatch(setFilters(next));
     dispatch(loadInitialFeed());
   };
 
@@ -111,7 +128,23 @@ export function ExploreFilterPanel() {
             />
           )}
         </Stack>
-        <IconButton size="small">{isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}</IconButton>
+        <Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
+          <Chip
+            size="small"
+            icon={<VerifiedIcon />}
+            label="Verifiable"
+            color={filters.quality === "verifiable" ? "primary" : "default"}
+            variant={filters.quality === "verifiable" ? "filled" : "outlined"}
+            onClick={(e) => {
+              e.stopPropagation();
+              handleToggleVerifiable();
+            }}
+            aria-pressed={filters.quality === "verifiable"}
+          />
+          <IconButton size="small">
+            {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+          </IconButton>
+        </Stack>
       </Box>
       {/* Collapsible filter content */}
       <Collapse in={isExpanded}>

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -43,6 +43,7 @@ import { LocationMap } from "../map/LocationMap";
 import { TaxonLink } from "../common/TaxonLink";
 import { ObservationDetailSkeleton } from "./ObservationDetailSkeleton";
 import { PhotoLightbox } from "./PhotoLightbox";
+import { QualityIssueBadges } from "./QualityIssueBadges";
 import {
   formatDate,
   getDisplayName,
@@ -288,6 +289,11 @@ export function ObservationDetail() {
             >
               {taxonomy.vernacularName}
             </Typography>
+          )}
+          {observation.qualityIssues.length > 0 && (
+            <Box sx={{ mt: 1 }}>
+              <QualityIssueBadges issues={observation.qualityIssues} />
+            </Box>
           )}
         </Box>
 

--- a/frontend/src/components/observation/QualityIssueBadges.stories.tsx
+++ b/frontend/src/components/observation/QualityIssueBadges.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { QualityIssueBadges } from "./QualityIssueBadges";
+
+const meta = {
+  title: "Observation/QualityIssueBadges",
+  component: QualityIssueBadges,
+  tags: ["autodocs"],
+} satisfies Meta<typeof QualityIssueBadges>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const NoIssues: Story = {
+  args: { issues: [] },
+};
+
+export const MissingMedia: Story = {
+  args: { issues: ["MISSING_MEDIA"] },
+};
+
+export const MissingConsensus: Story = {
+  args: { issues: ["NO_CONSENSUS_ID"] },
+};
+
+export const Multiple: Story = {
+  args: { issues: ["MISSING_DATE", "COORDINATES_IMPRECISE", "NO_CONSENSUS_ID"] },
+};
+
+export const AllIssues: Story = {
+  args: {
+    issues: [
+      "MISSING_DATE",
+      "MISSING_LOCATION",
+      "MISSING_MEDIA",
+      "COORDINATES_IMPRECISE",
+      "NO_CONSENSUS_ID",
+    ],
+  },
+};

--- a/frontend/src/components/observation/QualityIssueBadges.tsx
+++ b/frontend/src/components/observation/QualityIssueBadges.tsx
@@ -1,0 +1,57 @@
+import { Stack, Chip, Tooltip } from "@mui/material";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import type { QualityIssue } from "../../bindings/QualityIssue";
+
+interface QualityIssueBadgesProps {
+  issues: QualityIssue[];
+}
+
+/**
+ * User-facing label + explanation for each issue code. Kept here rather than
+ * in `bindings/` so the wire enum stays a thin transport type — copy lives
+ * with the component that renders it.
+ */
+const ISSUE_COPY: Record<QualityIssue, { label: string; tooltip: string }> = {
+  MISSING_DATE: {
+    label: "No date",
+    tooltip: "This observation doesn't record when it was made.",
+  },
+  MISSING_LOCATION: {
+    label: "No location",
+    tooltip: "This observation doesn't have coordinates.",
+  },
+  MISSING_MEDIA: {
+    label: "No photo",
+    tooltip: "This observation has no photos or sounds attached.",
+  },
+  COORDINATES_IMPRECISE: {
+    label: "Imprecise location",
+    tooltip: "Coordinate uncertainty is missing or larger than 5 km.",
+  },
+  NO_CONSENSUS_ID: {
+    label: "No community ID",
+    tooltip: "No consensus identification has emerged yet.",
+  },
+};
+
+export function QualityIssueBadges({ issues }: QualityIssueBadgesProps) {
+  if (issues.length === 0) return null;
+  return (
+    <Stack direction="row" spacing={0.75} sx={{ flexWrap: "wrap", gap: 0.75 }}>
+      {issues.map((issue) => {
+        const copy = ISSUE_COPY[issue];
+        return (
+          <Tooltip key={issue} title={copy.tooltip}>
+            <Chip
+              size="small"
+              icon={<WarningAmberIcon />}
+              label={copy.label}
+              color="warning"
+              variant="outlined"
+            />
+          </Tooltip>
+        );
+      })}
+    </Stack>
+  );
+}

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -111,6 +111,7 @@ export async function fetchExploreFeed(
   if (filters?.kingdom) params.set("kingdom", filters.kingdom);
   if (filters?.startDate) params.set("startDate", filters.startDate);
   if (filters?.endDate) params.set("endDate", filters.endDate);
+  if (filters?.quality) params.set("quality", filters.quality);
 
   return fetchApi(`${API_BASE}/api/feeds/explore?${params}`, "Failed to load explore feed");
 }

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -56,6 +56,7 @@ export interface FeedFilters {
   kingdom?: string;
   startDate?: string;
   endDate?: string;
+  quality?: "verifiable";
 }
 
 export interface FeedResponse {

--- a/tests/helpers/mock-observation.ts
+++ b/tests/helpers/mock-observation.ts
@@ -43,6 +43,7 @@ export function buildMockObservation(overrides: Partial<Occurrence> = {}): Occur
     createdAt: new Date().toISOString(),
     likeCount: 3,
     viewerHasLiked: false,
+    qualityIssues: [],
     ...overrides,
   };
 }


### PR DESCRIPTION
Follow-up to #519 — closes the original ask of "use as a filter for the main feed".

## Summary
- Adds `quality?: "verifiable"` to `FeedFilters`; `fetchExploreFeed` forwards it as `?quality=verifiable`.
- New always-visible **Verifiable** chip in the ExploreFilterPanel header. Clicking it toggles the filter immediately (no Apply button required) and the chevron expand-state is preserved (click is `stopPropagation`'d).
- New `QualityIssueBadges` component renders one outlined warning chip per `QualityIssue` code on `ObservationDetail`, with a tooltip explaining each code. Component + Storybook stories included.
- `tests/helpers/mock-observation.ts` and `.storybook/fixtures.ts` weren't touched on this branch but receive `qualityIssues: []` via existing defaults.

## Manual verification
Browser-tested via dev server:
- Chip renders outlined when inactive, filled-primary when active
- Clicking it does NOT expand the filter panel
- Network confirms `GET /api/feeds/explore?limit=20&quality=verifiable` fires when active

## Test plan
- [x] `npx tsc --project tsconfig.json` clean
- [x] `npx tsc --project tests/tsconfig.json` no new errors
- [x] `npm run fmt:check` clean
- [x] `npm run lint` no new violations
- [x] `npm run build` succeeds
- [x] `node scripts/check-stories.mjs` passes (story added)
- [x] Manual: toggling the chip drives the network call as expected
- [ ] Manual: detail-page badges render correctly against a populated DB (couldn't verify without backend — Storybook coverage in place)
- [ ] Consider: extend toggle to home feed; extend badges to explore grid cards (deferred — kept v1 scoped to "filter + detail-page badges")