### PR TITLE
feat(home): always apply Complete quality filter on home feed

### DIFF
--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -117,7 +117,10 @@ export async function fetchExploreFeed(
 }
 
 export async function fetchHomeFeed(cursor?: string): Promise<HomeFeedResponse> {
-  const params = new URLSearchParams({ limit: DEFAULT_PAGE_SIZE });
+  // The home feed has no filter UI, so the Complete quality filter is always
+  // applied — incomplete observations (missing date/location/media/etc.) stay
+  // hidden from the signed-in landing view.
+  const params = new URLSearchParams({ limit: DEFAULT_PAGE_SIZE, quality: "complete" });
   if (cursor) params.set("cursor", cursor);
 
   const response = await fetch(`${API_BASE}/api/feeds/home?${params}`, {


### PR DESCRIPTION
## Summary
- `fetchHomeFeed` now always sends `?quality=complete`, so the signed-in landing feed at `/` hides observations missing date, location, precise coordinates, media, or a consensus ID.
- No backend change: `HomeFeedOptions.quality` was already wired through to the SQL filter in #519.
- The explore feed's user-controlled Complete chip is unchanged — only the home feed (which has no filter UI) is affected.

## Test plan
- [ ] Sign in and load `/` — confirm only "complete" observations appear.
- [ ] Sign out / open `/explore` — confirm the Complete chip still toggles normally and incomplete observations are visible when the chip is off.
- [ ] Network tab: confirm `/api/feeds/home` requests include `quality=complete`.