### PR TITLE
Extract pg-url-env crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2858,6 +2858,7 @@ dependencies = [
  "observing-db",
  "observing-lexicons",
  "observing-species-id-protocol",
+ "pg-url-env",
  "reqwest 0.13.3",
  "serde",
  "serde_json",
@@ -3161,6 +3162,10 @@ name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pg-url-env"
+version = "0.1.0"
 
 [[package]]
 name = "phf"
@@ -4734,6 +4739,7 @@ dependencies = [
  "clap",
  "observing-db",
  "observing-lexicons",
+ "pg-url-env",
  "reqwest 0.13.3",
  "serde",
  "serde_json",

--- a/crates/observing-appview/Cargo.toml
+++ b/crates/observing-appview/Cargo.toml
@@ -20,6 +20,8 @@ atproto-blob-resolver = { path = "../atproto-blob-resolver" }
 file-blob-cache = { path = "../file-blob-cache" }
 # Wire types for the species-id HTTP client
 observing-species-id-protocol = { path = "../observing-species-id-protocol" }
+# Postgres connection URL from env (DATABASE_URL or DB_* / Cloud SQL socket)
+pg-url-env = { path = "../pg-url-env" }
 
 # AT Protocol types (for record construction)
 jacquard-common = "0.12.0-beta.2"

--- a/crates/observing-appview/src/config.rs
+++ b/crates/observing-appview/src/config.rs
@@ -24,32 +24,10 @@ impl Config {
             .and_then(|p| p.parse().ok())
             .unwrap_or(3004);
 
-        // Support both DATABASE_URL and separate DB_* environment variables
-        // (for compatibility with Cloud SQL socket connections)
-        let database_url = if let Ok(url) = env::var("DATABASE_URL") {
-            url
-        } else if let Ok(host) = env::var("DB_HOST") {
-            let name = env::var("DB_NAME").unwrap_or_else(|_| "observing".to_string());
-            let user = env::var("DB_USER").unwrap_or_else(|_| "postgres".to_string());
-            let password = env::var("DB_PASSWORD").unwrap_or_default();
-
-            if host.starts_with("/cloudsql/") {
-                // Unix socket connection for Cloud SQL
-                format!(
-                    "postgresql://{}:{}@localhost/{}?host={}",
-                    user, password, name, host
-                )
-            } else {
-                // Regular TCP connection
-                let port = env::var("DB_PORT").unwrap_or_else(|_| "5432".to_string());
-                format!(
-                    "postgresql://{}:{}@{}:{}/{}",
-                    user, password, host, port, name
-                )
-            }
-        } else {
-            "postgres://localhost/observing".to_string()
-        };
+        // DATABASE_URL, else assembled from the DB_* vars (Cloud SQL socket
+        // aware), else a local default.
+        let database_url = pg_url_env::database_url_from_env("observing")
+            .unwrap_or_else(|| "postgres://localhost/observing".to_string());
 
         let cors_origins = env::var("CORS_ORIGINS")
             .map(|s| s.split(',').map(|o| o.trim().to_string()).collect())

--- a/crates/pg-url-env/Cargo.toml
+++ b/crates/pg-url-env/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "pg-url-env"
+version = "0.1.0"
+edition = "2021"
+description = "Build a PostgreSQL connection URL from DATABASE_URL or DB_HOST/DB_NAME/... env vars, including Cloud SQL unix sockets"
+license = "MIT OR Apache-2.0"
+
+[dependencies]

--- a/crates/pg-url-env/README.md
+++ b/crates/pg-url-env/README.md
@@ -1,0 +1,20 @@
+# pg-url-env
+
+Build a PostgreSQL connection URL from environment variables.
+
+Services on Cloud Run / Cloud SQL commonly accept either a single
+`DATABASE_URL` or a bundle of `DB_HOST` / `DB_NAME` / `DB_USER` /
+`DB_PASSWORD` / `DB_PORT` (where `DB_HOST` may be a `/cloudsql/...` unix-socket
+path). This crate turns those into a connection string, with optional
+`search_path` pinning.
+
+```rust,ignore
+// DATABASE_URL if set, else assembled from DB_* (None if neither is present):
+let url = pg_url_env::database_url_from_env("mydb")
+    .unwrap_or_else(|| "postgres://localhost/mydb".to_string());
+
+// DB_* only, pinning a schema search_path:
+let url = pg_url_env::postgres_url_from_db_env("mydb", Some("tap"));
+```
+
+Zero dependencies; the URL-assembly core is a pure function and unit-tested.

--- a/crates/pg-url-env/src/lib.rs
+++ b/crates/pg-url-env/src/lib.rs
@@ -1,0 +1,142 @@
+//! Build a PostgreSQL connection URL from environment variables.
+//!
+//! Services deployed on Cloud Run / Cloud SQL commonly accept either a single
+//! `DATABASE_URL` or a bundle of `DB_HOST` / `DB_NAME` / `DB_USER` /
+//! `DB_PASSWORD` / `DB_PORT` vars (where `DB_HOST` may be a `/cloudsql/...`
+//! unix socket path). This crate turns those into a connection string.
+//!
+//! ```ignore
+//! // DATABASE_URL if set, else assembled from DB_* (None if neither is set):
+//! let url = pg_url_env::database_url_from_env("mydb")
+//!     .unwrap_or_else(|| "postgres://localhost/mydb".to_string());
+//!
+//! // Assemble from DB_* only, pinning a schema search_path:
+//! let url = pg_url_env::postgres_url_from_db_env("mydb", Some("tap"));
+//! ```
+
+/// Build a connection URL from already-resolved parts.
+///
+/// A `/cloudsql/...` `host` is treated as a unix-socket directory (passed via
+/// the `?host=` query param against `localhost`); anything else is a TCP host.
+/// When `search_path` is `Some`, an `options=-c search_path=<sp>` parameter is
+/// appended (URL-encoded).
+fn build_url(
+    host: &str,
+    name: &str,
+    user: &str,
+    password: &str,
+    port: &str,
+    search_path: Option<&str>,
+) -> String {
+    let mut url = if host.starts_with("/cloudsql/") {
+        format!("postgresql://{user}:{password}@localhost/{name}?host={host}")
+    } else {
+        format!("postgresql://{user}:{password}@{host}:{port}/{name}")
+    };
+
+    if let Some(sp) = search_path {
+        let sep = if url.contains('?') { '&' } else { '?' };
+        url.push(sep);
+        // `-c search_path=<sp>`, percent-encoded (space -> %20, '=' -> %3D).
+        url.push_str("options=-c%20search_path%3D");
+        url.push_str(sp);
+    }
+
+    url
+}
+
+/// Assemble a Postgres URL from the `DB_HOST` / `DB_NAME` / `DB_USER` /
+/// `DB_PASSWORD` / `DB_PORT` environment variables.
+///
+/// Returns `None` if `DB_HOST` is unset. `DB_NAME` defaults to
+/// `default_db_name`, `DB_USER` to `postgres`, `DB_PASSWORD` to empty, and
+/// `DB_PORT` to `5432` (ignored for Cloud SQL sockets). See [`build_url`] for
+/// the `search_path` behavior.
+pub fn postgres_url_from_db_env(
+    default_db_name: &str,
+    search_path: Option<&str>,
+) -> Option<String> {
+    let host = std::env::var("DB_HOST").ok()?;
+    let name = std::env::var("DB_NAME").unwrap_or_else(|_| default_db_name.to_string());
+    let user = std::env::var("DB_USER").unwrap_or_else(|_| "postgres".to_string());
+    let password = std::env::var("DB_PASSWORD").unwrap_or_default();
+    let port = std::env::var("DB_PORT").unwrap_or_else(|_| "5432".to_string());
+    Some(build_url(
+        &host,
+        &name,
+        &user,
+        &password,
+        &port,
+        search_path,
+    ))
+}
+
+/// `DATABASE_URL` if set, otherwise [`postgres_url_from_db_env`] with no
+/// `search_path`. `None` if neither `DATABASE_URL` nor `DB_HOST` is present —
+/// the caller decides the fallback (a default URL, or an error).
+pub fn database_url_from_env(default_db_name: &str) -> Option<String> {
+    if let Ok(url) = std::env::var("DATABASE_URL") {
+        return Some(url);
+    }
+    postgres_url_from_db_env(default_db_name, None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_url;
+
+    #[test]
+    fn tcp_without_search_path() {
+        assert_eq!(
+            build_url("db.example.com", "mydb", "alice", "secret", "5432", None),
+            "postgresql://alice:secret@db.example.com:5432/mydb"
+        );
+    }
+
+    #[test]
+    fn tcp_with_search_path() {
+        assert_eq!(
+            build_url(
+                "db.example.com",
+                "mydb",
+                "alice",
+                "secret",
+                "6543",
+                Some("tap")
+            ),
+            "postgresql://alice:secret@db.example.com:6543/mydb?options=-c%20search_path%3Dtap"
+        );
+    }
+
+    #[test]
+    fn cloudsql_socket_without_search_path() {
+        assert_eq!(
+            build_url(
+                "/cloudsql/proj:region:inst",
+                "mydb",
+                "alice",
+                "secret",
+                "5432",
+                None
+            ),
+            "postgresql://alice:secret@localhost/mydb?host=/cloudsql/proj:region:inst"
+        );
+    }
+
+    #[test]
+    fn cloudsql_socket_with_search_path() {
+        // The socket form already carries `?host=`, so search_path is joined
+        // with `&`.
+        assert_eq!(
+            build_url(
+                "/cloudsql/proj:region:inst",
+                "mydb",
+                "alice",
+                "secret",
+                "5432",
+                Some("tap")
+            ),
+            "postgresql://alice:secret@localhost/mydb?host=/cloudsql/proj:region:inst&options=-c%20search_path%3Dtap"
+        );
+    }
+}

--- a/crates/tap-ingester/Cargo.toml
+++ b/crates/tap-ingester/Cargo.toml
@@ -13,6 +13,9 @@ tapped = { workspace = true }
 observing-db = { path = "../observing-db", features = ["processing"] }
 observing-lexicons = { path = "../observing-lexicons" }
 
+# Postgres connection URL from env (DATABASE_URL or DB_* / Cloud SQL socket)
+pg-url-env = { path = "../pg-url-env" }
+
 # Media resolver: AT URI parsing + DID → PDS resolution + HTTP fetch.
 at-uri-parser = { path = "../at-uri-parser" }
 atproto-blob-resolver = { path = "../atproto-blob-resolver" }

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -250,49 +250,17 @@ fn resolve_tap_database_url() -> String {
     if let Ok(url) = std::env::var("TAP_DATABASE_URL") {
         return url;
     }
-    let Ok(host) = std::env::var("DB_HOST") else {
-        return "sqlite:///data/tap.db".to_string();
-    };
-    let name = std::env::var("DB_NAME").unwrap_or_else(|_| "observing".to_string());
-    let user = std::env::var("DB_USER").unwrap_or_else(|_| "postgres".to_string());
-    let password = std::env::var("DB_PASSWORD").unwrap_or_default();
-    if host.starts_with("/cloudsql/") {
-        format!(
-            "postgresql://{user}:{password}@localhost/{name}?host={host}&options=-c%20search_path%3Dtap"
-        )
-    } else {
-        let port = std::env::var("DB_PORT").unwrap_or_else(|_| "5432".to_string());
-        format!(
-            "postgresql://{user}:{password}@{host}:{port}/{name}?options=-c%20search_path%3Dtap"
-        )
-    }
+    // Same DB_* bundle as the app DB, but pin Tap's tables to the `tap` schema.
+    pg_url_env::postgres_url_from_db_env("observing", Some("tap"))
+        .unwrap_or_else(|| "sqlite:///data/tap.db".to_string())
 }
 
 /// Build a Postgres connection string from either DATABASE_URL directly
 /// or the DB_HOST/DB_NAME/DB_USER/DB_PASSWORD bundle the existing
 /// services use for Cloud SQL socket connections.
 fn resolve_database_url() -> Result<String, Box<dyn std::error::Error>> {
-    if let Ok(url) = std::env::var("DATABASE_URL") {
-        return Ok(url);
-    }
-    let host = std::env::var("DB_HOST")
-        .map_err(|_| "DATABASE_URL or DB_HOST environment variable is required".to_string())?;
-    let name = std::env::var("DB_NAME").unwrap_or_else(|_| "observing".to_string());
-    let user = std::env::var("DB_USER").unwrap_or_else(|_| "postgres".to_string());
-    let password = std::env::var("DB_PASSWORD").unwrap_or_default();
-
-    if host.starts_with("/cloudsql/") {
-        Ok(format!(
-            "postgresql://{}:{}@localhost/{}?host={}",
-            user, password, name, host
-        ))
-    } else {
-        let port = std::env::var("DB_PORT").unwrap_or_else(|_| "5432".to_string());
-        Ok(format!(
-            "postgresql://{}:{}@{}:{}/{}",
-            user, password, host, port, name
-        ))
-    }
+    pg_url_env::database_url_from_env("observing")
+        .ok_or_else(|| "DATABASE_URL or DB_HOST environment variable is required".into())
 }
 
 async fn process_record(


### PR DESCRIPTION
## What

Extracts **`pg-url-env`**: builds a PostgreSQL connection URL from `DATABASE_URL` or the `DB_HOST` / `DB_NAME` / `DB_USER` / `DB_PASSWORD` / `DB_PORT` bundle (Cloud SQL `/cloudsql/...` unix sockets included), with an optional `search_path`.

## Why

`observing-appview/src/config.rs` and `tap-ingester/src/main.rs` each carried a near-identical copy of this logic. This de-duplicates them today and is reusable by any Postgres-on-Cloud-Run project.

## API

- `database_url_from_env(default_db_name) -> Option<String>` — `DATABASE_URL`, else assembled from `DB_*`, else `None` (caller picks the fallback).
- `postgres_url_from_db_env(default_db_name, search_path) -> Option<String>` — `DB_*` only, with optional schema pinning.

The URL-assembly core is a pure function (`build_url`), so the formats are unit-tested directly (TCP / Cloud SQL socket × with / without `search_path`) — something the inlined copies couldn't easily do.

## Consumers rewired

- **appview**: the inline `DATABASE_URL`/`DB_*` block → `database_url_from_env("observing").unwrap_or_else(|| "postgres://localhost/observing")`.
- **ingester**: `resolve_database_url` → `database_url_from_env`; `resolve_tap_database_url` keeps its `TAP_DATABASE_URL` override and sqlite fallback but uses `postgres_url_from_db_env("observing", Some("tap"))` for the middle case. Output strings are byte-for-byte identical to before.

## Verification

- `cargo check -p pg-url-env -p observing-appview -p tap-ingester` ✅
- `cargo clippy ... -- -D warnings` ✅
- `cargo test -p pg-url-env` ✅ (4 passed)

🤖 Draft PR opened as part of a sweep to extract reusable abstractions into standalone crates.