### PR TITLE
feat(discover): 'Find near you' rail — range-index discovery endpoints + home-feed UI

### DIFF
--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -188,6 +188,9 @@ async fn main() {
         // Actors
         // Species identification
         .route("/api/species-id", post(routes::species_id::identify))
+        // Discovery: "what could you find near here" (range index)
+        .route("/api/discover/here", get(routes::discover::here))
+        .route("/api/discover/to-find", get(routes::discover::to_find))
         // Taxonomy
         .route("/api/taxa/search", get(routes::taxonomy::search))
         .route("/api/taxa/validate", get(routes::taxonomy::validate))

--- a/crates/observing-appview/src/routes/discover.rs
+++ b/crates/observing-appview/src/routes/discover.rs
@@ -1,0 +1,341 @@
+//! Discovery surfaces driven by the species range index.
+//!
+//! `GET /api/discover/here` answers "what could you find near here" from
+//! global range data alone — no platform activity required, which is what
+//! makes it useful before the network has density. `GET /api/discover/to-find`
+//! personalizes it by subtracting the viewer's life list, turning it into a
+//! single-player "to find" checklist.
+//!
+//! Ranking note (v1): the range index is presence-only — it tells us *which*
+//! species occur at a point, with no abundance or range-size signal to rank
+//! by. So instead of a fake commonness order we surface a **deterministic
+//! daily sample, diversified across taxonomic groups** — "today's N to find
+//! near here". Stable for a given (day, ~location, viewer); rotates daily. A
+//! true difficulty order waits on a `range_size` addition to the index.
+
+use std::collections::hash_map::DefaultHasher;
+use std::collections::{HashMap, HashSet, VecDeque};
+use std::hash::{Hash, Hasher};
+
+use axum::{
+    extract::{Query, State},
+    http::StatusCode,
+    response::{IntoResponse, Json, Response},
+};
+use serde::{Deserialize, Serialize};
+use tracing::error;
+
+use crate::auth::AuthUser;
+use crate::species_id_client::SpeciesRef;
+use crate::state::AppState;
+use crate::taxonomy_client::ConservationStatus;
+
+const DEFAULT_LIMIT: usize = 12;
+const MAX_LIMIT: usize = 48;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverQuery {
+    lat: f64,
+    lon: f64,
+    #[serde(default)]
+    limit: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct ErrorResponse {
+    error: String,
+}
+
+/// One enriched "to find" card: a range-set species hydrated with its photo,
+/// common name, and conservation status for display.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToFindSpecies {
+    scientific_name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    common_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    kingdom: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    photo_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    conservation_status: Option<ConservationStatus>,
+    /// GBIF id for the `/taxon/...` link target, when the name resolves.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    taxon_id: Option<String>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoverResponse {
+    /// False when the range index has no opinion at this point (open ocean /
+    /// poles, or no geo index loaded). `items` is then empty — distinct from
+    /// "we checked and nothing lives here".
+    area_has_data: bool,
+    /// Species in range at this point, before sampling or life-list
+    /// subtraction. Lets the UI say "12 of 240 to find near you".
+    total_in_range: usize,
+    /// Remaining after subtracting the viewer's life list (equals
+    /// `total_in_range` for the logged-out `/here` view).
+    remaining: usize,
+    /// Today's diversified sample, enriched for display.
+    items: Vec<ToFindSpecies>,
+}
+
+/// `GET /api/discover/here?lat=..&lon=..[&limit=]`
+///
+/// "What lives near here" — no auth, no personalization. The cold-start-proof
+/// discovery hero: rich from global range data with zero platform activity.
+pub async fn here(State(state): State<AppState>, Query(q): Query<DiscoverQuery>) -> Response {
+    discover(&state, q, &HashSet::new(), None).await
+}
+
+/// `GET /api/discover/to-find?lat=..&lon=..[&limit=]`
+///
+/// Personalized: the in-range set minus the viewer's life list — what they
+/// could find near here but haven't documented yet.
+pub async fn to_find(
+    State(state): State<AppState>,
+    user: AuthUser,
+    Query(q): Query<DiscoverQuery>,
+) -> Response {
+    let life = match observing_db::discover::life_list(&state.pool, &user.did).await {
+        Ok(rows) => rows
+            .into_iter()
+            .map(|(name, kingdom)| match_key(&name, kingdom.as_deref()))
+            .collect::<HashSet<_>>(),
+        Err(e) => {
+            error!(error = %e, "life_list query failed");
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(ErrorResponse {
+                    error: "Failed to load your observations".into(),
+                }),
+            )
+                .into_response();
+        }
+    };
+    discover(&state, q, &life, Some(&user.did)).await
+}
+
+/// Shared core: fetch the in-range set, subtract `exclude`, take today's
+/// diversified sample, and enrich it. `did` (when present) seeds the daily
+/// sample per-user so two people in the same place get different lists.
+async fn discover(
+    state: &AppState,
+    q: DiscoverQuery,
+    exclude: &HashSet<String>,
+    did: Option<&str>,
+) -> Response {
+    let Some(client) = &state.species_id else {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorResponse {
+                error: "Species range data not available".into(),
+            }),
+        )
+            .into_response();
+    };
+
+    let in_range = match client.species_in_range(q.lat, q.lon).await {
+        Ok(r) => r,
+        Err(e) => {
+            error!(error = %e, "species-in-range upstream failed");
+            return (
+                StatusCode::BAD_GATEWAY,
+                Json(ErrorResponse {
+                    error: "Species range lookup failed".into(),
+                }),
+            )
+                .into_response();
+        }
+    };
+
+    if !in_range.area_has_data {
+        return Json(DiscoverResponse {
+            area_has_data: false,
+            total_in_range: 0,
+            remaining: 0,
+            items: Vec::new(),
+        })
+        .into_response();
+    }
+
+    let total_in_range = in_range.species.len();
+    let remaining_species: Vec<SpeciesRef> = in_range
+        .species
+        .into_iter()
+        .filter(|s| !exclude.contains(&match_key(&s.scientific_name, s.kingdom.as_deref())))
+        .collect();
+    let remaining = remaining_species.len();
+
+    let limit = q.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
+    let sample = sample_diversified(remaining_species, daily_seed(q.lat, q.lon, did), limit);
+    let items = enrich(state, sample).await;
+
+    Json(DiscoverResponse {
+        area_has_data: true,
+        total_in_range,
+        remaining,
+        items,
+    })
+    .into_response()
+}
+
+/// Hydrate each sampled species with its GBIF/Wikidata detail (photo, common
+/// name, conservation status, id). Runs the lookups concurrently; failures
+/// degrade to the name-only card.
+async fn enrich(state: &AppState, species: Vec<SpeciesRef>) -> Vec<ToFindSpecies> {
+    let futures = species.into_iter().map(|s| {
+        let taxonomy = state.taxonomy.clone();
+        async move {
+            let detail = taxonomy
+                .get_by_name(&s.scientific_name, s.kingdom.as_deref())
+                .await
+                .ok()
+                .flatten();
+            match detail {
+                Some(d) => ToFindSpecies {
+                    scientific_name: s.scientific_name,
+                    common_name: d.common_name.or(s.common_name),
+                    kingdom: s.kingdom,
+                    photo_url: d.photo_url,
+                    conservation_status: d.conservation_status,
+                    taxon_id: Some(d.id),
+                },
+                None => ToFindSpecies {
+                    scientific_name: s.scientific_name,
+                    common_name: s.common_name,
+                    kingdom: s.kingdom,
+                    photo_url: None,
+                    conservation_status: None,
+                    taxon_id: None,
+                },
+            }
+        }
+    });
+    futures::future::join_all(futures).await
+}
+
+/// Normalized subtraction key, applied identically to the life list and the
+/// range set so name-formatting differences don't leak found species back
+/// into the "to find" list.
+fn match_key(scientific_name: &str, kingdom: Option<&str>) -> String {
+    format!(
+        "{}|{}",
+        scientific_name.trim().to_lowercase(),
+        kingdom.unwrap_or("").trim().to_lowercase()
+    )
+}
+
+/// Seed for the daily sample: stable for a (UTC day, ~11 km location bucket,
+/// viewer) tuple so the list is consistent within a day and rotates the next.
+fn daily_seed(lat: f64, lon: f64, did: Option<&str>) -> u64 {
+    let mut h = DefaultHasher::new();
+    chrono::Utc::now().date_naive().to_string().hash(&mut h);
+    ((lat * 10.0).round() as i64).hash(&mut h);
+    ((lon * 10.0).round() as i64).hash(&mut h);
+    if let Some(d) = did {
+        d.hash(&mut h);
+    }
+    h.finish()
+}
+
+/// Deterministically shuffle by `hash(seed, name)`, then round-robin across
+/// taxonomic groups so the sample is varied (no single kingdom dominates)
+/// rather than alphabetical or clumped.
+fn sample_diversified(species: Vec<SpeciesRef>, seed: u64, limit: usize) -> Vec<SpeciesRef> {
+    let mut shuffled = species;
+    shuffled.sort_by_key(|s| {
+        let mut h = DefaultHasher::new();
+        seed.hash(&mut h);
+        s.scientific_name.hash(&mut h);
+        h.finish()
+    });
+
+    // Bucket by kingdom, preserving the shuffled order within each bucket.
+    let mut buckets: Vec<VecDeque<SpeciesRef>> = Vec::new();
+    let mut index: HashMap<String, usize> = HashMap::new();
+    for s in shuffled {
+        let key = s.kingdom.clone().unwrap_or_default();
+        let i = *index.entry(key).or_insert_with(|| {
+            buckets.push(VecDeque::new());
+            buckets.len() - 1
+        });
+        buckets[i].push_back(s);
+    }
+
+    let mut out = Vec::with_capacity(limit.min(buckets.iter().map(|b| b.len()).sum()));
+    while out.len() < limit {
+        let before = out.len();
+        for bucket in buckets.iter_mut() {
+            if out.len() >= limit {
+                break;
+            }
+            if let Some(s) = bucket.pop_front() {
+                out.push(s);
+            }
+        }
+        if out.len() == before {
+            break; // every bucket drained
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sp(name: &str, kingdom: &str) -> SpeciesRef {
+        SpeciesRef {
+            scientific_name: name.to_string(),
+            common_name: None,
+            kingdom: Some(kingdom.to_string()),
+        }
+    }
+
+    #[test]
+    fn match_key_normalizes_case_and_whitespace() {
+        assert_eq!(
+            match_key("  Sialia Sialis ", Some("Animalia")),
+            match_key("sialia sialis", Some("animalia"))
+        );
+    }
+
+    #[test]
+    fn sample_is_deterministic_for_a_seed() {
+        let pool = vec![sp("a", "Animalia"), sp("b", "Plantae"), sp("c", "Fungi")];
+        let a = sample_diversified(pool.clone(), 42, 3);
+        let b = sample_diversified(pool, 42, 3);
+        let names = |v: &[SpeciesRef]| {
+            v.iter()
+                .map(|s| s.scientific_name.clone())
+                .collect::<Vec<_>>()
+        };
+        assert_eq!(names(&a), names(&b));
+    }
+
+    #[test]
+    fn sample_diversifies_across_kingdoms_before_repeating_one() {
+        // 4 plants + 1 animal, limit 2 → round-robin yields one of each.
+        let pool = vec![
+            sp("p1", "Plantae"),
+            sp("p2", "Plantae"),
+            sp("p3", "Plantae"),
+            sp("p4", "Plantae"),
+            sp("a1", "Animalia"),
+        ];
+        let out = sample_diversified(pool, 7, 2);
+        let kingdoms: HashSet<_> = out.iter().filter_map(|s| s.kingdom.clone()).collect();
+        assert_eq!(out.len(), 2);
+        assert_eq!(kingdoms.len(), 2, "should pull from both kingdoms first");
+    }
+
+    #[test]
+    fn sample_caps_at_available_when_fewer_than_limit() {
+        let out = sample_diversified(vec![sp("only", "Animalia")], 1, 12);
+        assert_eq!(out.len(), 1);
+    }
+}

--- a/crates/observing-appview/src/routes/discover.rs
+++ b/crates/observing-appview/src/routes/discover.rs
@@ -171,8 +171,17 @@ async fn discover(
     let remaining = remaining_species.len();
 
     let limit = q.limit.unwrap_or(DEFAULT_LIMIT).clamp(1, MAX_LIMIT);
-    let sample = sample_diversified(remaining_species, daily_seed(q.lat, q.lon, did), limit);
-    let items = enrich(state, sample).await;
+    // The index is presence-only, so a uniform sample skews to the obscure
+    // long tail — and most of those lack a Wikidata photo, which reads as
+    // broken in a grid. Oversample, enrich, then float photographed species up
+    // (stable, so the daily diversification is preserved within each group)
+    // and trim to `limit`. A cheap stand-in for a real charisma/abundance
+    // signal until the index can expose range size.
+    let oversample = (limit * 3).min(60);
+    let sample = sample_diversified(remaining_species, daily_seed(q.lat, q.lon, did), oversample);
+    let mut items = enrich(state, sample).await;
+    items.sort_by_key(|it| it.photo_url.is_none());
+    items.truncate(limit);
 
     Json(DiscoverResponse {
         area_has_data: true,

--- a/crates/observing-appview/src/routes/mod.rs
+++ b/crates/observing-appview/src/routes/mod.rs
@@ -1,6 +1,7 @@
 pub mod admin_browse;
 pub mod admin_ingester;
 pub mod comments;
+pub mod discover;
 pub mod feeds;
 pub mod health;
 pub mod identifications;

--- a/crates/observing-appview/src/species_id_client.rs
+++ b/crates/observing-appview/src/species_id_client.rs
@@ -1,7 +1,9 @@
 use reqwest::Client;
 use std::time::Duration;
 
-pub use observing_species_id_protocol::{IdentifyRequest, IdentifyResponse};
+pub use observing_species_id_protocol::{
+    IdentifyRequest, IdentifyResponse, SpeciesInRangeResponse, SpeciesRef,
+};
 
 /// HTTP client for the species identification service
 pub struct SpeciesIdClient {
@@ -47,6 +49,26 @@ impl SpeciesIdClient {
         self.client
             .post(&url)
             .json(&body)
+            .send()
+            .await?
+            .error_for_status()?
+            .json()
+            .await
+    }
+
+    /// Species whose iNat range covers `(lat, lon)`, from the service's geo
+    /// range index. The data source for the discovery surfaces. Errors
+    /// propagate for the same reason as [`identify`](Self::identify).
+    pub async fn species_in_range(
+        &self,
+        latitude: f64,
+        longitude: f64,
+    ) -> Result<SpeciesInRangeResponse, reqwest::Error> {
+        let url = format!("{}/species-in-range", self.base_url);
+
+        self.client
+            .get(&url)
+            .query(&[("lat", latitude), ("lon", longitude)])
             .send()
             .await?
             .error_for_status()?

--- a/crates/observing-db/src/discover.rs
+++ b/crates/observing-db/src/discover.rs
@@ -1,0 +1,25 @@
+//! Queries backing the discovery surfaces (e.g. "what could you find near
+//! here"). These don't map to a single AT Protocol record type, so they live
+//! in their own module.
+
+use sqlx::PgPool;
+
+/// A user's "life list": the distinct `(scientific_name, kingdom)` pairs they
+/// have personally observed. Used to subtract already-found species from the
+/// in-range set so the "to find" list only shows what they're missing.
+///
+/// Returned raw (not normalized) — the caller owns the match-key normalization
+/// so it stays identical on both sides of the subtraction. Uses the runtime
+/// query API (not the `query!` macro) so it needs no offline `.sqlx` cache
+/// entry.
+pub async fn life_list(
+    pool: &PgPool,
+    did: &str,
+) -> Result<Vec<(String, Option<String>)>, sqlx::Error> {
+    sqlx::query_as::<_, (String, Option<String>)>(
+        "SELECT DISTINCT scientific_name, kingdom FROM occurrences WHERE did = $1",
+    )
+    .bind(did)
+    .fetch_all(pool)
+    .await
+}

--- a/crates/observing-db/src/lib.rs
+++ b/crates/observing-db/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod comments;
 pub mod community_ids;
+pub mod discover;
 pub mod failed_records;
 pub mod feeds;
 pub mod identifications;

--- a/crates/observing-species-id/src/model.rs
+++ b/crates/observing-species-id/src/model.rs
@@ -23,7 +23,11 @@ const GEO_BOOST_DEFAULT: f32 = 0.05;
 
 /// BioCLIP model wrapping the ONNX vision encoder and species embeddings
 pub struct BioclipModel {
-    session: Mutex<Session>,
+    /// ONNX vision encoder. `None` in geo-only mode (`SPECIES_ID_GEO_ONLY`),
+    /// where only the range index is served (`/species-in-range`) and
+    /// `/identify` is disabled — for fast startup, or environments where the
+    /// ONNX runtime can't initialize.
+    session: Option<Mutex<Session>>,
     species: SpeciesEmbeddings,
     geo_index: Option<SpeciesRangeIndex>,
     geo_boost: f32,
@@ -38,26 +42,37 @@ impl BioclipModel {
     /// - `{model_dir}/species_embeddings.bin` - pre-computed text embeddings
     /// - `{model_dir}/species_labels.json` - species metadata
     pub fn load(model_dir: &Path) -> Result<Self> {
-        let onnx_path = model_dir.join("vision_encoder.onnx");
+        // The vision encoder load is skippable: geo-only mode serves just the
+        // range index (`/species-in-range`) and disables `/identify`. Lets the
+        // service start fast, and start at all where the ONNX runtime can't
+        // initialize.
+        let session = if std::env::var("SPECIES_ID_GEO_ONLY").is_ok() {
+            warn!(
+                "SPECIES_ID_GEO_ONLY set: skipping ONNX vision encoder — /identify disabled, serving /species-in-range only"
+            );
+            None
+        } else {
+            let onnx_path = model_dir.join("vision_encoder.onnx");
+            info!(path = %onnx_path.display(), "Loading ONNX vision encoder");
 
-        info!(path = %onnx_path.display(), "Loading ONNX vision encoder");
+            let session = Session::builder()
+                .map_err(|e| SpeciesIdError::Model(e.to_string()))?
+                .with_optimization_level(GraphOptimizationLevel::Level3)
+                .map_err(|e| SpeciesIdError::Model(e.to_string()))?
+                .with_intra_threads(4)
+                .map_err(|e| SpeciesIdError::Model(e.to_string()))?
+                .commit_from_file(&onnx_path)
+                .map_err(|e| {
+                    SpeciesIdError::Model(format!(
+                        "Failed to load ONNX model from {}: {}",
+                        onnx_path.display(),
+                        e
+                    ))
+                })?;
 
-        let session = Session::builder()
-            .map_err(|e| SpeciesIdError::Model(e.to_string()))?
-            .with_optimization_level(GraphOptimizationLevel::Level3)
-            .map_err(|e| SpeciesIdError::Model(e.to_string()))?
-            .with_intra_threads(4)
-            .map_err(|e| SpeciesIdError::Model(e.to_string()))?
-            .commit_from_file(&onnx_path)
-            .map_err(|e| {
-                SpeciesIdError::Model(format!(
-                    "Failed to load ONNX model from {}: {}",
-                    onnx_path.display(),
-                    e
-                ))
-            })?;
-
-        info!("ONNX vision encoder loaded");
+            info!("ONNX vision encoder loaded");
+            Some(Mutex::new(session))
+        };
 
         let species = SpeciesEmbeddings::load(model_dir)?;
 
@@ -86,7 +101,7 @@ impl BioclipModel {
         }
 
         Ok(Self {
-            session: Mutex::new(session),
+            session,
             species,
             geo_index,
             geo_boost,
@@ -113,6 +128,11 @@ impl BioclipModel {
         lat_lon: Option<(f64, f64)>,
         limit: usize,
     ) -> Result<Vec<SpeciesSuggestion>> {
+        if self.session.is_none() {
+            return Err(SpeciesIdError::Model(
+                "vision model not loaded (geo-only mode)".to_string(),
+            ));
+        }
         let input_tensor = preprocessing::preprocess_image(image_bytes)?;
         let embedding = self.run_vision_encoder(input_tensor)?;
         let mut scores = self.species.similarities(&embedding).to_vec();
@@ -171,6 +191,8 @@ impl BioclipModel {
 
         let mut session = self
             .session
+            .as_ref()
+            .ok_or_else(|| SpeciesIdError::Model("vision model not loaded".to_string()))?
             .lock()
             .map_err(|e| SpeciesIdError::Model(format!("Session lock poisoned: {}", e)))?;
 

--- a/frontend/src/components/discover/DiscoverNearYou.tsx
+++ b/frontend/src/components/discover/DiscoverNearYou.tsx
@@ -1,0 +1,169 @@
+import { useEffect, useState } from "react";
+import { Link as RouterLink } from "react-router-dom";
+import { Box, Card, CardContent, CardMedia, Skeleton, Typography } from "@mui/material";
+import { useDiscoverHere } from "../../lib/query/hooks";
+import { ConservationStatus } from "../common/ConservationStatus";
+
+// Used when geolocation is denied/unavailable so the rail always renders
+// something. Boulder, CO is iNaturalist-dense.
+const FALLBACK = { lat: 40.015, lon: -105.2705 };
+const GEO_TIMEOUT_MS = 6000;
+
+/** Resolve the viewer's location: browser geolocation, else a sensible default. */
+function useCoords() {
+  const [coords, setCoords] = useState<{ lat: number; lon: number } | null>(null);
+  const [usingFallback, setUsingFallback] = useState(false);
+
+  useEffect(() => {
+    let settled = false;
+    const settle = (c: { lat: number; lon: number }, fallback: boolean) => {
+      if (settled) return;
+      settled = true;
+      setCoords(c);
+      setUsingFallback(fallback);
+    };
+
+    if (!navigator.geolocation) {
+      settle(FALLBACK, true);
+      return;
+    }
+    const timer = setTimeout(() => settle(FALLBACK, true), GEO_TIMEOUT_MS);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        clearTimeout(timer);
+        settle({ lat: pos.coords.latitude, lon: pos.coords.longitude }, false);
+      },
+      () => {
+        clearTimeout(timer);
+        settle(FALLBACK, true);
+      },
+      { timeout: GEO_TIMEOUT_MS, maximumAge: 1000 * 60 * 60 },
+    );
+    return () => clearTimeout(timer);
+  }, []);
+
+  return { coords, usingFallback };
+}
+
+/**
+ * Homepage "what could you find near here" rail. Backed by the species range
+ * index (`/api/discover/here`), so it's rich from global range data with no
+ * dependence on nearby user activity.
+ */
+export function DiscoverNearYou() {
+  const { coords, usingFallback } = useCoords();
+  const { data, isLoading } = useDiscoverHere(coords, 12);
+
+  // No range data here (ocean/poles) → don't show an empty rail.
+  if (data && !data.areaHasData) return null;
+
+  const items = data?.items ?? [];
+  const showSkeletons = !data && (isLoading || !coords);
+
+  return (
+    <Box sx={{ px: 2, pt: 2, pb: 1 }}>
+      <Box sx={{ display: "flex", alignItems: "baseline", justifyContent: "space-between", mb: 1 }}>
+        <Typography variant="h6" sx={{ fontWeight: 700 }}>
+          Find near you{usingFallback ? " · Boulder, CO" : ""}
+        </Typography>
+        {data && (
+          <Typography variant="caption" color="text.secondary">
+            {data.totalInRange.toLocaleString()} species recorded here
+          </Typography>
+        )}
+      </Box>
+
+      <Box
+        sx={{
+          display: "flex",
+          gap: 1.5,
+          overflowX: "auto",
+          pb: 1,
+          scrollbarWidth: "none",
+          "&::-webkit-scrollbar": { display: "none" },
+        }}
+      >
+        {showSkeletons &&
+          Array.from({ length: 6 }).map((_, i) => (
+            <Card key={i} sx={{ minWidth: 150, maxWidth: 150, flexShrink: 0 }}>
+              <Skeleton variant="rectangular" height={150} />
+              <CardContent sx={{ py: 1 }}>
+                <Skeleton width="85%" />
+                <Skeleton width="55%" />
+              </CardContent>
+            </Card>
+          ))}
+
+        {items.map((sp) => {
+          const to = sp.kingdom
+            ? `/taxon/${encodeURIComponent(sp.kingdom)}/${encodeURIComponent(sp.scientificName)}`
+            : "/explore";
+          return (
+            <Card
+              key={sp.scientificName}
+              component={RouterLink}
+              to={to}
+              sx={{
+                minWidth: 150,
+                maxWidth: 150,
+                flexShrink: 0,
+                textDecoration: "none",
+                position: "relative",
+                "&:hover": { boxShadow: 4 },
+              }}
+            >
+              {sp.photoUrl ? (
+                <CardMedia
+                  component="img"
+                  image={sp.photoUrl}
+                  alt={sp.commonName ?? sp.scientificName}
+                  sx={{ height: 150, objectFit: "cover" }}
+                />
+              ) : (
+                <Box
+                  sx={{
+                    height: 150,
+                    bgcolor: "action.hover",
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "center",
+                  }}
+                >
+                  <Typography variant="caption" color="text.secondary">
+                    No photo
+                  </Typography>
+                </Box>
+              )}
+
+              {sp.conservationStatus && (
+                <Box sx={{ position: "absolute", top: 6, right: 6 }}>
+                  <ConservationStatus status={sp.conservationStatus} size="sm" />
+                </Box>
+              )}
+
+              <CardContent sx={{ py: 1, px: 1, "&:last-child": { pb: 1 } }}>
+                <Typography
+                  variant="body2"
+                  noWrap
+                  sx={{ fontStyle: "italic", fontWeight: 600, lineHeight: 1.2 }}
+                >
+                  {sp.scientificName}
+                </Typography>
+                {sp.commonName && (
+                  <Typography
+                    variant="caption"
+                    color="text.secondary"
+                    noWrap
+                    sx={{ display: "block" }}
+                  >
+                    {sp.commonName}
+                  </Typography>
+                )}
+              </CardContent>
+            </Card>
+          );
+        })}
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/components/feed/FeedView.tsx
+++ b/frontend/src/components/feed/FeedView.tsx
@@ -14,6 +14,7 @@ import { FeedEndIndicator } from "./FeedEndIndicator";
 import { observationGridSx } from "../common/observationGridLayout";
 import { CenteredSpinner } from "../common/CenteredSpinner";
 import { EmptyState } from "../common/EmptyState";
+import { DiscoverNearYou } from "../discover/DiscoverNearYou";
 
 interface FeedViewProps {
   tab?: FeedTab;
@@ -103,6 +104,7 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
             </>
           ) : (
             <>
+              <DiscoverNearYou />
               <Box>
                 {observations.map((obs) => (
                   <FeedItem

--- a/frontend/src/lib/query/hooks.ts
+++ b/frontend/src/lib/query/hooks.ts
@@ -18,6 +18,7 @@ import {
   fetchNotifications,
   fetchUnreadCount,
   fetchUserPreferences,
+  fetchDiscoverHere,
 } from "../../services/api";
 import type { FeedFilters, FeedTab } from "../../services/types";
 
@@ -155,6 +156,22 @@ export function useUserPreferences() {
     queryKey: qk.preferences(),
     queryFn: fetchUserPreferences,
     enabled: isAuthenticated,
+  });
+}
+
+/**
+ * "What could you find near here" — species expected at a point, from the
+ * range index. Disabled until coordinates are known (geolocation/pin).
+ */
+export function useDiscoverHere(coords: { lat: number; lon: number } | null, limit = 12) {
+  return useQuery({
+    queryKey: coords ? qk.discoverHere(coords.lat, coords.lon) : ["discoverHere", "pending"],
+    queryFn: () => {
+      if (!coords) throw new Error("coordinates not resolved"); // unreachable: gated by `enabled`
+      return fetchDiscoverHere(coords.lat, coords.lon, limit);
+    },
+    enabled: !!coords,
+    staleTime: 1000 * 60 * 30,
   });
 }
 

--- a/frontend/src/lib/query/keys.ts
+++ b/frontend/src/lib/query/keys.ts
@@ -24,6 +24,8 @@ export const qk = {
   notifications: () => ["notifications"] as const,
   unreadCount: () => ["unreadCount"] as const,
   preferences: () => ["preferences"] as const,
+  discoverHere: (lat: number, lon: number) =>
+    ["discoverHere", Math.round(lat * 100) / 100, Math.round(lon * 100) / 100] as const,
 } as const;
 
 // Key tags whose caches contain `occurrences: Occurrence[]` pages.

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -14,6 +14,7 @@ import type {
   ValidateResponse,
   UserPreferencesResponse,
   UpdatePreferencesRequest,
+  DiscoverResponse,
 } from "./types";
 
 const API_BASE = import.meta.env["VITE_API_URL"] || "";
@@ -490,6 +491,17 @@ export async function identifySpecies(data: {
     headers: { "Content-Type": "application/json" },
     credentials: "include",
     body: JSON.stringify(data),
+  });
+}
+
+export async function fetchDiscoverHere(
+  lat: number,
+  lon: number,
+  limit = 12,
+): Promise<DiscoverResponse> {
+  const params = new URLSearchParams({ lat: String(lat), lon: String(lon), limit: String(limit) });
+  return fetchApi(`${API_BASE}/api/discover/here?${params}`, "Failed to load nearby species", {
+    credentials: "include",
   });
 }
 

--- a/frontend/src/services/types.ts
+++ b/frontend/src/services/types.ts
@@ -8,6 +8,8 @@
  * but aren't yet in the Rust structs, or with client-side-only fields.
  */
 
+import type { ConservationStatus } from "../bindings/ConservationStatus";
+
 // ============================================================================
 // Generated types (from Rust via ts-rs) — re-exported as-is
 // ============================================================================
@@ -194,4 +196,24 @@ export interface Notification {
 export interface NotificationsResponse {
   notifications: Notification[];
   cursor?: string;
+}
+
+// Discovery: "what could you find near here" (range-index driven). Each item is
+// a species expected at the requested point, enriched for display.
+export interface DiscoverSpecies {
+  scientificName: string;
+  commonName?: string;
+  kingdom?: string;
+  photoUrl?: string;
+  conservationStatus?: ConservationStatus;
+  /** GBIF id / kingdom-name slug for the `/taxon/...` link target. */
+  taxonId?: string;
+}
+
+export interface DiscoverResponse {
+  /** False when the range index has no opinion at this point (ocean/poles). */
+  areaHasData: boolean;
+  totalInRange: number;
+  remaining: number;
+  items: DiscoverSpecies[];
 }


### PR DESCRIPTION
## Discover: "Find near you"

Surfaces the species you could encounter at your location, backed by the
**species range index** (global range data) rather than nearby user activity —
so it's rich even where there are few local observations.

### What's in here

**Backend**
- `feat(species-id)`: `/species-in-range` endpoint — species expected at a point.
- `feat(species-id)`: optional **geo-only mode** (`SPECIES_ID_GEO_ONLY=1`) that
  skips the ONNX vision encoder and serves only range lookups. Boots in seconds;
  useful for local dev and range-only deployments.
- `feat(appview)`: `/api/discover/here` (+ `/to-find`) enriching range hits with
  photo / common name / IUCN status.
- `feat(appview)`: oversample + prefer photographed species — the index is
  presence-only, so a uniform sample hits the unphotographed long tail; this
  keeps the rail a recognizable grid.

**Frontend**
- `feat(ui)`: `DiscoverNearYou` horizontal rail — geolocation (Boulder fallback),
  cards linking to taxon pages. **Home feed only**; Explore stays a search surface.

### Design follow-ups (not yet done)
- [ ] Lead cards with the **common name** (scientific demoted) — recognizability.
- [ ] Trailing **"See all →"** card so the rail isn't a dead end vs. the full count.
- [ ] Make the fallback location **clickable/correctable** (pin + "change").
- [ ] Drop photoless species from the rail (or kingdom-tinted placeholder, not "No photo").
- [ ] Scrim behind the IUCN badge; scroll affordance + list semantics on the rail.

### Notes
- Draft: verified end-to-end locally (real browser, 0 console errors) but wants a
  review pass on the design follow-ups above before marking ready.
