### PR TITLE
feat(species-id): add /species-in-range endpoint (species expected at a point)

### DIFF
--- a/crates/observing-species-id-protocol/src/lib.rs
+++ b/crates/observing-species-id-protocol/src/lib.rs
@@ -61,3 +61,31 @@ pub struct IdentifyResponse {
     pub model_version: String,
     pub inference_time_ms: u64,
 }
+
+/// A species in the model's label set, identified by name only (no
+/// confidence — this isn't a ranked prediction). Returned by the
+/// `/species-in-range` endpoint.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeciesRef {
+    pub scientific_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub common_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kingdom: Option<String>,
+}
+
+/// Response shape for the species-id `/species-in-range` endpoint: the set of
+/// label-set species whose iNat range covers the requested point.
+///
+/// `area_has_data` distinguishes "we looked and nothing is expected here" from
+/// "we couldn't form an opinion" (no geo index loaded, or the H3 cell at that
+/// point is unknown to the index — typically open ocean / Antarctica). When
+/// it's `false`, `species` is always empty; callers should treat that as
+/// "no range data for this location" rather than "no species live here".
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SpeciesInRangeResponse {
+    pub area_has_data: bool,
+    pub species: Vec<SpeciesRef>,
+}

--- a/crates/observing-species-id/src/embeddings.rs
+++ b/crates/observing-species-id/src/embeddings.rs
@@ -12,7 +12,7 @@
 //! species embeddings is computed via a single matrix multiply.
 
 use crate::error::{Result, SpeciesIdError};
-use crate::types::SpeciesSuggestion;
+use crate::types::{SpeciesRef, SpeciesSuggestion};
 use ndarray::{Array1, Array2};
 use serde::Deserialize;
 use std::path::Path;
@@ -113,6 +113,19 @@ impl SpeciesEmbeddings {
     /// Number of species in the label set
     pub fn len(&self) -> usize {
         self.labels.len()
+    }
+
+    /// Resolve a species index (e.g. one returned by the geo range index) to
+    /// a name-only [`SpeciesRef`]. Indices originate from the same label set,
+    /// validated against `labels.len()` at index load time, so this indexes
+    /// directly like [`top_k_from_scores`](Self::top_k_from_scores).
+    pub fn species_ref(&self, idx: usize) -> SpeciesRef {
+        let label = &self.labels[idx];
+        SpeciesRef {
+            scientific_name: label.scientific_name.clone(),
+            common_name: label.common_name.clone(),
+            kingdom: label.kingdom.clone(),
+        }
     }
 
     /// Embedding dimension (inferred from the loaded model data)
@@ -223,5 +236,14 @@ mod tests {
             "in_range should not appear in JSON when None: {}",
             json
         );
+    }
+
+    #[test]
+    fn species_ref_resolves_index_to_label() {
+        let species = make_embeddings(5, 4);
+        let r = species.species_ref(3);
+        assert_eq!(r.scientific_name, "Species 3");
+        assert_eq!(r.common_name, None);
+        assert_eq!(r.kingdom, None);
     }
 }

--- a/crates/observing-species-id/src/model.rs
+++ b/crates/observing-species-id/src/model.rs
@@ -6,7 +6,7 @@
 use crate::embeddings::SpeciesEmbeddings;
 use crate::error::{Result, SpeciesIdError};
 use crate::preprocessing;
-use crate::types::SpeciesSuggestion;
+use crate::types::{SpeciesRef, SpeciesSuggestion};
 use ndarray::{Array1, Array4};
 use ort::session::{builder::GraphOptimizationLevel, Session};
 use ort::value::Value;
@@ -119,6 +119,23 @@ impl BioclipModel {
         let in_range = self.in_range_at(lat_lon);
         self.apply_geo_prior(&mut scores, lat_lon, in_range);
         Ok(self.species.top_k_from_scores(&scores, limit, in_range))
+    }
+
+    /// Species whose iNat range covers `(lat, lon)`, resolved from the geo
+    /// range index to name-only [`SpeciesRef`]s.
+    ///
+    /// `None` carries the same meaning as [`in_range_at`](Self::in_range_at):
+    /// we couldn't form an opinion (no geo index loaded, or the H3 cell at
+    /// that point is unknown to the index). `Some` is always non-empty — a
+    /// known cell with no expected species collapses to `None` upstream. This
+    /// is the data source for "what species could you find near here".
+    pub fn species_in_range(&self, lat: f64, lon: f64) -> Option<Vec<SpeciesRef>> {
+        let ids = self.in_range_at(Some((lat, lon)))?;
+        Some(
+            ids.iter()
+                .map(|&idx| self.species.species_ref(idx as usize))
+                .collect(),
+        )
     }
 
     /// Sorted-ascending slice of species indices whose iNat range covers

--- a/crates/observing-species-id/src/server.rs
+++ b/crates/observing-species-id/src/server.rs
@@ -1,16 +1,16 @@
 //! HTTP server for species identification service
 
 use crate::model::BioclipModel;
-use crate::types::{HealthResponse, IdentifyRequest, IdentifyResponse};
+use crate::types::{HealthResponse, IdentifyRequest, IdentifyResponse, SpeciesInRangeResponse};
 use axum::{
-    extract::{DefaultBodyLimit, State},
+    extract::{DefaultBodyLimit, Query, State},
     http::StatusCode,
     response::{IntoResponse, Json, Response},
     routing::{get, post},
     Router,
 };
 use chrono::{DateTime, Utc};
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tower_http::cors::CorsLayer;
 use tracing::{error, info};
