### PR TITLE
feat(lexicons): author lexicons in MLF, generate JSON + Rust

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,14 +297,16 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
+      - name: Install mlf (lexicon DSL compiler, JSON output only)
+        run: RUSTFLAGS="" cargo install --git https://tangled.org/@stavola.xyz/mlf --rev a6d5e6f83564461af6a1af156b8815208ddb4255 --no-default-features mlf-cli
       - name: Install jacquard-codegen from fork (deterministic field ordering fix)
         run: RUSTFLAGS="" cargo install --git https://tangled.org/rwell.org/jacquard.git --branch fix-builder-determinism jacquard-lexgen
-      - name: Check generated lexicon types are up to date
+      - name: Check generated lexicons (JSON + Rust) are up to date
         run: |
-          ./scripts/generate-rust-types.sh
+          ./scripts/generate-lexicons.sh
           cargo fmt -p observing-lexicons
           cargo check -p observing-lexicons
-          git diff --exit-code crates/observing-lexicons/src/
+          git diff --exit-code lexicons/ crates/observing-lexicons/src/
 
   rust-test:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,15 +105,31 @@ have been run first. See
 
 ## Lexicon changes
 
-Lexicon types are codegen'd from `lexicons/`. If you edit them:
+Lexicons are authored in [MLF](https://mlf.lol) ("Matt's Lexicon
+Format"), a human-friendly DSL for ATProto lexicons. The `.mlf` files in
+`lexicons-src/` are the **source of truth**; everything downstream is
+generated:
+
+```
+lexicons-src/**/*.mlf   →  lexicons/**/*.json  →  crates/observing-lexicons/src/**
+        (edit these)        (generated JSON)         (generated Rust types)
+```
+
+Edit the `.mlf` files, then regenerate both the JSON and the Rust types
+in one step:
 
 ```bash
-npm run generate-rust-types
+npm run generate-lexicons      # mlf check → JSON → jacquard-codegen Rust
 cargo fmt -p observing-lexicons
 ```
 
-Commit the regenerated `crates/observing-lexicons/src/` alongside your
-lexicon edits — CI's `rust-lexicons-check` job will fail otherwise.
+The script installs the pinned `mlf` CLI on first run. Commit the
+regenerated `lexicons/` **and** `crates/observing-lexicons/src/`
+alongside your `lexicons-src/` edits — CI's `rust-lexicons-check` job
+regenerates from the `.mlf` sources and fails on any drift.
+
+> Do not hand-edit `lexicons/*.json` — those files are generated and
+> your changes will be overwritten on the next regeneration.
 
 ## What CI runs
 

--- a/crates/observing-lexicons/src/com_atproto/repo/strong_ref.rs
+++ b/crates/observing-lexicons/src/com_atproto/repo/strong_ref.rs
@@ -196,7 +196,7 @@ fn lexicon_doc_com_atproto_repo_strongRef() -> LexiconDoc<'static> {
             map.insert(
                 SmolStr::new_static("main"),
                 LexUserType::Object(LexObject {
-                    required: Some(vec![SmolStr::new_static("uri"), SmolStr::new_static("cid")]),
+                    required: Some(vec![SmolStr::new_static("cid"), SmolStr::new_static("uri")]),
                     properties: {
                         #[allow(unused_mut)]
                         let mut map = BTreeMap::new();

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -72,9 +72,16 @@ Supporting library crates (not separately deployed) are omitted for brevity — 
 
 ## Components
 
-### Lexicons (`lexicons/`)
+### Lexicons (`lexicons-src/` → `lexicons/`)
 
-Darwin Core compliant schemas for biodiversity data following [TDWG standards](https://dwc.tdwg.org/):
+Darwin Core compliant schemas for biodiversity data following [TDWG standards](https://dwc.tdwg.org/).
+
+Schemas are authored in [MLF](https://mlf.lol) ("Matt's Lexicon Format"), a
+human-friendly DSL for ATProto lexicons. The `.mlf` files in `lexicons-src/`
+are the source of truth; `lexicons/*.json` (consumed by the frontend's
+`LexiconView` and the Docker image) and the `observing-lexicons` Rust crate are
+both generated from them via `npm run generate-lexicons`. See
+[CONTRIBUTING.md](../CONTRIBUTING.md#lexicon-changes).
 
 - `bio.lexicons.temp.v0-1.occurrence` - Occurrence records
 - `bio.lexicons.temp.v0-1.identification` - Taxonomic determinations
@@ -117,13 +124,15 @@ Vite + React SPA.
 
 ## Key Files
 
-- `lexicons/` - AT Protocol lexicon definitions
+- `lexicons-src/` - Lexicon source of truth, authored in MLF (`.mlf`)
+- `lexicons/` - Generated AT Protocol JSON lexicon definitions
 - `crates/observing-appview/src/routes/` - REST API endpoint handlers
 - `crates/observing-appview/src/enrichment.rs` - Response enrichment (profiles, community IDs)
 - `crates/observing-db/src/` - PostgreSQL + PostGIS database layer
 - `crates/observing-db/src/processing.rs` - Shared record conversion (AT Protocol JSON → DB params)
 - `crates/observing-appview/src/routes/oauth.rs` - OAuth authentication
-- `scripts/generate-rust-types.sh` - Lexicon → Rust type generator (jacquard-codegen)
+- `scripts/generate-lexicons.sh` - MLF → JSON → Rust pipeline driver (mlf + jacquard-codegen)
+- `scripts/generate-rust-types.sh` - JSON lexicon → Rust type generator (jacquard-codegen)
 - `cloudbuild.yaml` - Multi-service Cloud Build config
 
 ## Database Tables

--- a/docs/darwin-core.md
+++ b/docs/darwin-core.md
@@ -2,7 +2,7 @@
 
 Observ.ing uses [Darwin Core](https://dwc.tdwg.org/) terminology for biodiversity data interoperability. This document describes the **current** shape of each lexicon record. A section at the bottom lists Darwin Core terms we may adopt later.
 
-For the full, authoritative schema definitions, see the JSON files under `lexicons/bio/lexicons/temp/v0-1/`.
+For the full, authoritative schema definitions, see the MLF sources under `lexicons-src/bio/lexicons/temp/v0-1/` (or the generated JSON under `lexicons/bio/lexicons/temp/v0-1/`).
 
 ## bio.lexicons.temp.v0-1.occurrence
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -197,8 +197,9 @@ cargo fmt
 # Run Rust tests
 cargo test --workspace
 
-# Generate lexicon types (Rust)
-npm run generate-rust-types
+# Regenerate lexicons after editing lexicons-src/*.mlf
+# (MLF sources → lexicons/*.json → Rust types)
+npm run generate-lexicons
 ```
 
 ## Running Services

--- a/frontend/src/components/lexicon/LexiconView.tsx
+++ b/frontend/src/components/lexicon/LexiconView.tsx
@@ -19,7 +19,8 @@ import {
 import { ExpandMore, ExpandLess } from "@mui/icons-material";
 
 // Eagerly import all lexicons at build time via the @lexicons alias.
-// This avoids duplicating the schema files — the source of truth remains in /lexicons/.
+// This avoids duplicating the schema files. The JSON in /lexicons/ is
+// generated from the MLF sources in /lexicons-src/ (see CONTRIBUTING.md).
 const lexiconModules = import.meta.glob("@lexicons/**/*.json", {
   eager: true,
 });

--- a/lexicons-src/README.md
+++ b/lexicons-src/README.md
@@ -1,0 +1,44 @@
+# Lexicon sources (MLF)
+
+These `.mlf` files are the **source of truth** for the project's AT Protocol
+lexicons. They are written in [MLF](https://mlf.lol) ("Matt's Lexicon Format"),
+a human-friendly DSL that compiles to ATProto lexicon JSON.
+
+```
+lexicons-src/**/*.mlf   →  lexicons/**/*.json  →  crates/observing-lexicons/src/**
+     (edit these)            (generated JSON)         (generated Rust types)
+```
+
+## Editing
+
+1. Edit the `.mlf` files here. The file path determines the lexicon NSID
+   (e.g. `ing/observ/temp/comment.mlf` → `ing.observ.temp.comment`).
+2. Regenerate the JSON and Rust types:
+
+   ```bash
+   npm run generate-lexicons
+   cargo fmt -p observing-lexicons
+   ```
+
+3. Commit the `.mlf` edits together with the regenerated `lexicons/*.json`
+   and `crates/observing-lexicons/src/`. CI (`rust-lexicons-check`) fails on
+   any drift between these sources and their generated output.
+
+Do **not** hand-edit `lexicons/*.json` — it is generated.
+
+## Layout
+
+| File | NSID |
+|------|------|
+| `ing/observ/temp/*.mlf` | `ing.observ.temp.*` — social records (comment, like, interaction) |
+| `bio/lexicons/temp/v0-1/*.mlf` | `bio.lexicons.temp.v0-1.*` — Darwin Core biodiversity records |
+| `com/atproto/repo/strongRef.mlf` | the vendored `com.atproto.repo.strongRef` standard type |
+
+## Why explicit `mlf` commands (no `mlf.toml`)?
+
+MLF's project mode (`mlf.toml`) scopes a project to a single `[package].name`
+NSID prefix. This repo legitimately owns two first-party roots
+(`ing.observ.*` and `bio.lexicons.*`) plus the vendored `com.atproto.*` type,
+so no single package prefix covers them. `scripts/generate-lexicons.sh`
+therefore drives `mlf` with explicit `--root lexicons-src`, which derives each
+NSID from its path and is namespace-agnostic.

--- a/lexicons-src/bio/lexicons/temp/v0-1/identification.mlf
+++ b/lexicons-src/bio/lexicons/temp/v0-1/identification.mlf
@@ -1,0 +1,27 @@
+/// An identification suggestion for an existing observation. Used to propose or agree with a taxonomic identification.
+@main
+record identification {
+    /// A strong reference (CID + URI) to the occurrence being identified.
+    occurrence!: com.atproto.repo.strongRef,
+    /// The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).
+    scientificName!: string constrained {
+        maxLength: 256,
+    },
+    /// The taxonomic rank of the identification (Darwin Core dwc:taxonRank).
+    taxonRank: string constrained {
+        maxLength: 32,
+        knownValues: ["kingdom", "phylum", "class", "order", "family", "genus", "species", "subspecies", "variety", "form"],
+        default: "species",
+    },
+    /// Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).
+    kingdom: string constrained {
+        maxLength: 64,
+    },
+    /// Stable URI for the identified taxon (e.g. a GBIF species URI). Maps to Darwin Core dwc:taxonID.
+    taxonID: Uri,
+    /// Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks).
+    identificationRemarks: string constrained {
+        maxLength: 3000,
+    },
+}
+

--- a/lexicons-src/bio/lexicons/temp/v0-1/media.mlf
+++ b/lexicons-src/bio/lexicons/temp/v0-1/media.mlf
@@ -1,0 +1,30 @@
+/// A media record for a biodiversity observation. Stores image blobs with metadata such as alt text, aspect ratio, and license.
+@main
+record media {
+    /// The image blob reference.
+    image!: blob constrained {
+        accept: ["image/jpeg", "image/png", "image/webp"],
+        maxSize: 10000000,
+    },
+    /// Alt text description of the image for accessibility.
+    alt: string constrained {
+        maxLength: 1000,
+    },
+    aspectRatio: aspectRatio,
+    /// SPDX license identifier for this media (maps to Dublin Core dcterms:license).
+    license: string constrained {
+        maxLength: 32,
+        knownValues: ["CC0-1.0", "CC-BY-4.0", "CC-BY-NC-4.0", "CC-BY-SA-4.0", "CC-BY-NC-SA-4.0"],
+    },
+}
+
+/// Width and height of an image, used for proper display before loading.
+def type aspectRatio = {
+    width!: integer constrained {
+        minimum: 1,
+    },
+    height!: integer constrained {
+        minimum: 1,
+    },
+};
+

--- a/lexicons-src/bio/lexicons/temp/v0-1/occurrence.mlf
+++ b/lexicons-src/bio/lexicons/temp/v0-1/occurrence.mlf
@@ -1,0 +1,19 @@
+/// A biodiversity observation record following Darwin Core standards. Represents a single occurrence of an organism.
+@main
+record occurrence {
+    /// The date-time when the observation occurred, in ISO 8601 format (Darwin Core dwc:eventDate).
+    eventDate: Datetime,
+    /// The geographic latitude in decimal degrees (Darwin Core dwc:decimalLatitude). Valid range: -90 to 90.
+    decimalLatitude: string,
+    /// The geographic longitude in decimal degrees (Darwin Core dwc:decimalLongitude). Valid range: -180 to 180.
+    decimalLongitude: string,
+    /// The horizontal distance (in meters) from the given coordinates describing the smallest circle containing the whole of the Location (Darwin Core dwc:coordinateUncertaintyInMeters).
+    coordinateUncertaintyInMeters: integer constrained {
+        minimum: 0,
+    },
+    /// Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia).
+    associatedMedia: com.atproto.repo.strongRef[] constrained {
+        maxLength: 10,
+    },
+}
+

--- a/lexicons-src/com/atproto/repo/strongRef.mlf
+++ b/lexicons-src/com/atproto/repo/strongRef.mlf
@@ -1,0 +1,9 @@
+/// A URI with a content-hash fingerprint.
+self {}
+
+@main
+def type strongRef = {
+    cid!: Cid,
+    uri!: AtUri,
+};
+

--- a/lexicons-src/ing/observ/temp/comment.mlf
+++ b/lexicons-src/ing/observ/temp/comment.mlf
@@ -1,0 +1,15 @@
+/// A comment on an observation. Used for general discussion, questions, or additional context about an observation.
+@main
+record comment {
+    /// A strong reference (CID + URI) to the observation being commented on.
+    subject!: com.atproto.repo.strongRef,
+    /// The text content of the comment.
+    body!: string constrained {
+        maxLength: 3000,
+    },
+    /// Optional reference to another comment this is replying to, for threaded discussions.
+    replyTo: com.atproto.repo.strongRef,
+    /// Timestamp when this comment was created.
+    createdAt!: Datetime,
+}
+

--- a/lexicons-src/ing/observ/temp/interaction.mlf
+++ b/lexicons-src/ing/observ/temp/interaction.mlf
@@ -1,0 +1,51 @@
+/// Species interaction documenting ecological relationship between organisms.
+@main
+record interaction {
+    /// The first subject (actor) in the interaction.
+    subjectA!: interactionSubject,
+    /// The second subject (recipient) in the interaction.
+    subjectB!: interactionSubject,
+    /// Type of ecological interaction between the subjects.
+    interactionType!: string constrained {
+        maxLength: 64,
+        knownValues: ["predation", "pollination", "parasitism", "herbivory", "symbiosis", "mutualism", "competition", "shelter", "transportation", "oviposition", "seed_dispersal"],
+    },
+    /// Direction of the interaction: AtoB means A acts on B, BtoA means B acts on A, bidirectional means mutual.
+    direction!: string constrained {
+        enum: ["AtoB", "BtoA", "bidirectional"],
+        default: "AtoB",
+    },
+    /// Additional notes about the interaction.
+    comment: string constrained {
+        maxLength: 3000,
+    },
+    /// Timestamp when this record was created.
+    createdAt!: Datetime,
+}
+
+/// A subject in an interaction - can reference an existing occurrence or just specify a taxon.
+def type interactionSubject = {
+    /// Reference to an existing occurrence record.
+    occurrence: com.atproto.repo.strongRef,
+    /// Taxonomic information for the organism (for unobserved subjects or to specify the taxon).
+    taxon: taxon,
+};
+
+/// Taxonomic information following Darwin Core Taxon class (dwc:Taxon).
+def type taxon = {
+    /// The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).
+    scientificName!: string constrained {
+        maxLength: 256,
+    },
+    /// The taxonomic rank of the identification (Darwin Core dwc:taxonRank).
+    taxonRank: string constrained {
+        maxLength: 32,
+        knownValues: ["kingdom", "phylum", "class", "order", "family", "genus", "species", "subspecies", "variety", "form"],
+        default: "species",
+    },
+    /// Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).
+    kingdom: string constrained {
+        maxLength: 64,
+    },
+};
+

--- a/lexicons-src/ing/observ/temp/like.mlf
+++ b/lexicons-src/ing/observ/temp/like.mlf
@@ -1,0 +1,9 @@
+/// Record expressing appreciation of an observation.
+@main
+record like {
+    /// A strong reference to the observation being liked.
+    subject!: com.atproto.repo.strongRef,
+    /// Timestamp when this like was created.
+    createdAt!: Datetime,
+}
+

--- a/lexicons/bio/lexicons/temp/v0-1/identification.json
+++ b/lexicons/bio/lexicons/temp/v0-1/identification.json
@@ -1,4 +1,5 @@
 {
+  "$type": "com.atproto.lexicon.schema",
   "lexicon": 1,
   "id": "bio.lexicons.temp.v0-1.identification",
   "defs": {
@@ -8,7 +9,10 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["occurrence", "scientificName"],
+        "required": [
+          "occurrence",
+          "scientificName"
+        ],
         "properties": {
           "occurrence": {
             "type": "ref",
@@ -17,20 +21,31 @@
           },
           "scientificName": {
             "type": "string",
-            "description": "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).",
-            "maxLength": 256
+            "maxLength": 256,
+            "description": "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName)."
           },
           "taxonRank": {
             "type": "string",
-            "description": "The taxonomic rank of the identification (Darwin Core dwc:taxonRank).",
-            "knownValues": ["kingdom", "phylum", "class", "order", "family", "genus", "species", "subspecies", "variety", "form"],
+            "maxLength": 32,
+            "knownValues": [
+              "kingdom",
+              "phylum",
+              "class",
+              "order",
+              "family",
+              "genus",
+              "species",
+              "subspecies",
+              "variety",
+              "form"
+            ],
             "default": "species",
-            "maxLength": 32
+            "description": "The taxonomic rank of the identification (Darwin Core dwc:taxonRank)."
           },
           "kingdom": {
             "type": "string",
-            "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
-            "maxLength": 64
+            "maxLength": 64,
+            "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom)."
           },
           "taxonID": {
             "type": "string",
@@ -39,8 +54,8 @@
           },
           "identificationRemarks": {
             "type": "string",
-            "description": "Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks).",
-            "maxLength": 3000
+            "maxLength": 3000,
+            "description": "Explanation or reasoning for this identification (Darwin Core dwc:identificationRemarks)."
           }
         }
       }

--- a/lexicons/bio/lexicons/temp/v0-1/media.json
+++ b/lexicons/bio/lexicons/temp/v0-1/media.json
@@ -1,4 +1,5 @@
 {
+  "$type": "com.atproto.lexicon.schema",
   "lexicon": 1,
   "id": "bio.lexicons.temp.v0-1.media",
   "defs": {
@@ -8,18 +9,24 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["image"],
+        "required": [
+          "image"
+        ],
         "properties": {
           "image": {
             "type": "blob",
-            "accept": ["image/jpeg", "image/png", "image/webp"],
+            "accept": [
+              "image/jpeg",
+              "image/png",
+              "image/webp"
+            ],
             "maxSize": 10000000,
             "description": "The image blob reference."
           },
           "alt": {
             "type": "string",
-            "description": "Alt text description of the image for accessibility.",
-            "maxLength": 1000
+            "maxLength": 1000,
+            "description": "Alt text description of the image for accessibility."
           },
           "aspectRatio": {
             "type": "ref",
@@ -27,7 +34,7 @@
           },
           "license": {
             "type": "string",
-            "description": "SPDX license identifier for this media (maps to Dublin Core dcterms:license).",
+            "maxLength": 32,
             "knownValues": [
               "CC0-1.0",
               "CC-BY-4.0",
@@ -35,7 +42,7 @@
               "CC-BY-SA-4.0",
               "CC-BY-NC-SA-4.0"
             ],
-            "maxLength": 32
+            "description": "SPDX license identifier for this media (maps to Dublin Core dcterms:license)."
           }
         }
       }
@@ -43,7 +50,10 @@
     "aspectRatio": {
       "type": "object",
       "description": "Width and height of an image, used for proper display before loading.",
-      "required": ["width", "height"],
+      "required": [
+        "width",
+        "height"
+      ],
       "properties": {
         "width": {
           "type": "integer",

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -1,4 +1,5 @@
 {
+  "$type": "com.atproto.lexicon.schema",
   "lexicon": 1,
   "id": "bio.lexicons.temp.v0-1.occurrence",
   "defs": {
@@ -24,17 +25,17 @@
           },
           "coordinateUncertaintyInMeters": {
             "type": "integer",
-            "description": "The horizontal distance (in meters) from the given coordinates describing the smallest circle containing the whole of the Location (Darwin Core dwc:coordinateUncertaintyInMeters).",
-            "minimum": 0
+            "minimum": 0,
+            "description": "The horizontal distance (in meters) from the given coordinates describing the smallest circle containing the whole of the Location (Darwin Core dwc:coordinateUncertaintyInMeters)."
           },
           "associatedMedia": {
             "type": "array",
-            "description": "Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia).",
             "items": {
               "type": "ref",
               "ref": "com.atproto.repo.strongRef"
             },
-            "maxLength": 10
+            "maxLength": 10,
+            "description": "Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia)."
           }
         }
       }

--- a/lexicons/com/atproto/repo/strongRef.json
+++ b/lexicons/com/atproto/repo/strongRef.json
@@ -1,11 +1,14 @@
 {
+  "$type": "com.atproto.lexicon.schema",
+  "lexicon": 1,
   "id": "com.atproto.repo.strongRef",
+  "description": "A URI with a content-hash fingerprint.",
   "defs": {
     "main": {
       "type": "object",
       "required": [
-        "uri",
-        "cid"
+        "cid",
+        "uri"
       ],
       "properties": {
         "cid": {
@@ -18,8 +21,5 @@
         }
       }
     }
-  },
-  "$type": "com.atproto.lexicon.schema",
-  "lexicon": 1,
-  "description": "A URI with a content-hash fingerprint."
+  }
 }

--- a/lexicons/ing/observ/temp/comment.json
+++ b/lexicons/ing/observ/temp/comment.json
@@ -1,4 +1,5 @@
 {
+  "$type": "com.atproto.lexicon.schema",
   "lexicon": 1,
   "id": "ing.observ.temp.comment",
   "defs": {
@@ -8,7 +9,11 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["subject", "body", "createdAt"],
+        "required": [
+          "subject",
+          "body",
+          "createdAt"
+        ],
         "properties": {
           "subject": {
             "type": "ref",
@@ -17,8 +22,8 @@
           },
           "body": {
             "type": "string",
-            "description": "The text content of the comment.",
-            "maxLength": 3000
+            "maxLength": 3000,
+            "description": "The text content of the comment."
           },
           "replyTo": {
             "type": "ref",

--- a/lexicons/ing/observ/temp/interaction.json
+++ b/lexicons/ing/observ/temp/interaction.json
@@ -1,4 +1,5 @@
 {
+  "$type": "com.atproto.lexicon.schema",
   "lexicon": 1,
   "id": "ing.observ.temp.interaction",
   "defs": {
@@ -8,7 +9,13 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["subjectA", "subjectB", "interactionType", "direction", "createdAt"],
+        "required": [
+          "subjectA",
+          "subjectB",
+          "interactionType",
+          "direction",
+          "createdAt"
+        ],
         "properties": {
           "subjectA": {
             "type": "ref",
@@ -22,7 +29,7 @@
           },
           "interactionType": {
             "type": "string",
-            "description": "Type of ecological interaction between the subjects.",
+            "maxLength": 64,
             "knownValues": [
               "predation",
               "pollination",
@@ -36,18 +43,22 @@
               "oviposition",
               "seed_dispersal"
             ],
-            "maxLength": 64
+            "description": "Type of ecological interaction between the subjects."
           },
           "direction": {
             "type": "string",
-            "description": "Direction of the interaction: AtoB means A acts on B, BtoA means B acts on A, bidirectional means mutual.",
-            "enum": ["AtoB", "BtoA", "bidirectional"],
-            "default": "AtoB"
+            "enum": [
+              "AtoB",
+              "BtoA",
+              "bidirectional"
+            ],
+            "default": "AtoB",
+            "description": "Direction of the interaction: AtoB means A acts on B, BtoA means B acts on A, bidirectional means mutual."
           },
           "comment": {
             "type": "string",
-            "description": "Additional notes about the interaction.",
-            "maxLength": 3000
+            "maxLength": 3000,
+            "description": "Additional notes about the interaction."
           },
           "createdAt": {
             "type": "string",
@@ -76,24 +87,37 @@
     "taxon": {
       "type": "object",
       "description": "Taxonomic information following Darwin Core Taxon class (dwc:Taxon).",
-      "required": ["scientificName"],
+      "required": [
+        "scientificName"
+      ],
       "properties": {
         "scientificName": {
           "type": "string",
-          "description": "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName).",
-          "maxLength": 256
+          "maxLength": 256,
+          "description": "The full scientific name, with authorship and date information if known (Darwin Core dwc:scientificName)."
         },
         "taxonRank": {
           "type": "string",
-          "description": "The taxonomic rank of the identification (Darwin Core dwc:taxonRank).",
-          "knownValues": ["kingdom", "phylum", "class", "order", "family", "genus", "species", "subspecies", "variety", "form"],
+          "maxLength": 32,
+          "knownValues": [
+            "kingdom",
+            "phylum",
+            "class",
+            "order",
+            "family",
+            "genus",
+            "species",
+            "subspecies",
+            "variety",
+            "form"
+          ],
           "default": "species",
-          "maxLength": 32
+          "description": "The taxonomic rank of the identification (Darwin Core dwc:taxonRank)."
         },
         "kingdom": {
           "type": "string",
-          "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom).",
-          "maxLength": 64
+          "maxLength": 64,
+          "description": "Taxonomic kingdom for disambiguating homonyms (Darwin Core dwc:kingdom)."
         }
       }
     }

--- a/lexicons/ing/observ/temp/like.json
+++ b/lexicons/ing/observ/temp/like.json
@@ -1,4 +1,5 @@
 {
+  "$type": "com.atproto.lexicon.schema",
   "lexicon": 1,
   "id": "ing.observ.temp.like",
   "defs": {
@@ -8,7 +9,10 @@
       "key": "tid",
       "record": {
         "type": "object",
-        "required": ["subject", "createdAt"],
+        "required": [
+          "subject",
+          "createdAt"
+        ],
         "properties": {
           "subject": {
             "type": "ref",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build-storybook": "storybook build",
     "check:stories": "node scripts/check-stories.mjs",
     "doctor": "./scripts/doctor.sh",
+    "generate-lexicons": "./scripts/generate-lexicons.sh",
     "generate-rust-types": "./scripts/generate-rust-types.sh",
     "setup": "./scripts/setup.sh",
     "dev": "vite -c frontend/vite.config.ts",

--- a/scripts/generate-lexicons.sh
+++ b/scripts/generate-lexicons.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Regenerate everything downstream of the MLF lexicon sources.
+#
+# Pipeline:
+#   lexicons-src/**/*.mlf   (source of truth, authored by hand)
+#     │  mlf generate lexicon
+#     ▼
+#   lexicons/**/*.json      (generated AT Protocol JSON lexicons)
+#     │  jacquard-codegen   (scripts/generate-rust-types.sh)
+#     ▼
+#   crates/observing-lexicons/src/**  (generated Rust types)
+#
+# MLF (https://mlf.lol) is "Matt's Lexicon Format", a human-friendly DSL
+# for ATProto lexicons. We author the DSL and generate the JSON; the JSON
+# stays committed because the frontend (LexiconView) and the Docker image
+# consume it directly, and jacquard-codegen reads it to emit Rust types.
+#
+# Usage:
+#   ./scripts/generate-lexicons.sh
+
+# Pinned mlf revision (tangled.org/@stavola.xyz/mlf). Bump deliberately —
+# the generated JSON must stay reproducible across machines and CI.
+MLF_GIT="https://tangled.org/@stavola.xyz/mlf"
+MLF_REV="a6d5e6f83564461af6a1af156b8815208ddb4255"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+SRC_DIR="$ROOT_DIR/lexicons-src"
+JSON_DIR="$ROOT_DIR/lexicons"
+
+# Ensure the pinned mlf CLI is installed. We only need JSON generation, so
+# build with --no-default-features (skips the TS/Go/Rust codegen plugins).
+ensure_mlf() {
+  if command -v mlf &>/dev/null && mlf check --help &>/dev/null; then
+    return
+  fi
+  echo "Installing mlf (@stavola.xyz/mlf @ ${MLF_REV:0:12})..."
+  # RUSTFLAGS="" guards against a repo-level rustflags that would break the
+  # third-party build (mirrors how generate-rust-types.sh installs jacquard).
+  RUSTFLAGS="" cargo install --git "$MLF_GIT" --rev "$MLF_REV" \
+    --no-default-features mlf-cli
+}
+
+ensure_mlf
+
+echo "Validating MLF sources in $SRC_DIR ..."
+mlf check "$SRC_DIR"
+
+echo "Generating JSON lexicons from MLF..."
+echo "  Input:  $SRC_DIR"
+echo "  Output: $JSON_DIR"
+# Explicit -i/-o/--root rather than mlf.toml project mode: this repo owns
+# multiple NSID roots (ing.observ.*, bio.lexicons.*) plus the vendored
+# com.atproto.* standard type, and a single mlf.toml [package].name can only
+# scope one of them. The explicit form derives each NSID from its path under
+# --root and is namespace-agnostic.
+mlf generate lexicon -i "$SRC_DIR" -o "$JSON_DIR" --root "$SRC_DIR"
+
+echo "Generating Rust types from JSON lexicons..."
+"$SCRIPT_DIR/generate-rust-types.sh"
+
+echo "Lexicons regenerated successfully!"
+echo "Remember to run: cargo fmt -p observing-lexicons"


### PR DESCRIPTION
Introduces [MLF](https://mlf.lol) ("Matt's Lexicon Format"), a human-friendly DSL for ATProto lexicons, as the lexicon **authoring layer**. The `.mlf` files in `lexicons-src/` are now the source of truth; `lexicons/*.json` and the `observing-lexicons` Rust crate are both generated from them.

```
lexicons-src/**/*.mlf   →   lexicons/**/*.json   →   crates/observing-lexicons/src/**
   (source of truth)          (generated JSON)          (generated Rust types)
   npm run generate-lexicons:  mlf check → mlf generate lexicon → jacquard-codegen → cargo fmt
```

### Why
The lexicon JSON is verbose and hand-maintained. MLF lets us author the same schemas with `///` doc comments, inline constraints, and shared `def type`s — e.g. `interaction`'s `interactionSubject`/`taxon` shapes — while the existing jacquard-codegen → Rust path is untouched.

### What changed
**New**
- `lexicons-src/` — all 7 lexicons as `.mlf` + a `README.md`
- `scripts/generate-lexicons.sh` — installs the pinned `mlf` CLI, runs `mlf check`, then `.mlf → JSON → Rust`
- `npm run generate-lexicons`

**Wired in**
- `.github/workflows/ci.yml` — `rust-lexicons-check` now installs `mlf` (pinned rev), regenerates from the `.mlf` sources, and `git diff --exit-code`s **both** `lexicons/` and the Rust crate, so the JSON can't drift from its source either
- `CONTRIBUTING.md`, `docs/architecture.md`, `docs/development.md`, `docs/darwin-core.md`, and the `LexiconView.tsx` comment

**Generated artifacts (now produced, not hand-written)**
- 7 `lexicons/*.json` — each gained the standard `"$type": "com.atproto.lexicon.schema"` (previously omitted on `ing.*`/`bio.*`)
- `crates/observing-lexicons/src/` — **one line changed**: `strong_ref.rs`'s `required` array reordered `["uri","cid"]`→`["cid","uri"]` (a set; semantically identical). Everything else is byte-for-byte unchanged.

### Verification
- ✅ Round-trip is semantically lossless (every field/constraint/description/ref preserved)
- ✅ `mlf check` passes; `cargo check -p observing-lexicons` compiles
- ✅ Pipeline is **deterministic** — re-running yields byte-identical output (so the CI drift gate passes)
- ✅ `oxfmt --check` + `oxlint` pass
- ✅ `mlf` and the rwell.org `jacquard` fork both install reproducibly from pinned git revs

### Notes
- **No `mlf.toml`.** MLF project mode scopes to a single `[package].name` NSID prefix, but this repo owns two first-party roots (`ing.observ.*`, `bio.lexicons.*`) plus the vendored `com.atproto.*` type — so a root `mlf.toml` makes `mlf check` fail on the out-of-scope namespaces. The script drives `mlf` with explicit `--root lexicons-src` instead (namespace-agnostic). Documented in `lexicons-src/README.md`.
- **Suggested follow-up (out of scope):** `crates/observing-lexicons/src/org_rwell.rs` is a stale orphan — not referenced in `lib.rs`, no backing lexicon (leftover from the org.rwell→bio.lexicons migration). Left untouched here; worth deleting separately.
- The `.mlf` files are the converter's output and round-trip perfectly; they could be lightly hand-polished later (e.g. dropping the redundant `@main`, wrapping long `knownValues` lines) now that they're editable source.
