### PR TITLE
ci: add macOS smoke test for setup and doctor scripts

### DIFF
--- a/.github/workflows/setup-smoke-mac.yml
+++ b/.github/workflows/setup-smoke-mac.yml
@@ -1,0 +1,103 @@
+name: setup-smoke-mac
+
+# Smoke-test the local-dev setup and doctor scripts on macOS. Catches
+# breakage in scripts/setup.sh, scripts/doctor.sh, scripts/install-tap.sh,
+# the Brewfile, .tool-versions, and .env.example before contributors hit
+# it. Gated on paths so we only spend macOS runner minutes when something
+# that could break setup actually changes.
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'scripts/setup.sh'
+      - 'scripts/doctor.sh'
+      - 'scripts/install-tap.sh'
+      - 'scripts/download-models.sh'
+      - 'Brewfile'
+      - '.tool-versions'
+      - '.env.example'
+      - 'process-compose.yaml'
+      - 'package.json'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/setup-smoke-mac.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'scripts/setup.sh'
+      - 'scripts/doctor.sh'
+      - 'scripts/install-tap.sh'
+      - 'scripts/download-models.sh'
+      - 'Brewfile'
+      - '.tool-versions'
+      - '.env.example'
+      - 'process-compose.yaml'
+      - 'package.json'
+      - 'rust-toolchain.toml'
+      - '.github/workflows/setup-smoke-mac.yml'
+  workflow_dispatch:
+
+jobs:
+  setup-smoke-mac:
+    runs-on: macos-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      # Pin toolchains via the same actions the rest of CI uses, rather
+      # than relying on the Brewfile's `rustup` / `node@24` formulae —
+      # that keeps this job's signal scoped to "do the scripts work?"
+      # rather than "did a brew formula get renamed this week?"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '24'
+          cache: 'npm'
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      # The system-level prereqs are what the Brewfile would install for
+      # a real contributor. Installing them by hand here (instead of
+      # `brew bundle`) lets us skip the toolchain rows that we already
+      # set up via actions above.
+      - name: Install system prerequisites
+        run: |
+          brew install process-compose postgresql@16 postgis onnxruntime
+          # postgresql@16 is keg-only; expose its binaries on PATH.
+          echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
+
+      - name: Start Postgres and create database with PostGIS
+        run: |
+          brew services start postgresql@16
+          for i in $(seq 1 30); do
+            pg_isready -q && break
+            sleep 1
+          done
+          createdb observing
+          psql -d observing -c "CREATE EXTENSION postgis;"
+
+      - name: Prepare .env (override DATABASE_URL for peer auth)
+        # .env.example assumes the Docker recipe (password mysecretpassword).
+        # brew's postgres uses peer auth for the local user, so override.
+        run: |
+          cp .env.example .env
+          sed -i.bak "s|^DATABASE_URL=.*|DATABASE_URL=postgresql:///observing|" .env
+          rm .env.bak
+
+      - name: Stub BioCLIP models
+        # download-models.sh short-circuits if vision_encoder.onnx exists.
+        # We're testing setup orchestration, not the 1.4 GB tar download.
+        run: |
+          mkdir -p models/bioclip
+          touch models/bioclip/vision_encoder.onnx
+
+      - name: Run npm run setup
+        run: npm run setup
+
+      - name: Run npm run doctor
+        run: npm run doctor

--- a/.github/workflows/setup-smoke-mac.yml
+++ b/.github/workflows/setup-smoke-mac.yml
@@ -69,13 +69,20 @@ jobs:
         run: |
           # process-compose lives in an upstream tap, not core homebrew.
           brew tap f1bonacc1/tap
-          brew install f1bonacc1/tap/process-compose postgresql@16 postgis onnxruntime
-          # postgresql@16 is keg-only; expose its binaries on PATH.
-          echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
+          # postgis pulls in the matching postgresql@N formula as a
+          # dependency — installing them separately can land postgis's
+          # extension control file in the wrong tree.
+          brew install f1bonacc1/tap/process-compose onnxruntime postgis
+          # Discover whichever postgresql@N formula postgis depends on,
+          # expose it on PATH, and pass the formula name to later steps.
+          PG_FORMULA=$(brew deps --1 postgis | grep -E '^postgresql@' | head -1)
+          echo "Postgres formula: $PG_FORMULA"
+          echo "PG_FORMULA=$PG_FORMULA" >> "$GITHUB_ENV"
+          echo "$(brew --prefix "$PG_FORMULA")/bin" >> "$GITHUB_PATH"
 
       - name: Start Postgres and create database with PostGIS
         run: |
-          brew services start postgresql@16
+          brew services start "$PG_FORMULA"
           for i in $(seq 1 30); do
             pg_isready -q && break
             sleep 1

--- a/.github/workflows/setup-smoke-mac.yml
+++ b/.github/workflows/setup-smoke-mac.yml
@@ -67,7 +67,9 @@ jobs:
       # set up via actions above.
       - name: Install system prerequisites
         run: |
-          brew install process-compose postgresql@16 postgis onnxruntime
+          # process-compose lives in an upstream tap, not core homebrew.
+          brew tap f1bonacc1/tap
+          brew install f1bonacc1/tap/process-compose postgresql@16 postgis onnxruntime
           # postgresql@16 is keg-only; expose its binaries on PATH.
           echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
 

--- a/.github/workflows/setup-smoke-mac.yml
+++ b/.github/workflows/setup-smoke-mac.yml
@@ -69,14 +69,15 @@ jobs:
         run: |
           # process-compose lives in an upstream tap, not core homebrew.
           brew tap f1bonacc1/tap
