### PR TITLE
perf: route-based code-splitting + lazy maplibre

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,35 +1,68 @@
-import { useEffect, useMemo, useState } from "react";
+import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { Provider } from "react-redux";
-import { ThemeProvider, CssBaseline, Box, Alert } from "@mui/material";
+import { ThemeProvider, CssBaseline, Box, Alert, CircularProgress } from "@mui/material";
 import { getTheme } from "./theme";
 import { store, useAppDispatch, useAppSelector } from "./store";
 import { checkAuth } from "./store/authSlice";
 import { updateSystemTheme } from "./store/uiSlice";
 import { resumePendingSubmissions } from "./store/pendingSlice";
 import { useUnreadCount } from "./lib/query/hooks";
+// Eager: the shell (layout, always-mounted modals, global UI) — needed on
+// every page, so splitting them buys nothing.
 import { Sidebar } from "./components/layout/Sidebar";
 import { TopBar } from "./components/layout/TopBar";
-import { LandingPage } from "./components/landing/LandingPage";
-import { FeedView } from "./components/feed/FeedView";
-import { ObservationDetail } from "./components/observation/ObservationDetail";
-import { ProfileView } from "./components/profile/ProfileView";
-import { TaxonExplorer } from "./components/taxon/TaxonExplorer";
 import { LoginModal } from "./components/modals/LoginModal";
 import { UploadModal } from "./components/modals/UploadModal";
 import { DeleteConfirmDialog } from "./components/modals/DeleteConfirmDialog";
 import { FAB } from "./components/common/FAB";
 import { ToastContainer } from "./components/common/Toast";
-import { NotFound } from "./components/common/NotFound";
 import { OfflineBanner } from "./components/common/OfflineBanner";
 import { UpdatePrompt } from "./components/common/UpdatePrompt";
-import { LexiconView } from "./components/lexicon/LexiconView";
-import { DocsPage } from "./components/docs/DocsPage";
-import { NotificationsPage } from "./components/notifications/NotificationsPage";
-import { SettingsPage } from "./components/settings/SettingsPage";
-import { TransparencyPage } from "./components/transparency/TransparencyPage";
 import { QueryProvider } from "./lib/query/QueryProvider";
 import "./styles/global.css";
+
+// Lazy: route pages load on navigation. Their chunks are precached by the
+// service worker, so after the first visit they're instant (and offline).
+const LandingPage = lazy(() =>
+  import("./components/landing/LandingPage").then((m) => ({ default: m.LandingPage })),
+);
+const FeedView = lazy(() =>
+  import("./components/feed/FeedView").then((m) => ({ default: m.FeedView })),
+);
+const ObservationDetail = lazy(() =>
+  import("./components/observation/ObservationDetail").then((m) => ({
+    default: m.ObservationDetail,
+  })),
+);
+const ProfileView = lazy(() =>
+  import("./components/profile/ProfileView").then((m) => ({ default: m.ProfileView })),
+);
+const TaxonExplorer = lazy(() =>
+  import("./components/taxon/TaxonExplorer").then((m) => ({ default: m.TaxonExplorer })),
+);
+const NotificationsPage = lazy(() =>
+  import("./components/notifications/NotificationsPage").then((m) => ({
+    default: m.NotificationsPage,
+  })),
+);
+const LexiconView = lazy(() =>
+  import("./components/lexicon/LexiconView").then((m) => ({ default: m.LexiconView })),
+);
+const DocsPage = lazy(() =>
+  import("./components/docs/DocsPage").then((m) => ({ default: m.DocsPage })),
+);
+const SettingsPage = lazy(() =>
+  import("./components/settings/SettingsPage").then((m) => ({ default: m.SettingsPage })),
+);
+const TransparencyPage = lazy(() =>
+  import("./components/transparency/TransparencyPage").then((m) => ({
+    default: m.TransparencyPage,
+  })),
+);
+const NotFound = lazy(() =>
+  import("./components/common/NotFound").then((m) => ({ default: m.NotFound })),
+);
 
 function AppContent() {
   const dispatch = useAppDispatch();
@@ -103,20 +136,28 @@ function AppContent() {
           minHeight: 0,
         }}
       >
