### PR TITLE
chore(species-id): bump species-range-index to v0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,8 +4457,8 @@ dependencies = [
 
 [[package]]
 name = "species-range-index"
-version = "0.1.0"
-source = "git+https://github.com/observ-ing/species-range-index?tag=v0.1.0#435fc8363b228d31b3104491893a0ef4c64908ef"
+version = "0.5.0"
+source = "git+https://github.com/observ-ing/species-range-index?tag=v0.5.0#c63b07308cf7f036ce53fa38466b9423dc2e258b"
 dependencies = [
  "bytemuck",
  "h3o",

--- a/crates/observing-species-id/Cargo.toml
+++ b/crates/observing-species-id/Cargo.toml
@@ -39,7 +39,7 @@ chrono = { workspace = true }
 base64 = "0.22"
 
 # Cell→ID geo index (geo-prior reranking over H3 cells)
-species-range-index = { git = "https://github.com/observ-ing/species-range-index", tag = "v0.1.0" }
+species-range-index = { git = "https://github.com/observ-ing/species-range-index", tag = "v0.5.0" }
 
 # Zero-copy embedding load
 bytemuck = { version = "1", features = ["derive"] }


### PR DESCRIPTION
Follow-up to #550. Bumps the `species-range-index` git dependency from `v0.1.0` to `v0.5.0`.

Since #550 extracted the crate, the dedicated repo gained (all additive):
- `v0.2.0` metadata getters + PyO3 bindings
- `v0.3.0` / `v0.4.0` the canonical OGI1 writer (Rust + Python)
- `v0.5.0` bundled type stubs

core only uses the reader (`load` + `ids_at`), which is unchanged, so this is a straight version bump. `cargo test -p observing-species-id` + `fmt` pass; `Cargo.lock` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)