-          # postgis pulls in the matching postgresql@N formula as a
-          # dependency — installing them separately can land postgis's
-          # extension control file in the wrong tree.
           brew install f1bonacc1/tap/process-compose onnxruntime postgis
-          # Discover whichever postgresql@N formula postgis depends on,
-          # expose it on PATH, and pass the formula name to later steps.
-          PG_FORMULA=$(brew deps --1 postgis | grep -E '^postgresql@' | head -1)
-          echo "Postgres formula: $PG_FORMULA"
+          # postgis declares postgresql@N as a *build* dep (not runtime),
+          # and its bottle ships the extension control file under that
+          # specific postgres tree. Installing a different postgresql@N
+          # leaves postgis.control unreachable. Detect the build dep
+          # and install that exact postgres formula.
+          PG_FORMULA=$(brew deps --include-build postgis | grep -E '^postgresql@' | head -1)
+          echo "postgis is built against $PG_FORMULA"
+          brew install "$PG_FORMULA"
           echo "PG_FORMULA=$PG_FORMULA" >> "$GITHUB_ENV"
           echo "$(brew --prefix "$PG_FORMULA")/bin" >> "$GITHUB_PATH"
 

--- a/Brewfile
+++ b/Brewfile
@@ -9,8 +9,10 @@ brew "node@24"
 brew "rustup"            # `rustup` manages Rust per rust-toolchain.toml
 brew "go"                # for building the upstream `tap` binary
 
-# Service orchestration
-brew "process-compose"
+# Service orchestration. process-compose ships via the upstream tap,
+# not core homebrew — see https://github.com/F1bonacc1/process-compose.
+tap "f1bonacc1/tap"
+brew "f1bonacc1/tap/process-compose"
 
 # Database
 brew "postgresql@16"

--- a/Brewfile
+++ b/Brewfile
@@ -14,8 +14,8 @@ brew "go"                # for building the upstream `tap` binary
 tap "f1bonacc1/tap"
 brew "f1bonacc1/tap/process-compose"
 
-# Database
-brew "postgresql@16"
+# Database. brew's `postgis` formula pulls in the matching postgresql
+# formula as a dependency, so installing postgis is enough.
 brew "postgis"
 
 # species-id native dependency

--- a/Brewfile
+++ b/Brewfile
@@ -14,8 +14,11 @@ brew "go"                # for building the upstream `tap` binary
 tap "f1bonacc1/tap"
 brew "f1bonacc1/tap/process-compose"
 
-# Database. brew's `postgis` formula pulls in the matching postgresql
-# formula as a dependency, so installing postgis is enough.
+# Database. `postgis` declares its postgresql version as a *build* dep
+# (currently postgresql@17). The bottle's extension control file only
+# lives in that postgres tree, so installing a different major leaves
+# `CREATE EXTENSION postgis;` broken. Keep these two pinned in lockstep.
+brew "postgresql@17"
 brew "postgis"
 
 # species-id native dependency

--- a/docs/development.md
+++ b/docs/development.md
@@ -4,7 +4,7 @@
 
 - Node.js 24+ (matches `engines.node` in `package.json` and the version CI runs)
 - Rust (pinned to the channel in `rust-toolchain.toml`; `rustup` will pick it up automatically)
-- PostgreSQL 16 with the PostGIS extension
+- PostgreSQL (14+) with the PostGIS extension — production runs 16, but any modern version works locally
 - [`process-compose`](https://github.com/F1bonacc1/process-compose) to orchestrate the dev stack
 - ONNX Runtime, for the `species-id` service:
   - macOS: `brew install onnxruntime`


### PR DESCRIPTION
## Summary
- New \`.github/workflows/setup-smoke-mac.yml\` that runs \`npm run setup\` and \`npm run doctor\` on \`macos-latest\` and asserts both exit 0
- Catches breakage in setup orchestration, the Brewfile, \`.tool-versions\`, and \`.env.example\` reference rot
- Path-gated: only runs when files that could affect local setup change (\`scripts/**\`, \`Brewfile\`, \`.tool-versions\`, \`.env.example\`, \`process-compose.yaml\`, \`package.json\`, \`rust-toolchain.toml\`, or the workflow itself)

This is Phase 2.5 — a follow-up to #527. **Stacks on #527** until that lands, then rebases.

## Implementation notes
- Toolchains (Node 24, Rust, Go 1.26) come from the same actions the rest of CI uses, not \`brew bundle\`, so the job's signal is scoped to "do the scripts work?" rather than "did a brew formula rename?"
- \`DATABASE_URL\` is overridden to a peer-auth socket URL — \`.env.example\`'s default password is for the Docker recipe, not brew's postgres
- BioCLIP models are stubbed (\`touch vision_encoder.onnx\`) so \`download-models.sh\`'s short-circuit kicks in; the 1.4 GB tarball is out of scope for a smoke test

## Cost model
- macOS runner minutes are ~10x Linux, so this is intentionally gated to a narrow set of paths
- Most PRs won't trigger it; a typical run is ~10–15 min uncached, ~5–8 min with rust-cache warm

## Test plan
- [ ] Workflow YAML parses (validated locally with \`ruby -ryaml\`)
- [ ] First run on this PR turns green (or surfaces real bugs in setup/doctor on macOS)
- [ ] Touch an unrelated file and confirm the workflow does **not** trigger (path gating works)
- [ ] Touch \`scripts/setup.sh\` on a follow-up branch and confirm it **does** trigger