### PR TITLE
feat(admin): per-repo Tap state table in the ingester admin browser

### DIFF
--- a/crates/observing-appview/src/routes/admin_ingester.rs
+++ b/crates/observing-appview/src/routes/admin_ingester.rs
@@ -27,6 +27,9 @@ enum View {
     /// The embedded Tap's state — repo/record/buffer counts and cursors — as
     /// metric/value rows. From `/api/tap-stats`.
     TapState,
+    /// One row per tracked repo, each enriched with its Tap `repo_info`
+    /// (state, rev, error, retries, record count). From `/api/repos`.
+    Repos,
 }
 
 impl View {
@@ -35,6 +38,7 @@ impl View {
         match self {
             View::RecentEvents | View::Stats => "/api/stats",
             View::TapState => "/api/tap-stats",
+            View::Repos => "/api/repos",
         }
     }
 
@@ -44,6 +48,7 @@ impl View {
             View::RecentEvents => "recent_events",
             View::Stats => "stats",
             View::TapState => "tap_state",
+            View::Repos => "repos",
         }
     }
 }
@@ -61,7 +66,7 @@ impl IngesterApi {
     pub fn tables(base_url: &str) -> Vec<IngesterApi> {
         let base = base_url.trim_end_matches('/').to_string();
         let client = reqwest::Client::new();
-        [View::RecentEvents, View::Stats, View::TapState]
+        [View::RecentEvents, View::Stats, View::TapState, View::Repos]
             .into_iter()
             .map(|view| IngesterApi {
                 client: client.clone(),
@@ -129,6 +134,24 @@ impl IngesterApi {
                 }
                 rows
             }
+            // Each element is already a per-repo object; pass them through.
+            View::Repos => {
+                let mut rows = snapshot
+                    .get("repos")
+                    .and_then(Value::as_array)
+                    .cloned()
+                    .unwrap_or_default();
+                // If the list came back empty *and* the ingester reported a
+                // top-level error (pool/Tap not ready, DID query failed),
+                // surface it as a row so the admin sees why the table is empty
+                // rather than an unexplained blank.
+                if rows.is_empty() {
+                    if let Some(err) = snapshot.get("error").and_then(Value::as_str) {
+                        rows.push(json!({ "did": "(error)", "info_error": err }));
+                    }
+                }
+                rows
+            }
         }
     }
 }
@@ -169,6 +192,19 @@ impl TableSource for IngesterApi {
         let (cols, pk) = match self.view {
             View::RecentEvents => (columns(&["type", "action", "uri", "time"]), "uri"),
             View::Stats | View::TapState => (columns(&["metric", "value"]), "metric"),
+            View::Repos => (
+                columns(&[
+                    "did",
+                    "handle",
+                    "state",
+                    "rev",
+                    "retries",
+                    "records",
+                    "error",
+                    "info_error",
+                ]),
+                "did",
+            ),
         };
         Ok(TableMeta {
             columns: cols,
@@ -272,6 +308,31 @@ mod tests {
         assert_eq!(errors["value"], json!(["repo_count: boom"]));
         // Missing counts/cursors still render as null rows.
         assert_eq!(rows[0], json!({ "metric": "repo_count", "value": null }));
+    }
+
+    #[test]
+    fn repos_pass_through_each_repo_row() {
+        let snapshot = json!({
+            "repos": [
+                { "did": "did:plc:a", "handle": "a.test", "state": "active", "rev": "3k...", "error": "", "retries": 0, "records": 12 },
+                { "did": "did:plc:b", "handle": "", "state": "unknown", "rev": "", "error": "", "retries": 0, "records": 0, "info_error": "timeout" }
+            ],
+            "error": null
+        });
+        let rows = table("repos").rows_from(&snapshot);
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0]["did"], "did:plc:a");
+        assert_eq!(rows[0]["state"], "active");
+        assert_eq!(rows[1]["info_error"], "timeout");
+    }
+
+    #[test]
+    fn repos_surface_top_level_error_when_empty() {
+        let snapshot = json!({ "repos": [], "error": "tap not yet initialized" });
+        let rows = table("repos").rows_from(&snapshot);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["did"], "(error)");
+        assert_eq!(rows[0]["info_error"], "tap not yet initialized");
     }
 
     #[test]

