### PR TITLE
feat(query): observation create/update/delete via cache invalidation

### DIFF
--- a/frontend/src/components/modals/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/modals/DeleteConfirmDialog.tsx
@@ -13,6 +13,7 @@ import { useAppDispatch, useAppSelector } from "../../store";
 import { closeDeleteConfirm, addToast } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
 import { deleteObservation, pollObservation } from "../../services/api";
+import { invalidateOccurrenceLists, removeObservation } from "../../lib/query/occurrenceCache";
 import { getErrorMessage } from "../../lib/utils";
 
 export function DeleteConfirmDialog() {
@@ -37,9 +38,14 @@ export function DeleteConfirmDialog() {
     try {
       await deleteObservation(observation.uri);
 
-      // Wait for the ingester to remove the row; the navigate/reload below
-      // would otherwise briefly show the deleted observation in the feed.
+      // Wait for the ingester to remove the row; refreshing the feed caches
+      // before this would otherwise briefly show the deleted observation.
       await pollObservation(observation.uri, (r) => !r?.occurrence);
+
+      // Drop the detail cache and refetch the feeds so the observation
+      // disappears everywhere — no full-page reload needed.
+      removeObservation(observation.uri);
+      await invalidateOccurrenceLists();
 
       dispatch(
         addToast({
@@ -49,13 +55,9 @@ export function DeleteConfirmDialog() {
       );
       dispatch(closeDeleteConfirm());
 
-      // Navigate away if on the observation detail page
-      const isOnDetailPage = location.pathname.includes("/observation/");
-      if (isOnDetailPage) {
+      // If we were on the deleted observation's detail page, leave it.
+      if (location.pathname.includes("/observation/")) {
         navigate("/");
-      } else {
-        // Reload the page to refresh the feed
-        window.location.reload();
       }
     } catch (error) {
       const message = getErrorMessage(error, "Failed to delete observation");

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -25,9 +25,11 @@ import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
 import ExifReader from "exifreader";
+import { useNavigate } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeUploadModal, addToast, consumePendingUploadFiles } from "../../store/uiSlice";
 import { useUserPreferences } from "../../lib/query/hooks";
+import { invalidateObservation, invalidateOccurrenceLists } from "../../lib/query/occurrenceCache";
 import {
   submitObservation,
   updateObservation,
@@ -58,6 +60,7 @@ function toDatetimeLocal(date: Date): string {
 
 export function UploadModal() {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const isOpen = useAppSelector((state) => state.ui.uploadModalOpen);
   const editingObservation = useAppSelector((state) => state.ui.editingObservation);
   const user = useAppSelector((state) => state.auth.user);
@@ -401,8 +404,14 @@ export function UploadModal() {
         );
       }
 
-      // Navigate to the observation page
-      window.location.href = getObservationUrl(observationUri);
+      // Refresh the feeds (and the observation's own detail, on edit) so the
+      // new/updated observation shows, then close the modal and client-side
+      // navigate to it — no full-page reload.
+      invalidateObservation(observationUri);
+      await invalidateOccurrenceLists();
+      dispatch(closeUploadModal());
+      resetForm();
+      navigate(getObservationUrl(observationUri));
     } catch (error) {
       dispatch(
         addToast({

--- a/frontend/src/lib/query/mutations.ts
+++ b/frontend/src/lib/query/mutations.ts
@@ -20,7 +20,6 @@ import {
   updateUserPreferences,
   submitComment,
   submitIdentification,
-  deleteIdentification,
 } from "../../services/api";
 import type { UpdatePreferencesRequest, UserPreferencesResponse } from "../../services/types";
 
@@ -132,16 +131,6 @@ export function useSubmitIdentification() {
     mutationFn: submitIdentification,
     onSuccess: (_data, vars) => {
       void queryClient.invalidateQueries({ queryKey: qk.observation(vars.occurrenceUri) });
-    },
-  });
-}
-
-/** Delete an identification by its uri; invalidate the observation it belongs to. */
-export function useDeleteIdentification(occurrenceUri: string) {
-  return useMutation({
-    mutationFn: (identificationUri: string) => deleteIdentification(identificationUri),
-    onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: qk.observation(occurrenceUri) });
     },
   });
 }

--- a/frontend/src/lib/query/occurrenceCache.ts
+++ b/frontend/src/lib/query/occurrenceCache.ts
@@ -49,3 +49,24 @@ export function setOccurrenceLike(uri: string, liked: boolean): void {
     data ? { ...data, occurrence: applyLike(data.occurrence, liked) } : data,
   );
 }
+
+/**
+ * Refetch every occurrence list (feed / profile / taxon). Call after a
+ * create / update / delete so the new/changed/removed observation is reflected
+ * everywhere — replaces the old full-page reloads.
+ */
+export function invalidateOccurrenceLists(): Promise<void> {
+  return queryClient.invalidateQueries({
+    predicate: (query) => OCCURRENCE_LIST_TAGS.some((tag) => tag === query.queryKey[0]),
+  });
+}
+
+/** Refetch one observation's detail cache (after an edit). */
+export function invalidateObservation(uri: string): Promise<void> {
+  return queryClient.invalidateQueries({ queryKey: ["observation", uri] });
+}
+
+/** Drop one observation's detail cache (after a delete). */
+export function removeObservation(uri: string): void {
+  queryClient.removeQueries({ queryKey: ["observation", uri] });
+}


### PR DESCRIPTION
Phase 4 (final substantial phase) of the TanStack Query migration. Replaces the **full-page reloads** that followed observation writes with scoped cache invalidation, so the UI updates reactively.

## Changes
- **`occurrenceCache`** — adds `invalidateOccurrenceLists` (refetch every feed/profile/taxon list), `invalidateObservation`, and `removeObservation`.
- **`UploadModal`** — after create/update (and the existing ingester poll), invalidate the feeds + the observation's detail, close the modal, and **client-side `navigate`** to it. Replaces `window.location.href = …`.
- **`DeleteConfirmDialog`** — after delete (and poll), `removeObservation` + refetch feeds. Replaces `window.location.reload()`. Still navigates home when deleting from the detail page.
- Removes the now-dead `useDeleteIdentification` (the only delete-identification flow keeps its ingester-poll path in `ObservationDetail`).

The ingester-poll flows are preserved — they wait for the write to propagate before the caches refetch, so nothing flickers stale.

## Validation
tsc clean · 140 unit tests · oxlint clean · oxfmt clean · app prod build green.

## Migration status after this PR
All API reads and writes go through TanStack Query. The only "server data" left in Redux is the **auth session** (a deliberate keep). Image uploads/comments/identifications remain online-only (offline-replay is likes-only by design).

🤖 Generated with [Claude Code](https://claude.com/claude-code)