### PR TITLE
feat(suggest-id): mirror new-observation kingdom display logic

### DIFF
--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -1,8 +1,23 @@
 import { useState, useCallback, type FormEvent } from "react";
-import { Box, Typography, Button, Stack, Divider, CircularProgress } from "@mui/material";
+import {
+  Avatar,
+  Box,
+  Typography,
+  Button,
+  Chip,
+  Stack,
+  Divider,
+  CircularProgress,
+  FormControl,
+  InputLabel,
+  Select,
+  MenuItem,
+} from "@mui/material";
 import CheckIcon from "@mui/icons-material/Check";
 import EditIcon from "@mui/icons-material/Edit";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
 import { submitIdentification } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
@@ -12,6 +27,8 @@ import { TaxonLink } from "../common/TaxonLink";
 import { useAppDispatch } from "../../store";
 import { addToast } from "../../store/uiSlice";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
+import { KINGDOMS } from "../../lib/kingdoms";
+import { TAXON_RANKS } from "../../lib/taxonRanks";
 
 interface IdentificationPanelProps {
   observation: {
@@ -42,6 +59,8 @@ export function IdentificationPanel({
   const [showSuggestForm, setShowSuggestForm] = useState(false);
   const [taxonName, setTaxonName] = useState("");
   const [matchedTaxon, setMatchedTaxon] = useState<TaxaResult | null>(null);
+  const [kingdom, setKingdom] = useState("");
+  const [rank, setRank] = useState("");
 
   const currentId = observation.communityId || observation.scientificName || "Unknown";
 
@@ -60,16 +79,19 @@ export function IdentificationPanel({
     onSuccess: () => onSuccess?.(),
   });
 
+  const effectiveKingdom = matchedTaxon?.kingdom ?? (kingdom || undefined);
+  const effectiveRank = matchedTaxon?.rank ?? (rank || undefined);
+
   const suggestFn = useCallback(
     () =>
       submitIdentification({
         occurrenceUri: observation.uri,
         occurrenceCid: observation.cid,
         scientificName: taxonName.trim(),
-        ...(matchedTaxon?.kingdom ? { kingdom: matchedTaxon.kingdom } : {}),
-        ...(matchedTaxon?.rank ? { taxonRank: matchedTaxon.rank } : {}),
+        ...(effectiveKingdom ? { kingdom: effectiveKingdom } : {}),
+        ...(effectiveRank ? { taxonRank: effectiveRank } : {}),
       }),
-    [observation.uri, observation.cid, taxonName, matchedTaxon],
+    [observation.uri, observation.cid, taxonName, effectiveKingdom, effectiveRank],
   );
 
   const { isSubmitting: isSuggesting, handleSubmit: doSuggest } = useFormSubmit(suggestFn, {
@@ -78,6 +100,8 @@ export function IdentificationPanel({
       setShowSuggestForm(false);
       setTaxonName("");
       setMatchedTaxon(null);
+      setKingdom("");
+      setRank("");
       onSuccess?.();
     },
   });
@@ -95,6 +119,16 @@ export function IdentificationPanel({
 
     if (!taxonName.trim()) {
       dispatch(addToast({ message: "Please enter a taxon name", type: "error" }));
+      return;
+    }
+
+    if (!matchedTaxon && !kingdom) {
+      dispatch(
+        addToast({
+          message: "Please select a kingdom for the taxon name you entered",
+          type: "error",
+        }),
+      );
       return;
     }
 
@@ -170,30 +204,69 @@ export function IdentificationPanel({
                   setTaxonName(name);
                   if (name === "") {
                     setMatchedTaxon(null);
+                    setKingdom("");
+                    setRank("");
                   }
                 }}
-                onMatchChange={setMatchedTaxon}
+                onMatchChange={(match) => {
+                  setMatchedTaxon(match);
+                  if (match?.kingdom) {
+                    setKingdom(match.kingdom);
+                  }
+                  if (match) {
+                    setRank("");
+                  }
+                }}
                 label="Taxon Name"
                 size="small"
                 margin="none"
                 bottomContent={
-                  <VisualIdCards
-                    suggestions={visualId.suggestions}
-                    onSelectSpecies={(s) => {
-                      setTaxonName(s.scientificName);
-                      setMatchedTaxon(s.taxonMatch ?? null);
-                    }}
-                    onSelectAncestor={(ancestor) => {
-                      setTaxonName(ancestor.name);
-                      setMatchedTaxon({
-                        id: `${ancestor.kingdom ?? ""}/${ancestor.name}`,
-                        scientificName: ancestor.name,
-                        rank: ancestor.rank,
-                        ...(ancestor.kingdom ? { kingdom: ancestor.kingdom } : {}),
-                        source: "visual-id-rollup",
-                      });
-                    }}
-                  />
+                  taxonName.trim() ? (
+                    matchedTaxon ? (
+                      <Chip
+                        {...(matchedTaxon.photoUrl
+                          ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
+                          : { icon: <CheckCircleOutlinedIcon /> })}
+                        label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
+                          .filter((p): p is string => Boolean(p))
+                          .join(" · ")}
+                        color="success"
+                        size="small"
+                        variant="outlined"
+                        sx={{ mt: 0.5 }}
+                      />
+                    ) : (
+                      <Chip
+                        icon={<AddCircleOutlinedIcon />}
+                        label="New taxon"
+                        color="info"
+                        size="small"
+                        variant="outlined"
+                        sx={{ mt: 0.5 }}
+                      />
+                    )
+                  ) : (
+                    <VisualIdCards
+                      suggestions={visualId.suggestions}
+                      onSelectSpecies={(s) => {
+                        setTaxonName(s.scientificName);
+                        if (s.taxonMatch) {
+                          setMatchedTaxon(s.taxonMatch);
+                          setKingdom(s.taxonMatch.kingdom ?? "");
+                          setRank("");
+                        } else {
+                          setMatchedTaxon(null);
+                          if (s.kingdom) setKingdom(s.kingdom);
+                        }
+                      }}
+                      onSelectAncestor={(ancestor) => {
+                        setTaxonName(ancestor.name);
+                        setMatchedTaxon(null);
+                        if (ancestor.kingdom) setKingdom(ancestor.kingdom);
+                        setRank(ancestor.rank);
+                      }}
+                    />
+                  )
                 }
               />
             </Box>
@@ -217,6 +290,48 @@ export function IdentificationPanel({
             )}
           </Stack>
 
+          {!!taxonName.trim() && !matchedTaxon && (
+            <FormControl fullWidth margin="normal" required size="small">
+              <InputLabel id="suggest-kingdom-label">Kingdom</InputLabel>
+              <Select
+                labelId="suggest-kingdom-label"
+                value={kingdom}
+                label="Kingdom"
+                onChange={(e) => setKingdom(e.target.value)}
+              >
+                <MenuItem value="">
+                  <em>None</em>
+                </MenuItem>
+                {KINGDOMS.map((k) => (
+                  <MenuItem key={k.value} value={k.value}>
+                    {k.label}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+
+          {!!taxonName.trim() && !matchedTaxon && (
+            <FormControl fullWidth margin="normal" size="small">
+              <InputLabel id="suggest-rank-label">Rank (optional)</InputLabel>
+              <Select
+                labelId="suggest-rank-label"
+                value={rank}
+                label="Rank (optional)"
+                onChange={(e) => setRank(e.target.value)}
+              >
+                <MenuItem value="">
+                  <em>None</em>
+                </MenuItem>
+                {TAXON_RANKS.map((r) => (
+                  <MenuItem key={r} value={r}>
+                    {r}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          )}
+
           <Stack
             direction="row"
             spacing={1}
@@ -232,6 +347,8 @@ export function IdentificationPanel({
                 setShowSuggestForm(false);
                 setTaxonName("");
                 setMatchedTaxon(null);
+                setKingdom("");
+                setRank("");
               }}
             >
               Cancel

--- a/tests/identification.spec.ts
+++ b/tests/identification.spec.ts
@@ -86,6 +86,13 @@ authTest.describe("Identification - Logged In", () => {
 
       const taxonInput = page.getByLabel("Taxon Name");
       await taxonInput.fill("Quercus rubra");
+      // Dismiss the autocomplete popper so it doesn't cover the Kingdom select.
+      await taxonInput.press("Escape");
+
+      // Free-form names that don't match a known taxon require a Kingdom,
+      // matching the new-observation flow.
+      await muiSelect(page, "Kingdom").click();
+      await page.getByRole("option", { name: "Plants" }).click();
 
       const postRequest = page.waitForRequest(
         (req: Request) => req.method() === "POST" && req.url().includes("/api/identifications"),
@@ -94,6 +101,7 @@ authTest.describe("Identification - Logged In", () => {
       const req = await postRequest;
       const body = JSON.parse(req.postData() || "{}");
       authExpect(body.scientificName).toBe("Quercus rubra");
+      authExpect(body.kingdom).toBe("Plantae");
     },
   );
 


### PR DESCRIPTION
## Summary

- Closes #386
- Ports the kingdom display logic from `UploadModal` into `IdentificationPanel`'s "Suggest Different ID" form so the two flows behave the same when a free-form taxon name is entered.
- New behavior: an "Existing taxon" / "New taxon" chip, a required Kingdom `<Select>` and optional Rank `<Select>` (gated on `taxonName.trim() && !matchedTaxon`), kingdom-required validation, and kingdom/rank state hydrated from autocomplete matches and Visual ID picks. Submit now sends `kingdom` and `taxonRank` whether they come from a match or from manual entry.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` clean (only 3 pre-existing warnings in `UploadModal`)
- [x] `npm run fmt` ran
- [x] Storybook (`Identification/IdentificationPanel/Default`) — typing a free-form name shows the "New taxon" chip, required Kingdom select, and optional Rank select
- [ ] Manual end-to-end: from an observation page, click **Suggest Different ID**, type an unmatched name, confirm Kingdom is required to submit and is persisted on the resulting identification