### PR TITLE
refactor(ui): extract UserCard for avatar+name+handle

### DIFF
--- a/frontend/src/components/comment/CommentSection.tsx
+++ b/frontend/src/components/comment/CommentSection.tsx
@@ -1,9 +1,7 @@
 import { useState, useCallback, type FormEvent } from "react";
-import { Link as RouterLink } from "react-router-dom";
 import {
   Box,
   Typography,
-  Avatar,
   Stack,
   Paper,
   TextField,
@@ -22,6 +20,7 @@ import { useSubmitComment } from "../../lib/query/mutations";
 import type { Comment } from "../../services/types";
 import { getPdslsUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
+import { UserCard } from "../common/UserCard";
 
 interface CommentSectionProps {
   observationUri: string;
@@ -147,45 +146,16 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
                 },
               }}
             >
-              <Stack
-                direction="row"
-                spacing={1.5}
-                sx={{
-                  alignItems: "flex-start",
-                }}
-              >
-                <RouterLink
-                  to={`/profile/${encodeURIComponent(comment.commenter?.did || comment.did)}`}
-                >
-                  <Avatar
-                    {...(comment.commenter?.avatar ? { src: comment.commenter.avatar } : {})}
-                    sx={{ width: 32, height: 32 }}
-                  >
-                    {(comment.commenter?.displayName || comment.commenter?.handle || "?")[0]}
-                  </Avatar>
-                </RouterLink>
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Stack
-                    direction="row"
-                    spacing={1}
-                    sx={{
-                      alignItems: "center",
-                    }}
-                  >
-                    <RouterLink
-                      to={`/profile/${encodeURIComponent(comment.commenter?.did || comment.did)}`}
-                      style={{ textDecoration: "none" }}
-                    >
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          fontWeight: "medium",
-                          color: "text.primary",
-                        }}
-                      >
-                        {comment.commenter?.displayName || comment.commenter?.handle || "Unknown"}
-                      </Typography>
-                    </RouterLink>
+              <UserCard
+                actor={comment.commenter ?? {}}
+                linkDid={comment.commenter?.did || comment.did}
+                avatarSize={32}
+                alignItems="flex-start"
+                link
+                nameVariant="body2"
+                nameSx={{ fontWeight: "medium" }}
+                trailing={
+                  <>
                     <Typography
                       variant="caption"
                       sx={{
@@ -221,12 +191,14 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
                         </MenuItem>
                       </Menu>
                     </Box>
-                  </Stack>
+                  </>
+                }
+                belowName={
                   <Typography variant="body2" sx={{ mt: 0.5, whiteSpace: "pre-wrap" }}>
                     {comment.body}
                   </Typography>
-                </Box>
-              </Stack>
+                }
+              />
             </Box>
           ))}
         </Stack>

