### PR TITLE
feat(db): drop occurrence-ref FKs from firehose records (soft references)

### DIFF
--- a/crates/observing-db/migrations/20260602000000_drop_occurrence_ref_fks.sql
+++ b/crates/observing-db/migrations/20260602000000_drop_occurrence_ref_fks.sql
@@ -1,0 +1,61 @@
+-- Drop the FKs from firehose-delivered social/annotation records to
+-- occurrences(uri); treat those references as SOFT (resolved at read time)
+-- instead of enforced at write time.
+--
+-- Affected: identifications, comments, likes, interactions (subject_a + _b).
+-- These are the records the ingester pulls independently off the firehose
+-- (the bio.lexicons.temp.v0-1.identification / .occurrence and
+-- ing.observ.temp.{comment,interaction,like} collections), each referencing an
+-- occurrence by URI.
+--
+-- Why: each FK is checked at INSERT, which assumes firehose records arrive
+-- ordered and complete. They don't. A referencing record can be ingested
+-- before its occurrence (out-of-order delivery, within or across commits), or
+-- the occurrence may never arrive (firehose gap past relay retention, a deleted
+-- occurrence, or a cross-repo subject whose repo isn't tracked yet). Under the
+-- hard FK every such case became a *permanent* failure: the insert was rejected
+-- (..._fkey), parked in ingester.failed_records, and never retried -- stuck
+-- forever if the occurrence never showed. We hit this with identifications
+-- (136 stuck rows); the others share the identical shape and only escaped so
+-- far because likes/comments/interactions are after-the-fact actions on an
+-- already-present observation, so they rarely race their occurrence. This
+-- removes the failure class entirely. Continues what
+-- 20260522000000_optional_occurrence_location.sql began from the occurrence
+-- side.
+--
+-- Soft reference makes ingestion order-independent: the record is always
+-- stored, and its occurrence is joined at read time. The consumers that matter
+-- already INNER JOIN occurrences (the ingester.community_ids materialized view;
+-- the appview feeds; like/comment/interaction displays are occurrence-scoped),
+-- so a row with no occurrence is simply invisible until/unless the occurrence
+-- lands, at which point it self-heals with no replay.
+--
+-- Intentional tradeoffs:
+--   * Loses ON DELETE CASCADE on these tables. Deleting an occurrence no longer
+--     auto-removes its identifications/comments/likes/interactions; they become
+--     harmless orphans (excluded by the inner joins above). Reclaim with a
+--     periodic sweep, e.g.:
+--         DELETE FROM identifications i
+--         WHERE NOT EXISTS (SELECT 1 FROM occurrences o WHERE o.uri = i.subject_uri);
+--       (and likewise comments.subject_uri, likes.subject_uri,
+--        interactions.subject_a_occurrence_uri / subject_b_occurrence_uri)
+--   * Counts that don't join occurrences (e.g. the profile identification count
+--     COUNT(*) FROM identifications WHERE did = $1) now include orphans -- they
+--     count records authored, regardless of whether the subject occurrence is
+--     present.
+--
+-- NOT dropped: occurrence_observers.occurrence_uri. That table is not an
+-- independently-delivered collection -- it's the observer/recordedBy list
+-- written *with* the occurrence, so its parent always exists. No ordering
+-- exposure; its cascade is correct.
+--
+-- Subject columns and their indexes are kept (still used for the read-time
+-- join). Unqualified names resolve via the migrate role's search_path
+-- (= ingester), matching 20260522000000. Constraint names are Postgres'
+-- auto-generated defaults; IF EXISTS keeps this idempotent.
+
+ALTER TABLE identifications DROP CONSTRAINT IF EXISTS identifications_subject_uri_fkey;
+ALTER TABLE comments        DROP CONSTRAINT IF EXISTS comments_subject_uri_fkey;
+ALTER TABLE likes           DROP CONSTRAINT IF EXISTS likes_subject_uri_fkey;
+ALTER TABLE interactions    DROP CONSTRAINT IF EXISTS interactions_subject_a_occurrence_uri_fkey;
+ALTER TABLE interactions    DROP CONSTRAINT IF EXISTS interactions_subject_b_occurrence_uri_fkey;


### PR DESCRIPTION
## Problem

The FKs from firehose-delivered records to `occurrences(uri)` are enforced at **INSERT time**, which assumes records arrive **ordered and complete**. Neither holds on a firehose:
- a referencing record can be ingested **before** its occurrence (out-of-order delivery), or
- the occurrence may **never** arrive (gap past relay retention, a deleted occurrence, or a cross-repo subject whose repo isn't tracked yet).

Under a hard FK, every such case is a *permanent* failure: rejected by the `..._fkey`, parked in `ingester.failed_records`, never retried.

We hit this in prod with **identifications** — 136 stuck rows (134 only needed their already-present occurrences re-upserted; 2 reference an occurrence that was never delivered, which a hard FK can't represent). `comments` / `likes` / `interactions` share the identical shape and only escaped so far because they're after-the-fact actions on an already-present observation, so they rarely race their occurrence (empirically **zero** in `failed_records`).

## Change

Treat these references as **soft**, resolved at read time. One migration drops the constraints; subject columns and their indexes stay (still used for the join).

| Table.column | Action |
|---|---|
| `identifications.subject_uri` | drop |
| `comments.subject_uri` | drop |
| `likes.subject_uri` | drop |
| `interactions.subject_a_occurrence_uri` / `subject_b_occurrence_uri` | drop |
| `occurrence_observers.occurrence_uri` | **keep** |

Ingestion becomes order-independent: the record is always stored, and its occurrence is joined at read time. The consumers that matter already **INNER JOIN** occurrences (`ingester.community_ids`; the appview feeds; like/comment/interaction displays are occurrence-scoped), so an orphan is invisible until its occurrence lands — then **self-heals with no replay**. Continues from the referencing side what `20260522000000_optional_occurrence_location.sql` began from the occurrence side.

**Why `occurrence_observers` is kept:** it's not an independently-delivered collection — it's the observer/`recordedBy` list written *with* the occurrence, so the parent always exists. No ordering exposure; its cascade is correct.

## Tradeoffs (intentional, documented in the migration)

- **Loses `ON DELETE CASCADE`** on the four tables. Deleting an occurrence no longer auto-removes its referencing rows; they become harmless orphans (excluded by the inner joins). Reclaim with a periodic sweep (query in the migration).
- **Counts that don't join occurrences** (e.g. the profile identification count) now include orphans — they count records authored, regardless of whether the subject occurrence is present.

## Scope / safety

- Pure migration, **no `query!` changes** → `.sqlx` cache untouched, `prepare --check` unaffected. FK drops don't change any query's result shape/nullability.
- Verified against prod (read-only): all five constraint names match exactly, so each `DROP … IF EXISTS` targets one (no silent no-op). Migrate role (`postgres`) owns the tables and already `ALTER`s them in `20260522000000`.

## Follow-ups (not in this PR)

- **Cross-repo discovery:** the `SubjectResolver` previously `/repos/add`-ed a subject's DID *reactively on FK failure*. With the FKs gone that trigger no longer fires — discovery now relies on `signal_collection(occurrence)`. Worth making subject-DID tracking **proactive** on ingest.
- A scheduled **orphan sweep** for hygiene.