### PR TITLE
fix(modals): remove "Posting as" banner from new observation window

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -9,7 +9,6 @@ import {
   Chip,
   Stack,
   IconButton,
-  Alert,
   CircularProgress,
   FormControl,
   InputLabel,
@@ -56,7 +55,6 @@ export function UploadModal() {
   const toast = useToast();
   const isOpen = useAppSelector((state) => state.ui.uploadModalOpen);
   const editingObservation = useAppSelector((state) => state.ui.editingObservation);
-  const user = useAppSelector((state) => state.auth.user);
   const defaultLicense = useUserPreferences().data?.defaultLicense ?? null;
   const currentLocation = useAppSelector((state) => state.ui.currentLocation);
 
@@ -394,11 +392,6 @@ export function UploadModal() {
   return (
     <>
       <ModalOverlay isOpen={isOpen} onClose={handleRequestClose}>
-        {user && (
-          <Alert severity="success" sx={{ mb: 2, mx: -1, mt: -1 }}>
-            Posting as {user.handle ? `@${user.handle}` : user.did}
-          </Alert>
-        )}
         <Typography variant="h5" sx={{ fontWeight: 600, mb: 2 }}>
           {isEditMode ? "Edit Observation" : "New Observation"}
         </Typography>


### PR DESCRIPTION
## Summary
- Removes the "Posting as @handle" success banner from the New/Edit Observation modal
- Cleans up the now-unused `Alert` import and `user` selector

## Test plan
- Open the New Observation modal and confirm the banner no longer appears
- `oxlint` passes on the file (only a pre-existing `exhaustive-deps` warning remains)