### PR TITLE
refactor(feed): derive feed tab from the route, not a Redux mirror

### DIFF
--- a/frontend/src/components/feed/ExploreFilterPanel.stories.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.stories.tsx
@@ -20,18 +20,12 @@ export const WithActiveFilters: Story = {
     storeOptions: {
       preloadedState: {
         feed: {
-          observations: [],
-          cursor: undefined,
-          isLoading: false,
-          currentTab: "explore" as const,
-          hasMore: true,
           filters: {
             taxon: "Quercus robur",
             kingdom: "Plantae",
             startDate: "2026-01-01",
             endDate: "2026-04-30",
           },
-          isAuthenticated: false,
         },
       },
     },

--- a/frontend/src/components/feed/FeedView.tsx
+++ b/frontend/src/components/feed/FeedView.tsx
@@ -1,8 +1,7 @@
-import { useEffect, useRef, useCallback } from "react";
+import { useRef, useCallback } from "react";
 import { Box, Container, Typography, CircularProgress } from "@mui/material";
-import { useAppDispatch, useAppSelector } from "../../store";
+import { useAppDispatch } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
-import { switchTab } from "../../store/feedSlice";
 import { useFeed } from "../../lib/query/hooks";
 import { openEditModal, openDeleteConfirm } from "../../store/uiSlice";
 import type { FeedTab, Occurrence } from "../../services/types";
@@ -20,17 +19,9 @@ interface FeedViewProps {
 export function FeedView({ tab = "home" }: FeedViewProps) {
   usePageTitle(tab === "explore" ? "Explore" : "Home");
   const dispatch = useAppDispatch();
-  const currentTab = useAppSelector((state) => state.feed.currentTab);
   const contentRef = useRef<HTMLDivElement>(null);
 
-  // Sync route tab into the store; useFeed reads it back as a query input.
-  useEffect(() => {
-    if (tab !== currentTab) {
-      dispatch(switchTab(tab));
-    }
-  }, [dispatch, tab, currentTab]);
-
-  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useFeed();
+  const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useFeed(tab);
   const observations = data?.pages.flatMap((page) => page.occurrences) ?? [];
   const hasMore = hasNextPage;
 
@@ -60,7 +51,7 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
   return (
     <Box sx={{ flex: 1, display: "flex", flexDirection: "column", minHeight: 0 }}>
       {/* Filter panel for explore tab only */}
-      {currentTab === "explore" && (
+      {tab === "explore" && (
         <Box sx={{ flexShrink: 0 }}>
           <Container maxWidth="sm" disableGutters>
             <Box sx={{ px: 2, pt: 2 }}>
@@ -80,8 +71,8 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
           "&::-webkit-scrollbar": { display: "none" },
         }}
       >
-        <Container maxWidth={currentTab === "explore" ? "md" : "sm"} disableGutters>
-          {currentTab === "explore" ? (
+        <Container maxWidth={tab === "explore" ? "md" : "sm"} disableGutters>
+          {tab === "explore" ? (
             <>
               <Box
                 sx={{

--- a/frontend/src/lib/query/README.md
+++ b/frontend/src/lib/query/README.md
@@ -47,7 +47,8 @@ observation detail, taxon detail/children, taxa search, notifications + unread
 count, likes, comments, identifications.
 
 **Stays in Redux (UI/client state):** `uiSlice` (modals, toasts, theme,
-geolocation), `feedSlice` (currentTab + filters — the query _inputs_), and the
+geolocation), `feedSlice` (explore filters — a query _input_ shared with the
+filter panel; the active tab is the route, read from the `tab` prop), and the
 auth _session_.
 
 ## Deliberate exceptions / follow-ups

--- a/frontend/src/lib/query/hooks.ts
+++ b/frontend/src/lib/query/hooks.ts
@@ -19,7 +19,7 @@ import {
   fetchUnreadCount,
   fetchUserPreferences,
 } from "../../services/api";
-import type { FeedFilters } from "../../services/types";
+import type { FeedFilters, FeedTab } from "../../services/types";
 
 type Cursor = string | undefined;
 const initialCursor: Cursor = undefined;
@@ -27,9 +27,11 @@ const nextCursor = (last: { cursor?: string }): Cursor => last.cursor ?? undefin
 
 // ── Occurrence feeds (infinite) ──────────────────────────────────────────────
 
-/** Home/explore feed. Reads tab + filters + auth from Redux as query inputs. */
-export function useFeed() {
-  const tab = useAppSelector((s) => s.feed.currentTab);
+/**
+ * Home/explore feed. The active tab comes from the route (passed by the
+ * caller); filters + auth are read from Redux. All three form the query key.
+ */
+export function useFeed(tab: FeedTab) {
   const filters = useAppSelector((s) => s.feed.filters);
   const isAuthenticated = useAppSelector((s) => s.auth.user !== null);
 

--- a/frontend/src/store/feedSlice.test.ts
+++ b/frontend/src/store/feedSlice.test.ts
@@ -1,22 +1,16 @@
 import { describe, it, expect } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
-import feedReducer, { switchTab, setFilters } from "./feedSlice";
+import feedReducer, { setFilters } from "./feedSlice";
 
-// feedSlice now holds only UI state (tab + filters); feed data is fetched via
-// TanStack Query (lib/query/hooks `useFeed`), so there are no fetch thunks here.
+// feedSlice holds only the explore filters; feed data is fetched via TanStack
+// Query (lib/query/hooks `useFeed`) and the active tab is the route, so there
+// are no fetch thunks and no tab state here.
 const createTestStore = () => configureStore({ reducer: { feed: feedReducer } });
 
 describe("feedSlice", () => {
   it("has the expected initial UI state", () => {
     const state = createTestStore().getState().feed;
-    expect(state.currentTab).toBe("explore");
     expect(state.filters).toEqual({});
-  });
-
-  it("switchTab sets the current tab", () => {
-    const store = createTestStore();
-    store.dispatch(switchTab("home"));
-    expect(store.getState().feed.currentTab).toBe("home");
   });
 
   it("setFilters replaces the filters", () => {

--- a/frontend/src/store/feedSlice.ts
+++ b/frontend/src/store/feedSlice.ts
@@ -1,17 +1,16 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
-import type { FeedTab, FeedFilters } from "../services/types";
+import type { FeedFilters } from "../services/types";
 
-// Feed *server data* now lives in the TanStack Query cache (see
-// lib/query/hooks.ts `useFeed`). This slice keeps only the UI inputs that
-// select which feed to show; changing them changes the query key, which
-// drives the refetch.
+// Feed *server data* lives in the TanStack Query cache (see lib/query/hooks.ts
+// `useFeed`). This slice keeps only the explore filters — set by
+// `ExploreFilterPanel`, a sibling of the feed, so they need shared state — which
+// feed into the query key and drive refetch. The active tab is NOT stored here:
+// it's just the route, read straight from the `tab` prop in `FeedView`/`useFeed`.
 interface FeedState {
-  currentTab: FeedTab;
   filters: FeedFilters;
 }
 
 const initialState: FeedState = {
-  currentTab: "explore",
   filters: {},
 };
 
@@ -19,14 +18,11 @@ const feedSlice = createSlice({
   name: "feed",
   initialState,
   reducers: {
-    switchTab: (state, action: PayloadAction<FeedTab>) => {
-      state.currentTab = action.payload;
-    },
     setFilters: (state, action: PayloadAction<FeedFilters>) => {
       state.filters = action.payload;
     },
   },
 });
 
-export const { switchTab, setFilters } = feedSlice.actions;
+export const { setFilters } = feedSlice.actions;
 export default feedSlice.reducer;


### PR DESCRIPTION
## Problem

`FeedView` mirrored the route's `tab` prop into `feedSlice.currentTab` through an effect, and `useFeed` read it back out of Redux to build its query key:

```js
const currentTab = useAppSelector((s) => s.feed.currentTab);
useEffect(() => { if (tab !== currentTab) dispatch(switchTab(tab)); }, [tab, currentTab]);
const { ... } = useFeed();   // reads s.feed.currentTab internally
```

That round-trip for a value the component already holds caused a **stale first render**, which is part of why the home feed "looks different on initial load vs. coming back to it":

- Cold load of `/`: Redux still has the initial `currentTab: "explore"`, so the **first render** keys `useFeed` to the *explore* query while sitting on the home route. The effect then dispatches `switchTab("home")` → second render → corrects to the home query.
- Arriving at `/` from a profile/observation page: Redux already says `home`, so that detour is skipped and the right query runs on the first render.

Two arrival paths, two code paths, potentially different paint.

## Fix

The route is the source of truth for the active tab, and the `tab` prop already carries it. So stop mirroring it:

- `useFeed(tab)` takes the tab as an argument; `FeedView` passes the prop and renders off the prop.
- Remove the sync `useEffect`, the `switchTab` action, and the `currentTab` state field.
- `feedSlice` now holds only `filters` — which **stays** in Redux because the sibling `ExploreFilterPanel` sets them, so they genuinely need shared state.

Net: −1 effect, −1 action, −1 state field, and the cold-load/back-nav paths now run the same single render.

## Also updated

- `feedSlice.test.ts` — drop the `switchTab`/`currentTab` assertions.
- `ExploreFilterPanel.stories.tsx` — trim preloaded `feed` state (it still listed pre-TanStack fields like `observations`/`cursor`/`hasMore`) down to `filters`.
- `lib/query/README.md` — correct the "stays in Redux" note.

## Companion

Independent of the backend PR #581, which fixes the *other* half of the symptom (non-deterministic feed ordering from a non-unique `created_at`).

## Test

`tsc --noEmit` clean, `oxfmt` clean, `oxlint` clean (the 2 remaining warnings are pre-existing, in untouched files), `vitest` feedSlice tests pass.