### PR TITLE
feat(appview): sort feed by PDS authoring time (stamp createdAt on occurrences)

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -512,9 +512,13 @@ async fn upload_media_records(
     Ok((blob_entries, media_refs))
 }
 
-/// Build the `bio.lexicons.temp.v0-1.occurrence` record body (schema fields only)
-/// and serialize it to JSON for the PDS write API. `media_refs` are attached
-/// via the typed builder's `associatedMedia` field. Defaults `eventDate` to now.
+/// Build the `bio.lexicons.temp.v0-1.occurrence` record body and serialize it
+/// to JSON for the PDS write API. `media_refs` are attached via the typed
+/// builder's `associatedMedia` field. Defaults `eventDate` to now, and stamps a
+/// `createdAt` field (the AT Protocol authoring time) so the firehose ingester
+/// records when the post was authored on the PDS rather than when it was
+/// ingested. `createdAt` is an app-specific extension, not part of the upstream
+/// occurrence lexicon; see the matching handling in the identification path.
 fn build_occurrence_record_json(
     latitude: f64,
     longitude: f64,
@@ -546,7 +550,20 @@ fn build_occurrence_record_json(
         .maybe_associated_media(associated_media)
         .build();
 
-    auth::serialize_at_record(&record)
+    let mut record_value = auth::serialize_at_record(&record)?;
+
+    // App-specific fields (not in upstream lexicon, stored as extra data in the
+    // AT Protocol record). `createdAt` is the post authoring time; the ingester
+    // reads it into `occurrences.created_at` (which the feed sorts by), falling
+    // back to ingestion time only when it is absent.
+    if let Some(obj) = record_value.as_object_mut() {
+        obj.insert(
+            "createdAt".to_string(),
+            serde_json::json!(chrono::Utc::now().to_rfc3339()),
+        );
+    }
+
+    Ok(record_value)
 }
 
 /// Create an identification record on the PDS for the given occurrence. The

--- a/crates/observing-db/migrations/20260602010000_occurrence_created_at_authoring_time.sql
+++ b/crates/observing-db/migrations/20260602010000_occurrence_created_at_authoring_time.sql
@@ -1,0 +1,39 @@
+-- Occurrence feed time is now the PDS authoring time, not the ingestion time.
+--
+-- Background: the home/explore feeds sort by occurrences.created_at DESC. That
+-- column is populated by the ingester from the record's `createdAt` field
+-- (observing-db processing.rs), falling back to the firehose ingestion time
+-- (Utc::now()) when the field is absent. Until now the occurrence write path
+-- never stamped `createdAt` -- it isn't part of the bio.lexicons.temp.v0-1
+-- .occurrence lexicon -- so every occurrence fell through to the fallback and
+-- the feed was effectively ordered by *ingestion* time. The appview now writes
+-- a `createdAt` extension field on occurrence creation (matching what
+-- identifications/comments/likes already do), so newly authored occurrences
+-- carry their true PDS authoring time end-to-end.
+--
+-- This migration is intentionally a NO-OP on data. It exists to document why
+-- existing rows are left untouched.
+--
+-- Why no backfill: the true authoring time of an already-ingested occurrence is
+-- unrecoverable here. We do not retain the raw record JSON for successful
+-- occurrences (only ingester.failed_records keeps record_json, and only for
+-- failures), so there is no stored `createdAt` to read. The columns we do have
+-- are all wrong or lossy as a substitute:
+--   * created_at  -- already the best available estimate. For normally
+--                    live-ingested posts it sits within seconds of authoring
+--                    time; rewriting it gains nothing.
+--   * indexed_at  -- the DB insert time; same ingestion-time bias, no better.
+--   * event_date  -- when the observation *occurred*, a user-supplied value
+--                    routinely backdated to when a photo was taken. Copying it
+--                    into created_at would yank any backdated observation far
+--                    down the feed -- corrupting the common case to maybe help
+--                    the rare replayed-record case. Not worth it.
+--
+-- So existing rows keep their ingestion-time created_at (a close estimate for
+-- the live-ingested majority), and the fix is forward-looking: occurrences
+-- authored after this deploy carry an accurate PDS authoring time. Records from
+-- other AT Protocol clients that never set `createdAt` continue to fall back to
+-- ingestion time, by design.
+--
+-- No schema or data changes below -- this file is documentation-only.
+SELECT 1;


### PR DESCRIPTION
## Problem

The home/explore feeds sort by `occurrences.created_at DESC`. The ingester fills `created_at` from the record's `createdAt` field (`observing-db/src/processing.rs`), **falling back to the firehose ingestion time** (`Utc::now()`) when the field is absent.

The occurrence write path never stamped `createdAt` — it isn't part of the `bio.lexicons.temp.v0-1.occurrence` lexicon — so **every occurrence hit the fallback** and the feed was effectively ordered by *ingestion* time, not when the author posted on their PDS. (Identifications, comments, and likes already stamp `createdAt`, so they were unaffected.)

## Change

- **`occurrences/write.rs`** — stamp a `createdAt` extension field on occurrence creation, mirroring the existing identification/comment/like pattern. The ingester read path already prefers `createdAt`, so newly authored occurrences now carry their true PDS authoring time end-to-end. **No ingester or read-side change needed.**
- **Migration `20260602010000_..._authoring_time.sql`** — documentation-only (`SELECT 1;`), explaining why existing rows are intentionally **not** backfilled.

## Why no backfill of existing rows

The original authoring time of an already-ingested occurrence is unrecoverable: we don't retain raw record JSON for successful occurrences (only `failed_records` keeps it). The available columns are all poor substitutes:

- `created_at` (current value) — already within seconds of authoring time for live-ingested posts; rewriting gains nothing.
- `indexed_at` — same ingestion-time bias.
- `event_date` — when the observation *occurred*, routinely backdated to a photo's date; copying it would yank backdated observations down the feed, corrupting the common case.

So existing rows keep their ingestion-time `created_at` (a close estimate for the live-ingested majority), and the fix is forward-looking.

## Caveats

- Forward-only: posts authored before this deploy keep ingestion-time ordering.
- Records from other AT Protocol clients that never set `createdAt` still fall back to ingestion time, by design.

## Test plan

- [x] `cargo check -p observing-appview`
- [x] `cargo fmt`
- [ ] Post a new observation through the app and confirm the firehose round-trip lands the authored `createdAt` in `occurrences.created_at` and the feed orders by it.