### PR TITLE
feat(query): comment + identification writes via mutation hooks

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -3,6 +3,7 @@ import { withThemeFromJSXProvider } from "@storybook/addon-themes";
 import { ThemeProvider, CssBaseline } from "@mui/material";
 import { MemoryRouter } from "react-router-dom";
 import { Provider } from "react-redux";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { initialize, mswLoader } from "msw-storybook-addon";
 import { darkTheme, lightTheme } from "../frontend/src/theme";
 import { makeMockStore } from "./mockStore";
@@ -40,12 +41,20 @@ const preview: Preview = {
     }),
     (Story, context) => {
       const store = makeMockStore(context.parameters.storeOptions);
+      // Fresh client per render so components using query hooks (likes,
+      // comments, identifications) have a QueryClient and don't bleed cache
+      // between stories.
+      const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+      });
       const initialEntries = context.parameters.routerInitialEntries ?? ["/"];
       return (
         <Provider store={store}>
-          <MemoryRouter initialEntries={initialEntries}>
-            <Story />
-          </MemoryRouter>
+          <QueryClientProvider client={queryClient}>
+            <MemoryRouter initialEntries={initialEntries}>
+              <Story />
+            </MemoryRouter>
+          </QueryClientProvider>
         </Provider>
       );
     },

--- a/frontend/src/components/comment/CommentSection.tsx
+++ b/frontend/src/components/comment/CommentSection.tsx
@@ -15,10 +15,10 @@ import {
 } from "@mui/material";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutlineOutlined";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { submitComment } from "../../services/api";
 import { useAppSelector, useAppDispatch } from "../../store";
 import { addToast } from "../../store/uiSlice";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