-        <Routes>
-          <Route path="/" element={showLanding ? <LandingPage /> : <FeedView tab="home" />} />
-          <Route path="/explore" element={<FeedView tab="explore" />} />
-          <Route path="/observation/:did/:rkey" element={<ObservationDetail />} />
-          <Route path="/profile/:did" element={<ProfileView />} />
-          <Route path="/notifications" element={<NotificationsPage />} />
-          <Route path="/taxon/:kingdom/:name" element={<TaxonExplorer />} />
-          <Route path="/taxon/:id" element={<TaxonExplorer />} />
-          <Route path="/lexicons" element={<LexiconView />} />
-          <Route path="/docs" element={<DocsPage />} />
-          <Route path="/settings" element={<SettingsPage />} />
-          <Route path="/transparency" element={<TransparencyPage />} />
-          <Route path="*" element={<NotFound />} />
-        </Routes>
+        <Suspense
+          fallback={
+            <Box sx={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
+              <CircularProgress />
+            </Box>
+          }
+        >
+          <Routes>
+            <Route path="/" element={showLanding ? <LandingPage /> : <FeedView tab="home" />} />
+            <Route path="/explore" element={<FeedView tab="explore" />} />
+            <Route path="/observation/:did/:rkey" element={<ObservationDetail />} />
+            <Route path="/profile/:did" element={<ProfileView />} />
+            <Route path="/notifications" element={<NotificationsPage />} />
+            <Route path="/taxon/:kingdom/:name" element={<TaxonExplorer />} />
+            <Route path="/taxon/:id" element={<TaxonExplorer />} />
+            <Route path="/lexicons" element={<LexiconView />} />
+            <Route path="/docs" element={<DocsPage />} />
+            <Route path="/settings" element={<SettingsPage />} />
+            <Route path="/transparency" element={<TransparencyPage />} />
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </Suspense>
       </Box>
       {!showLanding && <FAB />}
       <LoginModal />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { UploadModal } from "./components/modals/UploadModal";
 import { DeleteConfirmDialog } from "./components/modals/DeleteConfirmDialog";
 import { FAB } from "./components/common/FAB";
 import { ToastContainer } from "./components/common/Toast";
+import { ErrorBoundary } from "./components/common/ErrorBoundary";
 import { OfflineBanner } from "./components/common/OfflineBanner";
 import { UpdatePrompt } from "./components/common/UpdatePrompt";
 import { QueryProvider } from "./lib/query/QueryProvider";
@@ -136,28 +137,32 @@ function AppContent() {
           minHeight: 0,
         }}
       >
