### PR TITLE
fix(ui): TaxonLink light-mode hover

### DIFF
--- a/frontend/src/components/common/TaxonLink.tsx
+++ b/frontend/src/components/common/TaxonLink.tsx
@@ -95,7 +95,9 @@ export function TaxonLink({
           fontStyle: shouldItalicize ? "italic" : "normal",
           cursor: "pointer",
           "&:hover": {
-            bgcolor: "rgba(255, 255, 255, 0.08)",
+            // Theme token (mode-aware): a hardcoded white rgba was invisible /
+            // wrong in light mode.
+            bgcolor: "action.hover",
           },
         }}
       />


### PR DESCRIPTION
`TaxonLink`'s hover background was hardcoded `rgba(255, 255, 255, 0.08)` — a faint white overlay that's correct in dark mode but **invisible/wrong in light mode** (the theme supports both). Use the mode-aware `action.hover` token (which is that same value in dark mode, so no visual change there).

One of four bugs from a frontend modernization audit. tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)