### PR TITLE
refactor(ui): extract EmptyState/CenteredSpinner list primitives

### DIFF
--- a/frontend/src/components/common/CenteredSpinner.stories.tsx
+++ b/frontend/src/components/common/CenteredSpinner.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { CenteredSpinner } from "./CenteredSpinner";
+
+const meta = {
+  title: "Common/CenteredSpinner",
+  component: CenteredSpinner,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: { control: { type: "number" } },
+    p: { control: { type: "number" } },
+  },
+} satisfies Meta<typeof CenteredSpinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Primary: Story = {
+  args: {
+    color: "primary",
+  },
+};
+
+export const Large: Story = {
+  args: {
+    size: 40,
+  },
+};
+
+export const TighterPadding: Story = {
+  args: {
+    p: 3,
+  },
+};

--- a/frontend/src/components/common/CenteredSpinner.tsx
+++ b/frontend/src/components/common/CenteredSpinner.tsx
@@ -1,0 +1,26 @@
+import { Box, CircularProgress } from "@mui/material";
+import type { CircularProgressProps } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material/styles";
+
+export interface CenteredSpinnerProps {
+  /** CircularProgress size in px. Defaults to 24. */
+  size?: number | undefined;
+  /** CircularProgress color. */
+  color?: CircularProgressProps["color"] | undefined;
+  /** Padding applied to the centering Box. Defaults to `4`. */
+  p?: number | undefined;
+  /** Additional styles merged onto the centering Box. */
+  sx?: SxProps<Theme> | undefined;
+}
+
+/**
+ * Horizontally-centered spinner used as the "loading more" indicator at the
+ * bottom of paginated list/feed views.
+ */
+export function CenteredSpinner({ size = 24, color, p = 4, sx }: CenteredSpinnerProps) {
+  return (
+    <Box sx={{ display: "flex", justifyContent: "center", p, ...sx }}>
+      <CircularProgress size={size} {...(color ? { color } : {})} />
+    </Box>
+  );
+}

--- a/frontend/src/components/common/EmptyState.stories.tsx
+++ b/frontend/src/components/common/EmptyState.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import CameraAltIcon from "@mui/icons-material/CameraAlt";
+import { EmptyState } from "./EmptyState";
+
+const meta = {
+  title: "Common/EmptyState",
+  component: EmptyState,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    p: { control: { type: "number" } },
+  },
+} satisfies Meta<typeof EmptyState>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    message: "No observations yet. Be the first to post!",
+  },
+};
+
+export const NoActivity: Story = {
+  args: {
+    message: "No activity yet",
+  },
+};
+
+export const WithIcon: Story = {
+  args: {
+    message: "No observations yet. Be the first to post!",
+    icon: <CameraAltIcon sx={{ fontSize: 40, color: "text.disabled", mb: 1 }} />,
+  },
+};

--- a/frontend/src/components/common/EmptyState.tsx
+++ b/frontend/src/components/common/EmptyState.tsx
@@ -1,0 +1,27 @@
+import { Box, Typography } from "@mui/material";
+import type { ReactNode } from "react";
+import type { SxProps, Theme } from "@mui/material/styles";
+
+export interface EmptyStateProps {
+  /** Message shown when there is nothing to display. */
+  message: ReactNode;
+  /** Optional node (e.g. an icon) rendered above the message. */
+  icon?: ReactNode | undefined;
+  /** Padding applied to the centering Box. Defaults to `4`. */
+  p?: number | undefined;
+  /** Additional styles merged onto the centering Box. */
+  sx?: SxProps<Theme> | undefined;
+}
+
+/**
+ * Centered empty-state message for list/feed views, matching the
+ * `<Box p:4 textAlign:center>` + secondary `<Typography>` look used across the app.
+ */
+export function EmptyState({ message, icon, p = 4, sx }: EmptyStateProps) {
+  return (
+    <Box sx={{ p, textAlign: "center", ...sx }}>
+      {icon}
+      <Typography sx={{ color: "text.secondary" }}>{message}</Typography>
+    </Box>
+  );
+}