--- a/crates/observing-db/src/lib.rs
+++ b/crates/observing-db/src/lib.rs
@@ -13,6 +13,7 @@ pub mod private_data;
 #[cfg(feature = "processing")]
 pub mod processing;
 pub mod quality;
+pub mod repos;
 pub mod taxa;
 pub mod taxonomy_resolver;
 pub mod types;

--- a/crates/observing-db/src/repos.rs
+++ b/crates/observing-db/src/repos.rs
@@ -1,0 +1,29 @@
+//! Repo-level queries for the ingester admin surface.
+
+use crate::PgPool;
+
+/// Distinct DIDs that have produced any ingested lexicon record, unioned
+/// across the five collections the ingester writes (occurrences,
+/// identifications, comments, interactions, likes).
+///
+/// This is the set of repos Tap is expected to be tracking — the ingester
+/// dashboard enriches each one with its live Tap `repo_info` state so the
+/// admin can spot a repo that's stuck (e.g. `resyncing`/`error`) or whose
+/// record count diverges from what's on its PDS.
+///
+/// Uses the runtime query API rather than the `sqlx::query!` macro on purpose:
+/// it's a fixed, parameter-less, admin-only read, so skipping the macro avoids
+/// a `.sqlx` offline-cache entry (and the DB-backed `cargo sqlx prepare` churn)
+/// for what is effectively a diagnostic.
+pub async fn tracked_dids(pool: &PgPool) -> Result<Vec<String>, sqlx::Error> {
+    sqlx::query_scalar::<_, String>(
+        "SELECT did FROM occurrences \
+         UNION SELECT did FROM identifications \
+         UNION SELECT did FROM comments \
+         UNION SELECT did FROM interactions \
+         UNION SELECT did FROM likes \
+         ORDER BY did",
+    )
+    .fetch_all(pool)
+    .await
+}

--- a/crates/tap-ingester/src/dashboard.rs
+++ b/crates/tap-ingester/src/dashboard.rs
@@ -15,6 +15,9 @@
 //!                            loopback (JSON).
 //!   GET /api/failed-records  Recent rows from `ingester.failed_records`
 //!                            (JSON) for the dashboard's failures panel.
