### PR TITLE
feat(map): MapTiler basemaps with light/dark + basemap selector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,21 @@ SPECIES_ID_SERVICE_URL=http://localhost:3005
 
 
 # ---------------------------------------------------------------------------
+# Frontend (Vite) — VITE_-prefixed vars are baked into the browser bundle
+# ---------------------------------------------------------------------------
+# Read at build/dev time and exposed to the client, so treat these as public.
+
+# MapTiler API key for the map basemap (Outdoor — label-rich topo, light+dark).
+# Create a free key at https://cloud.maptiler.com (Account -> Keys) and, since
+# it ships in the bundle, restrict it to your domain(s) in the MapTiler
+# dashboard. If unset, the map falls back to keyless CARTO vector tiles.
+# VITE_MAPTILER_KEY=
+
+# Optional: override the API base URL the frontend calls. Default: same origin.
+# VITE_API_URL=
+
+
+# ---------------------------------------------------------------------------
 # species-id (port 3005) — ML-based species identification
 # ---------------------------------------------------------------------------
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,6 +46,12 @@ jobs:
       - run: npm run build
         env:
           VITE_API_URL: https://observ.ing
+          # Map basemap key. The APK WebView runs at origin https://localhost
+          # (Capacitor default), so this key must allow https://localhost +
+          # capacitor://localhost in the MapTiler dashboard — NOT only
+          # observ.ing. Set the secret accordingly. Optional: unset → keyless
+          # CARTO fallback.
+          VITE_MAPTILER_KEY: ${{ secrets.VITE_MAPTILER_KEY }}
       - run: npx cap add android
       - run: npx cap sync android
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,15 @@ RUN npm ci
 
 COPY frontend/ frontend/
 COPY lexicons/ lexicons/
+
+# MapTiler key for the map basemap, baked into the JS bundle at build time.
+# Pass it when building the appview image:
+#   docker build --build-arg SERVICE=observing-appview \
+#     --build-arg VITE_MAPTILER_KEY=<key allowed for https://observ.ing> ...
+# Optional — without it the map falls back to keyless CARTO vector tiles. Lives
+# only in this build stage; the runtime image just copies dist/public.
+ARG VITE_MAPTILER_KEY=
+ENV VITE_MAPTILER_KEY=${VITE_MAPTILER_KEY}
 RUN npm run build
 
 # ---------------------------------------------------------------------------

