### PR TITLE
refactor(ui): build the 'No image' fallback into ImageWithSkeleton

### DIFF
--- a/frontend/src/components/common/ImageWithSkeleton.stories.tsx
+++ b/frontend/src/components/common/ImageWithSkeleton.stories.tsx
@@ -19,6 +19,7 @@ const meta = {
   argTypes: {
     src: { control: { type: "text" } },
     alt: { control: { type: "text" } },
+    emptyText: { control: { type: "text" } },
   },
 } satisfies Meta<typeof ImageWithSkeleton>;
 
@@ -29,6 +30,29 @@ export const Loaded: Story = {
   args: {
     src: "https://commons.wikimedia.org/wiki/Special:FilePath/Quercus_robur.jpg?width=320",
     alt: "Quercus robur leaves",
+  },
+};
+
+export const EmptyFallback: Story = {
+  args: {
+    src: undefined,
+    alt: "No observation image",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When no `src` is provided, the component renders the built-in 'No image' placeholder instead of an image.",
+      },
+    },
+  },
+};
+
+export const EmptyFallbackCustomText: Story = {
+  args: {
+    src: undefined,
+    alt: "No observation image",
+    emptyText: "No photo yet",
   },
 };
 

--- a/frontend/src/components/common/ImageWithSkeleton.tsx
+++ b/frontend/src/components/common/ImageWithSkeleton.tsx
@@ -1,16 +1,41 @@
 import { useState } from "react";
-import { Box, CardMedia, Skeleton } from "@mui/material";
+import { Box, CardMedia, Skeleton, Typography } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material";
 
 interface ImageWithSkeletonProps {
-  src: string;
+  src?: string | undefined;
   alt: string;
   sx?: SxProps<Theme>;
   loading?: "lazy" | "eager";
+  emptyText?: string;
 }
 
-export function ImageWithSkeleton({ src, alt, sx, loading = "lazy" }: ImageWithSkeletonProps) {
+export function ImageWithSkeleton({
+  src,
+  alt,
+  sx,
+  loading = "lazy",
+  emptyText = "No image",
+}: ImageWithSkeletonProps) {
   const [loaded, setLoaded] = useState(false);
+
+  if (!src) {
+    return (
+      <Box
+        sx={{
+          bgcolor: "action.hover",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          ...sx,
+        }}
+      >
+        <Typography variant="body2" sx={{ color: "text.disabled" }}>
+          {emptyText}
+        </Typography>
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ position: "relative", overflow: "hidden", ...sx }}>

--- a/frontend/src/components/feed/ExploreGridCard.tsx
+++ b/frontend/src/components/feed/ExploreGridCard.tsx
@@ -29,32 +29,11 @@ export const ExploreGridCard = memo(function ExploreGridCard({
           alignItems: "stretch",
         }}
       >
-        {observation.images[0] ? (
-          <ImageWithSkeleton
-            src={getImageUrl(observation.images[0].url)}
-            alt={species || "Observation"}
-            sx={{ aspectRatio: "1" }}
-          />
-        ) : (
-          <Box
-            sx={{
-              aspectRatio: "1",
-              bgcolor: "action.hover",
-              display: "flex",
-              alignItems: "center",
-              justifyContent: "center",
-            }}
-          >
-            <Typography
-              variant="body2"
-              sx={{
-                color: "text.disabled",
-              }}
-            >
-              No image
-            </Typography>
-          </Box>
-        )}
+        <ImageWithSkeleton
+          src={observation.images[0] ? getImageUrl(observation.images[0].url) : undefined}
+          alt={species || "Observation"}
+          sx={{ aspectRatio: "1" }}
+        />
         <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
           <Typography
             variant="body2"

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -268,32 +268,11 @@ export function ProfileView() {
                 to={getObservationUrl(occ.uri)}
                 sx={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "stretch" }}
               >
-                {occ.images[0] ? (
-                  <ImageWithSkeleton
-                    src={getImageUrl(occ.images[0].url)}
-                    alt={occ.communityId || occ.effectiveTaxonomy?.scientificName || "Observation"}
-                    sx={{ aspectRatio: "1" }}
-                  />
-                ) : (
-                  <Box
-                    sx={{
-                      aspectRatio: "1",
-                      bgcolor: "action.hover",
-                      display: "flex",
-                      alignItems: "center",
-                      justifyContent: "center",
-                    }}
-                  >
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        color: "text.disabled",
-                      }}
-                    >
-                      No image
-                    </Typography>
-                  </Box>
-                )}
+                <ImageWithSkeleton
+                  src={occ.images[0] ? getImageUrl(occ.images[0].url) : undefined}
+                  alt={occ.communityId || occ.effectiveTaxonomy?.scientificName || "Observation"}
+                  sx={{ aspectRatio: "1" }}
+                />
                 <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
                   <Typography
                     variant="body2"


### PR DESCRIPTION
## What

The "image, or a 'No image' placeholder Box" pattern was duplicated across two grid call sites. This folds the fallback into `ImageWithSkeleton`.

## API change (backward compatible)

- `src` is now optional (`string | undefined`). When empty/undefined, `ImageWithSkeleton` renders the placeholder itself: `bgcolor: action.hover`, flex-centered `text.disabled` "No image" `Typography`, inheriting any `aspectRatio` from `sx`.
- New optional `emptyText` prop overrides the default "No image" label.
- The normal `src` path (skeleton while loading) is **100% unchanged** — new behavior only triggers when `src` is empty/undefined.

## Sites refactored

- `frontend/src/components/feed/ExploreGridCard.tsx` — dropped inline placeholder Box.
- `frontend/src/components/profile/ProfileView.tsx` — dropped inline placeholder Box.

Both now pass `src={images[0] ? getImageUrl(...) : undefined}`. Identical visuals preserved.

## Callers verified (all 3)

- `ExploreGridCard.tsx` — refactored.
- `ProfileView.tsx` — refactored.
- `FeedItem.tsx` — unaffected (already gates on `imageUrl &&`, always passes a defined src).

## Stories

Added `EmptyFallback` and `EmptyFallbackCustomText` stories for the new empty state; `emptyText` added to argTypes.

## Verification

- `npm run fmt` / `fmt:check` — clean
- `npm run lint` — 0 errors (3 pre-existing warnings)
- `npm run check:stories` — OK, all 54 components have stories
- `tsc` — change introduces **0 new errors** (verified equal error count with/without the diff stashed; remaining errors are a pre-existing missing-dependency issue in the shared node_modules, unrelated to this change)