--- a/frontend/src/components/feed/FeedView.tsx
+++ b/frontend/src/components/feed/FeedView.tsx
@@ -1,5 +1,5 @@
 import { useRef, useCallback } from "react";
-import { Box, Container, Typography, CircularProgress } from "@mui/material";
+import { Box, Container } from "@mui/material";
 import { useAppDispatch } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useFeed } from "../../lib/query/hooks";
@@ -12,6 +12,8 @@ import { ExploreFilterPanel } from "./ExploreFilterPanel";
 import { ExploreGridCard } from "./ExploreGridCard";
 import { FeedEndIndicator } from "./FeedEndIndicator";
 import { observationGridSx } from "../common/observationGridLayout";
+import { CenteredSpinner } from "../common/CenteredSpinner";
+import { EmptyState } from "../common/EmptyState";
 
 interface FeedViewProps {
   tab?: FeedTab;
@@ -89,22 +91,10 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
                 )}
               </Box>
 
-              {isFetchingNextPage && (
-                <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
-                  <CircularProgress color="primary" size={24} />
-                </Box>
-              )}
+              {isFetchingNextPage && <CenteredSpinner color="primary" />}
 
               {!isLoading && observations.length === 0 && (
-                <Box sx={{ p: 4, textAlign: "center" }}>
-                  <Typography
-                    sx={{
-                      color: "text.secondary",
-                    }}
-                  >
-                    No observations yet. Be the first to post!
-                  </Typography>
-                </Box>
+                <EmptyState message="No observations yet. Be the first to post!" />
               )}
 
               {!isLoading && !hasMore && observations.length > 0 && (
@@ -126,22 +116,10 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
 
               {isLoading && observations.length === 0 && <FeedSkeletonList count={3} />}
 
-              {isFetchingNextPage && (
-                <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
-                  <CircularProgress color="primary" size={24} />
-                </Box>
-              )}
+              {isFetchingNextPage && <CenteredSpinner color="primary" />}
 
               {!isLoading && observations.length === 0 && (
-                <Box sx={{ p: 4, textAlign: "center" }}>
-                  <Typography
-                    sx={{
-                      color: "text.secondary",
-                    }}
-                  >
-                    No observations yet. Be the first to post!
-                  </Typography>
-                </Box>
+                <EmptyState message="No observations yet. Be the first to post!" />
               )}
 
               {!isLoading && !hasMore && observations.length > 0 && <FeedEndIndicator />}

--- a/frontend/src/components/notifications/NotificationsPage.tsx
+++ b/frontend/src/components/notifications/NotificationsPage.tsx
@@ -1,21 +1,14 @@
 import { useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  Box,
-  Container,
-  Typography,
-  Button,
-  CircularProgress,
-  List,
-  ListItem,
-  ListItemButton,
-} from "@mui/material";
+import { Box, Container, Typography, Button, List, ListItem, ListItemButton } from "@mui/material";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { getImageUrl } from "../../services/api";
 import type { Notification } from "../../services/types";
 import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { UserCard } from "../common/UserCard";
+import { CenteredSpinner } from "../common/CenteredSpinner";
+import { EmptyState } from "../common/EmptyState";
 import { useNotifications } from "../../lib/query/hooks";
 import { useMarkNotificationRead } from "../../lib/query/mutations";
 
@@ -93,15 +86,7 @@ export function NotificationsPage() {
         </Box>
 
         {!isLoading && notifications.length === 0 && (
-          <Typography
-            sx={{
-              color: "text.secondary",
-              textAlign: "center",
-              mt: 4,
-            }}
-          >
-            No notifications yet
-          </Typography>
+          <EmptyState message="No notifications yet" p={0} sx={{ mt: 4 }} />
         )}
 
         <List disablePadding>
@@ -139,11 +124,7 @@ export function NotificationsPage() {
           ))}
         </List>
 
-        {(isLoading || isFetchingNextPage) && (
-          <Box sx={{ display: "flex", justifyContent: "center", py: 3 }}>
-            <CircularProgress size={24} />
-          </Box>
-        )}
+        {(isLoading || isFetchingNextPage) && <CenteredSpinner p={0} sx={{ py: 3 }} />}
       </Container>
     </Box>
   );

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -7,7 +7,6 @@ import {
   Tabs,
   Tab,
   Button,
-  CircularProgress,
   Stack,
   Card,
   CardActionArea,
@@ -24,6 +23,8 @@ import { RelativeTime } from "../common/RelativeTime";
 import { UserCard } from "../common/UserCard";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
+import { CenteredSpinner } from "../common/CenteredSpinner";
+import { EmptyState } from "../common/EmptyState";
 import { ProfileHeaderSkeleton } from "./ProfileHeaderSkeleton";
 import { ProfileObservationCardSkeleton } from "./ProfileObservationCardSkeleton";
 import { ProfileIdentificationCardSkeleton } from "./ProfileIdentificationCardSkeleton";
@@ -343,21 +344,9 @@ export function ProfileView() {
           )}
         </Box>
       )}