--- a/frontend/src/components/map/BasemapSelector.stories.tsx
+++ b/frontend/src/components/map/BasemapSelector.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { BasemapSelector } from "./BasemapSelector";
+
+const meta = {
+  title: "Map/BasemapSelector",
+  component: BasemapSelector,
+  parameters: { layout: "centered" },
+  // The selector positions itself absolutely (bottom-left of its map), so give
+  // it a relatively-positioned stand-in for the map area.
+  decorators: [
+    (Story) => (
+      <Box
+        sx={{
+          position: "relative",
+          width: 360,
+          height: 200,
+          bgcolor: "action.hover",
+          borderRadius: 1,
+        }}
+      >
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof BasemapSelector>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/src/components/map/BasemapSelector.tsx
+++ b/frontend/src/components/map/BasemapSelector.tsx
@@ -1,0 +1,54 @@
+import { useState } from "react";
+import { IconButton, ListItemIcon, ListItemText, Menu, MenuItem, Tooltip } from "@mui/material";
+import LayersIcon from "@mui/icons-material/Layers";
+import CheckIcon from "@mui/icons-material/Check";
+import { BASEMAPS } from "./mapStyle";
+import { useBasemap } from "./useBasemap";
+
+/**
+ * Floating control (bottom-left of the map) for switching the basemap. The
+ * choice is persisted and shared across every map in the app via useBasemap.
+ */
+export function BasemapSelector() {
+  const [basemap, setBasemap] = useBasemap();
+  const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+
+  return (
+    <>
+      <Tooltip title="Basemap">
+        <IconButton
+          size="small"
+          aria-label="Choose basemap"
+          onClick={(e) => setAnchorEl(e.currentTarget)}
+          sx={{
+            position: "absolute",
+            bottom: 8,
+            left: 8,
+            zIndex: 1,
+            color: "text.primary",
+            bgcolor: "background.paper",
+            boxShadow: 2,
+            "&:hover": { bgcolor: "background.paper" },
+          }}
+        >
+          <LayersIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+        {BASEMAPS.map((b) => (
+          <MenuItem
+            key={b.id}
+            selected={b.id === basemap}
+            onClick={() => {
+              setBasemap(b.id);
+              setAnchorEl(null);
+            }}
+          >
+            <ListItemIcon>{b.id === basemap ? <CheckIcon fontSize="small" /> : null}</ListItemIcon>
+            <ListItemText>{b.label}</ListItemText>
+          </MenuItem>
+        ))}
+      </Menu>
+    </>
+  );
+}

--- a/frontend/src/components/map/LocationMap.tsx
+++ b/frontend/src/components/map/LocationMap.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useRef } from "react";
 import { Box, Typography, useTheme } from "@mui/material";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { darkMapFilter, mapContainerSx } from "./mapStyle";
+import { mapContainerSx, MAPTILER_ENABLED } from "./mapStyle";
 import {
   createCircleGeoJSON,
   createMap,
   getRadiusBounds,
   MAP_MARKER_COLOR,
   addUncertaintyLayers,
+  setBasemapStyle,
 } from "./mapUtils";
+import { useBasemap } from "./useBasemap";
+import { BasemapSelector } from "./BasemapSelector";
 import maplibregl from "maplibre-gl";
 
 export interface LocationMapProps {
@@ -21,6 +24,15 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
   const mapContainer = useRef<HTMLDivElement>(null);
   const map = useRef<maplibregl.Map | null>(null);
   const theme = useTheme();
+  const mode = theme.palette.mode;
+  const [basemap] = useBasemap();
+  // Read the latest mode/basemap inside the create effect without making them
+  // dependencies (theme/basemap changes swap the style in a separate effect
+  // rather than rebuilding the map).
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  const basemapRef = useRef(basemap);
+  basemapRef.current = basemap;
 
   const validCoords = Number.isFinite(latitude) && Number.isFinite(longitude);
 
@@ -41,7 +53,7 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
         interactive: true,
         scrollZoom: false,
       },
-      { geolocate: false },
+      { geolocate: false, mode: modeRef.current, basemap: basemapRef.current },
     );
 
     mapInstance.on("load", () => {
@@ -75,6 +87,17 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
     };
   }, [latitude, longitude, uncertaintyMeters, validCoords]);
 
+  // Swap the style when the theme or basemap changes, without rebuilding the
+  // map (skips the initial render — the map starts in the right style).
+  const firstStyle = useRef(true);
+  useEffect(() => {
+    if (firstStyle.current) {
+      firstStyle.current = false;
+      return;
+    }
+    if (map.current) setBasemapStyle(map.current, basemap, mode);
+  }, [mode, basemap]);
+
   if (!validCoords) {
     return (
       <Box
@@ -101,13 +124,9 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
   }
 
   return (
-    <Box
-      ref={mapContainer}
-      sx={[
-        { position: "relative" },
-        mapContainerSx,
-        theme.palette.mode === "dark" && darkMapFilter,
-      ]}
-    />
+    <Box sx={[{ position: "relative" }, mapContainerSx]}>
+      <Box ref={mapContainer} sx={{ position: "absolute", inset: 0 }} />
+      {MAPTILER_ENABLED && <BasemapSelector />}
+    </Box>
   );
 }

--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -16,14 +16,17 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
-import { darkMapFilter, mapContainerSx } from "./mapStyle";
+import { mapContainerSx, MAPTILER_ENABLED } from "./mapStyle";
 import {
   MAP_MARKER_COLOR,
   addUncertaintyLayers,
   createCircleGeoJSON,
   createMap,
   getRadiusBounds,
+  setBasemapStyle,
 } from "./mapUtils";