@@ -33,6 +33,7 @@ pub fn create_router(state: SharedState) -> Router {
     Router::new()
         .route("/health", get(health))
         .route("/identify", post(identify))
+        .route("/species-in-range", get(species_in_range))
         .layer(DefaultBodyLimit::max(20 * 1024 * 1024)) // 20MB for base64-encoded images
         .layer(CorsLayer::permissive())
         .with_state(state)
@@ -53,6 +54,52 @@ async fn health(State(state): State<SharedState>) -> Json<HealthResponse> {
         model_version: state.model.version.clone(),
         species_count: state.model.species_count(),
     })
+}
+
+/// Query parameters for `/species-in-range`. Missing or non-numeric `lat`/`lon`
+/// are rejected by axum as `400 Bad Request` before the handler runs.
+#[derive(Debug, Deserialize)]
+struct InRangeQuery {
+    lat: f64,
+    lon: f64,
+}
+
+/// `GET /species-in-range?lat=..&lon=..`
+///
+/// Returns the label-set species whose iNat range covers the point — the data
+/// behind "what could you find near here". This is a pure in-memory geo-index
+/// lookup (no model inference), so it's sub-millisecond and needs no
+/// `spawn_blocking`. See [`SpeciesInRangeResponse`] for the `area_has_data`
+/// semantics (no range data at this point vs. nothing expected here).
+async fn species_in_range(
+    State(state): State<SharedState>,
+    Query(q): Query<InRangeQuery>,
+) -> Json<SpeciesInRangeResponse> {
+    match state.model.species_in_range(q.lat, q.lon) {
+        Some(species) => {
+            info!(
+                lat = q.lat,
+                lon = q.lon,
+                count = species.len(),
+                "species-in-range lookup"
+            );
+            Json(SpeciesInRangeResponse {
+                area_has_data: true,
+                species,
+            })
+        }
+        None => {
+            info!(
+                lat = q.lat,
+                lon = q.lon,
+                "species-in-range: no range data at point"
+            );
+            Json(SpeciesInRangeResponse {
+                area_has_data: false,
+                species: Vec::new(),
+            })
+        }
+    }
 }
 
 /// Species identification endpoint

--- a/crates/observing-species-id/src/types.rs
+++ b/crates/observing-species-id/src/types.rs
@@ -7,7 +7,9 @@
 
 use serde::Serialize;
 
-pub use observing_species_id_protocol::{IdentifyRequest, IdentifyResponse, SpeciesSuggestion};
+pub use observing_species_id_protocol::{
+    IdentifyRequest, IdentifyResponse, SpeciesInRangeResponse, SpeciesRef, SpeciesSuggestion,
+};
 
 #[derive(Debug, Clone, Serialize)]
 pub struct HealthResponse {


### PR DESCRIPTION
## What

Exposes the geo range index — until now used **only internally** for geo-prior reranking inside `/identify` — as a first-class lookup:

```
GET /species-in-range?lat=40.0&lon=-105.27
→ { "areaHasData": true,
    "species": [ { "scientificName": "Sialia sialis", "commonName": "Eastern Bluebird", "kingdom": "Animalia" }, … ] }
```

Given a point, it returns the label-set species whose iNat range covers that H3 cell.

## Why

This is the **keystone for cold-start discovery**. It answers *"what could you find near here"* from **global range data alone** — zero dependence on platform activity (no other users' observations required), which is exactly the property a low-traffic app needs. It's the data source behind a future "species near you" / personal to-find list.

## Design notes

- **Presence-only.** The index (`SpeciesRangeIndex::ids_at`) returns *which* species, with no abundance or per-species range size — so there's intentionally **no ranking** here. Ordering/curation is a job for the consumer (and a candidate `range_size` enhancement to the index crate later).
- **`areaHasData`** distinguishes *"no range data for this point"* (no geo index loaded, or H3 cell unknown — ocean/poles) from *"nothing expected here."* Mirrors the existing `in_range_at` "no opinion" semantics; `species` is empty whenever `areaHasData` is false, and non-empty otherwise.
- **Cheap.** Pure in-memory index lookup + label resolution — no ONNX inference, no `spawn_blocking`. Reuses the already-exercised `in_range_at` → `ids_at` path.
- Wire types (`SpeciesRef`, `SpeciesInRangeResponse`) are `Serialize/Deserialize` only, matching `IdentifyResponse`. TS bindings get added when the frontend consumes them (the appview layer).

## Scope

**Service-only — PR 1 of 2.** The appview `/api/discover/to-find` layer (life-list subtraction + taxonomy/photo/IUCN enrichment + pagination) is the follow-up. Two product decisions still open for that layer: **v1 ranking** (daily-sampled-by-group vs. waiting on a `range_size` index addition) and **location source** (explicit pin / observation centroid / browser geo).

## Testing

- `cargo build -p observing-species-id-protocol -p observing-species-id` ✅
- `cargo test -p observing-species-id-protocol -p observing-species-id` ✅ (adds `species_ref_resolves_index_to_label`)
- Live response needs the `species_geo_index.bin` artifact present (same one the geo-prior reranking already loads); without it the endpoint correctly returns `areaHasData: false`.