### PR TITLE
atproto-blob-resolver: add fetch_record (getRecord)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,7 +4745,6 @@ dependencies = [
  "tracing-stackdriver",
  "tracing-subscriber",
  "url",
- "urlencoding",
 ]
 
 [[package]]

--- a/crates/atproto-blob-resolver/src/error.rs
+++ b/crates/atproto-blob-resolver/src/error.rs
@@ -6,6 +6,9 @@ use std::fmt;
 pub enum BlobResolverError {
     Http(Box<reqwest::Error>),
     DidResolution(String),
+    /// A `com.atproto.repo.getRecord` request failed or returned an
+    /// unexpected body.
+    RecordFetch(String),
 }
 
 impl fmt::Display for BlobResolverError {
@@ -13,6 +16,7 @@ impl fmt::Display for BlobResolverError {
         match self {
             BlobResolverError::Http(err) => write!(f, "HTTP error: {}", err),
             BlobResolverError::DidResolution(msg) => write!(f, "DID resolution error: {}", msg),
+            BlobResolverError::RecordFetch(msg) => write!(f, "record fetch error: {}", msg),
         }
     }
 }

--- a/crates/atproto-blob-resolver/src/resolver.rs
+++ b/crates/atproto-blob-resolver/src/resolver.rs
@@ -19,6 +19,13 @@ impl BlobResolver {
         }
     }
 
+    /// Create a resolver using a caller-provided HTTP client — e.g. one
+    /// configured with a request timeout. [`BlobResolver::new`] uses a default
+    /// client with no timeout.
+    pub fn with_client(client: Client) -> Self {
+        Self { client }
+    }
+
     /// Resolve a DID to its PDS URL
     pub async fn resolve_pds_url(&self, did: &Did) -> Result<String> {
         match did.method() {
@@ -111,6 +118,45 @@ impl BlobResolver {
         );
 
         Ok((data, content_type))
+    }
+
+    /// Fetch a record from a PDS via `com.atproto.repo.getRecord`, returning
+    /// the record's `value` (the lexicon record body).
+    ///
+    /// `getRecord` wraps the record as `{ uri, cid, value }`; this returns the
+    /// unwrapped `value`. Use [`BlobResolver::resolve_pds_url`] to obtain
+    /// `pds_url` from a DID first.
+    pub async fn fetch_record(
+        &self,
+        pds_url: &str,
+        did: &str,
+        collection: &str,
+        rkey: &str,
+    ) -> Result<serde_json::Value> {
+        let url = format!(
+            "{}/xrpc/com.atproto.repo.getRecord?repo={}&collection={}&rkey={}",
+            pds_url.trim_end_matches('/'),
+            urlencoding::encode(did),
+            urlencoding::encode(collection),
+            urlencoding::encode(rkey),
+        );
+
+        debug!(url = %url, "Fetching record from PDS");
+
+        let response = self.client.get(&url).send().await?;
+
+        if !response.status().is_success() {
+            warn!(status = %response.status(), url = %url, "Failed to fetch record");
+            return Err(BlobResolverError::RecordFetch(format!(
+                "PDS returned status {}",
+                response.status()
+            )));
+        }
+
+        let body: serde_json::Value = response.json().await?;
+        body.get("value").cloned().ok_or_else(|| {
+            BlobResolverError::RecordFetch("getRecord response missing `value` field".to_string())
+        })
     }
 }
 

--- a/crates/tap-ingester/Cargo.toml
+++ b/crates/tap-ingester/Cargo.toml
@@ -46,9 +46,8 @@ chrono = { workspace = true }
 # CLI
 clap = { version = "4", features = ["derive", "env"] }
 
-# URL utilities (used by media resolver)
+# URL utilities
 url = { workspace = true }
-urlencoding = { workspace = true }
 
 [[bin]]
 name = "tap-ingester"

--- a/crates/tap-ingester/src/media_resolver.rs
+++ b/crates/tap-ingester/src/media_resolver.rs
@@ -25,18 +25,17 @@ use tracing::warn;
 /// Fetches `bio.lexicons.temp.v0-1.media` records from PDSes and converts them to
 /// the `BlobEntry` shape stored in `occurrences.associated_media`.
 pub struct MediaResolver {
-    client: Client,
     blob_resolver: BlobResolver,
 }
 
 impl MediaResolver {
     pub fn new() -> Self {
+        let client = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .build()
+            .expect("reqwest client build should not fail with defaults");
         Self {
-            client: Client::builder()
-                .timeout(Duration::from_secs(10))
-                .build()
-                .expect("reqwest client build should not fail with defaults"),
-            blob_resolver: BlobResolver::new(),
+            blob_resolver: BlobResolver::with_client(client),
         }
     }
 
@@ -59,32 +58,11 @@ impl MediaResolver {
         let did = Did::parse(&at_uri.did).ok()?;
         let pds_url = self.blob_resolver.resolve_pds_url(&did).await.ok()?;
         let record = self
+            .blob_resolver
             .fetch_record(&pds_url, &at_uri.did, &at_uri.collection, &at_uri.rkey)
-            .await?;
+            .await
+            .ok()?;
         media_record_to_blob_entry(&record)
-    }
-
-    async fn fetch_record(
-        &self,
-        pds_url: &str,
-        did: &str,
-        collection: &str,
-        rkey: &str,
-    ) -> Option<Value> {
-        let url = format!(
-            "{}/xrpc/com.atproto.repo.getRecord?repo={}&collection={}&rkey={}",
-            pds_url.trim_end_matches('/'),
-            urlencoding::encode(did),
-            urlencoding::encode(collection),
-            urlencoding::encode(rkey),
-        );
-        let resp = self.client.get(&url).send().await.ok()?;
-        if !resp.status().is_success() {
-            return None;
-        }
-        let body: Value = resp.json().await.ok()?;
-        // getRecord wraps the record in `{ uri, cid, value }`.
-        body.get("value").cloned()
     }
 }
 


### PR DESCRIPTION
## What

Adds a `fetch_record` method to `BlobResolver` in the existing **`atproto-blob-resolver`** crate — the `com.atproto.repo.getRecord` companion to its existing `fetch_blob`. `getRecord` is the most common AT Protocol read, and the crate already does DID→PDS resolution (`resolve_pds_url`), so this fills an obvious gap and makes the crate useful to any project that needs to hydrate records, not just blobs.

## API added

- `BlobResolver::fetch_record(pds_url, did, collection, rkey) -> Result<serde_json::Value>` — returns the unwrapped record `value` from the `{ uri, cid, value }` envelope.
- `BlobResolver::with_client(client)` — construct with a caller-provided reqwest client (e.g. one with a timeout); `new()` still uses a default client.
- New `BlobResolverError::RecordFetch` variant.

## Where it came from

`tap-ingester`'s `MediaResolver` had a private, identical `getRecord` implementation. It now calls the shared `fetch_record` and supplies its 10s-timeout client via `with_client`. The ingester no longer references `urlencoding` (removed from its `Cargo.toml`; the one-line `Cargo.lock` edge is included).

## Verification

- `cargo check -p atproto-blob-resolver -p tap-ingester` ✅
- `cargo clippy ... -- -D warnings` ✅
- `cargo test -p atproto-blob-resolver` ✅ (5 passed)

🤖 Draft PR opened as part of a sweep to extract reusable abstractions into standalone crates.