### PR TITLE
fix(a11y): fallback alt text for observation images

### DIFF
--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -320,7 +320,7 @@ export function ObservationDetail() {
               <Box
                 component="img"
                 src={getImageUrl(activeImage.url)}
-                alt={species}
+                alt={species || "Observation photo"}
                 sx={{
                   width: "100%",
                   maxHeight: 400,
@@ -550,7 +550,7 @@ export function ObservationDetail() {
           open={lightboxOpen}
           onClose={() => setLightboxOpen(false)}
           src={getImageUrl(activeImage.url)}
-          alt={species}
+          alt={species || "Observation photo"}
           license={activeImage.license}
         />
       )}


### PR DESCRIPTION
On the observation detail page, the main photo and the lightbox used `alt={species}`, but `species` can be `undefined` (unidentified observations) — which omits the `alt` attribute entirely on meaningful content images. Fall back to `"Observation photo"` (matching the feed card behavior).

One of four bugs from a frontend modernization audit. tsc + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)