### PR TITLE
fix(identification): read taxonID (canonical Darwin Core casing)

### DIFF
--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -234,8 +234,10 @@ pub fn identification_from_json(
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
+    // Darwin Core canonical casing is `taxonID` (uppercase ID); camelCasing it
+    // would silently drop the field. See the identification lexicon on lexicons.bio.
     let taxon_id = record_json
-        .get("taxonId")
+        .get("taxonID")
         .and_then(|v| v.as_str())
         .map(|s| s.to_string());
 
@@ -467,7 +469,7 @@ mod tests {
             "scientificName": "Quercus alba",
             "taxonRank": "species",
             "kingdom": "Plantae",
-            "taxonId": "gbif:2879737",
+            "taxonID": "https://www.gbif.org/species/2879737",
             "occurrence": {
                 "uri": "at://did:plc:author/bio.lexicons.temp.v0-1.occurrence/abc",
                 "cid": "bafyreioccurrence"
@@ -493,7 +495,10 @@ mod tests {
         assert_eq!(params.scientific_name, "Quercus alba");
         assert_eq!(params.taxon_rank.as_deref(), Some("species"));
         assert_eq!(params.kingdom.as_deref(), Some("Plantae"));
-        assert_eq!(params.taxon_id.as_deref(), Some("gbif:2879737"));
+        assert_eq!(
+            params.taxon_id.as_deref(),
+            Some("https://www.gbif.org/species/2879737")
+        );
         assert_eq!(
             params.subject_uri,
             "at://did:plc:author/bio.lexicons.temp.v0-1.occurrence/abc"
@@ -538,6 +543,77 @@ mod tests {
         .expect("record should parse without createdAt");
 
         assert_eq!(params.date_identified, fallback);
+    }
+
+    /// Regression guard: `taxonID` is the canonical Darwin Core casing
+    /// (uppercase ID) per the bio.lexicons.temp.v0-1.identification schema on
+    /// lexicons.bio. A prior bug read the camelCased `taxonId`, silently
+    /// dropping inbound values — including the iNaturalist URLs produced by
+    /// the import script. This test pins both halves:
+    ///   - `taxonID` (canonical) → extracted into `params.taxon_id`
+    ///   - `taxonId` (wrong case) → not silently picked up
+    #[test]
+    fn test_identification_from_json_extracts_canonical_taxon_id_casing() {
+        // Half 1: canonical casing with an iNaturalist URL flows through.
+        let canonical = serde_json::json!({
+            "$type": "bio.lexicons.temp.v0-1.identification",
+            "scientificName": "Danaus plexippus",
+            "taxonID": "https://www.inaturalist.org/taxa/48662",
+            "occurrence": {
+                "uri": "at://did:plc:author/bio.lexicons.temp.v0-1.occurrence/abc",
+                "cid": "bafyreioccurrence"
+            },
+            "createdAt": "2024-06-15T08:30:45Z"
+        });
+
+        // Validates against the typed lexicon struct + runtime schema
+        // constraints, so any future schema drift on `taxonID` (renamed,
+        // re-cased, removed) surfaces here before the parser assertion.
+        assert_valid_lexicon::<Identification>(&canonical);
+
+        let fallback = DateTime::parse_from_rfc3339("2024-01-01T00:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+
+        let params = identification_from_json(
+            &canonical,
+            "uri".into(),
+            "cid".into(),
+            "did:plc:x".into(),
+            fallback,
+        )
+        .expect("record with canonical taxonID should parse");
+        assert_eq!(
+            params.taxon_id.as_deref(),
+            Some("https://www.inaturalist.org/taxa/48662"),
+            "canonical taxonID (Darwin Core casing) must flow through to params.taxon_id"
+        );
+
+        // Half 2: camelCased `taxonId` must not be silently accepted. If a
+        // future refactor re-introduces the wrong casing in the parser, this
+        // assertion fails and forces a decision rather than a silent drop.
+        let wrong_case = serde_json::json!({
+            "$type": "bio.lexicons.temp.v0-1.identification",
+            "scientificName": "Danaus plexippus",
+            "taxonId": "https://www.inaturalist.org/taxa/48662",
+            "occurrence": {
+                "uri": "at://did:plc:author/bio.lexicons.temp.v0-1.occurrence/abc",
+                "cid": "bafyreioccurrence"
+            }
+        });
+
+        let params = identification_from_json(
+            &wrong_case,
+            "uri".into(),
+            "cid".into(),
+            "did:plc:x".into(),
+            fallback,
+        )
+        .expect("record without taxonID is still structurally valid");
+        assert!(
+            params.taxon_id.is_none(),
+            "wrong-cased `taxonId` must not be picked up by the parser"
+        );
     }
 
     /// Baseline happy-path coverage for `comment_from_json`.

--- a/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/identification.rs
+++ b/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/identification.rs
@@ -16,7 +16,7 @@ use jacquard_common::{BosStr, CowStr, DefaultStr, FromStaticStr};
 use jacquard_common::deps::codegen::unicode_segmentation::UnicodeSegmentation;
 use jacquard_common::deps::smol_str::SmolStr;
 use jacquard_common::types::collection::{Collection, RecordError};
-use jacquard_common::types::string::{AtUri, Cid};
+use jacquard_common::types::string::{AtUri, Cid, UriValue};
 use jacquard_common::types::uri::{RecordUri, UriError};
 use jacquard_common::types::value::Data;
 use jacquard_common::xrpc::XrpcResp;
@@ -48,6 +48,9 @@ pub struct Identification<S: BosStr = DefaultStr> {
     pub occurrence: StrongRef<S>,
     ///The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).
     pub scientific_name: S,
+    ///Stable URI for the identified taxon (e.g. a GBIF species URI). Maps to Darwin Core dwc:taxonID.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub taxon_id: Option<UriValue<S>>,
     ///The taxonomic rank of the identification (Darwin Core dwc:taxonRank).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub taxon_rank: Option<IdentificationTaxonRank<S>>,
@@ -318,6 +321,7 @@ pub struct IdentificationBuilder<S: BosStr, St: identification_state::State> {
         Option<S>,
         Option<StrongRef<S>>,
         Option<S>,
+        Option<UriValue<S>>,
         Option<IdentificationTaxonRank<S>>,
     ),
     _type: PhantomData<fn() -> S>,
@@ -335,7 +339,7 @@ impl<S: BosStr> IdentificationBuilder<S, identification_state::Empty> {
     pub fn new() -> Self {
         IdentificationBuilder {
             _state: PhantomData,
-            _fields: (None, None, None, None, None),
+            _fields: (None, None, None, None, None, None),
             _type: PhantomData,
         }
     }
@@ -406,14 +410,27 @@ where
 }
 
 impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
+    /// Set the `taxonID` field (optional)
+    pub fn taxon_id(mut self, value: impl Into<Option<UriValue<S>>>) -> Self {
+        self._fields.4 = value.into();
+        self
+    }
+    /// Set the `taxonID` field to an Option value (optional)
+    pub fn maybe_taxon_id(mut self, value: Option<UriValue<S>>) -> Self {
+        self._fields.4 = value;
+        self
+    }
+}
+
+impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
     /// Set the `taxonRank` field (optional)
     pub fn taxon_rank(mut self, value: impl Into<Option<IdentificationTaxonRank<S>>>) -> Self {
-        self._fields.4 = value.into();
+        self._fields.5 = value.into();
         self
     }
     /// Set the `taxonRank` field to an Option value (optional)
     pub fn maybe_taxon_rank(mut self, value: Option<IdentificationTaxonRank<S>>) -> Self {
-        self._fields.4 = value;
+        self._fields.5 = value;
         self
     }
 }
@@ -431,7 +448,8 @@ where
             kingdom: self._fields.1,
             occurrence: self._fields.2.unwrap(),
             scientific_name: self._fields.3.unwrap(),
-            taxon_rank: self._fields.4,
+            taxon_id: self._fields.4,
+            taxon_rank: self._fields.5,
             extra_data: Default::default(),
         }
     }
@@ -442,7 +460,8 @@ where
             kingdom: self._fields.1,
             occurrence: self._fields.2.unwrap(),
             scientific_name: self._fields.3.unwrap(),
-            taxon_rank: self._fields.4,
+            taxon_id: self._fields.4,
+            taxon_rank: self._fields.5,
             extra_data: Some(extra_data),
         }
     }
@@ -517,6 +536,18 @@ fn lexicon_doc_bio_lexicons_temp_v0_1_identification() -> LexiconDoc<'static> {
                                         ),
                                     ),
                                     max_length: Some(256usize),
