### PR TITLE
refactor(quality): rename Verifiable filter to Complete

### DIFF
--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -71,7 +71,7 @@ pub async fn get_explore_feed(
 /// an empty list for the row. Keep these two in sync.
 fn push_quality_filter(qb: &mut QueryBuilder<'_, Postgres>, quality: QualityFilter) {
     match quality {
-        QualityFilter::Verifiable => {
+        QualityFilter::Complete => {
             qb.push(" AND event_date IS NOT NULL");
             qb.push(" AND location IS NOT NULL");
             qb.push(" AND coordinate_uncertainty_meters IS NOT NULL");

--- a/crates/observing-db/src/types.rs
+++ b/crates/observing-db/src/types.rs
@@ -339,8 +339,10 @@ pub struct ExploreFeedOptions {
 #[derive(Debug, Clone, Copy, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum QualityFilter {
-    /// Hide observations with any issues from [`crate::quality::compute_issues`].
-    Verifiable,
+    /// Hide observations with any issues from [`crate::quality::compute_issues`] —
+    /// i.e. those whose date, location, precise coords, media, and consensus
+    /// identification are all populated.
+    Complete,
 }
 
 /// Options for profile feed queries

--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -20,7 +20,7 @@ import FilterListIcon from "@mui/icons-material/FilterList";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ClearIcon from "@mui/icons-material/Clear";
-import VerifiedIcon from "@mui/icons-material/Verified";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
@@ -83,14 +83,14 @@ export function ExploreFilterPanel() {
     dispatch(loadInitialFeed());
   };
 
-  // Toggle the Verifiable chip. Applies immediately rather than waiting for
+  // Toggle the Complete chip. Applies immediately rather than waiting for
   // the Apply button so it feels like a one-click affordance.
-  const handleToggleVerifiable = () => {
+  const handleToggleComplete = () => {
     const next: FeedFilters = { ...filters };
-    if (filters.quality === "verifiable") {
+    if (filters.quality === "complete") {
       delete next.quality;
     } else {
-      next.quality = "verifiable";
+      next.quality = "complete";
     }
     dispatch(setFilters(next));
     dispatch(loadInitialFeed());
@@ -131,15 +131,15 @@ export function ExploreFilterPanel() {
         <Stack direction="row" spacing={0.5} sx={{ alignItems: "center" }}>
           <Chip
             size="small"
-            icon={<VerifiedIcon />}
-            label="Verifiable"
-            color={filters.quality === "verifiable" ? "primary" : "default"}
-            variant={filters.quality === "verifiable" ? "filled" : "outlined"}
+            icon={<CheckCircleIcon />}
+            label="Complete"
+            color={filters.quality === "complete" ? "primary" : "default"}
+            variant={filters.quality === "complete" ? "filled" : "outlined"}
             onClick={(e) => {
               e.stopPropagation();
-              handleToggleVerifiable();
+              handleToggleComplete();
             }}
-            aria-pressed={filters.quality === "verifiable"}
+            aria-pressed={filters.quality === "complete"}
           />
           <IconButton size="small">
             {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}

--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -134,7 +134,7 @@ export function ExploreFilterPanel() {
             icon={<CheckCircleIcon />}
             label="Complete"
             color={filters.quality === "complete" ? "primary" : "default"}
-            variant={filters.quality === "complete" ? "filled" : "outlined"}
+            variant="outlined"
             onClick={(e) => {
               e.stopPropagation();
               handleToggleComplete();

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -56,7 +56,7 @@ export interface FeedFilters {
   kingdom?: string;
   startDate?: string;
   endDate?: string;
-  quality?: "verifiable";
+  quality?: "complete";
 }
 
 export interface FeedResponse {


### PR DESCRIPTION
Naming follow-up to #519 / #520. "Verifiable" describes potential ("can be verified"), which is confusing for an observation that already has the metadata. "Complete" describes the state we actually filter on: date + location + precise coords + media + consensus ID are all populated.

Also adjusts the active style of the chip so it doesn't read as a Twitter-style verified badge.

## Changes
- **Rust**: `QualityFilter::Verifiable` → `QualityFilter::Complete`. Wire string changes from `?quality=verifiable` → `?quality=complete`.
- **Frontend type**: `FeedFilters.quality?: "verifiable"` → `"complete"`.
- **Chip**: label "Verifiable" → "Complete"; icon `Verified` → `CheckCircle`; active state is now an outlined chip with primary-color border/text/icon instead of a filled green badge.

## Wire compatibility
Anyone hitting the API with `?quality=verifiable` will now get a 400 (unknown enum value) rather than a silent no-op. Acceptable since the param shipped less than a day ago and isn't relied on by anything yet.

## Test plan
- [x] `cargo test -p observing-db --lib quality::` (12 tests pass)
- [x] `cargo clippy -p observing-db -p observing-appview -- -D warnings` clean
- [x] `npx tsc --project tsconfig.json` clean
- [x] `npx tsc --project tests/tsconfig.json` no new errors
- [x] `npm run fmt:check` / `npm run lint` clean
- [x] Manual: browser-tested both inactive (grey) and active (green outline) chip states; network confirmed `GET /api/feeds/explore?quality=complete` fires when toggled on