-      {isFetchingNextPage && (
-        <Box sx={{ display: "flex", justifyContent: "center", p: 4 }}>
-          <CircularProgress color="primary" size={24} />
-        </Box>
-      )}
+      {isFetchingNextPage && <CenteredSpinner color="primary" />}
       {!isLoading && occurrences.length === 0 && identifications.length === 0 && (
-        <Box sx={{ p: 4, textAlign: "center" }}>
-          <Typography
-            sx={{
-              color: "text.secondary",
-            }}
-          >
-            No activity yet
-          </Typography>
-        </Box>
+        <EmptyState message="No activity yet" />
       )}
       {hasMore && !isLoading && !isFetchingNextPage && (
         <Box sx={{ p: 2, textAlign: "center" }}>


### PR DESCRIPTION
## Summary

Several list/feed views reimplemented the same centered empty-state and "loading more" spinner JSX inline. This extracts two small, focused shared primitives and adopts them, removing the duplicated markup. No data-fetching or display-card logic was touched.

## New components (frontend/src/components/common/)
- `EmptyState.tsx` — centered `text.secondary` message with optional icon, matching the existing `<Box sx={{ p: 4, textAlign: "center" }}>` look. Configurable `p` and `sx` for the couple of call sites that vary the padding/margin.
- `CenteredSpinner.tsx` — the `<Box display:flex justifyContent:center p:4><CircularProgress/></Box>` loading-more indicator. Configurable `size`, `color`, `p`, `sx`.

Each has a sibling `*.stories.tsx` (satisfies the `check:stories` CI gate).

## Sites refactored
- `feed/FeedView.tsx` — both the explore grid and home list branches (2x spinner + 2x empty state collapsed)
- `profile/ProfileView.tsx` — shared bottom spinner + "No activity yet" empty state; dropped now-unused `CircularProgress` import
- `notifications/NotificationsPage.tsx` — combined loading/loading-more spinner and "No notifications yet" empty state; dropped now-unused `CircularProgress` import

Exact text, colors, sizes, padding, and the show/hide conditions are preserved.

## Scope notes
- `CommentSection` and `IdentificationHistory` use a left-aligned inline `body2` empty message inside a `Paper` (different shape from the centered list empty state), so they were intentionally left as-is to avoid changing their appearance — per the "don't contort callers" guidance.

## Verification (all green)
- `npm run fmt:check` — clean
- `npm run lint` — 0 errors (2 pre-existing warnings in unrelated files)
- `npx tsc --project tsconfig.json` — 0 errors
- `npm run check:stories` — all components have stories