### PR TITLE
refactor(ui): add useToast hook, replace inline addToast dispatches

### DIFF
--- a/frontend/src/components/comment/CommentSection.tsx
+++ b/frontend/src/components/comment/CommentSection.tsx
@@ -15,9 +15,9 @@ import {
 } from "@mui/material";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutlineOutlined";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
-import { useAppSelector, useAppDispatch } from "../../store";
-import { addToast } from "../../store/uiSlice";
+import { useAppSelector } from "../../store";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
+import { useToast } from "../../hooks/useToast";
 import { useSubmitComment } from "../../lib/query/mutations";
 import type { Comment } from "../../services/types";
 import { getPdslsUrl } from "../../lib/utils";
@@ -30,7 +30,7 @@ interface CommentSectionProps {
 }
 
 export function CommentSection({ observationUri, observationCid, comments }: CommentSectionProps) {
-  const dispatch = useAppDispatch();
+  const toast = useToast();
   const user = useAppSelector((state) => state.auth.user);
   const [showForm, setShowForm] = useState(false);
   const [body, setBody] = useState("");
@@ -69,7 +69,7 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
     e.preventDefault();
 
     if (!body.trim()) {
-      dispatch(addToast({ message: "Please enter a comment", type: "error" }));
+      toast.error("Please enter a comment");
       return;
     }
 

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -24,9 +24,8 @@ import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { VisualIdCards } from "./VisualIdCards";
 import { useVisualId } from "../../hooks/useVisualId";
 import { TaxonLink } from "../common/TaxonLink";
-import { useAppDispatch } from "../../store";
-import { addToast } from "../../store/uiSlice";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
+import { useToast } from "../../hooks/useToast";
 import { KINGDOMS } from "../../lib/kingdoms";
 import { TAXON_RANKS } from "../../lib/taxonRanks";
 
@@ -53,7 +52,7 @@ export function IdentificationPanel({
   latitude,
   longitude,
 }: IdentificationPanelProps) {
-  const dispatch = useAppDispatch();
+  const toast = useToast();
   const [showSuggestForm, setShowSuggestForm] = useState(false);
   const [taxonName, setTaxonName] = useState("");
   const [matchedTaxon, setMatchedTaxon] = useState<TaxaResult | null>(null);
@@ -118,17 +117,12 @@ export function IdentificationPanel({
     e.preventDefault();
 
     if (!taxonName.trim()) {
-      dispatch(addToast({ message: "Please enter a taxon name", type: "error" }));
+      toast.error("Please enter a taxon name");
       return;
     }
 
     if (!matchedTaxon && !kingdom) {
-      dispatch(
-        addToast({
-          message: "Please select a kingdom for the taxon name you entered",
-          type: "error",
-        }),
-      );
+      toast.error("Please select a kingdom for the taxon name you entered");
       return;
     }
 

--- a/frontend/src/components/modals/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/modals/DeleteConfirmDialog.tsx
@@ -10,14 +10,16 @@ import {
   CircularProgress,
 } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../store";
-import { closeDeleteConfirm, addToast } from "../../store/uiSlice";
+import { closeDeleteConfirm } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
 import { deleteObservation, pollObservation } from "../../services/api";
 import { invalidateOccurrenceLists, removeObservation } from "../../lib/query/occurrenceCache";
 import { getErrorMessage } from "../../lib/utils";
+import { useToast } from "../../hooks/useToast";
 
 export function DeleteConfirmDialog() {
   const dispatch = useAppDispatch();
+  const toast = useToast();
   const navigate = useNavigate();
   const location = useLocation();
   const observation = useAppSelector((state) => state.ui.deleteConfirmObservation);
@@ -47,12 +49,7 @@ export function DeleteConfirmDialog() {
       removeObservation(observation.uri);
       await invalidateOccurrenceLists();
 
-      dispatch(
-        addToast({
-          message: "Observation deleted successfully",
-          type: "success",
-        }),
-      );
+      toast.success("Observation deleted successfully");
       dispatch(closeDeleteConfirm());
 
       // If we were on the deleted observation's detail page, leave it.
@@ -61,7 +58,7 @@ export function DeleteConfirmDialog() {
       }
     } catch (error) {
       const message = getErrorMessage(error, "Failed to delete observation");
-      dispatch(addToast({ message, type: "error" }));
+      toast.error(message);
       if (message.includes("Session expired")) {
         dispatch(checkAuth());
       }

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -26,8 +26,9 @@ import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
 import ExifReader from "exifreader";
 import { useAppDispatch, useAppSelector } from "../../store";
-import { closeUploadModal, addToast, consumePendingUploadFiles } from "../../store/uiSlice";
+import { closeUploadModal, consumePendingUploadFiles } from "../../store/uiSlice";
 import { trackSubmission } from "../../store/pendingSlice";
+import { useToast } from "../../hooks/useToast";
 import { useUserPreferences } from "../../lib/query/hooks";
 import { submitObservation, updateObservation, validateTaxon } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
@@ -54,6 +55,7 @@ function toDatetimeLocal(date: Date): string {
 
 export function UploadModal() {
   const dispatch = useAppDispatch();
+  const toast = useToast();
   const isOpen = useAppSelector((state) => state.ui.uploadModalOpen);
   const editingObservation = useAppSelector((state) => state.ui.editingObservation);
   const user = useAppSelector((state) => state.auth.user);
@@ -168,32 +170,17 @@ export function UploadModal() {
   const addFiles = (files: File[]) => {
     for (const file of files) {
       if (!VALID_TYPES.includes(file.type)) {
-        dispatch(
-          addToast({
-            message: `Invalid file type: ${file.name}. Use JPG, PNG, or WebP.`,
-            type: "error",
-          }),
-        );
+        toast.error(`Invalid file type: ${file.name}. Use JPG, PNG, or WebP.`);
         continue;
       }
 
       if (file.size > MAX_FILE_SIZE) {
-        dispatch(
-          addToast({
-            message: `File too large: ${file.name}. Max size is 10MB.`,
-            type: "error",
-          }),
-        );
+        toast.error(`File too large: ${file.name}. Max size is 10MB.`);
         continue;
       }
 
       if (images.length >= MAX_IMAGES) {
-        dispatch(
-          addToast({
-            message: `Maximum ${MAX_IMAGES} images allowed.`,
-            type: "error",
-          }),
-        );
+        toast.error(`Maximum ${MAX_IMAGES} images allowed.`);
         break;
       }
 
@@ -213,7 +200,7 @@ export function UploadModal() {
   const handlePickImages = async () => {
     const remaining = MAX_IMAGES - images.length;
     if (remaining <= 0) {
-      dispatch(addToast({ message: `Maximum ${MAX_IMAGES} images allowed.`, type: "error" }));
+      toast.error(`Maximum ${MAX_IMAGES} images allowed.`);
       return;
     }
     const files = await pickPhotos({
@@ -262,9 +249,7 @@ export function UploadModal() {
 
           setLat(latitude.toFixed(6));
           setLng(longitude.toFixed(6));
-          dispatch(
-            addToast({ message: "Location extracted from photo EXIF data", type: "success" }),
-          );
+          toast.success("Location extracted from photo EXIF data");
         }
       }
 
@@ -276,7 +261,7 @@ export function UploadModal() {
         const date = new Date(parsed);
         if (!isNaN(date.getTime())) {
           setObservationDate(toDatetimeLocal(date));
-          dispatch(addToast({ message: "Date extracted from photo EXIF data", type: "success" }));
+          toast.success("Date extracted from photo EXIF data");
         }
       }
     } catch (error) {
@@ -306,18 +291,13 @@ export function UploadModal() {
     e.preventDefault();
 
     if (!lat || !lng) {
-      dispatch(addToast({ message: "Please provide a location", type: "error" }));
+      toast.error("Please provide a location");
       return;
     }
 
     const trimmedSpecies = species.trim();
     if (trimmedSpecies && !matchedTaxon && !kingdom) {
-      dispatch(
-        addToast({
-          message: "Please select a kingdom for the taxon name you entered",
-          type: "error",
-        }),
-      );
+      toast.error("Please select a kingdom for the taxon name you entered");
       return;
     }
 
@@ -380,12 +360,7 @@ export function UploadModal() {
       resetForm();
       void dispatch(trackSubmission({ uri: result.uri, cid: result.cid, kind }));
     } catch (error) {
-      dispatch(
-        addToast({
-          message: `Failed to ${isEditMode ? "update" : "submit"}: ${getErrorMessage(error)}`,
-          type: "error",
-        }),
-      );
+      toast.error(`Failed to ${isEditMode ? "update" : "submit"}: ${getErrorMessage(error)}`);
     } finally {
       setIsSubmitting(false);
     }

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -28,10 +28,11 @@ import { useQueryClient } from "@tanstack/react-query";
 import { getImageUrl, deleteIdentification, pollObservation } from "../../services/api";
 import { useAppSelector, useAppDispatch } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
+import { useToast } from "../../hooks/useToast";
 import { useObservation } from "../../lib/query/hooks";
 import { useLike } from "../../lib/query/mutations";
 import { qk } from "../../lib/query/keys";
-import { openDeleteConfirm, openEditModal, addToast } from "../../store/uiSlice";
+import { openDeleteConfirm, openEditModal } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
 import { IdentificationPanel } from "../identification/IdentificationPanel";
 import { IdentificationHistory } from "../identification/IdentificationHistory";
@@ -54,6 +55,7 @@ export function ObservationDetail() {
   const { did, rkey } = useParams<{ did: string; rkey: string }>();
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const toast = useToast();
   const user = useAppSelector((state) => state.auth.user);
 
   const [activeImageIndex, setActiveImageIndex] = useState(0);
@@ -486,11 +488,11 @@ export function ObservationDetail() {
                         (r) => !r?.identifications?.some((id) => id.uri === uri),
                       );
                     }
-                    dispatch(addToast({ message: "Identification deleted", type: "success" }));
+                    toast.success("Identification deleted");
                     refreshObservation();
                   } catch (error) {
                     const message = getErrorMessage(error, "Failed to delete identification");
-                    dispatch(addToast({ message, type: "error" }));
+                    toast.error(message);
                     if (message.includes("Session expired")) {
                       dispatch(checkAuth());
                     }

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -13,8 +13,9 @@ import {
 } from "@mui/material";
 import { LightMode, DarkMode, SettingsBrightness } from "@mui/icons-material";
 import { usePageTitle } from "../../hooks/usePageTitle";
+import { useToast } from "../../hooks/useToast";
 import { useAppDispatch, useAppSelector } from "../../store";
-import { setThemeMode, type ThemeMode, addToast } from "../../store/uiSlice";
+import { setThemeMode, type ThemeMode } from "../../store/uiSlice";
 import { useUserPreferences } from "../../lib/query/hooks";
 import { useUpdatePreferences } from "../../lib/query/mutations";
 import { LICENSE_OPTIONS } from "../../lib/licenses";
@@ -24,6 +25,7 @@ const NO_DEFAULT = "__none__";
 export function SettingsPage() {
   usePageTitle("Settings");
   const dispatch = useAppDispatch();
+  const toast = useToast();
   const themeMode = useAppSelector((state) => state.ui.themeMode);
   const user = useAppSelector((state) => state.auth.user);
   const { data: prefs } = useUserPreferences();
@@ -42,12 +44,7 @@ export function SettingsPage() {
       { defaultLicense: next },
       {
         onError: (err) =>
-          dispatch(
-            addToast({
-              message: err instanceof Error ? err.message : "Failed to save preference",
-              type: "error",
-            }),
-          ),
+          toast.error(err instanceof Error ? err.message : "Failed to save preference"),
       },
     );
   };

--- a/frontend/src/hooks/useToast.test.tsx
+++ b/frontend/src/hooks/useToast.test.tsx
@@ -1,0 +1,69 @@
+import { describe, it, expect } from "vitest";
+import type { ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import { act, renderHook } from "@testing-library/react";
+import { useToast } from "./useToast";
+import uiReducer from "../store/uiSlice";
+import authReducer from "../store/authSlice";
+import feedReducer from "../store/feedSlice";
+
+function makeStore() {
+  return configureStore({
+    reducer: { auth: authReducer, feed: feedReducer, ui: uiReducer },
+  });
+}
+
+function wrapper(store: ReturnType<typeof makeStore>) {
+  return ({ children }: { children: ReactNode }) => <Provider store={store}>{children}</Provider>;
+}
+
+describe("useToast", () => {
+  it("dispatches a success toast", () => {
+    const store = makeStore();
+    const { result } = renderHook(() => useToast(), { wrapper: wrapper(store) });
+
+    act(() => {
+      result.current.success("Saved!");
+    });
+
+    const toasts = store.getState().ui.toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toMatchObject({ message: "Saved!", type: "success" });
+  });
+
+  it("dispatches an error toast", () => {
+    const store = makeStore();
+    const { result } = renderHook(() => useToast(), { wrapper: wrapper(store) });
+
+    act(() => {
+      result.current.error("Boom");
+    });
+
+    const toasts = store.getState().ui.toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toMatchObject({ message: "Boom", type: "error" });
+  });
+
+  it("dispatches via show with an explicit type", () => {
+    const store = makeStore();
+    const { result } = renderHook(() => useToast(), { wrapper: wrapper(store) });
+
+    act(() => {
+      result.current.show("Hello", "success");
+    });
+
+    const toasts = store.getState().ui.toasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0]).toMatchObject({ message: "Hello", type: "success" });
+  });
+
+  it("returns a stable object across renders", () => {
+    const store = makeStore();
+    const { result, rerender } = renderHook(() => useToast(), { wrapper: wrapper(store) });
+
+    const first = result.current;
+    rerender();
+    expect(result.current).toBe(first);
+  });
+});

--- a/frontend/src/hooks/useToast.ts
+++ b/frontend/src/hooks/useToast.ts
@@ -1,0 +1,39 @@
+import { useCallback, useMemo } from "react";
+import { useAppDispatch } from "../store";
+import { addToast } from "../store/uiSlice";
+
+type ToastType = "success" | "error";
+
+/**
+ * Thin wrapper over the `addToast` Redux action so components can show toasts
+ * without importing the action + `useAppDispatch` directly. The returned object
+ * and its callbacks are stable across renders.
+ *
+ * @returns `{ success, error, show }` toast dispatchers.
+ */
+export function useToast() {
+  const dispatch = useAppDispatch();
+
+  const show = useCallback(
+    (message: string, type: ToastType) => {
+      dispatch(addToast({ message, type }));
+    },
+    [dispatch],
+  );
+
+  const success = useCallback(
+    (message: string) => {
+      show(message, "success");
+    },
+    [show],
+  );
+
+  const error = useCallback(
+    (message: string) => {
+      show(message, "error");
+    },
+    [show],
+  );
+
+  return useMemo(() => ({ success, error, show }), [success, error, show]);
+}


### PR DESCRIPTION
## What

Introduces a thin `useToast()` hook so components stop importing the Redux `addToast` action + `useAppDispatch` just to show a toast — giving a single choke point for toast dispatch.

## The hook

`frontend/src/hooks/useToast.ts` wraps `useAppDispatch` + `addToast` and returns stable callbacks `{ success, error, show }`, memoized via `useCallback`/`useMemo`. Types match what `uiSlice` actually supports (`type: "success" | "error"`; no `info` type or `duration` field exists in the slice, so none were invented).

## Components updated (6)

- `modals/UploadModal.tsx` (8 sites)
- `modals/DeleteConfirmDialog.tsx` (2 sites)
- `comment/CommentSection.tsx` (1 site)
- `identification/IdentificationPanel.tsx` (2 sites)
- `observation/ObservationDetail.tsx` (2 sites)
- `settings/SettingsPage.tsx` (1 site)

~18 `dispatch(addToast(...))` call expressions collapsed (covering the ~28 message/type lines). Toast message text and type are preserved exactly. Removed now-unused `addToast` imports everywhere; removed `useAppDispatch` in `CommentSection` and `IdentificationPanel` where it was only used for toasts. `useAppDispatch` is retained in the other four files where `dispatch` still drives non-toast actions.

Adds `useToast.test.tsx` matching the sibling-test convention in `frontend/src/hooks/`.

Scope: toasts only. No mutation/form-submit/markup changes.

## Verification

- `npm run fmt` / `fmt:check` — clean
- `npm run lint` — 0 errors (2 pre-existing unrelated warnings)
- `npx tsc --project tsconfig.json` — 0 errors
- `npm run check:stories` — green