--- a/frontend/src/components/common/UserCard.stories.tsx
+++ b/frontend/src/components/common/UserCard.stories.tsx
@@ -1,0 +1,121 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router-dom";
+import { Stack, Typography } from "@mui/material";
+import { UserCard } from "./UserCard";
+
+const actor = {
+  did: "did:plc:abc123xyz",
+  handle: "alice.bsky.social",
+  displayName: "Alice Naturalist",
+  avatar: "https://i.pravatar.cc/150?img=5",
+};
+
+const meta = {
+  title: "Common/UserCard",
+  component: UserCard,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <MemoryRouter>
+        <Story />
+      </MemoryRouter>
+    ),
+  ],
+  args: {
+    actor,
+  },
+  argTypes: {
+    showHandle: { control: { type: "boolean" } },
+    link: { control: { type: "boolean" } },
+    avatarSize: { control: { type: "number" } },
+  },
+} satisfies Meta<typeof UserCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithHandle: Story = {
+  args: {
+    showHandle: true,
+  },
+};
+
+export const Linked: Story = {
+  args: {
+    link: true,
+    showHandle: true,
+  },
+};
+
+export const ProfileHeader: Story = {
+  args: {
+    avatarSize: 80,
+    spacing: 2,
+    nameVariant: "h5",
+    showHandle: true,
+    handleVariant: "body1",
+  },
+};
+
+export const NoAvatarUsesInitial: Story = {
+  args: {
+    actor: { did: "did:plc:noavatar", handle: "bob.example.com", displayName: "Bob Birder" },
+    showHandle: true,
+  },
+};
+
+export const HandleOnlyFallback: Story = {
+  args: {
+    actor: { did: "did:plc:nohandle", handle: "charlie.example.com" },
+    showHandle: true,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "With no `displayName`, `getDisplayName` falls back to the handle for both the name and the avatar initial.",
+      },
+    },
+  },
+};
+
+export const WithTrailingAndBelowName: Story = {
+  args: {
+    nameVariant: "body2",
+    nameSx: { fontWeight: "medium" },
+    trailing: (
+      <Typography variant="caption" sx={{ color: "text.secondary" }}>
+        2h ago
+      </Typography>
+    ),
+    belowName: (
+      <Typography variant="body2" sx={{ mt: 0.5 }}>
+        Nice find — looks like a juvenile to me.
+      </Typography>
+    ),
+    alignItems: "flex-start",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The `trailing` slot sits on the name's baseline row (e.g. a timestamp) and `belowName` renders beneath it (e.g. a comment body).",
+      },
+    },
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <Stack spacing={2} sx={{ alignItems: "flex-start" }}>
+      <UserCard {...args} avatarSize={32} nameVariant="body2" showHandle />
+      <UserCard {...args} avatarSize={40} showHandle />
+      <UserCard {...args} avatarSize={80} spacing={2} nameVariant="h5" showHandle />
+    </Stack>
+  ),
+};