+//!   GET /api/repos           Per-repo Tap state (JSON): each tracked DID
+//!                            enriched with its `repo_info` (state, rev,
+//!                            error, retries, record count).
 
 use crate::{
     server::SharedState,
@@ -26,7 +29,7 @@ use axum::{
     routing::get,
     Router,
 };
-use observing_db::failed_records;
+use observing_db::{failed_records, repos};
 use serde::Serialize;
 use sqlx::postgres::PgPool;
 use std::sync::Arc;
@@ -60,6 +63,7 @@ pub fn router(state: DashboardState) -> Router {
         .route("/api/stats", get(stats))
         .route("/api/tap-stats", get(tap_stats))
         .route("/api/failed-records", get(failed_records_handler))
+        .route("/api/repos", get(repos_handler))
         .layer(CorsLayer::permissive())
         .with_state(state)
 }
@@ -221,6 +225,100 @@ async fn failed_records_handler(State(s): State<DashboardState>) -> Json<FailedR
         total,
         items,
         error,
+    })
+}
+
+/// One tracked repo's live Tap state, as rendered for the admin.
+#[derive(Serialize)]
+struct RepoRow {
+    did: String,
+    handle: String,
+    /// Tap's `RepoState`, lowercased (`active`/`resyncing`/`error`/…), or
+    /// `unknown` if `repo_info` failed for this DID.
+    state: String,
+    rev: String,
+    /// Tap-side error string for the repo (empty when healthy).
+    error: String,
+    retries: u32,
+    records: u64,
+    /// Set only when the `repo_info` call itself failed for this DID; the
+    /// other fields are then placeholders.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    info_error: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ReposResponse {
+    repos: Vec<RepoRow>,
+    /// Top-level failure (pool/Tap not ready, or the DID query failed). Per-DID
+    /// `repo_info` failures are reported inline via `RepoRow::info_error`.
+    error: Option<String>,
+}
+
+/// Enumerate the DIDs that have produced ingested records and enrich each with
+/// its embedded-Tap `repo_info`. Tap has no "list tracked repos" endpoint, so
+/// the DID set comes from our own tables; `repo_info` is the per-DID lookup.
+async fn repos_handler(State(s): State<DashboardState>) -> Json<ReposResponse> {
+    let Some(pool) = s.pool.get() else {
+        return Json(ReposResponse {
+            repos: Vec::new(),
+            error: Some("database pool not yet initialized".to_string()),
+        });
+    };
+    let Some(tap) = s.tap.get() else {
+        return Json(ReposResponse {
+            repos: Vec::new(),
+            error: Some("tap not yet initialized".to_string()),
+        });
+    };
+
+    let dids = match repos::tracked_dids(pool).await {
+        Ok(dids) => dids,
+        Err(e) => {
+            warn!(error = %e, "tracked_dids query failed");
+            return Json(ReposResponse {
+                repos: Vec::new(),
+                error: Some(format!("dids: {e}")),
+            });
+        }
+    };
+
+    // Sequential is fine: the tracked set is tiny (single digits) and each
+    // call is a loopback request to the embedded Tap.
+    let mut rows = Vec::with_capacity(dids.len());
+    for did in dids {
+        match tap.repo_info(&did).await {
+            Ok(info) => rows.push(RepoRow {
+                did: info.did,
+                handle: info.handle,
+                // RepoState is `#[serde(rename_all = "lowercase")]`, so it
+                // serializes to a bare string; pull that out for the row.
+                state: serde_json::to_value(info.state)
+                    .ok()
+                    .and_then(|v| v.as_str().map(str::to_string))
+                    .unwrap_or_else(|| "unknown".to_string()),
+                rev: info.rev,
+                error: info.error,
+                retries: info.retries,
+                records: info.records,
+                info_error: None,
+            }),
+            Err(e) => rows.push(RepoRow {
+                did,
+                handle: String::new(),
+                state: "unknown".to_string(),
+                rev: String::new(),
+                error: String::new(),
+                retries: 0,
+                records: 0,
+                info_error: Some(e.to_string()),
+            }),
+        }
+    }
+
+    Json(ReposResponse {
+        repos: rows,
+        error: None,
     })
 }
 


### PR DESCRIPTION
## What

Adds a read-only **`repos`** table under the **ingester** group in the admin browser. Each row is a tracked repo enriched with its live Tap `repo_info`:

| did | handle | state | rev | retries | records | error | info_error |
|---|---|---|---|---|---|---|---|

`state` is Tap's `RepoState` (`active` / `resyncing` / `desynchronized` / `error` / …), so you can immediately spot a repo that's stuck or whose `records` count diverges from what's actually on its PDS.

## Why

Came out of debugging an observation that uploaded fine but never indexed. The ingester's existing admin views show *aggregate* counters (`repoCount`, cursors, buffers) but nothing **per repo**, so there was no way to see an individual repo's sync state from the admin. This fills that gap.

## How

Tap has **no list-tracked-repos endpoint** — only `repo_info(did)` per DID. So:

- **observing-db** — `repos::tracked_dids(pool)`: distinct `did`s unioned across the five ingested collections (occurrences / identifications / comments / interactions / likes). Runtime query (not the `sqlx::query!` macro) so it needs no `.sqlx` offline-cache entry for an admin-only read.
- **tap-ingester** — `GET /api/repos`: enumerates those DIDs and calls `repo_info` on each over the loopback `TapClient`. Per-DID failures are reported inline (`info_error`); top-level failures (pool/Tap not ready) come back in `error`.
- **observing-appview** — `View::Repos` added to the existing `IngesterApi` `TableSource`; appears automatically when `INGESTER_URL` is set (production). Pass-through rows + a synthetic error row so an empty table is never unexplained.

## Scope / safety

- **Read-only.** The only new surface is an extra `GET` on the ingester; no change to its auth posture.
- Sequential `repo_info` calls — the tracked set is single digits.
- Unit tests added for the new view (pass-through + empty/error cases); all `admin_ingester` tests green.

## Follow-up (separate PR)

The mutating recovery action — **"resync repo"** (`/repos/remove` + `/repos/add` → fresh PDS backfill, the firehose-independent recovery path) — is intentionally **not** here. It requires locking down the ingester's currently-unauthenticated surface first.