### PR TITLE
fix(db): stable feed pagination via (created_at, uri) keyset cursor

### DIFF
--- a/crates/observing-appview/src/enrichment.rs
+++ b/crates/observing-appview/src/enrichment.rs
@@ -46,6 +46,17 @@ pub struct OccurrenceResponse {
     pub quality_issues: Vec<QualityIssue>,
 }
 
+impl OccurrenceResponse {
+    /// Keyset-pagination cursor for the feeds: `created_at` paired with the
+    /// unique `uri` tiebreaker, matching the feed `ORDER BY (created_at DESC,
+    /// uri DESC)`. `created_at` alone is not unique, so a timestamp-only cursor
+    /// skips or duplicates rows that share a timestamp. The db side decodes
+    /// this in `observing_db::feeds::push_keyset_cursor`.
+    pub fn feed_cursor(&self) -> String {
+        format!("{}|{}", self.created_at, self.uri)
+    }
+}
+
 /// A single image attached to an occurrence, with the SPDX license the
 /// uploader chose (when one is recorded on the underlying media record).
 #[derive(Debug, Clone, Serialize, TS)]

--- a/crates/observing-appview/src/routes/feeds.rs
+++ b/crates/observing-appview/src/routes/feeds.rs
@@ -57,7 +57,7 @@ pub async fn get_explore(
     .await;
 
     let next_cursor = if occurrences.len() as i64 == limit {
-        occurrences.last().map(|o| o.created_at.clone())
+        occurrences.last().map(|o| o.feed_cursor())
     } else {
         None
     };
@@ -113,7 +113,7 @@ pub async fn get_home(
     .await;
 
     let next_cursor = if occurrences.len() as i64 == limit {
-        occurrences.last().map(|o| o.created_at.clone())
+        occurrences.last().map(|o| o.feed_cursor())
     } else {
         None
     };

--- a/crates/observing-appview/src/routes/taxonomy.rs
+++ b/crates/observing-appview/src/routes/taxonomy.rs
@@ -167,7 +167,7 @@ pub async fn get_taxon_occurrences_by_kingdom_name(
     )
     .await;
 
-    let next_cursor = occurrences.last().map(|o| o.created_at.clone());
+    let next_cursor = occurrences.last().map(|o| o.feed_cursor());
 
     Ok(Json(OccurrenceListResponse {
         occurrences,
@@ -260,7 +260,7 @@ pub async fn get_taxon_occurrences_by_id(
     )
     .await;
 
-    let next_cursor = occurrences.last().map(|o| o.created_at.clone());
+    let next_cursor = occurrences.last().map(|o| o.feed_cursor());
 
     Ok(Json(OccurrenceListResponse {
         occurrences,

--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -6,6 +6,33 @@ use crate::types::{
 };
 use sqlx::{PgPool, Postgres, QueryBuilder};
 
+/// Append the keyset-pagination predicate for a feed cursor.
+///
+/// Feeds order by `(created_at DESC, uri DESC)`. `created_at` is not unique, so
+/// a timestamp-only cursor (`created_at < $ts`) skips every other row sharing
+/// the boundary timestamp and ties sort arbitrarily between queries. The cursor
+/// encodes both halves as `"<created_at>|<uri>"` (see
+/// `OccurrenceResponse::feed_cursor` in the appview) and we compare the row
+/// tuple against it. Any caller that uses this MUST order by
+/// `created_at DESC, uri DESC` so the predicate and sort agree. Legacy
+/// single-value cursors (no `|`) fall back to the timestamp-only predicate.
+fn push_keyset_cursor(qb: &mut QueryBuilder<Postgres>, cursor: &str) {
+    match cursor.split_once('|') {
+        Some((created_at, uri)) => {
+            qb.push(" AND (created_at, uri) < (");
+            qb.push_bind(created_at.to_string());
+            qb.push("::timestamptz, ");
+            qb.push_bind(uri.to_string());
+            qb.push(")");
+        }
+        None => {
+            qb.push(" AND created_at < ");
+            qb.push_bind(cursor.to_string());
+            qb.push("::timestamptz");
+        }
+    }
+}
+
 /// Get the explore feed with optional filters
 pub async fn get_explore_feed(
     executor: impl sqlx::PgExecutor<'_>,
@@ -53,13 +80,11 @@ pub async fn get_explore_feed(
     }
 
     if let Some(cursor) = options.cursor.as_deref() {
-        qb.push(" AND created_at < ");
-        qb.push_bind(cursor);
-        qb.push("::timestamptz");
+        push_keyset_cursor(&mut qb, cursor);
     }
 
     let limit = options.limit.unwrap_or(20);
-    qb.push(" ORDER BY created_at DESC LIMIT ");
+    qb.push(" ORDER BY created_at DESC, uri DESC LIMIT ");
     qb.push_bind(limit);
 
     qb.build_query_as::<OccurrenceRow>()
@@ -250,13 +275,11 @@ pub async fn get_home_feed(
     }
 
     if let Some(cursor) = options.cursor.as_deref() {
-        qb.push(" AND created_at < ");
-        qb.push_bind(cursor);
-        qb.push("::timestamptz");
+        push_keyset_cursor(&mut qb, cursor);
     }
 
     let limit = options.limit.unwrap_or(20);
-    qb.push(" ORDER BY created_at DESC LIMIT ");
+    qb.push(" ORDER BY created_at DESC, uri DESC LIMIT ");
     qb.push_bind(limit);
 
     qb.build_query_as::<OccurrenceRow>()
@@ -297,12 +320,10 @@ pub async fn get_occurrences_by_taxon(
     }
 
     if let Some(cursor) = options.cursor.as_deref() {
-        qb.push(" AND created_at < ");
-        qb.push_bind(cursor);
-        qb.push("::timestamptz");
+        push_keyset_cursor(&mut qb, cursor);
     }
 
-    qb.push(" ORDER BY created_at DESC LIMIT ");
+    qb.push(" ORDER BY created_at DESC, uri DESC LIMIT ");
     qb.push_bind(limit);
 
     qb.build_query_as::<OccurrenceRow>()
@@ -358,4 +379,32 @@ fn push_consensus_rank_filter(qb: &mut QueryBuilder<Postgres>, rank_lower: &str,
     qb.push(" = ");
     qb.push_bind(taxon_name);
     qb.push(")");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keyset_cursor_compound_uses_row_value_comparison() {
+        let mut qb = QueryBuilder::<Postgres>::new("SELECT 1 FROM occurrences WHERE TRUE");
+        push_keyset_cursor(&mut qb, "2026-06-02T21:13:49Z|at://did:plc:x/coll/rkey");
+        let sql = qb.sql();
+        let sql = sql.as_str();
+        // Tuple comparison against (created_at, uri) so a shared timestamp can't
+        // skip or duplicate rows at the page boundary.
+        assert!(sql.contains("(created_at, uri) < ("), "got: {sql}");
+        assert!(sql.contains("::timestamptz"));
+    }
+
+    #[test]
+    fn keyset_cursor_legacy_value_falls_back_to_timestamp() {
+        let mut qb = QueryBuilder::<Postgres>::new("SELECT 1 FROM occurrences WHERE TRUE");
+        push_keyset_cursor(&mut qb, "2026-06-02T21:13:49Z");
+        let sql = qb.sql();
+        let sql = sql.as_str();
+        // A pre-upgrade cursor (no `|`) still paginates, just without the tiebreaker.
+        assert!(sql.contains("AND created_at < "), "got: {sql}");
+        assert!(!sql.contains("(created_at, uri)"), "got: {sql}");
+    }
 }


### PR DESCRIPTION
## Problem

The home feed (and explore + taxon feeds, which share the code) sometimes shows **different results / a different order** on a fresh load versus when you navigate back to it later.

Root cause is in the feed SQL: it orders by `created_at DESC`, but `created_at` is **not unique** (and right now a large population of rows carry ingestion-time timestamps, so ties are common). With no tiebreaker:

- **Unstable order** — Postgres is free to return rows that share a timestamp in any order, and that order can differ between two executions of the identical query. Same feed, different paint.
- **Boundary skip/dup** — the cursor is just `created_at < $ts`. When several rows share the boundary timestamp, the next page either skips or duplicates them.

## Fix

Make feed pagination a proper keyset on a **total order**:

- `ORDER BY created_at DESC, uri DESC` on all three feed queries (`uri` is unique).
- Cursor carries both halves as `"<created_at>|<uri>"` and the predicate becomes a row-value comparison `(created_at, uri) < ($ts, $uri)`.
- Encoding: `OccurrenceResponse::feed_cursor`. Decoding: `feeds::push_keyset_cursor` (shared by all three queries — predicate and `ORDER BY` are kept in sync, with a comment to that effect).
- **Backward compatible:** legacy single-value cursors (no `|`) fall back to the old timestamp-only predicate, so pagination in flight during deploy keeps working.

## Notes

- There is no `occurrences.created_at` index today, so the feeds already sort without index support — adding the `uri` tiebreaker column to the sort doesn't change the plan. A `(created_at DESC, uri DESC)` index would help both this and the pre-existing `ORDER BY` and is a worthwhile **follow-up**.
- Companion frontend PR (`refactor/feedview-drop-currenttab-mirror`) removes a stale-first-render in `FeedView` that made the *same* "initial load looks different" symptom more visible; the two are independent.

## Test

Added unit tests for `push_keyset_cursor` (compound vs. legacy-fallback predicate) — pure SQL-fragment assertions, no DB needed. `cargo build`/`cargo test` for `observing-db` + `observing-appview` pass.