--- a/frontend/src/components/common/UserCard.tsx
+++ b/frontend/src/components/common/UserCard.tsx
@@ -1,0 +1,162 @@
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { Avatar, Box, Stack, Typography } from "@mui/material";
+import type { SxProps, Theme, TypographyProps } from "@mui/material";
+import { getDisplayName } from "../../lib/utils";
+
+/** The minimal actor shape rendered by UserCard (matches Profile / NotificationActor). */
+export interface UserCardActor {
+  did?: string;
+  handle?: string | null;
+  displayName?: string | null;
+  avatar?: string | null;
+}
+
+export interface UserCardProps {
+  /** The actor to display (avatar + name + handle). */
+  actor: UserCardActor;
+  /** Avatar diameter in pixels (default 40). */
+  avatarSize?: number;
+  /**
+   * Avatar image URL override. When omitted, `actor.avatar` is used. Pass this
+   * when the URL needs transforming (e.g. `getImageUrl(actor.avatar)`).
+   */
+  avatarSrc?: string | undefined;
+  /** Render the `@handle` line beneath the name (default false). */
+  showHandle?: boolean;
+  /** Typography variant for the `@handle` line (default "body2"). */
+  handleVariant?: TypographyProps["variant"];
+  /**
+   * Wrap the avatar + name in a profile link to `/profile/{did}`. The `did` is
+   * taken from `linkDid` when provided, otherwise `actor.did`.
+   */
+  link?: boolean;
+  /** DID to link to / fall back to for the display name (overrides `actor.did`). */
+  linkDid?: string;
+  /** Typography variant for the display name. */
+  nameVariant?: TypographyProps["variant"];
+  /** Extra `sx` applied to the display name. */
+  nameSx?: SxProps<Theme>;
+  /** `sx` for the outer row Stack. */
+  sx?: SxProps<Theme>;
+  /** Horizontal spacing between avatar and text block (Stack `spacing`, default 1.5). */
+  spacing?: number;
+  /** Stop click propagation on the profile link (useful inside clickable cards). */
+  stopPropagation?: boolean;
+  /** Trailing content rendered after the name on the same baseline row. */
+  trailing?: ReactNode;
+  /**
+   * Content rendered below the name within the text column (e.g. a comment
+   * body). Takes the place of the `@handle` line when provided alongside it.
+   */
+  belowName?: ReactNode;
+  /** Vertical alignment of the avatar against the text column (default "center"). */
+  alignItems?: "center" | "flex-start";
+}
+
+/**
+ * Avatar + display name (+ optional `@handle`) cluster used across feed,
+ * observation, profile, comment, and notification views. Routes the display
+ * name and avatar-initial fallback through `getDisplayName`.
+ */
+export function UserCard({
+  actor,
+  avatarSize = 40,
+  avatarSrc,
+  showHandle = false,
+  handleVariant = "body2",
+  link = false,
+  linkDid,
+  nameVariant,
+  nameSx,
+  sx,
+  spacing = 1.5,
+  stopPropagation = false,
+  trailing,
+  belowName,
+  alignItems = "center",
+}: UserCardProps) {
+  const did = linkDid ?? actor.did;
+  const displayName = getDisplayName({
+    ...(actor.displayName != null ? { displayName: actor.displayName } : {}),
+    ...(actor.handle != null ? { handle: actor.handle } : {}),
+    ...(did ? { did } : {}),
+  });
+  const handle = actor.handle ? `@${actor.handle}` : "";
+  const src = avatarSrc ?? actor.avatar ?? undefined;
+
+  const stop = stopPropagation ? (e: React.MouseEvent) => e.stopPropagation() : undefined;
+
+  const avatar = (
+    <Avatar
+      {...(src ? { src } : {})}
+      alt={displayName}
+      sx={{ width: avatarSize, height: avatarSize }}
+    >
+      {displayName[0]}
+    </Avatar>
+  );
+
+  const name = (
+    <Typography
+      {...(nameVariant ? { variant: nameVariant } : {})}
+      sx={{ fontWeight: 600, color: "text.primary", ...nameSx }}
+    >
+      {displayName}
+    </Typography>
+  );
+
+  const linkSx = {
+    textDecoration: "none",
+    color: "inherit",
+  } as const;
+
+  const avatarEl =
+    link && did ? (
+      <Box
+        component={Link}
+        to={`/profile/${encodeURIComponent(did)}`}
+        {...(stop ? { onClick: stop } : {})}
+        sx={{ display: "inline-flex", ...linkSx }}
+      >
+        {avatar}
+      </Box>
+    ) : (
+      avatar
+    );
+
+  const nameEl =
+    link && did ? (
+      <Box
+        component={Link}
+        to={`/profile/${encodeURIComponent(did)}`}
+        {...(stop ? { onClick: stop } : {})}
+        sx={{ ...linkSx, "&:hover": { textDecoration: "underline" } }}
+      >
+        {name}
+      </Box>
+    ) : (
+      name
+    );
+
+  return (
+    <Stack direction="row" spacing={spacing} sx={{ alignItems, ...sx }}>
+      {avatarEl}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: "baseline", flexWrap: "wrap" }}>
+          {nameEl}
+          {trailing}
+        </Stack>
+        {showHandle && handle && (
+          <Typography
+            {...(handleVariant ? { variant: handleVariant } : {})}
+            sx={{ color: "text.disabled" }}
+          >
+            {handle}
+          </Typography>
+        )}
+        {belowName}
+      </Box>
+    </Stack>
+  );
+}

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -1,18 +1,15 @@
 import { memo, useState } from "react";
