### PR TITLE
test(lib): cover taxonSlug + licenses

### DIFF
--- a/frontend/src/lib/licenses.test.ts
+++ b/frontend/src/lib/licenses.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from "vitest";
+import { LICENSE_OPTIONS, DEFAULT_LICENSE, isLicenseValue, getLicenseLabel } from "./licenses";
+
+describe("LICENSE_OPTIONS", () => {
+  it("exposes a non-empty list of options", () => {
+    expect(LICENSE_OPTIONS.length).toBeGreaterThan(0);
+  });
+
+  it("has a unique value for each entry", () => {
+    const values = LICENSE_OPTIONS.map((o) => o.value);
+    expect(new Set(values).size).toBe(values.length);
+  });
+});
+
+describe("DEFAULT_LICENSE", () => {
+  it("is one of the listed options", () => {
+    expect(LICENSE_OPTIONS.some((o) => o.value === DEFAULT_LICENSE)).toBe(true);
+  });
+});
+
+describe("isLicenseValue", () => {
+  it("accepts every listed license value", () => {
+    for (const opt of LICENSE_OPTIONS) {
+      expect(isLicenseValue(opt.value)).toBe(true);
+    }
+  });
+
+  it("rejects unknown values", () => {
+    expect(isLicenseValue("CC-BY-3.0")).toBe(false);
+    expect(isLicenseValue("MIT")).toBe(false);
+    expect(isLicenseValue("")).toBe(false);
+  });
+});
+
+describe("getLicenseLabel", () => {
+  it("returns the human-readable label for a known value", () => {
+    expect(getLicenseLabel("CC0-1.0")).toBe("CC0 (Public Domain)");
+    expect(getLicenseLabel("CC-BY-4.0")).toBe("CC BY (Attribution)");
+  });
+
+  it("returns the input verbatim for an unknown value", () => {
+    // Intentional: records written by other clients may carry SPDX
+    // identifiers outside our allow-list, and we still want to render them.
+    expect(getLicenseLabel("CC-BY-3.0")).toBe("CC-BY-3.0");
+    expect(getLicenseLabel("Apache-2.0")).toBe("Apache-2.0");
+  });
+
+  it("returns the empty string verbatim", () => {
+    expect(getLicenseLabel("")).toBe("");
+  });
+});

--- a/frontend/src/lib/taxonSlug.test.ts
+++ b/frontend/src/lib/taxonSlug.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { nameToSlug, slugToName } from "./taxonSlug";
+
+describe("nameToSlug", () => {
+  it("replaces spaces with hyphens", () => {
+    expect(nameToSlug("Quercus alba")).toBe("Quercus-alba");
+  });
+
+  it("handles multi-word names with multiple spaces", () => {
+    expect(nameToSlug("Homo sapiens sapiens")).toBe("Homo-sapiens-sapiens");
+  });
+
+  it("leaves names without spaces unchanged", () => {
+    expect(nameToSlug("Plantae")).toBe("Plantae");
+  });
+
+  it("returns the empty string unchanged", () => {
+    expect(nameToSlug("")).toBe("");
+  });
+
+  it("preserves existing hyphens", () => {
+    expect(nameToSlug("Homo neanderthalensis")).toBe("Homo-neanderthalensis");
+    expect(nameToSlug("X-Y Z")).toBe("X-Y-Z");
+  });
+});
+
+describe("slugToName", () => {
+  it("replaces hyphens with spaces", () => {
+    expect(slugToName("Quercus-alba")).toBe("Quercus alba");
+  });
+
+  it("leaves slugs without hyphens unchanged", () => {
+    expect(slugToName("Plantae")).toBe("Plantae");
+  });
+
+  it("returns the empty string unchanged", () => {
+    expect(slugToName("")).toBe("");
+  });
+});
+
+describe("nameToSlug / slugToName round-trip", () => {
+  // The pair is *not* a perfect inverse — a name already containing hyphens
+  // round-trips to a different string. These tests pin that behavior so any
+  // future change to use a reversible encoding is intentional.
+  it("round-trips a space-only name", () => {
+    const name = "Quercus alba";
+    expect(slugToName(nameToSlug(name))).toBe(name);
+  });
+
+  it("does NOT round-trip a name containing hyphens (known limitation)", () => {
+    const name = "Foo-bar baz";
+    // After encode: "Foo-bar-baz". After decode: "Foo bar baz" — hyphen lost.
+    expect(slugToName(nameToSlug(name))).toBe("Foo bar baz");
+  });
+});


### PR DESCRIPTION
## Summary
Follow-up to #538. Adds vitest coverage for the two remaining pure-logic modules under `frontend/src/lib/`:

- **`taxonSlug.ts`** — round-trips between scientific names and URL slugs. The pair is *not* a perfect inverse: names containing hyphens lose them on round-trip. That limitation is pinned by an explicit test so any future move to a reversible encoding is intentional.
- **`licenses.ts`** — invariants on the option list (non-empty, unique values, `DEFAULT_LICENSE` is one of them), the `isLicenseValue` type guard, and the verbatim-passthrough behavior of `getLicenseLabel` for unknown SPDX identifiers (records from other clients).

18 tests across the two files. Brings the unit-test count to 8 files / 110 tests on top of main, or 9 files / 139 tests once #538 is merged.

## Not covered: hooks
`hooks/useAutocomplete.ts` and `hooks/useFormSubmit.ts` were on the original candidate list but they're React hooks — testing them needs a DOM env (`happy-dom` or `jsdom`) and `@testing-library/react`. That's standard React testing setup, but it's a separate infrastructure decision worth its own PR. Deferred.

## Test plan
- [x] `npm run test:unit` passes (8 files / 110 tests on this branch)
- [x] `npm run fmt:check` clean
- [x] `npx oxlint` clean on the new files