### PR TITLE
refactor(ui): extract shared observation-grid layout constant

### DIFF
--- a/frontend/src/components/common/observationGridLayout.ts
+++ b/frontend/src/components/common/observationGridLayout.ts
@@ -1,0 +1,20 @@
+import type { SxProps, Theme } from "@mui/material";
+
+/**
+ * Responsive observation-card grid styles shared between the feed and profile
+ * views. Columns scale with breakpoint: 2 (xs) -> 3 (sm). Pass `mdColumns` to
+ * opt into a wider 4-column layout at the `md` breakpoint (used by the feed
+ * explore grid); omit it to keep the 3-column layout (used by profile grids).
+ */
+export function observationGridSx(mdColumns?: 4): SxProps<Theme> {
+  return {
+    display: "grid",
+    gridTemplateColumns: {
+      xs: "repeat(2, 1fr)",
+      sm: "repeat(3, 1fr)",
+      ...(mdColumns ? { md: `repeat(${mdColumns}, 1fr)` } : {}),
+    },
+    gap: 1.5,
+    p: 1.5,
+  };
+}

--- a/frontend/src/components/feed/FeedView.tsx
+++ b/frontend/src/components/feed/FeedView.tsx
@@ -11,6 +11,7 @@ import { ProfileObservationCardSkeleton } from "../profile/ProfileObservationCar
 import { ExploreFilterPanel } from "./ExploreFilterPanel";
 import { ExploreGridCard } from "./ExploreGridCard";
 import { FeedEndIndicator } from "./FeedEndIndicator";
+import { observationGridSx } from "../common/observationGridLayout";
 
 interface FeedViewProps {
   tab?: FeedTab;
@@ -74,18 +75,7 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
         <Container maxWidth={tab === "explore" ? "md" : "sm"} disableGutters>
           {tab === "explore" ? (
             <>
-              <Box
-                sx={{
-                  display: "grid",
-                  gridTemplateColumns: {
-                    xs: "repeat(2, 1fr)",
-                    sm: "repeat(3, 1fr)",
-                    md: "repeat(4, 1fr)",
-                  },
-                  gap: 1.5,
-                  p: 1.5,
-                }}
-              >
+              <Box sx={observationGridSx(4)}>
                 {observations.map((obs) => (
                   <ExploreGridCard key={obs.uri} observation={obs} />
                 ))}

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -28,6 +28,7 @@ import { ProfileHeaderSkeleton } from "./ProfileHeaderSkeleton";
 import { ProfileObservationCardSkeleton } from "./ProfileObservationCardSkeleton";
 import { ProfileIdentificationCardSkeleton } from "./ProfileIdentificationCardSkeleton";
 import { PROFILE_HEADER_SX, PROFILE_STAT_BOX_SX, PROFILE_AVATAR_SIZE } from "./profileLayout";
+import { observationGridSx } from "../common/observationGridLayout";
 import { usePageTitle } from "../../hooks/usePageTitle";
 
 type ProfileTab = "observations" | "identifications";
@@ -250,17 +251,7 @@ export function ProfileView() {
       </Tabs>
       {/* Observations Grid */}
       {activeTab === "observations" && (
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: {
-              xs: "repeat(2, 1fr)",
-              sm: "repeat(3, 1fr)",
-            },
-            gap: 1.5,
-            p: 1.5,
-          }}
-        >
+        <Box sx={observationGridSx()}>
           {occurrences.map((occ) => (
             <Card key={occ.uri} sx={{ display: "flex", flexDirection: "column" }}>
               <CardActionArea
@@ -338,17 +329,7 @@ export function ProfileView() {
       )}
       {/* Identifications Grid */}
       {activeTab === "identifications" && (
-        <Box
-          sx={{
-            display: "grid",
-            gridTemplateColumns: {
-              xs: "repeat(2, 1fr)",
-              sm: "repeat(3, 1fr)",
-            },
-            gap: 1.5,
-            p: 1.5,
-          }}
-        >
+        <Box sx={observationGridSx()}>
           {identifications.map((id) => (
             <Card key={id.uri} sx={{ display: "flex", flexDirection: "column" }}>
               <CardActionArea


### PR DESCRIPTION
## What

The responsive observation-card grid `sx` (display grid, `gridTemplateColumns`, `gap: 1.5`, `p: 1.5`) was duplicated across three sites. Extracted it into a shared factory and reused it.

## Where the constant lives

`frontend/src/components/common/observationGridLayout.ts` — a plain `.ts` module (no story needed) exporting `observationGridSx(mdColumns?: 4)`.

The feed and profile grids share the same xs (2 cols) / sm (3 cols) breakpoints, but the feed explore grid additionally goes to 4 columns at `md` while the profile grids do not. Rather than flatten these into one wrong value, the factory parameterizes the `md` breakpoint: call `observationGridSx(4)` for the wider feed layout, `observationGridSx()` for the 3-column profile layout.

## Usages updated (3)

- `frontend/src/components/feed/FeedView.tsx` — explore grid -> `observationGridSx(4)`
- `frontend/src/components/profile/ProfileView.tsx` — observations grid -> `observationGridSx()`
- `frontend/src/components/profile/ProfileView.tsx` — identifications grid -> `observationGridSx()`

Layout is pixel-identical; this is a pure refactor of grid column styles only.