### PR TITLE
feat(query): migration follow-ups — logout cache eviction + preferences

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,7 +4,7 @@ import { Provider } from "react-redux";
 import { ThemeProvider, CssBaseline, Box, Alert } from "@mui/material";
 import { getTheme } from "./theme";
 import { store, useAppDispatch, useAppSelector } from "./store";
-import { checkAuth, loadUserPreferences } from "./store/authSlice";
+import { checkAuth } from "./store/authSlice";
 import { updateSystemTheme } from "./store/uiSlice";
 import { useUnreadCount } from "./lib/query/hooks";
 import { Sidebar } from "./components/layout/Sidebar";
@@ -46,10 +46,6 @@ function AppContent() {
   useEffect(() => {
     dispatch(checkAuth());
   }, [dispatch]);
-
-  useEffect(() => {
-    if (user) dispatch(loadUserPreferences());
-  }, [user, dispatch]);
 
   // Listen for system theme changes
   useEffect(() => {

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -27,6 +27,7 @@ import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
 import ExifReader from "exifreader";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeUploadModal, addToast, consumePendingUploadFiles } from "../../store/uiSlice";
+import { useUserPreferences } from "../../lib/query/hooks";
 import {
   submitObservation,
   updateObservation,
@@ -60,7 +61,7 @@ export function UploadModal() {
   const isOpen = useAppSelector((state) => state.ui.uploadModalOpen);
   const editingObservation = useAppSelector((state) => state.ui.editingObservation);
   const user = useAppSelector((state) => state.auth.user);
-  const defaultLicense = useAppSelector((state) => state.auth.defaultLicense);
+  const defaultLicense = useUserPreferences().data?.defaultLicense ?? null;
   const currentLocation = useAppSelector((state) => state.ui.currentLocation);
 
   const isEditMode = !!editingObservation;

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -1,4 +1,3 @@
-import { useState } from "react";
 import {
   Box,
   Container,
@@ -16,9 +15,9 @@ import { LightMode, DarkMode, SettingsBrightness } from "@mui/icons-material";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { setThemeMode, type ThemeMode, addToast } from "../../store/uiSlice";
-import { setDefaultLicense } from "../../store/authSlice";
+import { useUserPreferences } from "../../lib/query/hooks";
+import { useUpdatePreferences } from "../../lib/query/mutations";
 import { LICENSE_OPTIONS } from "../../lib/licenses";
-import { updateUserPreferences } from "../../services/api";
 
 const NO_DEFAULT = "__none__";
 
@@ -27,32 +26,30 @@ export function SettingsPage() {
   const dispatch = useAppDispatch();
   const themeMode = useAppSelector((state) => state.ui.themeMode);
   const user = useAppSelector((state) => state.auth.user);
-  const defaultLicense = useAppSelector((state) => state.auth.defaultLicense);
-  const [saving, setSaving] = useState(false);
+  const { data: prefs } = useUserPreferences();
+  const defaultLicense = prefs?.defaultLicense ?? null;
+  const updatePrefs = useUpdatePreferences();
 
   const handleThemeChange = (_: React.MouseEvent<HTMLElement>, value: ThemeMode | null) => {
     if (value) dispatch(setThemeMode(value));
   };
 
-  const handleLicenseChange = async (e: SelectChangeEvent<string>) => {
+  const handleLicenseChange = (e: SelectChangeEvent<string>) => {
     const raw = e.target.value;
     const next = raw === NO_DEFAULT ? null : raw;
-    const previous = defaultLicense;
-    dispatch(setDefaultLicense(next));
-    setSaving(true);
-    try {
-      await updateUserPreferences({ defaultLicense: next });
-    } catch (err) {
-      dispatch(setDefaultLicense(previous));
-      dispatch(
-        addToast({
-          message: err instanceof Error ? err.message : "Failed to save preference",
-          type: "error",
-        }),
-      );
-    } finally {
-      setSaving(false);
-    }
+    // The hook applies the change optimistically and rolls back on error.
+    updatePrefs.mutate(
+      { defaultLicense: next },
+      {
+        onError: (err) =>
+          dispatch(
+            addToast({
+              message: err instanceof Error ? err.message : "Failed to save preference",
+              type: "error",
+            }),
+          ),
+      },
+    );
   };
 
   return (
@@ -127,7 +124,7 @@ export function SettingsPage() {
               Pre-fill the license for new observation photos. You can still change it on each
               upload.
             </Typography>
-            <FormControl fullWidth size="small" disabled={saving}>
+            <FormControl fullWidth size="small" disabled={updatePrefs.isPending}>
               <InputLabel id="default-license-label">Default license</InputLabel>
               <Select
                 labelId="default-license-label"

--- a/frontend/src/lib/query/README.md
+++ b/frontend/src/lib/query/README.md
@@ -55,15 +55,12 @@ auth _session_.
 - **Auth session (`/oauth/me`)** stays in `authSlice`. It's the auth gate read
   by many components, has no offline value (it's a session check), and
   migrating it is high-blast-radius for no benefit.
-- **User preferences / `defaultLicense`** still load via `authSlice`
-  (`loadUserPreferences`). `useUserPreferences` / `useUpdatePreferences` hooks
-  exist and are ready, but `SettingsPage` + `UploadModal` + `App` all read
-  `defaultLicense` from Redux today; migrating is a contained follow-up.
 - **`useObservationsGeoJSON`** hook exists but has no consumer yet (no map view
   calls the geojson endpoint). Ready when a map feature needs it.
-- **Cache eviction on logout** is not yet wired — on logout/account-switch we
-  should `queryClient.clear()` + drop the persisted IndexedDB key so a shared
-  device can't surface a previous viewer's cached data. Tracked as a follow-up.
 - **Offline replay is wired for likes only.** Larger writes (observation
   upload/edit with images, comments, identifications) are online-only; they
   invalidate caches on success.
+
+Done in later passes: cache eviction on logout (`clearQueryCache` in the logout
+thunk) and user preferences (`useUserPreferences` / `useUpdatePreferences`;
+`defaultLicense` no longer lives in Redux).

--- a/frontend/src/lib/query/mutations.ts
+++ b/frontend/src/lib/query/mutations.ts
@@ -22,7 +22,7 @@ import {
   submitIdentification,
   deleteIdentification,
 } from "../../services/api";
-import type { UpdatePreferencesRequest } from "../../services/types";
+import type { UpdatePreferencesRequest, UserPreferencesResponse } from "../../services/types";
 
 // ── Likes ──────────────────────────────────────────────────────────────────
 export const LIKE_MUTATION_KEY = ["like"] as const;
@@ -95,11 +95,24 @@ export function useMarkNotificationRead() {
 }
 
 // ── User preferences ─────────────────────────────────────────────────────────
+/**
+ * Update preferences with an optimistic cache patch + rollback. No refetch:
+ * the server echoes exactly what we send (it just stores `defaultLicense`), so
+ * the optimistic value already matches server truth on success.
+ */
 export function useUpdatePreferences() {
   return useMutation({
     mutationFn: (prefs: UpdatePreferencesRequest) => updateUserPreferences(prefs),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: qk.preferences() });
+    onMutate: async (prefs: UpdatePreferencesRequest) => {
+      await queryClient.cancelQueries({ queryKey: qk.preferences() });
+      const previous = queryClient.getQueryData<UserPreferencesResponse>(qk.preferences());
+      queryClient.setQueryData<UserPreferencesResponse>(qk.preferences(), {
+        defaultLicense: prefs.defaultLicense,
+      });
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(qk.preferences(), context.previous);
     },
   });
 }

--- a/frontend/src/lib/query/queryClient.ts
+++ b/frontend/src/lib/query/queryClient.ts
@@ -12,6 +12,7 @@ import { get, set, del } from "idb-keyval";
 
 const ONE_MINUTE = 60 * 1000;
 export const PERSIST_MAX_AGE = 7 * 24 * 60 * 60 * 1000; // 1 week
+const PERSIST_KEY = "obsv-query-cache";
 
 export const queryClient = new QueryClient({
   defaultOptions: {
@@ -34,10 +35,25 @@ export const queryClient = new QueryClient({
 // idb-keyval (get/set/del) adapted to the AsyncStorage shape the persister
 // wants. getItem must return null (not undefined) when a key is absent.
 export const persister = createAsyncStoragePersister({
-  key: "obsv-query-cache",
+  key: PERSIST_KEY,
   storage: {
     getItem: async (k) => (await get(k)) ?? null,
     setItem: async (k, v) => set(k, v),
     removeItem: async (k) => del(k),
   },
 });
+
+/**
+ * Wipe all cached server state — in-memory and the persisted IndexedDB blob.
+ * Call on logout / account switch so a shared device can never surface the
+ * previous viewer's cached, viewer-dependent data (likes, feeds, notifications).
+ */
+export async function clearQueryCache(): Promise<void> {
+  queryClient.clear();
+  try {
+    await del(PERSIST_KEY);
+  } catch {
+    // IndexedDB may be unavailable (private browsing, test env). The in-memory
+    // clear above is the critical part; never let this block logout.
+  }
+}

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -1,43 +1,36 @@
-import { createSlice, createAsyncThunk, type PayloadAction } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import type { User } from "../services/types";
 import * as api from "../services/api";
 import { clearQueryCache } from "../lib/query/queryClient";
 
+// Auth holds only the session (the viewer gate). User preferences are server
+// state and live in the TanStack Query cache (lib/query `useUserPreferences` /
+// `useUpdatePreferences`).
 interface AuthState {
   user: User | null;
   isLoading: boolean;
-  defaultLicense: string | null;
 }
 
 const initialState: AuthState = {
   user: null,
   isLoading: true,
-  defaultLicense: null,
 };
 
 export const checkAuth = createAsyncThunk("auth/checkAuth", async () => {
   return api.checkAuth();
 });
 
-export const loadUserPreferences = createAsyncThunk("auth/loadUserPreferences", async () => {
-  return api.fetchUserPreferences();
-});
-
 export const logout = createAsyncThunk("auth/logout", async () => {
   await api.logout();
   // Drop all cached per-user server state so the next viewer on this device
-  // can't see the previous one's likes/feeds/notifications.
+  // can't see the previous one's likes/feeds/notifications/preferences.
   await clearQueryCache();
 });
 
 const authSlice = createSlice({
   name: "auth",
   initialState,
-  reducers: {
-    setDefaultLicense: (state, action: PayloadAction<string | null>) => {
-      state.defaultLicense = action.payload;
-    },
-  },
+  reducers: {},
   extraReducers: (builder) => {
     builder
       .addCase(checkAuth.pending, (state) => {
@@ -51,16 +44,10 @@ const authSlice = createSlice({
         state.user = null;
         state.isLoading = false;
       })
-      .addCase(loadUserPreferences.fulfilled, (state, action) => {
-        state.defaultLicense = action.payload.defaultLicense ?? null;
-      })
       .addCase(logout.fulfilled, (state) => {
         state.user = null;
-        state.defaultLicense = null;
       });
   },
 });
-
-export const { setDefaultLicense } = authSlice.actions;
 
 export default authSlice.reducer;

--- a/frontend/src/store/authSlice.ts
+++ b/frontend/src/store/authSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, createAsyncThunk, type PayloadAction } from "@reduxjs/toolkit";
 import type { User } from "../services/types";
 import * as api from "../services/api";
+import { clearQueryCache } from "../lib/query/queryClient";
 
 interface AuthState {
   user: User | null;
@@ -24,6 +25,9 @@ export const loadUserPreferences = createAsyncThunk("auth/loadUserPreferences", 
 
 export const logout = createAsyncThunk("auth/logout", async () => {
   await api.logout();
+  // Drop all cached per-user server state so the next viewer on this device
+  // can't see the previous one's likes/feeds/notifications.
+  await clearQueryCache();
 });
 
 const authSlice = createSlice({


### PR DESCRIPTION
Follow-ups to the TanStack Query migration (#554), completing two items its README flagged. Both stack cleanly on `main`.

## 1. Logout cache eviction (security)
`clearQueryCache()` wipes the in-memory QueryClient **and** the persisted IndexedDB blob; the logout thunk calls it. Closes the cross-user gap: on a shared device, the next viewer can no longer see the previous user's cached likes/feeds/notifications/preferences. Resilient to IndexedDB being unavailable (private mode / test env).

## 2. User preferences → Query
- `SettingsPage` + `UploadModal` read `defaultLicense` via `useUserPreferences`.
- `SettingsPage` writes via `useUpdatePreferences` (optimistic patch + rollback; no refetch since the server just echoes the value).
- Removes `defaultLicense` / `loadUserPreferences` / `setDefaultLicense` from `authSlice` (now **session-only**) and the `App` preferences-load effect.

## Validation
tsc clean · 140 unit tests pass · oxlint clean · oxfmt clean · prod build green.

## Remaining (not in this PR)
Comment/identification write hooks (already written, not yet consumed), observation create/update/delete mutations, and extending offline-replay beyond likes. Auth session deliberately stays in Redux.

🤖 Generated with [Claude Code](https://claude.com/claude-code)