### PR TITLE
refactor(ui): add ConfirmDialog, standardize confirmation modals

### DIFF
--- a/frontend/src/components/common/ConfirmDialog.stories.tsx
+++ b/frontend/src/components/common/ConfirmDialog.stories.tsx
@@ -1,0 +1,57 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Typography } from "@mui/material";
+import { ConfirmDialog } from "./ConfirmDialog";
+
+const meta = {
+  title: "Common/ConfirmDialog",
+  component: ConfirmDialog,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  args: {
+    open: true,
+    onConfirm: () => undefined,
+    onCancel: () => undefined,
+  },
+} satisfies Meta<typeof ConfirmDialog>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    title: "Save changes?",
+    message: "Your changes will be applied immediately.",
+    confirmLabel: "Save",
+  },
+};
+
+export const Destructive: Story = {
+  args: {
+    title: "Delete Observation?",
+    confirmLabel: "Delete",
+    destructive: true,
+    children: (
+      <>
+        <Typography>
+          Are you sure you want to delete this observation of <strong>Larus argentatus</strong>?
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.secondary", mt: 1 }}>
+          This action cannot be undone. All identifications and comments will also be deleted.
+        </Typography>
+      </>
+    ),
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    title: "Delete Observation?",
+    message: "Are you sure you want to delete this observation?",
+    confirmLabel: "Delete",
+    pendingLabel: "Deleting...",
+    destructive: true,
+    pending: true,
+  },
+};

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -1,0 +1,81 @@
+import type { ReactNode } from "react";
+import {
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  Typography,
+  Button,
+  CircularProgress,
+  useMediaQuery,
+  useTheme,
+} from "@mui/material";
+
+type ConfirmColor = "primary" | "error" | "warning" | "info" | "success" | "inherit";
+
+interface ConfirmDialogProps {
+  open: boolean;
+  title: ReactNode;
+  /** Convenience for a plain text body. Use `children` for richer content. */
+  message?: ReactNode;
+  children?: ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  /** Renders the confirm button in the theme's error color. */
+  destructive?: boolean;
+  /** Explicit confirm button color; overrides `destructive`. */
+  confirmColor?: ConfirmColor;
+  /** When true, disables both buttons and shows a spinner on confirm. */
+  pending?: boolean;
+  /** Label shown on the confirm button while `pending`. */
+  pendingLabel?: string;
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  message,
+  children,
+  confirmLabel = "Confirm",
+  cancelLabel = "Cancel",
+  onConfirm,
+  onCancel,
+  destructive = false,
+  confirmColor,
+  pending = false,
+  pendingLabel,
+}: ConfirmDialogProps) {
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+
+  const resolvedConfirmColor: ConfirmColor = confirmColor ?? (destructive ? "error" : "primary");
+
+  const handleCancel = () => {
+    if (!pending) onCancel();
+  };
+
+  return (
+    <Dialog open={open} onClose={handleCancel} maxWidth="xs" fullWidth fullScreen={fullScreen}>
+      <DialogTitle>{title}</DialogTitle>
+      <DialogContent>
+        {message !== undefined ? <Typography>{message}</Typography> : children}
+      </DialogContent>
+      <DialogActions sx={{ px: 3, pb: 2 }}>
+        <Button onClick={handleCancel} disabled={pending} color="inherit">
+          {cancelLabel}
+        </Button>
+        <Button
+          onClick={onConfirm}
+          color={resolvedConfirmColor}
+          variant="contained"
+          disabled={pending}
+          startIcon={pending ? <CircularProgress size={16} color="inherit" /> : undefined}
+        >
+          {pending ? (pendingLabel ?? confirmLabel) : confirmLabel}
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/frontend/src/components/modals/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/modals/DeleteConfirmDialog.tsx
@@ -1,14 +1,7 @@
 import { useState } from "react";
 import { useNavigate, useLocation } from "react-router-dom";
-import {
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
-  Typography,
-  Button,
-  CircularProgress,
-} from "@mui/material";
+import { Typography } from "@mui/material";
+import { ConfirmDialog } from "../common/ConfirmDialog";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeDeleteConfirm, addToast } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
@@ -74,36 +67,28 @@ export function DeleteConfirmDialog() {
     observation?.communityId || observation?.effectiveTaxonomy?.scientificName || "Unidentified";
 
   return (
-    <Dialog open={isOpen} onClose={handleClose} maxWidth="xs" fullWidth>
-      <DialogTitle>Delete Observation?</DialogTitle>
-      <DialogContent>
-        <Typography>
-          Are you sure you want to delete this observation of <strong>{species}</strong>?
-        </Typography>
-        <Typography
-          variant="body2"
-          sx={{
-            color: "text.secondary",
-            mt: 1,
-          }}
-        >
-          This action cannot be undone. All identifications and comments will also be deleted.
-        </Typography>
-      </DialogContent>
-      <DialogActions sx={{ px: 3, pb: 2 }}>
-        <Button onClick={handleClose} disabled={isDeleting} color="inherit">
-          Cancel
-        </Button>
-        <Button
-          onClick={handleConfirmDelete}
-          color="error"
-          variant="contained"
-          disabled={isDeleting}
-          startIcon={isDeleting ? <CircularProgress size={16} color="inherit" /> : undefined}
-        >
-          {isDeleting ? "Deleting..." : "Delete"}
-        </Button>
-      </DialogActions>
-    </Dialog>
+    <ConfirmDialog
+      open={isOpen}
+      onCancel={handleClose}
+      onConfirm={handleConfirmDelete}
+      title="Delete Observation?"
+      confirmLabel="Delete"
+      pendingLabel="Deleting..."
+      destructive
+      pending={isDeleting}
+    >
+      <Typography>
+        Are you sure you want to delete this observation of <strong>{species}</strong>?
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{
+          color: "text.secondary",
+          mt: 1,
+        }}
+      >
+        This action cannot be undone. All identifications and comments will also be deleted.
+      </Typography>
+    </ConfirmDialog>
   );
 }

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -15,10 +15,6 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Dialog,
-  DialogTitle,
-  DialogContent,
-  DialogActions,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
@@ -32,6 +28,7 @@ import { useUserPreferences } from "../../lib/query/hooks";
 import { submitObservation, updateObservation, validateTaxon } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
