### PR TITLE
fix(ui): toast id collision (use crypto.randomUUID)

### DIFF
--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -84,7 +84,9 @@ const uiSlice = createSlice({
     },
     addToast: (state, action: PayloadAction<{ message: string; type: "success" | "error" }>) => {
       state.toasts.push({
-        id: Date.now().toString(),
+        // randomUUID, not Date.now(): two toasts dispatched in the same tick
+        // would collide, and removeToast filters by id — removing both.
+        id: crypto.randomUUID(),
         ...action.payload,
       });
     },


### PR DESCRIPTION
Toast IDs used `Date.now().toString()`. Two toasts dispatched in the same tick get the same id, and `removeToast` filters by id — so dismissing/auto-expiring one removes **both**. Switch to `crypto.randomUUID()`.

One of four bugs surfaced by a frontend modernization audit. tsc + 140 unit tests + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)