### PR TITLE
fix(appview): treat empty PUBLIC_URL as unset so dev OAuth uses loopback redirect

### DIFF
--- a/crates/observing-appview/src/config.rs
+++ b/crates/observing-appview/src/config.rs
@@ -45,7 +45,11 @@ impl Config {
 
         let species_id_service_url = env::var("SPECIES_ID_SERVICE_URL").ok();
 
-        let public_url = env::var("PUBLIC_URL").ok();
+        // Treat an empty/whitespace PUBLIC_URL (e.g. `PUBLIC_URL=` in a shell
+        // or process-compose) as unset. Otherwise `Some("")` takes the
+        // production OAuth path and builds a protocol-less redirect_uri, which
+        // the PDS rejects with a cryptic 400 invalid_request in local dev.
+        let public_url = env::var("PUBLIC_URL").ok().filter(|s| !s.trim().is_empty());
 
         let hidden_dids = env::var("HIDDEN_DIDS")
             .map(|s| parse_did_list(&s))

--- a/crates/observing-appview/src/routes/oauth.rs
+++ b/crates/observing-appview/src/routes/oauth.rs
@@ -45,7 +45,11 @@ pub async fn login(
         )
         .await
         .map_err(|e| {
-            error!(error = %e, "OAuth authorize failed");
+            error!(
+                error = %e,
+                "OAuth authorize failed (in local dev, an empty PUBLIC_URL can \
+                 produce an invalid redirect_uri and trigger a PDS 400)"
+            );
             AppError::BadRequest(format!("Could not initiate login: {e}"))
         })?;
 


### PR DESCRIPTION
## The bug

`crates/observing-appview/src/config.rs` read `PUBLIC_URL` with:

```rust
let public_url = env::var("PUBLIC_URL").ok();
```

`env::var` returns `Ok("")` when the variable is **set but empty** (e.g. `PUBLIC_URL=` in a shell or `process-compose`). So `public_url` became `Some("")` instead of `None`.

Downstream, the `is_production = public_url.is_some()` check in `main.rs` and `create_oauth_client` in `state.rs` then take the **production** branch and build a protocol-less `redirect_uri` (`"/oauth/callback"`).

## Symptom

In local dev this makes the PDS reject the OAuth flow with a cryptic error:

```
400 invalid_request ... "URL must use the https:/http: protocol ... at body.redirect_uri"
```

## The fix

1. In `config.rs`, treat an empty/whitespace `PUBLIC_URL` as `None` so dev falls back to the loopback redirect:

   ```rust
   let public_url = env::var("PUBLIC_URL").ok().filter(|s| !s.trim().is_empty());
   ```

   With a comment explaining why an empty env var must not trigger the production OAuth path.

2. Add a short hint to the existing "OAuth authorize failed" log in `routes/oauth.rs` pointing at an empty `PUBLIC_URL` as a likely cause of an invalid `redirect_uri` in local dev.

## Validation

- `cargo fmt -p observing-appview` (no changes)
- `cargo check -p observing-appview` passes

Tiny, surgical change — no unrelated files touched.