### PR TITLE
fix(modals): add X close button and go full-screen on mobile

### DIFF
--- a/frontend/src/components/modals/ModalOverlay.tsx
+++ b/frontend/src/components/modals/ModalOverlay.tsx
@@ -1,5 +1,6 @@
 import type { ReactNode } from "react";
-import { Dialog, DialogContent } from "@mui/material";
+import { Dialog, DialogContent, IconButton, useMediaQuery, useTheme } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
 
 interface ModalOverlayProps {
   isOpen: boolean;
@@ -9,16 +10,27 @@ interface ModalOverlayProps {
 }
 
 export function ModalOverlay({ isOpen, onClose, children, maxWidth = "sm" }: ModalOverlayProps) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+
   return (
     <Dialog
       open={isOpen}
       onClose={onClose}
       maxWidth={maxWidth}
       fullWidth
+      fullScreen={fullScreen}
       slotProps={{
-        paper: { sx: { maxHeight: "90vh" } },
+        paper: { sx: fullScreen ? undefined : { maxHeight: "90vh" } },
       }}
     >
+      <IconButton
+        aria-label="Close"
+        onClick={onClose}
+        sx={{ position: "absolute", top: 8, right: 8, zIndex: 1 }}
+      >
+        <CloseIcon />
+      </IconButton>
       <DialogContent sx={{ p: 3 }}>{children}</DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- Adds an explicit close (X) IconButton in the top-right corner of `ModalOverlay`, so the modal is dismissible without aiming for the backdrop strip.
- Switches the underlying MUI `Dialog` to `fullScreen` below the `sm` breakpoint, eliminating the tiny backdrop tap target on phones.

Closes #144.

## Test plan
- [ ] Open the new-observation modal on a desktop viewport — X button is visible in the top-right and dismisses the modal.
- [ ] Open the new-observation modal on a mobile viewport (≤600px) — modal fills the viewport, X button is reachable, dismissing works.
- [ ] Escape key still closes the modal.
- [ ] If the form is dirty, dismissing via the X still triggers the discard-confirmation dialog (`handleRequestClose` path).
- [ ] Storybook stories under `Modals / ModalOverlay` still render at all `maxWidth` values.