### PR TITLE
chore(appview): log the front-door URL + 127.0.0.1 OAuth note on startup

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -264,6 +264,18 @@ async fn main() {
 
     info!(port = config.port, "Listening");
 
+    // Surface the app's "front door" URL so humans (and tools) know where to
+    // open it. appview is always the front door on `PORT` — NOT the Vite dev
+    // server's :5173. In local dev the OAuth callback is registered at
+    // 127.0.0.1, so browsing at `localhost` breaks the session cookie origin.
+    match &config.public_url {
+        Some(url) => info!("Serving at {url}"),
+        None => info!(
+            "Open the app at http://127.0.0.1:{}  (use 127.0.0.1, not localhost, so OAuth callback cookies match)",
+            config.port
+        ),
+    }
+
     axum::serve(listener, app).await.expect("Server failed");
 }
 


### PR DESCRIPTION
## Motivation

There's recurring confusion about *which host/port to open* for the app:

- **appview is always the front door** on its configured `PORT` (default 3000). You open the app there, **not** at the Vite dev server's `:5173` (which appview proxies to behind the scenes).
- In **local dev** (no `PUBLIC_URL`), the OAuth callback is registered at `http://127.0.0.1:{port}/oauth/callback`, so you must browse at **`127.0.0.1`** — not `localhost` — for the session cookie origin to match.

None of this was surfaced at runtime; it lived only in `docs/development.md` and the OAuth client code (`state.rs`). A single startup log line fixes it for humans and tools alike.

## The change

Right after the existing `INFO ... "Listening" port=...` line in `crates/observing-appview/src/main.rs`, add one `info!`:

- **dev** (`public_url == None`): `Open the app at http://127.0.0.1:{port}  (use 127.0.0.1, not localhost, so OAuth callback cookies match)`
- **production-ish** (`public_url == Some(url)`): `Serving at {url}`

Log-only — no behavior, route, or config changes.

## Validation

- `cargo fmt`
- `cargo check -p observing-appview` (clean compile)