### PR TITLE
chore(deps): upgrade sqlx 0.8 → 0.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,10 +258,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
-          # Pinned: sqlx-cli 0.9.0 requires rustc >=1.94; we pin to 1.93
-          # in rust-toolchain.toml. Workspace uses sqlx 0.8.x, so 0.8.6
+          # Pinned: sqlx-cli 0.9.0 requires rustc >=1.94, matching the
+          # rust-toolchain.toml pin. Workspace uses sqlx 0.9.x, so 0.9.0
           # matches. Bump in lockstep when the toolchain pin moves.
-          tool: sqlx-cli@0.8.6
+          tool: sqlx-cli@0.9.0
           no-default-features: true
           features: postgres
       - run: cargo sqlx prepare --workspace --check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,18 +252,42 @@ jobs:
 
   rust-sqlx:
     runs-on: ubuntu-latest
+    # sqlx-cli 0.9 `prepare --check` requires a live database connection; the
+    # offline-without-DB mode that 0.8.x supported is gone. Stand up the same
+    # Postgres service the e2e/test jobs use and run migrations first so the
+    # query macros can re-describe against the real schema.
+    services:
+      postgres:
+        image: postgis/postgis:16-3.4
+        env:
+          POSTGRES_DB: observing
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/observing
     steps:
       - uses: actions/checkout@v4
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
-          # Pinned: sqlx-cli 0.9.0 requires rustc >=1.94, matching the
+          # Pinned: sqlx-cli 0.9.0 requires rustc >=1.94, satisfied by the
           # rust-toolchain.toml pin. Workspace uses sqlx 0.9.x, so 0.9.0
           # matches. Bump in lockstep when the toolchain pin moves.
           tool: sqlx-cli@0.9.0
           no-default-features: true
           features: postgres
+      - name: Run database migrations
+        # Sets the database-level search_path (ingester, appview, public) so
+        # the unqualified table names in the query macros resolve.
+        run: sqlx migrate run --source crates/observing-db/migrations
       - run: cargo sqlx prepare --workspace --check
 
   rust-lexicons-check:
@@ -321,7 +345,7 @@ jobs:
       - uses: taiki-e/cache-cargo-install-action@v3
         with:
           # See rust-sqlx job above for rationale on the version pin.
-          tool: sqlx-cli@0.8.6
+          tool: sqlx-cli@0.9.0
           no-default-features: true
           features: postgres
       - name: Run database migrations and seed

