### PR TITLE
fix(docker): bump Rust base image 1.93 → 1.95 to match rust-toolchain.toml

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,9 @@ RUN npm run build
 # ---------------------------------------------------------------------------
 # Stage: chef – install cargo-chef
 # ---------------------------------------------------------------------------
-FROM rust:1.93-slim-bookworm AS chef
+# Keep in lockstep with rust-toolchain.toml (and the sqlx MSRV it satisfies):
+# sqlx 0.9 requires rustc >= 1.94, so 1.93 here broke the image build / deploy.
+FROM rust:1.95-slim-bookworm AS chef
 
 RUN apt-get update && apt-get install -y \
     pkg-config \


### PR DESCRIPTION
## Deploys have been broken since #552

The sqlx 0.8 → 0.9 upgrade (#552) raised the workspace MSRV to **rustc 1.94** and bumped `rust-toolchain.toml` to **1.95** — but the `Dockerfile` chef stage was still pinned to `rust:1.93-slim-bookworm`.

CI's Rust test jobs honor `rust-toolchain.toml` (1.95) so they stayed green, masking the problem. Meanwhile **every `build-images` job has failed** in `cargo chef cook`:

```
error: rustc 1.93.1 is not supported by the following packages:
  sqlx@0.9.0 requires rustc 1.94.0
  sqlx-core@0.9.0 requires rustc 1.94.0
  ...
```

`build-images` gates `deploy`, so deploys have been down since #552 (2026-05-30 14:47). PRs #557–#559 all inherited the red main.

## Fix

One line: bump the Docker base image to `rust:1.95-slim-bookworm`, keeping it in lockstep with `rust-toolchain.toml`. Added a comment so the next toolchain bump moves both together.

## Verification

The failure is purely the toolchain pin (it's a build-time MSRV check before any compilation), and 1.95 is exactly what the rest of CI already builds with. Once merged, `build-images` and `deploy` should go green again. Not opened as a draft since it's unblocking deploys.