### PR TITLE
feat(taxa-autocomplete): add open-in-new-tab link to dropdown options

### DIFF
--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -1,8 +1,20 @@
 import type { ReactNode } from "react";
-import { Autocomplete, Box, Stack, Typography } from "@mui/material";
+import { Autocomplete, Box, IconButton, Stack, Typography } from "@mui/material";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import type { TaxaResult } from "../../services/types";
 import { ConservationStatus } from "./ConservationStatus";
 import { renderAutocompleteInput } from "./autocompleteInput";
+import { nameToSlug } from "../../lib/taxonSlug";
+
+function taxonUrlFor(option: TaxaResult): string | null {
+  if (option.rank?.toLowerCase() === "kingdom") {
+    return `/taxon/${nameToSlug(option.scientificName)}`;
+  }
+  if (option.kingdom) {
+    return `/taxon/${nameToSlug(option.kingdom)}/${nameToSlug(option.scientificName)}`;
+  }
+  return null;
+}
 
 interface TaxaAutocompleteViewProps {
   value: string;
@@ -81,6 +93,7 @@ export function TaxaAutocompleteView({
         }
         renderOption={(props, option) => {
           const { key, ...otherProps } = props;
+          const taxonUrl = taxonUrlFor(option);
           return (
             <Box
               component="li"
@@ -163,6 +176,24 @@ export function TaxaAutocompleteView({
                   </Typography>
                 )}
               </Box>
+              {taxonUrl && (
+                <IconButton
+                  size="small"
+                  component="a"
+                  href={taxonUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  // MUI Autocomplete picks the row on mousedown, not click —
+                  // so stopping at click alone would still select the option.
+                  onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
+                  title="Open taxon in new tab"
+                  aria-label={`Open ${option.scientificName} in new tab`}
+                  sx={{ p: 0.5, flexShrink: 0 }}
+                >
+                  <OpenInNewIcon sx={{ fontSize: 16 }} />
+                </IconButton>
+              )}
             </Box>
           );
         }}

--- a/tests/identification-select.spec.ts
+++ b/tests/identification-select.spec.ts
@@ -1,0 +1,81 @@
+// Regression coverage for #419 — the Suggest ID autocomplete in the
+// observation page should let users open a taxon in a new tab without
+// accidentally selecting the suggestion.
+import { test as authTest, expect as authExpect } from "./fixtures/mock-auth";
+import { navigateToMockedDetail } from "./helpers/mock-observation";
+import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
+
+authTest.describe("Suggest ID autocomplete options", () => {
+  authTest.beforeEach(async ({ authenticatedPage: page }) => {
+    await mockTaxaSearchRoute(page);
+    await navigateToMockedDetail(page);
+    await page.getByRole("button", { name: "Suggest Different ID" }).click();
+  });
+
+  authTest(
+    "clicking a suggestion populates the Taxon Name input",
+    async ({ authenticatedPage: page }) => {
+      const taxonInput = page.getByRole("combobox", { name: "Taxon Name" });
+      await authExpect(taxonInput).toBeVisible();
+      await taxonInput.click();
+
+      await Promise.all([
+        page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
+        taxonInput.pressSequentially("quercus", { delay: 50 }),
+      ]);
+
+      const option = page.locator(".MuiAutocomplete-option").first();
+      await authExpect(option).toBeVisible();
+      await option.click();
+
+      await authExpect(taxonInput).toHaveValue("Quercus alba");
+      await authExpect(page.locator(".MuiAutocomplete-popper")).not.toBeVisible();
+    },
+  );
+
+  authTest(
+    "each suggestion exposes an open-in-new-tab link to its taxon page",
+    async ({ authenticatedPage: page }) => {
+      const taxonInput = page.getByRole("combobox", { name: "Taxon Name" });
+      await taxonInput.click();
+      await Promise.all([
+        page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
+        taxonInput.pressSequentially("quercus", { delay: 50 }),
+      ]);
+
+      const albaLink = page.getByRole("link", { name: /open quercus alba in new tab/i });
+      await authExpect(albaLink).toBeVisible();
+      await authExpect(albaLink).toHaveAttribute("href", "/taxon/Plantae/Quercus-alba");
+      await authExpect(albaLink).toHaveAttribute("target", "_blank");
+    },
+  );
+
+  authTest(
+    "clicking the open-in-new-tab link does not select the suggestion",
+    async ({ authenticatedPage: page }) => {
+      const taxonInput = page.getByRole("combobox", { name: "Taxon Name" });
+      await taxonInput.click();
+      await Promise.all([
+        page.waitForResponse((r) => r.url().includes("/api/taxa/search")),
+        taxonInput.pressSequentially("quercus", { delay: 50 }),
+      ]);
+
+      const albaLink = page.getByRole("link", { name: /open quercus alba in new tab/i });
+      await authExpect(albaLink).toBeVisible();
+
+      // Real users see the link open a new tab; we just need to drive the
+      // click so MUI's option-row pointer handler sees the event. Letting
+      // the anchor navigate would leave the test on /taxon/... so we
+      // neutralize target before clicking.
+      await albaLink.evaluate((el: HTMLAnchorElement) => {
+        el.removeAttribute("target");
+        el.setAttribute("href", "javascript:void(0)");
+      });
+      await albaLink.click();
+
+      // The suggestion must NOT have been picked: input still has the typed
+      // text, not the suggestion's scientificName.
+      await authExpect(taxonInput).toHaveValue("quercus");
+    },
+  );
+});


### PR DESCRIPTION
## Summary
- Adds an `OpenInNew` icon button to each option in the taxa autocomplete dropdown (Suggest ID on the observation page, upload modal, etc.), mirroring the affordance the Visual ID suggestion cards have.
- URL pattern matches `TaxonLink` / `VisualIdCards`: `/taxon/{kingdom}/{slug}`, falling back to `/taxon/{slug}` when the option is itself a kingdom; no link when kingdom is unknown.
- `stopPropagation` on both `mousedown` and `click` — MUI Autocomplete commits the row on mousedown, so a click-only guard would still select the suggestion.

Closes #419.

## Test plan
- [x] `npx playwright test --config=tests/playwright.config.ts --project=integration` — 112 tests pass, including three new ones in `tests/identification-select.spec.ts`:
  - clicking a suggestion still populates the Taxon Name input and closes the popper
  - each suggestion exposes an open-in-new-tab link with the correct `/taxon/{kingdom}/{slug}` href and `target="_blank"`
  - clicking the link does NOT pick the suggestion (verifies the `mousedown` guard)
- [x] `npm run fmt:check` clean
- [x] `npm run lint` clean for changed files (3 pre-existing warnings in UploadModal untouched)