### PR TITLE
refactor(ingester): extract collection NSIDs into observing-collections crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2891,6 +2891,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "observing-collections"
+version = "0.1.0"
+dependencies = [
+ "jacquard-common",
+ "observing-lexicons",
+]
+
+[[package]]
 name = "observing-db"
 version = "0.1.0"
 dependencies = [
@@ -3712,6 +3720,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "observing-collections",
  "observing-db",
  "serde_json",
  "sqlx",
@@ -4715,6 +4724,7 @@ dependencies = [
  "ciborium",
  "clap",
  "futures-util",
+ "observing-collections",
  "observing-db",
  "observing-lexicons",
  "pg-url-env",

--- a/crates/observing-collections/Cargo.toml
+++ b/crates/observing-collections/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "observing-collections"
+version = "0.1.0"
+edition = "2021"
+description = "Canonical AT Protocol collection NSIDs ingested by observ.ing, derived from the generated lexicon types"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# Source of truth: the generated record types expose their NSID as an
+# associated const, so the collection constants below cannot drift from the
+# lexicon schemas (e.g. during the lexicons.bio migration).
+observing-lexicons = { path = "../observing-lexicons" }
+jacquard-common = "0.12.0-beta.2"

--- a/crates/observing-collections/src/lib.rs
+++ b/crates/observing-collections/src/lib.rs
@@ -1,0 +1,45 @@
+//! Canonical AT Protocol collection NSIDs ingested by observ.ing.
+//!
+//! Each constant is derived from the generated lexicon record type's
+//! [`Collection::NSID`], so it cannot drift from the schema — renaming a
+//! collection in the lexicons regenerates `observing-lexicons` and these
+//! constants follow automatically.
+//!
+//! They are used both as Tap collection-filters and as dispatch keys when
+//! routing firehose records to per-collection handlers.
+
+use jacquard_common::types::collection::Collection;
+use observing_lexicons::bio_lexicons::temp::v0_1::{
+    identification::IdentificationRecord, occurrence::OccurrenceRecord,
+};
+use observing_lexicons::ing_observ::temp::{
+    comment::CommentRecord, interaction::InteractionRecord, like::LikeRecord,
+};
+
+/// `bio.lexicons.temp.v0-1.occurrence`
+pub const OCCURRENCE_COLLECTION: &str = OccurrenceRecord::NSID;
+/// `bio.lexicons.temp.v0-1.identification`
+pub const IDENTIFICATION_COLLECTION: &str = IdentificationRecord::NSID;
+/// `ing.observ.temp.comment`
+pub const COMMENT_COLLECTION: &str = CommentRecord::NSID;
+/// `ing.observ.temp.interaction`
+pub const INTERACTION_COLLECTION: &str = InteractionRecord::NSID;
+/// `ing.observ.temp.like`
+pub const LIKE_COLLECTION: &str = LikeRecord::NSID;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nsids_match_lexicon_schemas() {
+        assert_eq!(OCCURRENCE_COLLECTION, "bio.lexicons.temp.v0-1.occurrence");
+        assert_eq!(
+            IDENTIFICATION_COLLECTION,
+            "bio.lexicons.temp.v0-1.identification"
+        );
+        assert_eq!(COMMENT_COLLECTION, "ing.observ.temp.comment");
+        assert_eq!(INTERACTION_COLLECTION, "ing.observ.temp.interaction");
+        assert_eq!(LIKE_COLLECTION, "ing.observ.temp.like");
+    }
+}

--- a/crates/replay-failed-records/Cargo.toml
+++ b/crates/replay-failed-records/Cargo.toml
@@ -9,6 +9,8 @@ license = "MIT OR Apache-2.0"
 # Reaches `processing::*_from_json` (feature-gated) plus the per-collection
 # upsert helpers and the failed_records reader.
 observing-db = { path = "../observing-db", features = ["processing"] }
+# Canonical collection NSIDs, shared with tap-ingester (no more hand-kept copy).
+observing-collections = { path = "../observing-collections" }
 
 tokio = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/replay-failed-records/src/main.rs
+++ b/crates/replay-failed-records/src/main.rs
@@ -30,14 +30,10 @@ use std::time::Duration;
 use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
-// Duplicated from tap-ingester::types because tap-ingester is a bin-only
-// crate with no library target to import from. Keep in sync if either side
-// changes.
-const OCCURRENCE_COLLECTION: &str = "bio.lexicons.temp.v0-1.occurrence";
-const IDENTIFICATION_COLLECTION: &str = "bio.lexicons.temp.v0-1.identification";
-const COMMENT_COLLECTION: &str = "ing.observ.temp.comment";
-const INTERACTION_COLLECTION: &str = "ing.observ.temp.interaction";
-const LIKE_COLLECTION: &str = "ing.observ.temp.like";
+use observing_collections::{
+    COMMENT_COLLECTION, IDENTIFICATION_COLLECTION, INTERACTION_COLLECTION, LIKE_COLLECTION,
+    OCCURRENCE_COLLECTION,
+};
 
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]

