### PR TITLE
fix(ingester): always-allocated CPU so the firehose consumer keeps pace

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -558,13 +558,26 @@ jobs:
             --region=$REGION \
             --wait
 
+      # --no-cpu-throttling is load-bearing here, not a tuning knob. Cloud
+      # Run's default ("CPU only during request processing") throttles the
+      # instance to ~0 CPU whenever no HTTP request is in flight. But the
+      # ingester does all its work in a long-running background loop (consume
+      # the full network firehose via the embedded Tap, filter, upsert) — it
+      # is not request-driven. Under the default the consumer is CPU-starved,
+      # caps at a few hundred events/s, can't keep pace with the live
+      # firehose, and falls irrecoverably behind the relay's ~72h retention
+      # window (see incident 2026-05-31). always-allocated CPU lets the loop
+      # run at full speed. --cpu=2 gives headroom for decoding every event on
+      # the network (CBOR decode is CPU-bound). min/max-instances=1 keeps it a
+      # singleton so there's exactly one consumer per cursor.
       - name: Deploy tap-ingester
         run: |
           gcloud run deploy tap-ingester \
             --image=$REGISTRY/tap-ingester:latest \
             --region=$REGION \
             --allow-unauthenticated \
-            --cpu=1 \
+            --cpu=2 \
+            --no-cpu-throttling \
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
             --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,TAP_MAX_DB_CONNS=5,TAP_INHERIT_STDIO=1 \

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,7 +9,7 @@ Deployed via GitHub Actions (`.github/workflows/ci.yml`) on push to `main` after
 | Service | Build arg | Public | Cloud SQL | DB role | Notes |
 |---------|-----------|--------|-----------|---------|-------|
 | observing-appview | `SERVICE=observing-appview` | Yes | Yes | `appview_runtime` | REST API + OAuth + media cache + GBIF taxonomy + serves frontend |
-| tap-ingester | `SERVICE=tap-ingester` | Yes | Yes | `ingester_runtime` | Sole firehose-driven ingester. Bundles the upstream `tap` Go binary (built from a pinned indigo commit) and spawns it as a child process. Tap state is persisted in the Cloud SQL `tap` schema (`search_path=tap`), so tracked-DID lists and cursors survive deploys and instance recycles. min-instances=1 / max-instances=1. |
+| tap-ingester | `SERVICE=tap-ingester` | Yes | Yes | `ingester_runtime` | Sole firehose-driven ingester. Bundles the upstream `tap` Go binary (built from a pinned indigo commit) and spawns it as a child process. Tap state is persisted in the Cloud SQL `tap` schema (`search_path=tap`), so tracked-DID lists and cursors survive deploys and instance recycles. min-instances=1 / max-instances=1. Runs with `--no-cpu-throttling` (always-allocated CPU) + 2 vCPU because the firehose consumer is a background loop, not request-driven — under Cloud Run's default request-scoped CPU it gets starved and falls behind the relay's ~72h retention window. |
 | observing-species-id | `SERVICE=observing-species-id` | Yes | No | — | BioCLIP species identification (2 CPU, 8 GiB, cpu-boost, min-instances=1) |
 
 ### Jobs


### PR DESCRIPTION
## Problem

A freshly uploaded observation wasn't showing up on observ.ing. Investigation showed the record was valid on the PDS and the appview returned `404` — i.e. the **ingester never indexed it**.

Root cause: **`tap-ingester` runs on Cloud Run with the default CPU model** ("CPU only allocated during request processing"). The firehose consumer is a long-running **background loop**, not a request handler, so it was throttled to ~0 CPU whenever no HTTP request was in flight.

Measured live during the incident (2026-05-31):

- Cursor advanced at a flat **~332 events/s** for 5+ days straight, with zero catch-up bursts.
- Repeated `i/o timeout` reading from the relay → firehose disconnects + crash loops (`exit(1)`).
- The consumer fell **past the relay's ~72h retention floor** (relay retains exactly 72h; the consumer's cursor mapped to the oldest retained event). At that point it can no longer replay the gap from the firehose, and new records stop being delivered entirely.

This is specific to the Cloud Run execution model — most `tap` deployments run on always-on compute (VM / k8s / Fly) where the process always has CPU.

## Fix

Deploy `tap-ingester` with **`--no-cpu-throttling`** (always-allocated CPU) so the background loop runs at full speed, and bump to **`--cpu=2`** for headroom decoding every event on the network (CBOR decode is CPU-bound). `min/max-instances=1` already keeps it a singleton consumer.

- `.github/workflows/ci.yml` — the deploy step (source of truth)
- `docs/deployment.md` — service description

The **live service was already updated** to match (revision `tap-ingester-00074-pcw`); this PR makes that durable so the next deploy doesn't revert it.

## Follow-up (not in this PR)

Because the consumer is currently past the 72h retention window, the CPU fix alone won't recover already-missed records. A one-time recovery is still needed:
1. Reset the firehose cursor to ~live head (stop the losing race against retention).
2. Re-backfill the tracked repos from their PDSes (`/repos/add`) to recover records dropped past retention.

These touch Tap's internal admin API and are being handled separately.