### PR TITLE
ci(tap-ingester): raise TAP_MAX_DB_CONNS 5 → 10 (+39% firehose throughput)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -580,7 +580,7 @@ jobs:
             --no-cpu-throttling \
             --memory=2Gi \
             --add-cloudsql-instances=$PROJECT_ID:$REGION:observing-db \
-            --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,TAP_MAX_DB_CONNS=5,TAP_INHERIT_STDIO=1 \
+            --set-env-vars=RUST_LOG=tap_ingester=info,DB_HOST=/cloudsql/$PROJECT_ID:$REGION:observing-db,DB_NAME=observing,DB_USER=ingester_runtime,TAP_MAX_DB_CONNS=10,TAP_INHERIT_STDIO=1 \
             --set-secrets=DB_PASSWORD=observing-db-ingester-password:latest \
             --min-instances=1 \
             --max-instances=1 \


### PR DESCRIPTION
## What

Raises the embedded Tap's DB connection pool from **5 → 10** in the `tap-ingester` Cloud Run deploy.

## Why

The deploy pinned `TAP_MAX_DB_CONNS=5` while indigo's `firehose-parallelism` defaults to **10** — so 10 firehose workers contended for 5 DB connections, an artificial throttle. A live env-var sweep on the Cloud Run service (config-only deploys, measuring `cursorAdvance/60` = firehose events/sec) showed:

| config | throughput | Δ | DB backends |
|---|---|---|---|
| `conns=5, fh=10` (baseline) | 400 ev/s | — | 10 |
| `conns=10, fh=10` | **556 ev/s** | **+39%** | 16 |
| `conns=15, fh=15` | 572 ev/s | +3% (noise) | 20 |

The entire win comes from un-starving the pool (5→10). Beyond that, more connections **and** more parallelism plateau at ~560–570 ev/s — the genuine internal indigo serialization ceiling — so neither extra parallelism nor a larger Cloud SQL tier helps firehose throughput.

`conns=10` matches the firehose-parallelism default 1:1 and stays well within `db-f1-micro`'s connection budget (peak 16 of ~25 backends).

## Notes

- The **live service is already updated** to `TAP_MAX_DB_CONNS=10` (rev `tap-ingester-00090-zqp`). This PR makes it durable: CI deploys use `--set-env-vars` (replaces all env), which would otherwise revert the live value to 5 on the next deploy.
- **Untested:** whether *resync* throughput (`resync_parallelism=5`, also DB-connection-heavy — the actual lag-recovery lever) is connection-starved. That's a separate experiment.