+import { useSubmitComment } from "../../lib/query/mutations";
 import type { Comment } from "../../services/types";
 import { getPdslsUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
@@ -27,29 +27,26 @@ interface CommentSectionProps {
   observationUri: string;
   observationCid: string;
   comments: Comment[];
-  onCommentAdded?: () => void;
 }
 
-export function CommentSection({
-  observationUri,
-  observationCid,
-  comments,
-  onCommentAdded,
-}: CommentSectionProps) {
+export function CommentSection({ observationUri, observationCid, comments }: CommentSectionProps) {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.auth.user);
   const [showForm, setShowForm] = useState(false);
   const [body, setBody] = useState("");
   const [menuAnchorEl, setMenuAnchorEl] = useState<{ [key: string]: HTMLElement | null }>({});
 
+  // The mutation invalidates the parent observation on success, so the new
+  // comment shows up without the caller wiring a refetch callback.
+  const submitComment = useSubmitComment();
   const submitFn = useCallback(
     () =>
-      submitComment({
+      submitComment.mutateAsync({
         occurrenceUri: observationUri,
         occurrenceCid: observationCid,
         body: body.trim(),
       }),
-    [observationUri, observationCid, body],
+    [submitComment, observationUri, observationCid, body],
   );
 
   const { isSubmitting, handleSubmit: doSubmit } = useFormSubmit(submitFn, {
@@ -57,7 +54,6 @@ export function CommentSection({
     onSuccess: () => {
       setBody("");
       setShowForm(false);
-      onCommentAdded?.();
     },
   });
 

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -18,8 +18,8 @@ import EditIcon from "@mui/icons-material/Edit";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
-import { submitIdentification } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
+import { useSubmitIdentification } from "../../lib/query/mutations";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { VisualIdCards } from "./VisualIdCards";
 import { useVisualId } from "../../hooks/useVisualId";
@@ -45,7 +45,6 @@ interface IdentificationPanelProps {
   latitude?: number | undefined;
   /** Observation longitude, passed to species-id for geo-prior context */
   longitude?: number | undefined;
-  onSuccess?: (() => void) | undefined;
 }
 
 export function IdentificationPanel({
@@ -53,7 +52,6 @@ export function IdentificationPanel({
   imageUrl,
   latitude,
   longitude,
-  onSuccess,
 }: IdentificationPanelProps) {
   const dispatch = useAppDispatch();
   const [showSuggestForm, setShowSuggestForm] = useState(false);
@@ -64,19 +62,22 @@ export function IdentificationPanel({
 
   const currentId = observation.communityId || observation.scientificName || "Unknown";
 
+  // The mutation invalidates the parent observation on success, so the new
+  // identification shows up without a caller-supplied refetch callback.
+  const submitId = useSubmitIdentification();
+
   const agreeFn = useCallback(
     () =>
-      submitIdentification({
+      submitId.mutateAsync({
         occurrenceUri: observation.uri,
         occurrenceCid: observation.cid,
         scientificName: currentId,
       }),
-    [observation.uri, observation.cid, currentId],
+    [submitId, observation.uri, observation.cid, currentId],
   );
 
   const { isSubmitting: isAgreeing, handleSubmit: handleAgree } = useFormSubmit(agreeFn, {
     successMessage: "Your agreement has been recorded!",
-    onSuccess: () => onSuccess?.(),
   });
 
   const effectiveKingdom = matchedTaxon?.kingdom ?? (kingdom || undefined);
@@ -84,14 +85,14 @@ export function IdentificationPanel({
 
   const suggestFn = useCallback(
     () =>
-      submitIdentification({
+      submitId.mutateAsync({
         occurrenceUri: observation.uri,
         occurrenceCid: observation.cid,
         scientificName: taxonName.trim(),
         ...(effectiveKingdom ? { kingdom: effectiveKingdom } : {}),
         ...(effectiveRank ? { taxonRank: effectiveRank } : {}),
       }),
-    [observation.uri, observation.cid, taxonName, effectiveKingdom, effectiveRank],
+    [submitId, observation.uri, observation.cid, taxonName, effectiveKingdom, effectiveRank],
   );
 
   const { isSubmitting: isSuggesting, handleSubmit: doSuggest } = useFormSubmit(suggestFn, {
@@ -102,7 +103,6 @@ export function IdentificationPanel({
       setMatchedTaxon(null);
       setKingdom("");
       setRank("");
-      onSuccess?.();
     },
   });
 

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -516,7 +516,6 @@ export function ObservationDetail() {
                       }
                       latitude={observation.location?.latitude}
                       longitude={observation.location?.longitude}
-                      onSuccess={refreshObservation}
                     />
                   ) : (
                     <Typography
@@ -541,7 +540,6 @@ export function ObservationDetail() {
               observationUri={observation.uri}
               observationCid={observation.cid}
               comments={comments}
-              onCommentAdded={refreshObservation}
             />
           </Box>
         </Box>


### PR DESCRIPTION
Phase 3 of the TanStack Query migration. Consumes the comment/identification mutation hooks that #554 added but left unused, and centralizes their cache invalidation. Independent of #564 (touches different files).

## Changes
- **CommentSection** → `useSubmitComment`, **IdentificationPanel** → `useSubmitIdentification`, both driven through the existing `useFormSubmit` wrapper via `mutateAsync` (keeps the toast / loading / form-reset UX).
- The hooks invalidate the parent observation on success, so the `onCommentAdded` / `onSuccess` callback props are **removed** from those components and from `ObservationDetail` — no more manual refetch plumbing.
- `ObservationDetail`'s delete-identification flow is unchanged (it keeps its ingester-poll-then-invalidate, which the generic hook intentionally doesn't do).
- **Storybook:** added a `QueryClientProvider` decorator to `preview.tsx` (fresh client per render). The storybook CI jobs only build/static-check stories, so query-hook components like `FeedItem` weren't actually being rendered — this makes them (and the newly-migrated panels) render correctly.

## Validation
tsc clean · 140 unit tests · oxlint clean · oxfmt clean · `check:stories` 53/53 · **storybook build succeeds** · app prod build green.

## Not in this PR
`useDeleteIdentification` stays defined-but-unused (the only delete flow needs the ingester poll); left out to avoid touching `mutations.ts`, which #564 also edits. Remaining: observation create/update/delete mutations (chunk 4), extend offline-replay beyond likes (chunk 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)