-import { Link, useNavigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 import {
   Box,
-  Avatar,
   Typography,
   IconButton,
   Menu,
   MenuItem,
   Card,
-  CardHeader,
   CardContent,
   CardActions,
   CardActionArea,
-  Stack,
   Tooltip,
 } from "@mui/material";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
@@ -23,7 +20,8 @@ import { useAppSelector } from "../../store";
 import { getImageUrl } from "../../services/api";
 import { useLike } from "../../lib/query/mutations";
 import { TaxonLink } from "../common/TaxonLink";
-import { getDisplayName, getPdslsUrl, getObservationUrl } from "../../lib/utils";
+import { UserCard } from "../common/UserCard";
+import { getPdslsUrl, getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
 import { FEED_CARD_SX, FEED_IMAGE_MAX_HEIGHT } from "./feedLayout";
@@ -47,7 +45,6 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
   const isOwnPost = currentUser?.did === observation.observer.did;
 
   const owner = observation.observer;
-  const displayName = getDisplayName(owner);
   const handle = owner.handle ? `@${owner.handle}` : "";
   const timeAgo = <RelativeTime date={new Date(observation.createdAt)} />;
 
@@ -93,97 +90,65 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
     navigate(observationUrl);
   };
 
-  const avatarEl = (
-    <Avatar
-      component={Link}
-      to={`/profile/${encodeURIComponent(owner.did)}`}
-      {...(owner.avatar ? { src: owner.avatar } : {})}
-      alt={displayName}
-      onClick={(e) => e.stopPropagation()}
-      sx={{ width: 40, height: 40, cursor: "pointer" }}
-    />
-  );
-
-  const titleEl = (
-    <Stack
-      direction="row"
-      spacing={1}
-      sx={{
-        alignItems: "baseline",
-        flexWrap: "wrap",
-      }}
-    >
-      <Typography
-        component={Link}
-        to={`/profile/${encodeURIComponent(owner.did)}`}
-        onClick={(e) => e.stopPropagation()}
-        sx={{
-          fontWeight: 600,
-          color: "text.primary",
-          textDecoration: "none",
-          "&:hover": { textDecoration: "underline" },
-        }}
-      >
-        {displayName}
-      </Typography>
-      {handle && (
-        <Typography
-          variant="body2"
-          sx={{
-            color: "text.disabled",
-          }}
-        >
-          {handle}
-        </Typography>
-      )}
-    </Stack>
-  );
-
   return (
     <Card sx={FEED_CARD_SX}>
       <CardActionArea onClick={handleCardClick} component="div">
-        <CardHeader
-          avatar={avatarEl}
-          title={titleEl}
-          subheader={timeAgo}
-          slotProps={{ subheader: { variant: "body2", color: "text.disabled" } }}
-          action={
-            <>
-              <IconButton
-                size="small"
-                onClick={handleMenuOpen}
-                aria-label="More options"
-                sx={{ color: "text.disabled" }}
-              >
-                <MoreVertIcon fontSize="small" />
-              </IconButton>
-              <Menu
-                anchorEl={anchorEl}
-                open={menuOpen}
-                onClose={handleMenuClose}
-                onClick={(e) => e.stopPropagation()}
-                anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                transformOrigin={{ vertical: "top", horizontal: "right" }}
-              >
-                {isOwnPost && onEdit && <MenuItem onClick={handleEditClick}>Edit</MenuItem>}
-                {isOwnPost && onDelete && (
-                  <MenuItem onClick={handleDeleteClick} sx={{ color: "error.main" }}>
-                    Delete
-                  </MenuItem>
-                )}
-                <MenuItem
-                  component="a"
-                  href={pdslsUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  View on AT Protocol
+        <Box sx={{ display: "flex", gap: 1, p: 2, alignItems: "flex-start" }}>
+          <UserCard
+            actor={owner}
+            avatarSize={40}
+            spacing={1}
+            link
+            stopPropagation
+            nameSx={{ "&:hover": { textDecoration: "underline" } }}
+            trailing={
+              handle ? (
+                <Typography variant="body2" sx={{ color: "text.disabled" }}>
+                  {handle}
+                </Typography>
+              ) : undefined
+            }
+            belowName={
+              <Typography variant="body2" sx={{ color: "text.disabled" }}>
+                {timeAgo}
+              </Typography>
+            }
+          />
+          <Box>
+            <IconButton
+              size="small"
+              onClick={handleMenuOpen}
+              aria-label="More options"
+              sx={{ color: "text.disabled" }}
+            >
+              <MoreVertIcon fontSize="small" />
+            </IconButton>
+            <Menu
+              anchorEl={anchorEl}
+              open={menuOpen}
+              onClose={handleMenuClose}
+              onClick={(e) => e.stopPropagation()}
+              anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+              transformOrigin={{ vertical: "top", horizontal: "right" }}
+            >
+              {isOwnPost && onEdit && <MenuItem onClick={handleEditClick}>Edit</MenuItem>}
+              {isOwnPost && onDelete && (
+                <MenuItem onClick={handleDeleteClick} sx={{ color: "error.main" }}>
+                  Delete
                 </MenuItem>
-              </Menu>
-            </>
-          }
-        />
+              )}
+              <MenuItem
+                component="a"
+                href={pdslsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={(e) => e.stopPropagation()}
+              >
+                View on AT Protocol
+              </MenuItem>
+            </Menu>
+          </Box>
+        </Box>
 
         {imageUrl && (
           <ImageWithSkeleton

--- a/frontend/src/components/notifications/NotificationsPage.tsx
+++ b/frontend/src/components/notifications/NotificationsPage.tsx
@@ -6,11 +6,8 @@ import {
   Typography,
   Button,
   CircularProgress,
-  Avatar,
   List,
   ListItem,
-  ListItemAvatar,
-  ListItemText,
   ListItemButton,
 } from "@mui/material";
 import { usePageTitle } from "../../hooks/usePageTitle";
@@ -18,6 +15,7 @@ import { getImageUrl } from "../../services/api";
 import type { Notification } from "../../services/types";
 import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
+import { UserCard } from "../common/UserCard";
 import { useNotifications } from "../../lib/query/hooks";
 import { useMarkNotificationRead } from "../../lib/query/mutations";
 
@@ -118,30 +116,22 @@ export function NotificationsPage() {
               }}
             >
               <ListItemButton onClick={() => handleClick(n)} sx={{ borderRadius: 2, py: 1.5 }}>
-                <ListItemAvatar>
-                  <Avatar
-                    {...(n.actor?.avatar ? { src: getImageUrl(n.actor.avatar) } : {})}
-                    sx={{ width: 40, height: 40 }}
-                  />
-                </ListItemAvatar>
-                <ListItemText
-                  primary={
-                    <>
-                      <Typography
-                        component="span"
-                        variant="body2"
-                        sx={{
-                          fontWeight: 600,
-                        }}
-                      >
-                        @{n.actor?.handle || n.actorDid}
-                      </Typography>{" "}
-                      <Typography component="span" variant="body2">
-                        {getKindText(n.kind)}
-                      </Typography>
-                    </>
+                <UserCard
+                  actor={n.actor ?? {}}
+                  linkDid={n.actorDid}
+                  avatarSize={40}
+                  {...(n.actor?.avatar ? { avatarSrc: getImageUrl(n.actor.avatar) } : {})}
+                  nameVariant="body2"
+                  trailing={
+                    <Typography component="span" variant="body2">
+                      {getKindText(n.kind)}
+                    </Typography>
                   }
-                  secondary={<RelativeTime date={new Date(n.createdAt)} />}
+                  belowName={
+                    <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                      <RelativeTime date={new Date(n.createdAt)} />
+                    </Typography>
+                  }
                 />
               </ListItemButton>
             </ListItem>

--- a/frontend/src/components/notifications/NotificationsPage.tsx
+++ b/frontend/src/components/notifications/NotificationsPage.tsx
@@ -122,6 +122,7 @@ export function NotificationsPage() {
                   avatarSize={40}
                   {...(n.actor?.avatar ? { avatarSrc: getImageUrl(n.actor.avatar) } : {})}
                   nameVariant="body2"
+                  showHandle
                   trailing={
                     <Typography component="span" variant="body2">
                       {getKindText(n.kind)}

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   Container,
   Typography,
-  Avatar,
   Button,
   Stack,
   IconButton,
@@ -14,7 +13,6 @@ import {
   List,
   ListItem,
   ListItemIcon,
-  ListItemAvatar,
   ListItemText,
   Tooltip,
 } from "@mui/material";
@@ -41,13 +39,8 @@ import { TaxonLink } from "../common/TaxonLink";
 import { ObservationDetailSkeleton } from "./ObservationDetailSkeleton";
 import { PhotoLightbox } from "./PhotoLightbox";
 import { QualityIssueBadges } from "./QualityIssueBadges";
-import {
-  formatDate,
-  getDisplayName,
-  getPdslsUrl,
-  buildOccurrenceAtUri,
-  getErrorMessage,
-} from "../../lib/utils";
+import { UserCard } from "../common/UserCard";
+import { formatDate, getPdslsUrl, buildOccurrenceAtUri, getErrorMessage } from "../../lib/utils";
 import { getLicenseLabel } from "../../lib/licenses";
 
 export function ObservationDetail() {
@@ -150,9 +143,6 @@ export function ObservationDetail() {
       </Box>
     );
   }
-
-  const displayName = getDisplayName(observation.observer);
-  const handle = observation.observer.handle ? `@${observation.observer.handle}` : "";
 
   const taxonomy = observation.effectiveTaxonomy;
 
@@ -386,20 +376,7 @@ export function ObservationDetail() {
               borderRadius: 1,
             }}
           >
-            <ListItemAvatar>
-              <Avatar
-                {...(observation.observer.avatar ? { src: observation.observer.avatar } : {})}
-                alt={displayName}
-              />
-            </ListItemAvatar>
-            <ListItemText
-              primary={displayName}
-              secondary={handle || undefined}
-              slotProps={{
-                primary: { sx: { fontWeight: 600 } },
-                secondary: { sx: { color: "text.disabled" } },
-              }}
-            />
+            <UserCard actor={observation.observer} avatarSize={40} spacing={2} showHandle />
           </ListItem>
 
           {/* Observation Details */}

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -3,7 +3,6 @@ import { useParams, Link } from "react-router-dom";
 import {
   Box,
   Container,
-  Avatar,
   Typography,
   Tabs,
   Tab,
@@ -20,8 +19,9 @@ import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import GrassIcon from "@mui/icons-material/Grass";
 import { getImageUrl } from "../../services/api";
 import { useProfileFeed } from "../../lib/query/hooks";
-import { getDisplayName, getObservationUrl } from "../../lib/utils";
+import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
+import { UserCard } from "../common/UserCard";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
 import { ProfileHeaderSkeleton } from "./ProfileHeaderSkeleton";
@@ -88,38 +88,15 @@ export function ProfileView() {
         <ProfileHeaderSkeleton />
       ) : (
         <Box sx={PROFILE_HEADER_SX}>
-          <Stack
-            direction="row"
+          <UserCard
+            actor={profile ?? {}}
+            linkDid={did}
+            avatarSize={PROFILE_AVATAR_SIZE}
             spacing={2}
-            sx={{
-              alignItems: "center",
-            }}
-          >
-            <Avatar
-              {...(profile?.avatar ? { src: profile.avatar } : {})}
-              alt={profile?.displayName || profile?.handle || did}
-              sx={{ width: PROFILE_AVATAR_SIZE, height: PROFILE_AVATAR_SIZE }}
-            />
-            <Box>
-              <Typography
-                variant="h5"
-                sx={{
-                  fontWeight: 600,
-                }}
-              >
-                {getDisplayName({ ...profile, did })}
-              </Typography>
-              {profile?.handle && (
-                <Typography
-                  sx={{
-                    color: "text.disabled",
-                  }}
-                >
-                  @{profile.handle}
-                </Typography>
-              )}
-            </Box>
-          </Stack>
+            nameVariant="h5"
+            showHandle
+            handleVariant="body1"
+          />
 
           {/* Stats */}
           {counts && (


### PR DESCRIPTION
## What

Adds `frontend/src/components/common/UserCard.tsx`, a presentational component for the avatar + display name + `@handle` cluster that was rebuilt inline in ~5 places. It supports the real variants found across sites: avatar `size`, optional `@handle` line, optional profile-link wrapper (with `stopPropagation` for clickable cards), and `trailing` / `belowName` slots for adornments (timestamps, menus, comment bodies). MUI Avatar `src` uses the conditional-spread idiom for `exactOptionalPropertyTypes`.

The display name **and** the avatar-initial fallback now route through the existing `getDisplayName` util.

## Sites refactored
- `feed/FeedItem.tsx` — header avatar+name+handle (40px, profile link, timestamp below, menu beside)
- `observation/ObservationDetail.tsx` — observer ListItem (40px, handle line)
- `profile/ProfileView.tsx` — header variant (80px avatar, h5 name, body1 handle)
- `comment/CommentSection.tsx` — replaces the inline `displayName || handle || "?"` / `"Unknown"` fallback chains; routes through `getDisplayName`
- `notifications/NotificationsPage.tsx` — actor avatar+name with kind text trailing

## Notes
- Adornments (timestamps, kebab menus, comment bodies, like buttons) are preserved around the UserCard; only the avatar+name+handle cluster was replaced.
- Adds sibling `UserCard.stories.tsx` (CI `check:stories` gate) covering size and handle variants.

## Verification
`npm run fmt` / `fmt:check`, `npm run lint` (only 2 pre-existing unrelated warnings), `npx tsc` (0 errors), `npm run check:stories` all pass.