+import { ConfirmDialog } from "../common/ConfirmDialog";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { VisualId } from "../identification/VisualId";
 import { LocationPicker } from "../map/LocationPicker";
@@ -778,27 +775,16 @@ export function UploadModal() {
           </Stack>
         </form>
       </ModalOverlay>
-      <Dialog
+      <ConfirmDialog
         open={discardConfirmOpen}
-        onClose={() => setDiscardConfirmOpen(false)}
-        maxWidth="xs"
-        fullWidth
-      >
-        <DialogTitle>Discard changes?</DialogTitle>
-        <DialogContent>
-          <Typography>
-            You have unsaved changes. If you close now, your in-progress data will be lost.
-          </Typography>
-        </DialogContent>
-        <DialogActions sx={{ px: 3, pb: 2 }}>
-          <Button onClick={() => setDiscardConfirmOpen(false)} color="inherit">
-            Keep editing
-          </Button>
-          <Button onClick={handleConfirmDiscard} color="error" variant="contained">
-            Discard
-          </Button>
-        </DialogActions>
-      </Dialog>
+        onCancel={() => setDiscardConfirmOpen(false)}
+        onConfirm={handleConfirmDiscard}
+        title="Discard changes?"
+        message="You have unsaved changes. If you close now, your in-progress data will be lost."
+        cancelLabel="Keep editing"
+        confirmLabel="Discard"
+        destructive
+      />
       <PhotoLightbox
         open={lightbox !== null}
         onClose={() => setLightbox(null)}


### PR DESCRIPTION
## What

Adds a reusable, presentational `ConfirmDialog` and standardizes the raw-MUI-`Dialog` confirmation sites onto it.

### New component
- `frontend/src/components/common/ConfirmDialog.tsx` — built on the existing MUI `Dialog`/`ModalOverlay` conventions (mobile full-screen via `useMediaQuery`, `maxWidth="xs"`). Props: `open`, `title`, `message`/`children`, `confirmLabel`, `cancelLabel`, `onConfirm`, `onCancel`, `destructive`/`confirmColor`, and `pending`/`pendingLabel` (disables both buttons + shows a spinner during async). Purely presentational — no business logic.
- `frontend/src/components/common/ConfirmDialog.stories.tsx` — covers Default, Destructive, and Loading variants (satisfies the `check:stories` CI gate).

### Sites migrated
- **DeleteConfirmDialog** — raw `Dialog` shell swapped for `ConfirmDialog`. All existing logic (delete handler, polling, cache invalidation, toasts, auth/session handling, `isDeleting` state) is unchanged; only the presentation moved. Preserves the "Delete"/"Deleting..." labels and error/red confirm color.
- **UploadModal** — the embedded "Discard changes?" raw `Dialog` swapped for `ConfirmDialog` ("Keep editing" / "Discard", error color). `handleConfirmDiscard` and surrounding state untouched.

### LoginModal — SKIPPED (intentionally)
`LoginModal` is a **form** modal, not a simple confirmation: it wraps a `<form onSubmit>`, contains a `TextField` (with `autoFocus`, `error`, `helperText`, controlled value), an inline `Alert`, and a `Link`, and its confirm button is `type="submit"`. `ConfirmDialog` is a confirm-button shell with no form/field support, so migrating it would change behavior. Left as-is per the task's "only if it cleanly fits without changing behavior" guidance.

## Scope
Strictly the presentational Dialog shell. No async/toast/mutation logic was refactored, to avoid conflicts with the in-flight mutation-hooks and useToast PRs.

## Verification
- `npm run fmt` — clean
- `npm run lint` — 0 errors (2 pre-existing `react-hooks/exhaustive-deps` warnings in UploadModal, unrelated)
- `npx tsc` — no type errors in changed files. Remaining `TS2307 Cannot find module` errors are pre-existing in this environment (shared `node_modules` is missing `@storybook/*`, `@tanstack/*`, etc.) and also fail identically on the base branch.
- `npm run check:stories` — OK: all 55 components have stories.