-        <Suspense
-          fallback={
-            <Box sx={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}>
-              <CircularProgress />
-            </Box>
-          }
-        >
-          <Routes>
-            <Route path="/" element={showLanding ? <LandingPage /> : <FeedView tab="home" />} />
-            <Route path="/explore" element={<FeedView tab="explore" />} />
-            <Route path="/observation/:did/:rkey" element={<ObservationDetail />} />
-            <Route path="/profile/:did" element={<ProfileView />} />
-            <Route path="/notifications" element={<NotificationsPage />} />
-            <Route path="/taxon/:kingdom/:name" element={<TaxonExplorer />} />
-            <Route path="/taxon/:id" element={<TaxonExplorer />} />
-            <Route path="/lexicons" element={<LexiconView />} />
-            <Route path="/docs" element={<DocsPage />} />
-            <Route path="/settings" element={<SettingsPage />} />
-            <Route path="/transparency" element={<TransparencyPage />} />
-            <Route path="*" element={<NotFound />} />
-          </Routes>
-        </Suspense>
+        <ErrorBoundary resetKey={location.pathname}>
+          <Suspense
+            fallback={
+              <Box
+                sx={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}
+              >
+                <CircularProgress />
+              </Box>
+            }
+          >
+            <Routes>
+              <Route path="/" element={showLanding ? <LandingPage /> : <FeedView tab="home" />} />
+              <Route path="/explore" element={<FeedView tab="explore" />} />
+              <Route path="/observation/:did/:rkey" element={<ObservationDetail />} />
+              <Route path="/profile/:did" element={<ProfileView />} />
+              <Route path="/notifications" element={<NotificationsPage />} />
+              <Route path="/taxon/:kingdom/:name" element={<TaxonExplorer />} />
+              <Route path="/taxon/:id" element={<TaxonExplorer />} />
+              <Route path="/lexicons" element={<LexiconView />} />
+              <Route path="/docs" element={<DocsPage />} />
+              <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/transparency" element={<TransparencyPage />} />
+              <Route path="*" element={<NotFound />} />
+            </Routes>
+          </Suspense>
+        </ErrorBoundary>
       </Box>
       {!showLanding && <FAB />}
       <LoginModal />