--- a/.sqlx/query-012aeae018864df6a7286e5f1e6ad8b3f577ca591cc2904bfa2977b9b98d91d1.json
+++ b/.sqlx/query-012aeae018864df6a7286e5f1e6ad8b3f577ca591cc2904bfa2977b9b98d91d1.json
@@ -6,92 +6,200 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "subject_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "subject_cid"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "identification_qualifier",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "identification_qualifier"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "identification_verification_status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "identification_verification_status"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "type_status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "type_status"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "date_identified",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "date_identified"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "genus"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-0f8dc0519fbe72c26f1fdc38dac8393ad8ee34d501e1fb384bf1e9016418ab81.json
+++ b/.sqlx/query-0f8dc0519fbe72c26f1fdc38dac8393ad8ee34d501e1fb384bf1e9016418ab81.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "community_ids",
+            "name": "scientific_name"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-1c11b4452dee3386eb3259fc4f43e6fce9b1bea147babf26df5dfaffebf8a01d.json
+++ b/.sqlx/query-1c11b4452dee3386eb3259fc4f43e6fce9b1bea147babf26df5dfaffebf8a01d.json
@@ -6,12 +6,19 @@
       {
         "ordinal": 0,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "likes",
+            "name": "subject_uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "count",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-2314feb90c848f01b06e99b39a119853180baa7bafb8cef23b554cce967e8e7a.json
+++ b/.sqlx/query-2314feb90c848f01b06e99b39a119853180baa7bafb8cef23b554cce967e8e7a.json
@@ -6,17 +6,35 @@
       {
         "ordinal": 0,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "user_preferences",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "default_license",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "user_preferences",
+            "name": "default_license"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "updated_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "user_preferences",
+            "name": "updated_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-25c520cc353d597aba224da8fe2ead8b114d8646499c7e34918976d924d2cab0.json
+++ b/.sqlx/query-25c520cc353d597aba224da8fe2ead8b114d8646499c7e34918976d924d2cab0.json
@@ -6,107 +6,213 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "event_date",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "event_date"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "latitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 6,
         "name": "longitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "coordinate_uncertainty_meters",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "coordinate_uncertainty_meters"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "associated_media",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "associated_media"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "recorded_by",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "recorded_by"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "genus"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "distance_meters",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 20,
         "name": "source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-29f43699a949bde40010b8223418bd4ee73103191e98ac3467f4933760676f26.json
+++ b/.sqlx/query-29f43699a949bde40010b8223418bd4ee73103191e98ac3467f4933760676f26.json
@@ -6,47 +6,101 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "subject_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "subject_cid"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "body",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "body"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "reply_to_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "reply_to_uri"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "reply_to_cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "reply_to_cid"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "created_at: chrono::DateTime<chrono::Utc>",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "comments",
+            "name": "created_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-2d9f4001b6b22468636ba540912b7f84e1a8b8a2b7a99097dbc006d4501fce6a.json
+++ b/.sqlx/query-2d9f4001b6b22468636ba540912b7f84e1a8b8a2b7a99097dbc006d4501fce6a.json
@@ -6,42 +6,85 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "recipient_did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "recipient_did"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "actor_did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "actor_did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "kind",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "kind"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "subject_uri"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "reference_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "reference_uri"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "read!: bool",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "created_at: DateTime<Utc>",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "created_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-440b0e267b51b2735bb100bfede0a18874f1c021ffb39eb8a692ce58f573c6b7.json
+++ b/.sqlx/query-440b0e267b51b2735bb100bfede0a18874f1c021ffb39eb8a692ce58f573c6b7.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count!",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-53b682bc34a8cae18fba78c0ae6f6e51ac2d1484f9075cdaebdc42cc4bf31418.json
+++ b/.sqlx/query-53b682bc34a8cae18fba78c0ae6f6e51ac2d1484f9075cdaebdc42cc4bf31418.json
@@ -6,42 +6,90 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "collection",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "collection"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "action",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "action"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "last_error",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "last_error"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "attempts",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "attempts"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "first_attempt_at: DateTime<Utc>",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "first_attempt_at"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "last_attempt_at: DateTime<Utc>",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "last_attempt_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-55e21c5cd9741166c798a2d8b43816de86a2652bccb58700ea30d7421bede2a6.json
+++ b/.sqlx/query-55e21c5cd9741166c798a2d8b43816de86a2652bccb58700ea30d7421bede2a6.json
@@ -6,107 +6,213 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "event_date",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "event_date"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "latitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 6,
         "name": "longitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "coordinate_uncertainty_meters",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "coordinate_uncertainty_meters"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "associated_media",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "associated_media"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "recorded_by",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "recorded_by"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "genus"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "distance_meters",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 20,
         "name": "source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-56b394891d771cf00d4e2ee9d7e5c6b3b72c3278f73299fcb00603cfaab32769.json
+++ b/.sqlx/query-56b394891d771cf00d4e2ee9d7e5c6b3b72c3278f73299fcb00603cfaab32769.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-607d2be0d4f3f6ea786a95ac8d983a3b698c22121e02654274e9afc22fc833f4.json
+++ b/.sqlx/query-607d2be0d4f3f6ea786a95ac8d983a3b698c22121e02654274e9afc22fc833f4.json
@@ -6,12 +6,24 @@
       {
         "ordinal": 0,
         "name": "occurrence_uri!",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "community_ids",
+            "name": "occurrence_uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "community_ids",
+            "name": "scientific_name"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-6a3a73c649d6c23699979c7f4cd88bcd9f76a6b16ebaa93e14711da7c44bd3ad.json
+++ b/.sqlx/query-6a3a73c649d6c23699979c7f4cd88bcd9f76a6b16ebaa93e14711da7c44bd3ad.json
@@ -6,107 +6,213 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "event_date",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "event_date"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "latitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 6,
         "name": "longitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "coordinate_uncertainty_meters",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "coordinate_uncertainty_meters"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "associated_media",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "associated_media"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "recorded_by",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "recorded_by"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "genus"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "distance_meters",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 20,
         "name": "source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-6fd011cf4a42f4a5d89416aa367e148ef56f3e4f268b0cd83352c04a30928d97.json
+++ b/.sqlx/query-6fd011cf4a42f4a5d89416aa367e148ef56f3e4f268b0cd83352c04a30928d97.json
@@ -6,37 +6,79 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "collection",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "collection"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "action",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "action"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "record_json",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "record_json"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "last_attempt_at!: DateTime<Utc>",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "failed_records",
+            "name": "last_attempt_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-8581ab35005155f6a02cb6d14030fe89b76225da5ab403f19579764ee1b46262.json
+++ b/.sqlx/query-8581ab35005155f6a02cb6d14030fe89b76225da5ab403f19579764ee1b46262.json
@@ -6,107 +6,213 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "event_date",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "event_date"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "latitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 6,
         "name": "longitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "coordinate_uncertainty_meters",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "coordinate_uncertainty_meters"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "associated_media",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "associated_media"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "recorded_by",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "recorded_by"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "genus"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "distance_meters",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 20,
         "name": "source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-90b182889123c2ab7ac7bc29641c377682603262140f5ad8e49c956a1af4ea87.json
+++ b/.sqlx/query-90b182889123c2ab7ac7bc29641c377682603262140f5ad8e49c956a1af4ea87.json
@@ -6,92 +6,200 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "subject_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "subject_cid"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "identification_qualifier",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "identification_qualifier"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "identification_verification_status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "identification_verification_status"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "type_status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "type_status"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "date_identified",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "date_identified"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "genus"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-93cddf856004d2fd523f897f48b17b30d21e0c6b44f13dab5b16b4b68a53b050.json
+++ b/.sqlx/query-93cddf856004d2fd523f897f48b17b30d21e0c6b44f13dab5b16b4b68a53b050.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "likes",
+            "name": "subject_uri"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-a0f6a08da6a6433205588ce42cab3014e611075a5b2f38681f5f02f2a3ce3bea.json
+++ b/.sqlx/query-a0f6a08da6a6433205588ce42cab3014e611075a5b2f38681f5f02f2a3ce3bea.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "value",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "oauth_sessions",
+            "name": "value"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-a18cb9f9dcd940df631c4744d64b6e4b6663d0acf63333e2bf1c98a9c6fbdbac.json
+++ b/.sqlx/query-a18cb9f9dcd940df631c4744d64b6e4b6663d0acf63333e2bf1c98a9c6fbdbac.json
@@ -6,92 +6,200 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "subject_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "subject_cid"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "identification_qualifier",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "identification_qualifier"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "identification_verification_status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "identification_verification_status"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "type_status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "type_status"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "date_identified",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "date_identified"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "genus"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-a18f97382781bc63b8fa7a5ebd137c40a377215045e4fbaddc0e6c6b72de0267.json
+++ b/.sqlx/query-a18f97382781bc63b8fa7a5ebd137c40a377215045e4fbaddc0e6c6b72de0267.json
@@ -6,72 +6,156 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "subject_a_occurrence_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_occurrence_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_a_taxon_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_taxon_name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "subject_a_kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_kingdom"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "subject_b_occurrence_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_occurrence_uri"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "subject_b_taxon_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_taxon_name"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "subject_b_kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_kingdom"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "interaction_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "interaction_type"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "direction",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "direction"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "comment",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "comment"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "indexed_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "indexed_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-a2dd890bb3d0dca5cfebf4b191ca6519eed3c85869df474e8c8149dfe379d4ab.json
+++ b/.sqlx/query-a2dd890bb3d0dca5cfebf4b191ca6519eed3c85869df474e8c8149dfe379d4ab.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "likes",
+            "name": "uri"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-ad9a1f33dd76c49bce53c7e316e9e0ac80065f528237525227c60b29438da4ee.json
+++ b/.sqlx/query-ad9a1f33dd76c49bce53c7e316e9e0ac80065f528237525227c60b29438da4ee.json
@@ -6,72 +6,156 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "subject_a_occurrence_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_occurrence_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_a_taxon_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_taxon_name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "subject_a_kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_kingdom"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "subject_b_occurrence_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_occurrence_uri"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "subject_b_taxon_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_taxon_name"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "subject_b_kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_kingdom"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "interaction_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "interaction_type"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "direction",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "direction"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "comment",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "comment"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "indexed_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "indexed_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-b3e236069e9762157daf2846a9f81816ed6af7fcc308b86f64bcd5af28476f37.json
+++ b/.sqlx/query-b3e236069e9762157daf2846a9f81816ed6af7fcc308b86f64bcd5af28476f37.json
@@ -6,7 +6,8 @@
       {
         "ordinal": 0,
         "name": "count",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-bd8e6f609aac49a1afcb690a275d88532a2eb0688348ef731214453943546719.json
+++ b/.sqlx/query-bd8e6f609aac49a1afcb690a275d88532a2eb0688348ef731214453943546719.json
@@ -6,107 +6,213 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "event_date",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "event_date"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "latitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 6,
         "name": "longitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "coordinate_uncertainty_meters",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "coordinate_uncertainty_meters"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "associated_media",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "associated_media"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "recorded_by",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "recorded_by"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "genus"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "distance_meters",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 20,
         "name": "source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-d1b7ed4e4c6111704aed426029cb837833651f0bfc9828577bdaf19f861057c9.json
+++ b/.sqlx/query-d1b7ed4e4c6111704aed426029cb837833651f0bfc9828577bdaf19f861057c9.json
@@ -6,42 +6,85 @@
       {
         "ordinal": 0,
         "name": "id",
-        "type_info": "Int8"
+        "type_info": "Int8",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "id"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "recipient_did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "recipient_did"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "actor_did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "actor_did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "kind",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "kind"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "subject_uri"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "reference_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "reference_uri"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "read!: bool",
-        "type_info": "Bool"
+        "type_info": "Bool",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "created_at: DateTime<Utc>",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "notifications",
+            "name": "created_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-d282892a66da0b07618c1443c5210e61e36d936871e5840197869b6b8d14ab43.json
+++ b/.sqlx/query-d282892a66da0b07618c1443c5210e61e36d936871e5840197869b6b8d14ab43.json
@@ -6,7 +6,13 @@
       {
         "ordinal": 0,
         "name": "value",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "oauth_state",
+            "name": "value"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-da60f067006f711414cc59fd19377b5435fefe6527680681bcda1af88b4c5eca.json
+++ b/.sqlx/query-da60f067006f711414cc59fd19377b5435fefe6527680681bcda1af88b4c5eca.json
@@ -6,22 +6,36 @@
       {
         "ordinal": 0,
         "name": "exact_latitude!",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 1,
         "name": "exact_longitude!",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 2,
         "name": "geoprivacy",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrence_private_data",
+            "name": "geoprivacy"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "effective_geoprivacy",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrence_private_data",
+            "name": "effective_geoprivacy"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-e244659cafe34c34bb75f976941a15a85a5ab102315cead747e945efa662dbf5.json
+++ b/.sqlx/query-e244659cafe34c34bb75f976941a15a85a5ab102315cead747e945efa662dbf5.json
@@ -6,92 +6,200 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "subject_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "subject_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "subject_cid"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "identification_qualifier",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "identification_qualifier"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "identification_verification_status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "identification_verification_status"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "type_status",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "type_status"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "date_identified",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "date_identified"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "identifications",
+            "name": "genus"
+          }
+        }
       }
     ],
     "parameters": {

--- a/.sqlx/query-e611a0eec458dc9f59d13e99eb6ac827383166b37b4f8f538d36542f3593ff7e.json
+++ b/.sqlx/query-e611a0eec458dc9f59d13e99eb6ac827383166b37b4f8f538d36542f3593ff7e.json
@@ -6,107 +6,213 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "event_date",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "event_date"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "latitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 6,
         "name": "longitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "coordinate_uncertainty_meters",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "coordinate_uncertainty_meters"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "associated_media",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "associated_media"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "recorded_by",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "recorded_by"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "genus"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "distance_meters",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 20,
         "name": "source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-f5774b8d2c1c5b603e5972d590027a2f657e5cb624d8237a12e864967bf7069e.json
+++ b/.sqlx/query-f5774b8d2c1c5b603e5972d590027a2f657e5cb624d8237a12e864967bf7069e.json
@@ -6,107 +6,213 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "scientific_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "scientific_name"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "event_date",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "event_date"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "latitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 6,
         "name": "longitude",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 7,
         "name": "coordinate_uncertainty_meters",
-        "type_info": "Int4"
+        "type_info": "Int4",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "coordinate_uncertainty_meters"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "associated_media",
-        "type_info": "Jsonb"
+        "type_info": "Jsonb",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "associated_media"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "recorded_by",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "recorded_by"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "taxon_id",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_id"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "taxon_rank",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "taxon_rank"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "kingdom"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "phylum",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "phylum"
+          }
+        }
       },
       {
         "ordinal": 14,
         "name": "class",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "class"
+          }
+        }
       },
       {
         "ordinal": 15,
         "name": "order_",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "order"
+          }
+        }
       },
       {
         "ordinal": 16,
         "name": "family",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "family"
+          }
+        }
       },
       {
         "ordinal": 17,
         "name": "genus",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "genus"
+          }
+        }
       },
       {
         "ordinal": 18,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 19,
         "name": "distance_meters",
-        "type_info": "Float8"
+        "type_info": "Float8",
+        "origin": "Expression"
       },
       {
         "ordinal": 20,
         "name": "source",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": "Expression"
       }
     ],
     "parameters": {

--- a/.sqlx/query-fb7b2f33b227f8f418b749c137eed629c6dcf73e50aba727fc9c0b693233eeac.json
+++ b/.sqlx/query-fb7b2f33b227f8f418b749c137eed629c6dcf73e50aba727fc9c0b693233eeac.json
@@ -6,72 +6,156 @@
       {
         "ordinal": 0,
         "name": "uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "uri"
+          }
+        }
       },
       {
         "ordinal": 1,
         "name": "cid",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "cid"
+          }
+        }
       },
       {
         "ordinal": 2,
         "name": "did",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "did"
+          }
+        }
       },
       {
         "ordinal": 3,
         "name": "subject_a_occurrence_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_occurrence_uri"
+          }
+        }
       },
       {
         "ordinal": 4,
         "name": "subject_a_taxon_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_taxon_name"
+          }
+        }
       },
       {
         "ordinal": 5,
         "name": "subject_a_kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_a_kingdom"
+          }
+        }
       },
       {
         "ordinal": 6,
         "name": "subject_b_occurrence_uri",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_occurrence_uri"
+          }
+        }
       },
       {
         "ordinal": 7,
         "name": "subject_b_taxon_name",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_taxon_name"
+          }
+        }
       },
       {
         "ordinal": 8,
         "name": "subject_b_kingdom",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "subject_b_kingdom"
+          }
+        }
       },
       {
         "ordinal": 9,
         "name": "interaction_type",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "interaction_type"
+          }
+        }
       },
       {
         "ordinal": 10,
         "name": "direction",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "direction"
+          }
+        }
       },
       {
         "ordinal": 11,
         "name": "comment",
-        "type_info": "Text"
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "comment"
+          }
+        }
       },
       {
         "ordinal": 12,
         "name": "created_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "created_at"
+          }
+        }
       },
       {
         "ordinal": 13,
         "name": "indexed_at",
-        "type_info": "Timestamptz"
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "interactions",
+            "name": "indexed_at"
+          }
+        }
       }
     ],
     "parameters": {

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,6 +767,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmov"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
+
+[[package]]
 name = "cobs"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1004,6 +1010,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctutils"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
+dependencies = [
+ "cmov",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1146,6 +1161,7 @@ dependencies = [
  "block-buffer 0.12.0",
  "const-oid 0.10.2",
  "crypto-common 0.2.1",
+ "ctutils",
 ]
 
 [[package]]
@@ -1259,13 +1275,12 @@ dependencies = [
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1363,9 +1378,9 @@ dependencies = [
 
 [[package]]
 name = "flume"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1712,11 +1727,11 @@ checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
-version = "0.10.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
 ]
 
 [[package]]
@@ -1829,11 +1844,11 @@ dependencies = [
 
 [[package]]
 name = "hkdf"
-version = "0.12.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+checksum = "4aaa26c720c68b866f2c96ef5c1264b3e6f473fe5d4ce61cd44bbe913e553018"
 dependencies = [
- "hmac",
+ "hmac 0.13.0",
 ]
 
 [[package]]
@@ -1846,19 +1861,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hmac"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "hmac-sha256"
 version = "1.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "http"
@@ -2452,9 +2467,6 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-dependencies = [
- "spin 0.9.8",
-]
 
 [[package]]
 name = "leb128fmt"
@@ -2483,18 +2495,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "libredox"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-dependencies = [
- "bitflags",
- "libc",
- "plain",
- "redox_syscall 0.7.5",
-]
 
 [[package]]
 name = "libsqlite3-sys"
@@ -2618,12 +2618,12 @@ dependencies = [
 
 [[package]]
 name = "md-5"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -2806,22 +2806,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-bigint-dig"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
-dependencies = [
- "lazy_static",
- "libm",
- "num-integer",
- "num-iter",
- "num-traits",
- "rand 0.8.6",
- "smallvec",
- "zeroize",
-]
-
-[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2846,24 +2830,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "num-iter"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
-dependencies = [
- "autocfg",
- "num-integer",
- "num-traits",
-]
-
-[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
- "libm",
 ]
 
 [[package]]
@@ -3177,7 +3149,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -3275,17 +3247,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
-name = "pkcs1"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
-dependencies = [
- "der 0.7.10",
- "pkcs8",
- "spki",
-]
-
-[[package]]
 name = "pkcs8"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3300,12 +3261,6 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "png"
@@ -3671,15 +3626,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.7.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3868,7 +3814,7 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
 dependencies = [
- "hmac",
+ "hmac 0.12.1",
  "subtle",
 ]
 
@@ -3884,26 +3830,6 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "rsa"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
-dependencies = [
- "const-oid 0.9.6",
- "digest 0.10.7",
- "num-bigint-dig",
- "num-integer",
- "num-traits",
- "pkcs1",
- "pkcs8",
- "rand_core 0.6.4",
- "signature",
- "spki",
- "subtle",
- "zeroize",
 ]
 
 [[package]]
@@ -4325,6 +4251,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4493,9 +4430,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+checksum = "378620ccc25c62c89d8be1c819e76a88d59bdcc3304733330788948e619bfd71"
 dependencies = [
  "sqlx-core",
  "sqlx-macros",
@@ -4506,12 +4443,13 @@ dependencies = [
 
 [[package]]
 name = "sqlx-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+checksum = "05b44e85bf579a8eeb4ceaa77a3a523baf2bf0e9bac7e40f405d537b5d2d5ccb"
 dependencies = [
  "base64",
  "bytes",
+ "cfg-if",
  "chrono",
  "crc",
  "crossbeam-queue",
@@ -4521,13 +4459,12 @@ dependencies = [
  "futures-intrusive",
  "futures-io",
  "futures-util",
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
  "hashlink",
  "indexmap",
  "log",
  "memchr",
  "native-tls",
- "once_cell",
  "percent-encoding",
  "serde",
  "serde_json",
@@ -4542,9 +4479,9 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+checksum = "bd2b84f2bc39a5705ef27ec785a11c934a41bbd4a24941e257927cddc26b60bf"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4555,15 +4492,15 @@ dependencies = [
 
 [[package]]
 name = "sqlx-macros-core"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+checksum = "fb8d96de5fdc85a5c4ec813432b523ec637e80ba98f046555f75f7908ddac7c3"
 dependencies = [
+ "cfg-if",
  "dotenvy",
  "either",
  "heck 0.5.0",
  "hex",
- "once_cell",
  "proc-macro2",
  "quote",
  "serde",
@@ -4574,58 +4511,43 @@ dependencies = [
  "sqlx-postgres",
  "sqlx-sqlite",
  "syn",
+ "thiserror 2.0.18",
  "tokio",
  "url",
 ]
 
 [[package]]
 name = "sqlx-mysql"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+checksum = "90b8020fe17c5f2c245bfa2505d7ef59c5604839527c740266ad2214acebea27"
 dependencies = [
- "atoi",
- "base64",
  "bitflags",
  "byteorder",
  "bytes",
  "chrono",
  "crc",
- "digest 0.10.7",
+ "digest 0.11.3",
  "dotenvy",
  "either",
- "futures-channel",
  "futures-core",
- "futures-io",
  "futures-util",
  "generic-array",
- "hex",
- "hkdf",
- "hmac",
- "itoa",
  "log",
- "md-5",
- "memchr",
- "once_cell",
  "percent-encoding",
- "rand 0.8.6",
- "rsa",
  "serde",
- "sha1",
- "sha2 0.10.9",
- "smallvec",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
  "sqlx-core",
- "stringprep",
  "thiserror 2.0.18",
  "tracing",
- "whoami",
 ]
 
 [[package]]
 name = "sqlx-postgres"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+checksum = "87a2bdd6e83f6b3ea525ca9fee568030508b58355a43d0b2c1674d5f79dcd65e"
 dependencies = [
  "atoi",
  "base64",
@@ -4640,17 +4562,15 @@ dependencies = [
  "futures-util",
  "hex",
  "hkdf",
- "hmac",
- "home",
+ "hmac 0.13.0",
  "itoa",
  "log",
  "md-5",
  "memchr",
- "once_cell",
- "rand 0.8.6",
+ "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "smallvec",
  "sqlx-core",
  "stringprep",
@@ -4661,13 +4581,14 @@ dependencies = [
 
 [[package]]
 name = "sqlx-sqlite"
-version = "0.8.6"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
  "chrono",
  "flume",
+ "form_urlencoded",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -4677,7 +4598,6 @@ dependencies = [
  "log",
  "percent-encoding",
  "serde",
- "serde_urlencoded",
  "sqlx-core",
  "thiserror 2.0.18",
  "tracing",
@@ -5239,7 +5159,7 @@ dependencies = [
  "rand 0.9.4",
  "rustls",
  "rustls-pki-types",
- "sha1",
+ "sha1 0.10.6",
  "thiserror 2.0.18",
  "utf-8",
 ]
@@ -5513,12 +5433,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5660,13 +5574,9 @@ dependencies = [
 
 [[package]]
 name = "whoami"
-version = "1.6.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
-dependencies = [
- "libredox",
- "wasite",
-]
+checksum = "998767ef88740d1f5b0682a9c53c24431453923962269c2db68ee43788c5a40d"
 
 [[package]]
 name = "widestring"
@@ -5787,15 +5697,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -5819,21 +5720,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -5871,12 +5757,6 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -5889,12 +5769,6 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -5904,12 +5778,6 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -5937,12 +5805,6 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -5952,12 +5814,6 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -5973,12 +5829,6 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -5988,12 +5838,6 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ reqwest = { version = "0.13", features = ["json"] }
 tapped = "0.3"
 
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "tls-native-tls", "postgres", "chrono"] }
+sqlx = { version = "0.9", features = ["runtime-tokio", "tls-native-tls", "postgres", "chrono"] }
 
 # Logging
 tracing = "0.1"

--- a/crates/axum-admin/src/lib.rs
+++ b/crates/axum-admin/src/lib.rs
@@ -276,7 +276,9 @@ async fn list(
         offset = offset,
     );
 
-    let mut query = sqlx::query_scalar::<_, JsonValue>(&sql);
+    // SQL is built from whitelisted, `quote_ident`-quoted identifiers with all
+    // values bound via `$1`, so the dynamic string is safe to assert.
+    let mut query = sqlx::query_scalar::<_, JsonValue>(sqlx::AssertSqlSafe(sql));
     if let Some(s) = &search_param {
         query = query.bind(s);
     }
@@ -316,7 +318,8 @@ async fn detail(
         tbl = quote_ident(&table),
         pk = quote_ident(pk),
     );
-    let row: Option<JsonValue> = sqlx::query_scalar(&sql)
+    // Identifiers are `quote_ident`-quoted and the pk value is bound via `$1`.
+    let row: Option<JsonValue> = sqlx::query_scalar(sqlx::AssertSqlSafe(sql))
         .bind(&pk_value)
         .fetch_optional(&admin.pool)
         .await?;

--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -69,7 +69,7 @@ pub async fn get_explore_feed(
 
 /// Push a WHERE clause matching [`crate::quality::compute_issues`] returning
 /// an empty list for the row. Keep these two in sync.
-fn push_quality_filter(qb: &mut QueryBuilder<'_, Postgres>, quality: QualityFilter) {
+fn push_quality_filter(qb: &mut QueryBuilder<Postgres>, quality: QualityFilter) {
     match quality {
         QualityFilter::Complete => {
             qb.push(" AND event_date IS NOT NULL");
@@ -342,11 +342,7 @@ pub async fn count_occurrences_by_taxon(
 /// not whatever the submitter typed into their occurrence record.
 /// Submitters routinely leave higher-rank columns blank, so filtering on
 /// `occurrences.kingdom` directly drops legitimate observations.
-fn push_consensus_rank_filter<'a>(
-    qb: &mut QueryBuilder<'a, Postgres>,
-    rank_lower: &str,
-    taxon_name: &'a str,
-) {
+fn push_consensus_rank_filter(qb: &mut QueryBuilder<Postgres>, rank_lower: &str, taxon_name: &str) {
     let column = match rank_lower {
         "species" | "subspecies" | "variety" => "t.species",
         "genus" => "t.genus",

--- a/crates/observing-db/src/taxa.rs
+++ b/crates/observing-db/src/taxa.rs
@@ -55,7 +55,8 @@ pub async fn get_by_key(
     taxon_key: i64,
 ) -> Result<Option<TaxonRow>, sqlx::Error> {
     let sql = format!("SELECT {SELECT_COLUMNS} FROM taxa WHERE taxon_key = $1");
-    sqlx::query_as::<_, TaxonRow>(&sql)
+    // `sql` interpolates only the static `SELECT_COLUMNS` const; the key is bound.
+    sqlx::query_as::<_, TaxonRow>(sqlx::AssertSqlSafe(sql))
         .bind(taxon_key)
         .fetch_optional(executor)
         .await
@@ -80,7 +81,8 @@ pub async fn get_by_name(
            ORDER BY (status = 'ACCEPTED') DESC, taxon_key ASC
            LIMIT 1"#
     );
-    sqlx::query_as::<_, TaxonRow>(&sql)
+    // `sql` interpolates only the static `SELECT_COLUMNS` const; values are bound.
+    sqlx::query_as::<_, TaxonRow>(sqlx::AssertSqlSafe(sql))
         .bind(scientific_name)
         .bind(kingdom_hint)
         .fetch_optional(executor)

--- a/crates/observing-resolve-taxa/src/main.rs
+++ b/crates/observing-resolve-taxa/src/main.rs
@@ -138,20 +138,22 @@ where
     if let Some(limit) = cli.limit {
         q.push_str(&format!(" LIMIT {limit}"));
     }
-    let pairs: Vec<(String, Option<String>)> = match sqlx::query(&q).fetch_all(pool).await {
-        Ok(rows) => rows
-            .into_iter()
-            .map(|r| {
-                let name: String = r.get("scientific_name");
-                let kingdom: Option<String> = r.try_get("kingdom").ok();
-                (name, kingdom)
-            })
-            .collect(),
-        Err(e) => {
-            error!(error = %e, "Failed to enumerate identifications needing resolution");
-            return Err(std::process::ExitCode::from(1));
-        }
-    };
+    // `q` is a static query plus an optional `LIMIT` from the typed `cli.limit` integer.
+    let pairs: Vec<(String, Option<String>)> =
+        match sqlx::query(sqlx::AssertSqlSafe(q)).fetch_all(pool).await {
+            Ok(rows) => rows
+                .into_iter()
+                .map(|r| {
+                    let name: String = r.get("scientific_name");
+                    let kingdom: Option<String> = r.try_get("kingdom").ok();
+                    (name, kingdom)
+                })
+                .collect(),
+            Err(e) => {
+                error!(error = %e, "Failed to enumerate identifications needing resolution");
+                return Err(std::process::ExitCode::from(1));
+            }
+        };
 
     info!(
         pairs = pairs.len(),

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.94"
+channel = "1.95"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.93"
+channel = "1.94"


### PR DESCRIPTION
## What

Upgrades sqlx to the latest release, **0.9.0** (from 0.8.6).

## Breaking changes handled

- **MSRV bump**: sqlx 0.9 requires Rust ≥ 1.94, so `rust-toolchain.toml` moves `1.93` → `1.94` and the pinned `sqlx-cli` in CI moves `0.8.6` → `0.9.0` to match.
- **`SqlSafeStr` requirement**: `query*()` no longer accept `&String`. The handful of intentionally-dynamic, audited SQL sites are now wrapped in `sqlx::AssertSqlSafe(...)` (identifiers go through `quote_ident`/whitelists; all values are bound). Affected: `axum-admin`, `observing-db/taxa.rs`, `observing-resolve-taxa`.
- **`QueryBuilder` lost its lifetime parameter**: `QueryBuilder<'_, Postgres>` → `QueryBuilder<Postgres>` in `observing-db/feeds.rs`, with the corresponding lifetime simplification in `push_consensus_rank_filter`.

## Other

- Regenerated the `.sqlx` query cache against the live schema — 0.9 adds a per-column `origin` field (improved nullability inference). Needed for `cargo sqlx prepare --workspace --check` to stay green.
- `Cargo.lock` regenerated (drops `rsa`/`num-bigint-dig`, bumps `whoami`, etc.).

## Verification

- `cargo check --locked --workspace` ✅
- `cargo clippy --workspace -- -D warnings` ✅
- `cargo test --workspace` ✅
- `cargo sqlx prepare --workspace --check` (offline, as CI runs it) ✅
- `cargo fmt --all -- --check` ✅
- `cargo deny check` ✅