### PR TITLE
chore(deps): fix npm audit vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6339,9 +6339,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7394,9 +7394,9 @@
       }
     },
     "node_modules/exifreader": {
-      "version": "4.38.1",
-      "resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.38.1.tgz",
-      "integrity": "sha512-VUQ8pnWJHpnQXPQLgx4XBwjhj+eE0f5t4KhVFn6BnnTYKLf79DfjVRntR5061qE9NZgx2ohvE+JLXe/FWfCaAA==",
+      "version": "4.40.0",
+      "resolved": "https://registry.npmjs.org/exifreader/-/exifreader-4.40.0.tgz",
+      "integrity": "sha512-0PE+68c0Bf6XwOZUyKUaA+25r4vf96HVsbbq+ImlcDgKOWFNypqiKJE0zC9SzRXDdk8+GcnC8HphZeHIUEniqQ==",
       "hasInstallScript": true,
       "license": "MPL-2.0",
       "optionalDependencies": {
@@ -12540,9 +12540,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary

Clears all outstanding `npm audit` findings (was 2 moderate + 1 high, now **0 vulnerabilities**). All three fixes fall within the existing semver ranges in `package.json`, so this is a lockfile-only change with no `package.json` edits and no breaking bumps.

| Package | Severity | Before | After | Advisory |
|---|---|---|---|---|
| `exifreader` | high | 4.38.1 | 4.40.0 | DoS via crafted ICC `mluc` tag ([GHSA-h64w-w9pr-82m4](https://github.com/advisories/GHSA-h64w-w9pr-82m4)) + unbounded metadata decompression ([GHSA-rr89-w3h9-m66j](https://github.com/advisories/GHSA-rr89-w3h9-m66j)) |
| `ws` | moderate | 8.20.0 | 8.21.0 | uninitialized memory disclosure ([GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx)) |
| `brace-expansion` | moderate | 5.0.5 | 5.0.6 | `max` DoS bypass ([GHSA-jxxr-4gwj-5jf2](https://github.com/advisories/GHSA-jxxr-4gwj-5jf2)) |

`exifreader` is the only production-facing dependency here (photo EXIF parsing); `ws` and `brace-expansion` are dev/tooling-only transitive deps.

## How it was done

Ran `npm audit fix --package-lock-only`. The diff is purely `version`/`resolved`/`integrity` field updates — nothing structural.

## Test plan

- [x] `npm audit` → 0 vulnerabilities
- [ ] CI: `npm install` syncs `node_modules` to the lockfile, then build / `npm run test:unit` confirm `exifreader` 4.40.0 behaves identically