### PR TITLE
fix(taxa-autocomplete): keep popper open when clicking taxon link

### DIFF
--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -184,8 +184,14 @@ export function TaxaAutocompleteView({
                   target="_blank"
                   rel="noopener noreferrer"
                   // MUI Autocomplete picks the row on mousedown, not click —
-                  // so stopping at click alone would still select the option.
-                  onMouseDown={(e: React.MouseEvent) => e.stopPropagation()}
+                  // stop propagation so the row doesn't select. Also
+                  // preventDefault: without it the input loses focus on
+                  // mousedown, MUI closes the popper, and the anchor
+                  // unmounts before its click event can navigate.
+                  onMouseDown={(e: React.MouseEvent) => {
+                    e.preventDefault();
+                    e.stopPropagation();
+                  }}
                   onClick={(e: React.MouseEvent) => e.stopPropagation()}
                   title="Open taxon in new tab"
                   aria-label={`Open ${option.scientificName} in new tab`}

--- a/tests/identification-select.spec.ts
+++ b/tests/identification-select.spec.ts
@@ -51,7 +51,7 @@ authTest.describe("Suggest ID autocomplete options", () => {
   );
 
   authTest(
-    "clicking the open-in-new-tab link does not select the suggestion",
+    "clicking the open-in-new-tab link opens a new tab and keeps the popper open",
     async ({ authenticatedPage: page }) => {
       const taxonInput = page.getByRole("combobox", { name: "Taxon Name" });
       await taxonInput.click();
@@ -63,19 +63,20 @@ authTest.describe("Suggest ID autocomplete options", () => {
       const albaLink = page.getByRole("link", { name: /open quercus alba in new tab/i });
       await authExpect(albaLink).toBeVisible();
 
-      // Real users see the link open a new tab; we just need to drive the
-      // click so MUI's option-row pointer handler sees the event. Letting
-      // the anchor navigate would leave the test on /taxon/... so we
-      // neutralize target before clicking.
-      await albaLink.evaluate((el: HTMLAnchorElement) => {
-        el.removeAttribute("target");
-        el.setAttribute("href", "javascript:void(0)");
-      });
+      // The real failure for issue #419 follow-up was that mousedown
+      // shifted focus, MUI closed the popper, and the anchor unmounted
+      // before `click` fired — so no new tab opened either. Drive a
+      // real mousedown + click on the icon (not the anchor child) so
+      // MUI's row-mousedown handler sees the same event chain a user
+      // would produce, then assert: (a) a new tab opened, (b) the
+      // suggestion was NOT picked, (c) the popper is still open.
+      const popupPromise = page.waitForEvent("popup", { timeout: 5000 });
       await albaLink.click();
+      const popup = await popupPromise;
+      await popup.close();
 
-      // The suggestion must NOT have been picked: input still has the typed
-      // text, not the suggestion's scientificName.
       await authExpect(taxonInput).toHaveValue("quercus");
+      await authExpect(page.locator(".MuiAutocomplete-option").first()).toBeVisible();
     },
   );
 });


### PR DESCRIPTION
## Summary
Follow-up to #532. The open-in-new-tab IconButton I added there only stopped propagation, so in a real browser the click shifted focus off the input → MUI closed the popper on blur → the anchor unmounted before its click could navigate. Result: dropdown vanished and no new tab opened.

`preventDefault` on mousedown keeps focus on the input, so the popper stays mounted and the click reaches the anchor.

## Test plan
- [x] `npx playwright test --config=tests/playwright.config.ts --project=integration identification-select` — 3/3 pass. The updated test drives a real click on the icon and asserts:
  - `page.waitForEvent("popup")` succeeds (a new tab opened)
  - the typed text "quercus" is still in the input (suggestion not picked)
  - `.MuiAutocomplete-option` is still visible (popper still open)
- The previous test masked the bug by replacing `href` with `javascript:void(0)` before clicking, which sidestepped the navigation path.