--- a/crates/tap-ingester/Cargo.toml
+++ b/crates/tap-ingester/Cargo.toml
@@ -12,6 +12,8 @@ tapped = { workspace = true }
 # Database write path (shared processing module).
 observing-db = { path = "../observing-db", features = ["processing"] }
 observing-lexicons = { path = "../observing-lexicons" }
+# Canonical collection NSIDs (Tap filters + record-dispatch keys).
+observing-collections = { path = "../observing-collections" }
 
 # Postgres connection URL from env (DATABASE_URL or DB_* / Cloud SQL socket)
 pg-url-env = { path = "../pg-url-env" }

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -48,6 +48,10 @@ use chrono::Utc;
 use clap::Parser;
 use dashboard::DashboardState;
 use database::Database;
+use observing_collections::{
+    COMMENT_COLLECTION, IDENTIFICATION_COLLECTION, INTERACTION_COLLECTION, LIKE_COLLECTION,
+    OCCURRENCE_COLLECTION,
+};
 use observing_db::failed_records::FailedRecord;
 use serde_json::Value;
 use server::{ServerState, SharedState};
@@ -56,10 +60,7 @@ use tapped::{Event, LogLevel, RecordAction, RecordEvent, TapClient, TapConfig, T
 use tokio::sync::RwLock;
 use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, EnvFilter};
-use types::{
-    RecentEvent, COMMENT_COLLECTION, IDENTIFICATION_COLLECTION, INTERACTION_COLLECTION,
-    LIKE_COLLECTION, OCCURRENCE_COLLECTION,
-};
+use types::RecentEvent;
 
 #[derive(Parser)]
 #[command(about = "Observ.ing AT Protocol Tap-sourced ingester")]

--- a/crates/tap-ingester/src/types.rs
+++ b/crates/tap-ingester/src/types.rs
@@ -23,14 +23,6 @@ pub struct RecentEvent {
     pub time: chrono::DateTime<chrono::Utc>,
 }
 
-/// Collections we ingest. Used both as Tap collection-filters and as
-/// dispatch keys in `process_record`.
-pub const OCCURRENCE_COLLECTION: &str = "bio.lexicons.temp.v0-1.occurrence";
-pub const IDENTIFICATION_COLLECTION: &str = "bio.lexicons.temp.v0-1.identification";
-pub const COMMENT_COLLECTION: &str = "ing.observ.temp.comment";
-pub const INTERACTION_COLLECTION: &str = "ing.observ.temp.interaction";
-pub const LIKE_COLLECTION: &str = "ing.observ.temp.like";
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -56,17 +48,5 @@ mod tests {
         let json = serde_json::to_string(&event).unwrap();
         assert!(json.contains("\"type\""));
         assert!(json.contains("occurrence"));
-    }
-
-    #[test]
-    fn test_collection_constants() {
-        assert_eq!(OCCURRENCE_COLLECTION, "bio.lexicons.temp.v0-1.occurrence");
-        assert_eq!(
-            IDENTIFICATION_COLLECTION,
-            "bio.lexicons.temp.v0-1.identification"
-        );
-        assert_eq!(COMMENT_COLLECTION, "ing.observ.temp.comment");
-        assert_eq!(INTERACTION_COLLECTION, "ing.observ.temp.interaction");
-        assert_eq!(LIKE_COLLECTION, "ing.observ.temp.like");
     }
 }


### PR DESCRIPTION
## What

The five ingested-collection NSID constants (`OCCURRENCE_COLLECTION`, `IDENTIFICATION_COLLECTION`, `COMMENT_COLLECTION`, `INTERACTION_COLLECTION`, `LIKE_COLLECTION`) were defined twice:

- `crates/tap-ingester/src/types.rs`
- `crates/replay-failed-records/src/main.rs` — a verbatim copy carrying a `// Keep in sync` comment

This PR hoists them into a new tiny `observing-collections` crate and **derives each from the generated lexicon record type's `Collection::NSID`** (e.g. `OccurrenceRecord::NSID`). They become a single source of truth that cannot drift from the schemas — if a collection is renamed in the lexicons, regenerating `observing-lexicons` updates these constants automatically.

## Why

- Removes a hand-maintained duplicate (the "keep in sync" comment is gone).
- Hardens the lexicons.bio migration: the constants track the generated NSIDs rather than re-stating string literals.

## Changes

- New crate `crates/observing-collections` (5 derived `pub const`s + a test asserting the wire values).
- `tap-ingester` and `replay-failed-records` now import from it.

## Testing

- `cargo build -p observing-collections -p tap-ingester -p replay-failed-records` ✅
- `cargo test -p observing-collections -p tap-ingester` ✅

No behavior change.