+                                    ..Default::default()
+                                }),
+                            );
+                            map.insert(
+                                SmolStr::new_static("taxonID"),
+                                LexObjectProperty::String(LexString {
+                                    description: Some(
+                                        CowStr::new_static(
+                                            "Stable URI for the identified taxon (e.g. a GBIF species URI). Maps to Darwin Core dwc:taxonID.",
+                                        ),
+                                    ),
+                                    format: Some(LexStringFormat::Uri),
                                     ..Default::default()
                                 }),
                             );

--- a/lexicons/bio/lexicons/temp/v0-1/identification.json
+++ b/lexicons/bio/lexicons/temp/v0-1/identification.json
@@ -32,6 +32,11 @@
             "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
             "maxLength": 64
           },
+          "taxonID": {
+            "type": "string",
+            "format": "uri",
+            "description": "Stable URI for the identified taxon (e.g. a GBIF species URI). Maps to Darwin Core dwc:taxonID."
+          },
           "identificationRemarks": {
             "type": "string",
             "description": "Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks).",


### PR DESCRIPTION
## Summary

`identification_from_json` was reading the camelCased `taxonId`, but the canonical Darwin Core / [lexicons.bio](https://lexicons.bio) casing is `taxonID` (uppercase ID). Inbound identifications carrying e.g. iNaturalist URLs (the form emitted by `scripts/import-inaturalist.ts`) had their taxon URI silently dropped before the upsert — the appview's `taxon_id` column was only ever populated by the post-ingest GBIF resolver, never by the value the author actually supplied.

- Add the `taxonID` property to `bio.lexicons.temp.v0-1.identification`, matching the upstream schema on lexicons.bio.
- Regenerate `observing-lexicons` Rust bindings (adds typed `taxon_id` field on `Identification`).
- Read `taxonID` in `identification_from_json` (`crates/observing-db/src/processing.rs`) and update the existing happy-path fixture to the canonical casing.
- Add a regression test (`test_identification_from_json_extracts_canonical_taxon_id_casing`) that pins both halves: canonical `taxonID` flows through to `params.taxon_id`, and a wrong-cased `taxonId` is **not** silently accepted.

## Out of scope

`occurrence_from_json` has an analogous issue (currently hardcodes `taxon_id: None` and ignores the field entirely), plus the local occurrence schema is missing several upstream fields (`taxonID`, `acceptedIdentificationID`, `organismQuantity`, `organismQuantityType`, `associatedMedia` → `media` rename). Larger blast radius — left for a follow-up.

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test -p observing-db --features processing processing::` (18 passed, including the new regression test)
- [x] `cargo fmt --all -- --check`