### PR TITLE
fix(taxon-explorer): cancel stale loadTaxon writes to avoid "not found" flash

### DIFF
--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -260,6 +260,10 @@ export function TaxonExplorer() {
       return;
     }
 
+    // Guard against a stale invocation (e.g. StrictMode double-fire, or rapid
+    // navigation) overwriting good state with a late "not found" response.
+    let cancelled = false;
+
     async function loadTaxon() {
       setLoading(true);
       setError(null);
@@ -285,10 +289,13 @@ export function TaxonExplorer() {
       try {
         result = await taxonPromise;
       } catch (e) {
+        if (cancelled) return;
         setError(e instanceof Error ? e.message : "Failed to load taxon");
         setLoading(false);
         return;
       }
+
+      if (cancelled) return;
 
       if (!result) {
         setError("Taxon not found");
@@ -297,6 +304,7 @@ export function TaxonExplorer() {
       }
 
       const obsResult = await obsPromise;
+      if (cancelled) return;
 
       setTaxon(result);
       mergeIntoTree(result);
@@ -325,6 +333,7 @@ export function TaxonExplorer() {
             }
           }),
         ).then((settled) => {
+          if (cancelled) return;
           for (const entry of settled) {
             if (entry) addChildrenToNodes(entry.ancestorId, entry.children);
           }
@@ -334,6 +343,9 @@ export function TaxonExplorer() {
     }
 
     loadTaxon();
+    return () => {
+      cancelled = true;
+    };
   }, [lookupKingdom, lookupName, lookupId, mergeIntoTree, addChildrenToNodes, rebuildTreeFromRoot]);
 
   const handleBack = () => {


### PR DESCRIPTION
## Summary
- The fetch effect in `TaxonExplorer` had no cleanup, so a stale invocation (StrictMode double-fire, rapid navigation) could overwrite good state — most visibly, the second invocation hitting the 404/null branch would call `setError("Taxon not found")` after the first had already rendered the real taxon.
- Track a `cancelled` flag in the effect and guard every state write that follows an await, including the background ancestor-siblings `Promise.all` that merges into the tree.
- Addresses the frontend half of #269. The backend race (concurrent GBIF `/species/match` calls returning inconsistent results because `match_name_raw` isn't cached) is still open as a follow-up.

## Test plan
- [ ] Visit `/taxon/Plantae/Quercus-agrifolia` in dev (StrictMode on) and confirm the page no longer flashes "Taxon not found" before settling.
- [ ] Navigate rapidly between several taxon pages and confirm the detail panel always reflects the URL (no stale taxon, no spurious error state).
- [ ] `npx playwright test tests/taxon-explorer.spec.ts` still passes.