### PR TITLE
refactor(bootstrap): extract shared axum serve() helper into observing-bootstrap

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2872,6 +2872,7 @@ dependencies = [
  "hickory-resolver",
  "jacquard-common",
  "moka",
+ "observing-bootstrap",
  "observing-db",
  "observing-lexicons",
  "observing-species-id-protocol",
@@ -2888,6 +2889,15 @@ dependencies = [
  "urlencoding",
  "wikidata-client",
  "wiremock",
+]
+
+[[package]]
+name = "observing-bootstrap"
+version = "0.1.0"
+dependencies = [
+ "axum",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -2960,6 +2970,7 @@ dependencies = [
  "chrono",
  "image",
  "ndarray",
+ "observing-bootstrap",
  "observing-species-id-protocol",
  "ort",
  "serde",
@@ -4724,6 +4735,7 @@ dependencies = [
  "ciborium",
  "clap",
  "futures-util",
+ "observing-bootstrap",
  "observing-collections",
  "observing-db",
  "observing-lexicons",

--- a/crates/observing-appview/Cargo.toml
+++ b/crates/observing-appview/Cargo.toml
@@ -7,6 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Internal crates
+observing-bootstrap = { path = "../observing-bootstrap" }
 axum-admin = { path = "../axum-admin" }
 observing-db = { path = "../observing-db", features = ["processing"] }
 atproto-identity = { path = "../atproto-identity" }

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -259,12 +259,6 @@ async fn main() {
         }
     };
 
-    let listener = tokio::net::TcpListener::bind(format!("0.0.0.0:{}", config.port))
-        .await
-        .expect("Failed to bind");
-
-    info!(port = config.port, "Listening");
-
     // Surface the app's "front door" URL so humans (and tools) know where to
     // open it. appview is always the front door on `PORT` — NOT the Vite dev
     // server's :5173. In local dev the OAuth callback is registered at
@@ -277,7 +271,9 @@ async fn main() {
         ),
     }
 
-    axum::serve(listener, app).await.expect("Server failed");
+    observing_bootstrap::serve(app, config.port)
+        .await
+        .expect("Server failed");
 }
 
 async fn vite_proxy(

--- a/crates/observing-bootstrap/Cargo.toml
+++ b/crates/observing-bootstrap/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "observing-bootstrap"
+version = "0.1.0"
+edition = "2021"
+description = "Shared service-bootstrap helpers for observ.ing binaries"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+axum = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/crates/observing-bootstrap/src/lib.rs
+++ b/crates/observing-bootstrap/src/lib.rs
@@ -1,0 +1,19 @@
+//! Shared bootstrap helpers for observ.ing service binaries.
+
+use std::net::SocketAddr;
+
+/// Bind an axum app to `0.0.0.0:<port>` and serve it until the process exits.
+///
+/// Centralizes the `SocketAddr::from(([0, 0, 0, 0], port))` →
+/// `TcpListener::bind` → `axum::serve` sequence that every HTTP service
+/// repeated. Binding to `0.0.0.0` (all interfaces) is required for the Cloud
+/// Run TCP startup probe to reach the container.
+///
+/// Returns the bind/serve [`std::io::Error`] to the caller; the message logged
+/// on startup includes the resolved address.
+pub async fn serve(router: axum::Router, port: u16) -> std::io::Result<()> {
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    tracing::info!("Starting HTTP server on {addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, router).await
+}

--- a/crates/observing-species-id/Cargo.toml
+++ b/crates/observing-species-id/Cargo.toml
@@ -8,6 +8,8 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # Wire types shared with the appview client
 observing-species-id-protocol = { path = "../observing-species-id-protocol" }
+# Shared HTTP server bootstrap (bind + serve)
+observing-bootstrap = { path = "../observing-bootstrap" }
 
 # ONNX inference
 ort = { version = "2.0.0-rc.12", features = ["load-dynamic", "ndarray"] }

--- a/crates/observing-species-id/src/server.rs
+++ b/crates/observing-species-id/src/server.rs
@@ -40,12 +40,7 @@ pub fn create_router(state: SharedState) -> Router {
 
 /// Start the HTTP server
 pub async fn start_server(state: SharedState, port: u16) -> std::io::Result<()> {
-    let router = create_router(state);
-    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
-    info!("Starting HTTP server on {}", addr);
-
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, router).await
+    observing_bootstrap::serve(create_router(state), port).await
 }
 
 /// Health check endpoint

--- a/crates/tap-ingester/Cargo.toml
+++ b/crates/tap-ingester/Cargo.toml
@@ -9,6 +9,9 @@ license = "MIT OR Apache-2.0"
 # Tap client wrapper — handles WebSocket + ack handshake + reconnection.
 tapped = { workspace = true }
 
+# Shared HTTP server bootstrap (bind + serve for the dashboard).
+observing-bootstrap = { path = "../observing-bootstrap" }
+
 # Database write path (shared processing module).
 observing-db = { path = "../observing-db", features = ["processing"] }
 observing-lexicons = { path = "../observing-lexicons" }

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -325,11 +325,7 @@ async fn heartbeat(state: SharedState, tap: TapClient, relay_url: String) {
 }
 
 async fn serve_http(state: DashboardState, port: u16) -> std::io::Result<()> {
-    let router = dashboard::router(state);
-    let addr = std::net::SocketAddr::from(([0, 0, 0, 0], port));
-    info!("Starting HTTP server on {}", addr);
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, router).await
+    observing_bootstrap::serve(dashboard::router(state), port).await
 }
 
 /// Backing DB URL for the embedded Tap.


### PR DESCRIPTION
## What

Three HTTP services repeated the identical bind-and-serve tail:

```rust
let addr = SocketAddr::from(([0, 0, 0, 0], port));
info!("Starting HTTP server on {addr}");
let listener = TcpListener::bind(addr).await?;
axum::serve(listener, router).await
```

This PR hoists it into a new `observing-bootstrap` crate as `serve(router, port)` and routes `tap-ingester`, `observing-species-id`, and `observing-appview` through it.

## Scope (deliberately narrow)

This is the "safe" slice of the larger bootstrap-consolidation idea. **No behavior change** beyond one log line:

- **Tracing init** — left untouched. The services intentionally differ (appview JSON, four services Stackdriver, replay plain text), and the Stackdriver output feeds GCP log-based metrics, so unifying it is out of scope here.
- **DB-pool tuning** — left untouched (per-service `max_connections`/timeouts are intentional).
- **DATABASE_URL resolution** — already handled by the existing `pg-url-env` crate; not duplicated here.

The only observable change: appview's startup log now reads `Starting HTTP server on 0.0.0.0:<port>` (matching the other two services) instead of a structured `port` field. Its front-door URL hint (`Open the app at http://127.0.0.1:…`) is unchanged.

## Changes

- New crate `crates/observing-bootstrap` with `serve()`.
- `tap-ingester::serve_http` and `observing-species-id::start_server` now one-liner through it.
- `observing-appview` main serves via the helper (front-door logging preserved).

## Testing

- `cargo build -p observing-bootstrap -p tap-ingester -p observing-species-id -p observing-appview` ✅ (no warnings)
- `cargo test -p observing-bootstrap -p observing-species-id` ✅