+import { useBasemap } from "./useBasemap";
+import { BasemapSelector } from "./BasemapSelector";
 
 interface LocationPickerProps {
   latitude: number | null;
@@ -76,6 +79,14 @@ export function LocationPicker({
   const [lngInput, setLngInput] = useState(longitude?.toFixed(6) ?? "");
   const [showCoordinates, setShowCoordinates] = useState(false);
   const theme = useTheme();
+  const mode = theme.palette.mode;
+  const [basemap] = useBasemap();
+  // Latest mode/basemap for the init effect (which runs once); theme/basemap
+  // changes are handled by swapping the style, not rebuilding the map.
+  const modeRef = useRef(mode);
+  modeRef.current = mode;
+  const basemapRef = useRef(basemap);
+  basemapRef.current = basemap;
 
   const updateMarker = useCallback(
     (lng: number, lat: number, radius?: number) => {
@@ -159,10 +170,14 @@ export function LocationPicker({
     const safeLat = latitude && Number.isFinite(latitude) ? latitude : 0;
     const safeLng = longitude && Number.isFinite(longitude) ? longitude : 0;
 
-    const { map: mapInstance, geolocateControl } = createMap(mapContainer.current, {
-      center: [safeLng, safeLat],
-      zoom: latitude && longitude ? 12 : 1,
-    });
+    const { map: mapInstance, geolocateControl } = createMap(
+      mapContainer.current,
+      {
+        center: [safeLng, safeLat],
+        zoom: latitude && longitude ? 12 : 1,
+      },
+      { mode: modeRef.current, basemap: basemapRef.current },
+    );
 
     // Update marker and inputs when user geolocates via the built-in control
     geolocateControl?.on("geolocate", (e: GeolocationPosition) => {
@@ -214,6 +229,18 @@ export function LocationPicker({
       marker.current = null;
     };
   }, []);
+
+  // Swap the style on theme/basemap change, preserving the current view,
+  // marker, and uncertainty circle (skips the initial render — the map starts
+  // in the right style).
+  const firstStyle = useRef(true);
+  useEffect(() => {
+    if (firstStyle.current) {
+      firstStyle.current = false;
+      return;
+    }
+    if (map.current) setBasemapStyle(map.current, basemap, mode);
+  }, [mode, basemap]);
 
   // Update marker and center when props change externally
   useEffect(() => {
@@ -318,10 +345,10 @@ export function LocationPicker({
           );
         }}
       />
-      <Box
-        ref={mapContainer}
-        sx={[mapContainerSx, theme.palette.mode === "dark" && darkMapFilter]}
-      />
+      <Box sx={[{ position: "relative" }, mapContainerSx]}>
+        <Box ref={mapContainer} sx={{ position: "absolute", inset: 0 }} />
+        {MAPTILER_ENABLED && <BasemapSelector />}
+      </Box>
       <Button
         size="small"
         onClick={() => setShowCoordinates((v) => !v)}

--- a/frontend/src/components/map/mapStyle.ts
+++ b/frontend/src/components/map/mapStyle.ts
@@ -1,38 +1,60 @@
-import type { StyleSpecification } from "maplibre-gl";
 import type { Theme } from "@mui/material";
 import type { SystemStyleObject } from "@mui/system";
 
-export const mapStyle: StyleSpecification = {
-  version: 8,
-  sources: {
-    carto: {
-      type: "raster",
-      tiles: [
-        "https://a.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://b.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://c.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-        "https://d.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}@2x.png",
-      ],
-      tileSize: 256,
-      attribution:
-        '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> &copy; <a href="https://carto.com/">CARTO</a>',
-    },
-  },
-  layers: [
-    {
-      id: "carto",
-      type: "raster",
-      source: "carto",
-    },
-  ],
+export type BasemapMode = "light" | "dark";
+export type BasemapId = "outdoor" | "streets" | "satellite";
+
+/** Basemaps offered in the selector, in display order. */
+export const BASEMAPS: ReadonlyArray<{ id: BasemapId; label: string }> = [
+  { id: "outdoor", label: "Outdoor" },
+  { id: "streets", label: "Streets" },
+  { id: "satellite", label: "Satellite" },
+];
+
+export const DEFAULT_BASEMAP: BasemapId = "outdoor";
+
+// MapTiler style slug per basemap + theme. "satellite" uses the Hybrid style so
+// place/road labels stay on top of the imagery, and imagery is identical in
+// light and dark (no separate dark slug).
+const MAPTILER_SLUGS: Record<BasemapId, { light: string; dark: string }> = {
+  outdoor: { light: "outdoor-v2", dark: "outdoor-v2-dark" },
+  streets: { light: "streets-v2", dark: "streets-v2-dark" },
+  satellite: { light: "hybrid", dark: "hybrid" },
 };
 
-/** CSS filter applied to the map canvas to invert Voyager tiles for dark mode. */
-export const darkMapFilter: SystemStyleObject<Theme> = {
-  "& .maplibregl-canvas": {
-    filter: "invert(1) hue-rotate(180deg)",
-  },
-};
+// Publishable MapTiler key, baked into the client bundle at build time. Safe to
+// expose (restrict it by domain in the MapTiler dashboard). See .env.example.
+const MAPTILER_KEY = import.meta.env["VITE_MAPTILER_KEY"] || "";
+
+/** Whether MapTiler basemaps are available (i.e. a key is configured). */
+export const MAPTILER_ENABLED = Boolean(MAPTILER_KEY);
+
+let warnedNoKey = false;
+
+/**
+ * Basemap style URL for the given basemap + theme mode.
+ *
+ * MapTiler styles are label-dense and have real light/dark variants, which
+ * matters when orienting where to ID an observation. When no key is configured
+ * (local dev / CI) it falls back to keyless CARTO vector tiles so the map still
+ * renders — the selector is hidden in that case (see MAPTILER_ENABLED).
+ */
+export function basemapStyleUrl(basemap: BasemapId, mode: BasemapMode): string {
+  if (MAPTILER_KEY) {
+    const slug = MAPTILER_SLUGS[basemap][mode];
+    return `https://api.maptiler.com/maps/${slug}/style.json?key=${MAPTILER_KEY}`;
+  }
+  if (!warnedNoKey) {
+    warnedNoKey = true;
+    console.warn(
+      "[map] VITE_MAPTILER_KEY is not set — falling back to keyless CARTO basemap. " +
+        "Set it (see .env.example) to use the MapTiler basemaps.",
+    );
+  }
+  return mode === "dark"
+    ? "https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json"
+    : "https://basemaps.cartocdn.com/gl/voyager-gl-style/style.json";
+}
 
 /** Shared styles for the map container element. */
 export const mapContainerSx: SystemStyleObject<Theme> = {

--- a/frontend/src/components/map/mapUtils.ts
+++ b/frontend/src/components/map/mapUtils.ts
@@ -1,5 +1,5 @@
 import maplibregl from "maplibre-gl";
-import { mapStyle } from "./mapStyle";
+import { basemapStyleUrl, DEFAULT_BASEMAP, type BasemapId, type BasemapMode } from "./mapStyle";
 
 /** Approximate meters per degree of latitude at the equator */
 export const METERS_PER_DEGREE = 111320;
@@ -13,12 +13,16 @@ interface CreateMapResult {
 export function createMap(
   container: HTMLElement,
   options: Omit<maplibregl.MapOptions, "container" | "style">,
-  { geolocate = true }: { geolocate?: boolean } = {},
+  {
+    geolocate = true,
+    basemap = DEFAULT_BASEMAP,
+    mode = "light",
+  }: { geolocate?: boolean; basemap?: BasemapId; mode?: BasemapMode } = {},
 ): CreateMapResult {
   const map = new maplibregl.Map({
     ...options,
     container,
-    style: mapStyle,
+    style: basemapStyleUrl(basemap, mode),
   });
 
   map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "top-right");
@@ -32,6 +36,29 @@ export function createMap(
   }
 
   return { map, geolocateControl };
+}
+
+/**
+ * Swap the basemap (chosen style + theme mode), preserving the runtime-added
+ * uncertainty source + layers across the style change (a plain `setStyle`
+ * would drop them). Markers are DOM overlays and persist on their own.
+ */
+export function setBasemapStyle(map: maplibregl.Map, basemap: BasemapId, mode: BasemapMode): void {
+  map.setStyle(basemapStyleUrl(basemap, mode), {
+    diff: true,
+    transformStyle: (previous, next) => {
+      if (!previous) return next;
+      const uncertainty = previous.sources["uncertainty"];
+      const keptLayers = previous.layers.filter(
+        (layer) => layer.id === "uncertainty-fill" || layer.id === "uncertainty-outline",
+      );
+      return {
+        ...next,
+        sources: uncertainty ? { ...next.sources, uncertainty } : next.sources,
+        layers: [...next.layers, ...keptLayers],
+      };
+    },
+  });
 }
 
 /** Color used for uncertainty circles and map markers */

--- a/frontend/src/components/map/useBasemap.ts
+++ b/frontend/src/components/map/useBasemap.ts
@@ -1,0 +1,49 @@
+import { useCallback, useEffect, useState } from "react";
+import { BASEMAPS, DEFAULT_BASEMAP, type BasemapId } from "./mapStyle";
+
+const STORAGE_KEY = "observing-basemap";
+const CHANGE_EVENT = "observing-basemap-change";
+
+const isBasemapId = (value: string | null): value is BasemapId =>
+  BASEMAPS.some((b) => b.id === value);
+
+export function getStoredBasemap(): BasemapId {
+  try {
+    const value = localStorage.getItem(STORAGE_KEY);
+    return isBasemapId(value) ? value : DEFAULT_BASEMAP;
+  } catch {
+    return DEFAULT_BASEMAP;
+  }
+}
+
+export function setStoredBasemap(id: BasemapId): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, id);
+  } catch {
+    // Storage disabled (private mode) — keep the in-memory choice via the event.
+  }
+  // The native `storage` event only fires in *other* tabs, so dispatch our own
+  // so every map in this document updates immediately.
+  window.dispatchEvent(new CustomEvent(CHANGE_EVENT));
+}
+
+/**
+ * Persisted basemap preference, shared across every map in the app and synced
+ * live between components (and across tabs).
+ */
+export function useBasemap(): [BasemapId, (id: BasemapId) => void] {
+  const [basemap, setLocal] = useState<BasemapId>(getStoredBasemap);
+
+  useEffect(() => {
+    const sync = () => setLocal(getStoredBasemap());
+    window.addEventListener(CHANGE_EVENT, sync);
+    window.addEventListener("storage", sync);
+    return () => {
+      window.removeEventListener(CHANGE_EVENT, sync);
+      window.removeEventListener("storage", sync);
+    };
+  }, []);
+
+  const setBasemap = useCallback((id: BasemapId) => setStoredBasemap(id), []);
+  return [basemap, setBasemap];
+}


### PR DESCRIPTION
## What & why

The map basemap was CARTO **raster** Voyager tiles with a `invert(1) hue-rotate(180deg)` CSS filter for dark mode — which also made labels too sparse/low-contrast for deciding *where* to ID an observation. This switches to **MapTiler vector** basemaps (label-dense, real light/dark variants) and adds a **basemap selector**.

## Changes

- **Basemaps:** Outdoor (default — topo/nature), Streets, Satellite (Hybrid = imagery + labels). Light/dark follow the theme (`outdoor-v2` / `outdoor-v2-dark`, etc.); satellite imagery is the same in both.
- **`basemapStyleUrl(basemap, mode)`** in `mapStyle.ts`. Keyless **CARTO fallback** when `VITE_MAPTILER_KEY` is unset, so dev/CI still render (selector hidden via `MAPTILER_ENABLED`).
- **`BasemapSelector`** — a layers menu overlaid bottom-left on the map. Choice is persisted in `localStorage` and synced live across maps + tabs via the new `useBasemap` hook. Rendered on both `LocationMap` and `LocationPicker`.
- **Runtime style swap** (`setBasemapStyle`): theme/basemap changes call `setStyle(..., { transformStyle })`, which **preserves the uncertainty source + layers** across the swap (markers are DOM overlays and persist on their own) — no map rebuild, view kept.
- Removed the `darkMapFilter` invert hack.

## Deploy config required (only you can do these)

`VITE_MAPTILER_KEY` is a publishable key baked into the bundle at build time — protect it via domain restrictions in the MapTiler dashboard.

- **Web image** (`observ.ing`): build with `--build-arg VITE_MAPTILER_KEY=<key allowed for https://observ.ing>` (wired into the `Dockerfile` frontend-builder stage).
- **Android APK** (`release.yml`): set repo secret `VITE_MAPTILER_KEY`. ⚠️ The Capacitor WebView origin is `https://localhost`, **not** observ.ing — so that key must allow `https://localhost` + `capacitor://localhost`.
- Local dev: `VITE_MAPTILER_KEY` in `.env` (documented in `.env.example`).

## Verification

- `tsc` / `oxlint` / `oxfmt` clean (only a pre-existing `exhaustive-deps` warning on the picker init effect).
- Verified in Storybook with a real key: Outdoor light + dark render; switching to Satellite swaps to imagery and the uncertainty circle/marker persist across the swap; attribution shows "© MapTiler © OpenStreetMap".
- MapTiler style slugs verified live (200): `outdoor-v2`(+dark), `streets-v2`(+dark), `hybrid`.

_Note: a throwaway `basemap-demo.html` comparison tool exists locally but is intentionally **not** part of this PR._