--- a/frontend/src/components/common/ErrorBoundary.stories.tsx
+++ b/frontend/src/components/common/ErrorBoundary.stories.tsx
@@ -1,0 +1,34 @@
+import type { ComponentProps } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+// Throws on render so the boundary's fallback UI is what the story shows.
+function Boom({ message }: { message: string }): null {
+  throw new Error(message);
+}
+
+const meta = {
+  title: "Common/ErrorBoundary",
+  component: ErrorBoundary,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<ComponentProps<typeof ErrorBoundary>>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+// A stale-chunk failure after a redeploy — gets the "Update available" copy.
+export const ChunkLoadError: Story = {
+  args: {
+    children: <Boom message="Failed to fetch dynamically imported module" />,
+  },
+};
+
+// Any other render error — generic "Something went wrong" copy.
+export const GenericError: Story = {
+  args: {
+    children: <Boom message="Unexpected render failure" />,
+  },
+};

--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,0 +1,110 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import { Box, Typography, Button, Stack } from "@mui/material";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
+
+interface Props {
+  children: ReactNode;
+  // When this value changes the boundary clears its error and re-renders its
+  // children. App passes the current pathname so navigating away from a broken
+  // route recovers without a full reload.
+  resetKey?: unknown;
+}
+
+interface State {
+  error: Error | null;
+  resetKey: unknown;
+}
+
+// A failed lazy import() (stale chunk after a redeploy, flaky network) rejects
+// and bubbles up as a render error. Catch it here so a single broken chunk
+// recovers with a reload instead of unmounting the whole app to a blank screen.
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { error: null, resetKey: props.resetKey };
+  }
+
+  static getDerivedStateFromError(error: Error): Partial<State> {
+    return { error };
+  }
+
+  // Clear the error when resetKey changes (App passes the pathname) so
+  // navigating away from a broken route recovers without a full reload.
+  static getDerivedStateFromProps(props: Props, state: State): Partial<State> | null {
+    if (props.resetKey !== state.resetKey) {
+      return { error: null, resetKey: props.resetKey };
+    }
+    return null;
+  }
+
+  override componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, info.componentStack);
+  }
+
+  override render() {
+    const { error } = this.state;
+    if (!error) return this.props.children;
+
+    // Chunk-load failures are fixed by reloading (the service worker fetches
+    // the current chunk hashes); generic render errors get the same escape
+    // hatch plus a path home.
+    const isChunkError = /loading.*chunk|dynamically imported module|importing a module/i.test(
+      error.message,
+    );
+
+    return (
+      <Box
+        sx={{
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          flex: 1,
+          p: 4,
+          textAlign: "center",
+        }}
+      >
+        <Box
+          sx={{
+            width: 120,
+            height: 120,
+            borderRadius: "50%",
+            bgcolor: "action.hover",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            mb: 3,
+          }}
+        >
+          <ErrorOutlineIcon sx={{ fontSize: 60, color: "text.disabled" }} />
+        </Box>
+        <Typography variant="h6" component="h2" sx={{ color: "text.secondary", mb: 1 }}>
+          {isChunkError ? "Update available" : "Something went wrong"}
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.disabled", mb: 4, maxWidth: 360 }}>
+          {isChunkError
+            ? "This page couldn't load, likely because a new version was just released. Reload to get the latest."
+            : "An unexpected error occurred while loading this page."}
+        </Typography>
+        <Stack direction="row" spacing={2}>
+          <Button
+            onClick={() => window.location.reload()}
+            variant="contained"
+            color="primary"
+            sx={{ px: 4, py: 1, fontWeight: 600 }}
+          >
+            Reload
+          </Button>
+          <Button
+            onClick={() => window.location.assign("/")}
+            variant="outlined"
+            color="inherit"
+            sx={{ px: 3 }}
+          >
+            Go home
+          </Button>
+        </Stack>
+      </Box>
+    );
+  }
+}

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, type FormEvent, type ChangeEvent } from "react";
+import { lazy, Suspense, useState, useEffect, type FormEvent, type ChangeEvent } from "react";
 import {
   Avatar,
   Box,
@@ -33,13 +33,18 @@ import { ModalOverlay } from "./ModalOverlay";
 import { ConfirmDialog } from "../common/ConfirmDialog";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { VisualId } from "../identification/VisualId";
-import { LocationPicker } from "../map/LocationPicker";
 import { PhotoLightbox } from "../observation/PhotoLightbox";
 import { getErrorMessage } from "../../lib/utils";
 import { KINGDOMS } from "../../lib/kingdoms";
 import { TAXON_RANKS } from "../../lib/taxonRanks";
 import { pickPhotos } from "../../lib/photoPicker";
 import { LICENSE_OPTIONS, DEFAULT_LICENSE } from "../../lib/licenses";
+
+// Lazy so maplibre-gl (heavy) is split into its own chunk, loaded only when the
+// upload modal actually opens (the MUI Dialog doesn't mount children until then).
+const LocationPicker = lazy(() =>
+  import("../map/LocationPicker").then((m) => ({ default: m.LocationPicker })),
+);
 
 interface ImagePreview {
   file: File;
@@ -554,16 +559,31 @@ export function UploadModal() {
             JPG, PNG, or WebP - Max 10MB each - Up to {MAX_IMAGES} photos
           </Typography>
 
-          <LocationPicker
-            latitude={lat ? parseFloat(lat) : null}
-            longitude={lng ? parseFloat(lng) : null}
-            onChange={handleLocationChange}
-            uncertaintyMeters={uncertaintyMeters}
-            onUncertaintyChange={(m) => {
-              setUncertaintyMeters(m);
-              setIsDirty(true);
-            }}
-          />
+          <Suspense
+            fallback={
+              <Box
+                sx={{
+                  height: 260,
+                  display: "flex",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                <CircularProgress size={24} />
+              </Box>
+            }
+          >
+            <LocationPicker
+              latitude={lat ? parseFloat(lat) : null}
+              longitude={lng ? parseFloat(lng) : null}
+              onChange={handleLocationChange}
+              uncertaintyMeters={uncertaintyMeters}
+              onUncertaintyChange={(m) => {
+                setUncertaintyMeters(m);
+                setIsDirty(true);
+              }}
+            />
+          </Suspense>
 
           <TaxaAutocomplete
             value={species}

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { lazy, Suspense, useState } from "react";
 import { useParams, useNavigate, Link } from "react-router-dom";
 import {
   Box,
@@ -33,7 +33,6 @@ import { checkAuth } from "../../store/authSlice";
 import { IdentificationPanel } from "../identification/IdentificationPanel";
 import { IdentificationHistory } from "../identification/IdentificationHistory";
 import { CommentSection } from "../comment/CommentSection";
-import { LocationMap } from "../map/LocationMap";
 import { TaxonLink } from "../common/TaxonLink";
 import { ObservationDetailSkeleton } from "./ObservationDetailSkeleton";
 import { PhotoLightbox } from "./PhotoLightbox";
@@ -41,6 +40,12 @@ import { QualityIssueBadges } from "./QualityIssueBadges";
 import { UserCard } from "../common/UserCard";
 import { formatDate, getPdslsUrl, buildOccurrenceAtUri, getErrorMessage } from "../../lib/utils";
 import { getLicenseLabel } from "../../lib/licenses";
+
+// Lazy so maplibre-gl is split into its own chunk, loaded only when an
+// observation actually has a location to map.
+const LocationMap = lazy(() =>
+  import("../map/LocationMap").then((m) => ({ default: m.LocationMap })),
+);
 
 export function ObservationDetail() {
   const { did, rkey } = useParams<{ did: string; rkey: string }>();
@@ -431,11 +436,13 @@ export function ObservationDetail() {
             </ListItem>
             {observation.location && (
               <Box sx={{ ml: 4.5, mb: 1 }}>
-                <LocationMap
-                  latitude={observation.location.latitude}
-                  longitude={observation.location.longitude}
-                  uncertaintyMeters={observation.location.uncertaintyMeters}
-                />
+                <Suspense fallback={<Box sx={{ height: 180 }} />}>
+                  <LocationMap
+                    latitude={observation.location.latitude}
+                    longitude={observation.location.longitude}
+                    uncertaintyMeters={observation.location.uncertaintyMeters}
+                  />
+                </Suspense>
               </Box>
             )}
           </List>

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -20,9 +20,6 @@ export default defineConfig({
         navigateFallbackDenylist: [/^\/api/, /^\/oauth/, /^\/media/, /^\/admin/],
         globPatterns: ["**/*.{js,css,html,ico,png,svg,webmanifest}"],
         cleanupOutdatedCaches: true,
-        // Bumped from default 2 MiB so the current bundle precaches.
-        // Code-splitting is the proper fix; tracked separately.
-        maximumFileSizeToCacheInBytes: 4 * 1024 * 1024,
         // Only cache routes whose responses are independent of the viewer.
         // /api/taxa/{...}/occurrences and other enrichment-touched routes
         // embed `viewer_has_liked` and must NOT be cached without per-user


### PR DESCRIPTION
Splits the single ~660 KB-gzip JS bundle into route + dependency chunks that load on demand. Closes the deferred TODO in `vite.config.ts` ("Code-splitting is the proper fix; tracked separately").

## Results
| | Before | After |
|---|--------|-------|
| Initial JS (gzip) | **659 KB** | **265 KB** (−60%) |
| maplibre-gl | in main chunk | own chunk (~274 KB gzip), loaded on map render |
| Route pages | in main chunk | per-route chunks (load on navigation) |

## Changes
- **Route pages** lazy-loaded via `React.lazy` + a `<Suspense>` fallback in `App.tsx` (shell, layout, always-mounted modals, and global UI stay eager).
- **Map components** (`LocationPicker`, `LocationMap`) lazy-loaded so **maplibre-gl** is split out — it now loads only when the upload modal opens or an observation with a location is viewed (the MUI Dialog doesn't mount the picker until open).
- **`vite.config.ts`:** removed the `maximumFileSizeToCacheInBytes: 4MB` override — the largest chunk is now ~1 MB, under Workbox's default 2 MiB precache limit. All 42 chunks still precache, so post-install navigation is instant + offline.

## Validation
tsc clean · 140 unit tests · oxlint clean · oxfmt clean · app build green · storybook build green · all chunks precache (no exclusions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)