### PR TITLE
fix(ci): bake VITE_MAPTILER_KEY into the appview image build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -492,7 +492,12 @@ jobs:
         with:
           context: .
           file: Dockerfile
-          build-args: SERVICE=${{ matrix.service }}
+          # VITE_MAPTILER_KEY is consumed only by the appview frontend build
+          # (other services prune that stage). Must be a key allowed for
+          # https://observ.ing. Unset → map falls back to keyless CARTO tiles.
+          build-args: |
+            SERVICE=${{ matrix.service }}
+            VITE_MAPTILER_KEY=${{ secrets.VITE_MAPTILER_KEY }}
           push: true
           tags: ${{ env.REGISTRY }}/${{ matrix.service }}:latest
           cache-from: |


### PR DESCRIPTION
## Problem

After merging #593, https://observ.ing still shows the **CARTO fallback** basemap. Root cause: the `build-images` job in `ci.yml` (which builds & pushes the deployed appview image) only passed `build-args: SERVICE=...` — not `VITE_MAPTILER_KEY`. So the production bundle was built with an empty key, and `MAPTILER_ENABLED` is false → CARTO fallback + no selector.

## Fix

Pass `VITE_MAPTILER_KEY` (from a repo secret) into the image build-args. It's consumed only by the appview frontend-builder stage; other services prune that stage.

## ⚠️ Required to take effect

1. Set repo **Actions secret** `VITE_MAPTILER_KEY` to a key allowed for `https://observ.ing` (your production key works). Without the secret, the build still falls back to CARTO.
2. Merge this PR — the push to `main` rebuilds + redeploys with the key.

Note: `release.yml` (Android APK) reads the **same** secret, but the Capacitor WebView origin is `https://localhost`, not observ.ing. To keep one secret working for both, set it to a key whose allowed origins include `https://observ.ing` + `https://localhost` + `capacitor://localhost`.