### PR TITLE
feat(taxa): resolve identification taxonID URIs (GBIF/iNat/Wikidata)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2958,6 +2958,7 @@ dependencies = [
  "tracing",
  "tracing-stackdriver",
  "tracing-subscriber",
+ "wikidata-client",
 ]
 
 [[package]]

--- a/crates/observing-resolve-taxa/Cargo.toml
+++ b/crates/observing-resolve-taxa/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 observing-db = { path = "../observing-db", features = ["processing"] }
 observing-taxonomy-gbif = { path = "../observing-taxonomy-gbif" }
+wikidata-client = { path = "../wikidata-client" }
 
 tokio = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/observing-resolve-taxa/src/main.rs
+++ b/crates/observing-resolve-taxa/src/main.rs
@@ -25,6 +25,8 @@
 //!   cargo run --bin resolve_taxa -- --interval-secs 300
 //!   cargo run --bin resolve_taxa -- --rate-limit-ms 200 --limit 1000
 
+mod taxon_uri;
+
 use std::time::Duration;
 
 use clap::Parser;
@@ -34,6 +36,12 @@ use sqlx::postgres::PgPoolOptions;
 use sqlx::{PgPool, Row};
 use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, EnvFilter};
+use wikidata_client::WikidataClient;
+
+use taxon_uri::TaxonRef;
+
+/// Wikidata property id for an iNaturalist taxon.
+const WIKIDATA_INATURALIST_PROPERTY: &str = "P3151";
 
 #[derive(Parser, Clone)]
 #[command(about = "Resolve and cache taxonomy for already-ingested identifications")]
@@ -91,9 +99,10 @@ async fn main() -> std::process::ExitCode {
 
     let upstream = GbifUpstream::default();
     let resolver = Resolver::new(&pool, &upstream);
+    let wikidata = WikidataClient::new();
 
     loop {
-        match run_pass(&pool, &resolver, &cli).await {
+        match run_pass(&pool, &resolver, &wikidata, &cli).await {
             Ok(PassOutcome::DryRunDone) => return std::process::ExitCode::SUCCESS,
             Ok(PassOutcome::Done) => {}
             Err(code) => return code,
@@ -115,13 +124,41 @@ enum PassOutcome {
     DryRunDone,
 }
 
-/// Run one resolution pass: enumerate unresolved pairs, resolve each,
-/// stamp matching identifications, refresh the matview.
+/// Run one resolution pass: resolve unresolved identifications by scientific
+/// name, then mop up any still-unresolved rows that carry a `taxon_id` URI by
+/// resolving the URI directly, and finally refresh the matview.
 async fn run_pass<U>(
     pool: &PgPool,
     resolver: &Resolver<'_, PgPool, U>,
+    wikidata: &WikidataClient,
     cli: &Cli,
 ) -> Result<PassOutcome, std::process::ExitCode>
+where
+    U: observing_db::taxonomy_resolver::TaxonomyUpstream,
+{
+    run_name_pass(pool, resolver, cli).await?;
+    run_taxon_id_pass(pool, resolver, wikidata, cli).await?;
+
+    if cli.dry_run {
+        return Ok(PassOutcome::DryRunDone);
+    }
+
+    // One matview refresh covers both passes.
+    info!("Resolution pass complete; refreshing community_ids");
+    if let Err(e) = observing_db::identifications::refresh_community_ids(pool).await {
+        error!(error = %e, "Failed to refresh community_ids matview");
+        return Err(std::process::ExitCode::from(1));
+    }
+
+    Ok(PassOutcome::Done)
+}
+
+/// Resolve unresolved identifications by `(scientific_name, kingdom)`.
+async fn run_name_pass<U>(
+    pool: &PgPool,
+    resolver: &Resolver<'_, PgPool, U>,
+    cli: &Cli,
+) -> Result<(), std::process::ExitCode>
 where
     U: observing_db::taxonomy_resolver::TaxonomyUpstream,
 {
@@ -161,14 +198,14 @@ where
     );
 
     if pairs.is_empty() {
-        return Ok(PassOutcome::Done);
+        return Ok(());
     }
 
     if cli.dry_run {
         for (name, kingdom) in &pairs {
-            info!(name = %name, kingdom = ?kingdom, "Would resolve");
+            info!(name = %name, kingdom = ?kingdom, "Would resolve by name");
         }
-        return Ok(PassOutcome::DryRunDone);
+        return Ok(());
     }
 
     let mut resolved = 0u64;
@@ -224,7 +261,7 @@ where
                 resolved,
                 not_found,
                 updated_rows,
-                "Progress",
+                "Name-pass progress",
             );
         }
         rate_limit(cli).await;
@@ -232,15 +269,166 @@ where
 
     info!(
         resolved,
-        not_found, errors, updated_rows, "Resolution pass complete; refreshing community_ids"
+        not_found, errors, updated_rows, "Name pass complete"
     );
+    Ok(())
+}
 
-    if let Err(e) = observing_db::identifications::refresh_community_ids(pool).await {
-        error!(error = %e, "Failed to refresh community_ids matview");
-        return Err(std::process::ExitCode::from(1));
+/// Mop up identifications that name resolution couldn't key but that carry a
+/// `taxon_id` URI: resolve the URI to a GBIF key directly and stamp it. Only
+/// touches rows still `accepted_taxon_key IS NULL`, so this is a strict
+/// fallback to the name pass above.
+async fn run_taxon_id_pass<U>(
+    pool: &PgPool,
+    resolver: &Resolver<'_, PgPool, U>,
+    wikidata: &WikidataClient,
+    cli: &Cli,
+) -> Result<(), std::process::ExitCode>
+where
+    U: observing_db::taxonomy_resolver::TaxonomyUpstream,
+{
+    let mut q = String::from(
+        r#"SELECT DISTINCT taxon_id
+           FROM identifications
+           WHERE accepted_taxon_key IS NULL
+             AND taxon_id IS NOT NULL
+             AND taxon_id <> ''
+           ORDER BY taxon_id"#,
+    );
+    if let Some(limit) = cli.limit {
+        q.push_str(&format!(" LIMIT {limit}"));
+    }
+    // `q` is a static query plus an optional `LIMIT` from the typed `cli.limit` integer.
+    let uris: Vec<String> = match sqlx::query(sqlx::AssertSqlSafe(q)).fetch_all(pool).await {
+        Ok(rows) => rows.into_iter().map(|r| r.get("taxon_id")).collect(),
+        Err(e) => {
+            error!(error = %e, "Failed to enumerate identifications with unresolved taxon_id");
+            return Err(std::process::ExitCode::from(1));
+        }
+    };
+
+    info!(uris = uris.len(), "Discovered taxon_id URIs to resolve");
+
+    if uris.is_empty() {
+        return Ok(());
     }
 
-    Ok(PassOutcome::Done)
+    if cli.dry_run {
+        for uri in &uris {
+            info!(uri = %uri, parsed = ?taxon_uri::parse(uri), "Would resolve by URI");
+        }
+        return Ok(());
+    }
+
+    let mut resolved = 0u64;
+    let mut not_found = 0u64;
+    let mut errors = 0u64;
+    let mut updated_rows = 0u64;
+
+    for (i, uri) in uris.iter().enumerate() {
+        let key = match resolve_taxon_uri(uri, resolver, wikidata).await {
+            Ok(Some(key)) => {
+                resolved += 1;
+                key
+            }
+            Ok(None) => {
+                not_found += 1;
+                rate_limit(cli).await;
+                continue;
+            }
+            Err(e) => {
+                errors += 1;
+                warn!(uri = %uri, error = %e, "taxon_id resolve failed");
+                rate_limit(cli).await;
+                continue;
+            }
+        };
+
+        // Stamp every identification carrying this exact URI that the name
+        // pass left unresolved.
+        let update_sql = r#"UPDATE identifications
+            SET accepted_taxon_key = $1, indexed_at = NOW()
+            WHERE accepted_taxon_key IS NULL
+              AND taxon_id = $2"#;
+        match sqlx::query(update_sql)
+            .bind(key)
+            .bind(uri)
+            .execute(pool)
+            .await
+        {
+            Ok(res) => updated_rows += res.rows_affected(),
+            Err(e) => {
+                errors += 1;
+                warn!(uri = %uri, error = %e, "Failed to update identifications");
+            }
+        }
+
+        if (i + 1) % 50 == 0 {
+            info!(
+                processed = i + 1,
+                total = uris.len(),
+                resolved,
+                not_found,
+                updated_rows,
+                "taxon_id-pass progress",
+            );
+        }
+        rate_limit(cli).await;
+    }
+
+    info!(
+        resolved,
+        not_found, errors, updated_rows, "taxon_id pass complete"
+    );
+    Ok(())
+}
+
+/// Resolve a single `taxon_id` URI to a GBIF usage key. GBIF URIs carry the
+/// key directly; iNaturalist / Wikidata URIs cross-walk to one through
+/// Wikidata's external-ID properties. Returns `Ok(None)` for an unrecognized
+/// URI, a missing cross-walk, or a key with no upstream match.
+async fn resolve_taxon_uri<U>(
+    uri: &str,
+    resolver: &Resolver<'_, PgPool, U>,
+    wikidata: &WikidataClient,
+) -> Result<Option<i64>, observing_db::taxonomy_resolver::ResolveError>
+where
+    U: observing_db::taxonomy_resolver::TaxonomyUpstream,
+{
+    let key = match taxon_uri::parse(uri) {
+        TaxonRef::Gbif(key) => key,
+        TaxonRef::INaturalist(id) => {
+            match wikidata
+                .gbif_key_for(WIKIDATA_INATURALIST_PROPERTY, &id)
+                .await
+            {
+                Some(key) => key,
+                None => {
+                    warn!(uri = %uri, "No GBIF cross-walk for iNaturalist taxon_id");
+                    return Ok(None);
+                }
+            }
+        }
+        TaxonRef::Wikidata(qid) => match wikidata.gbif_key_for_entity(&qid).await {
+            Some(key) => key,
+            None => {
+                warn!(uri = %uri, "No GBIF cross-walk for Wikidata taxon_id");
+                return Ok(None);
+            }
+        },
+        TaxonRef::Unknown(u) => {
+            warn!(uri = %u, "Unrecognized taxon_id URI; skipping");
+            return Ok(None);
+        }
+    };
+
+    match resolver.resolve_by_key(key).await? {
+        Some(row) => Ok(Some(row.accepted_taxon_key.unwrap_or(row.taxon_key))),
+        None => {
+            warn!(uri = %uri, key, "taxon_id key not found upstream");
+            Ok(None)
+        }
+    }
 }
 
 async fn rate_limit(cli: &Cli) {

--- a/crates/observing-resolve-taxa/src/taxon_uri.rs
+++ b/crates/observing-resolve-taxa/src/taxon_uri.rs
@@ -1,0 +1,176 @@
+//! Parser for Darwin Core `taxonID` URIs into a known taxonomy source.
+//!
+//! Identification records carry an optional `taxonID` — a stable URI pointing
+//! at a taxon in some external authority (GBIF, iNaturalist, Wikidata, …).
+//! This module classifies the URI so the resolver can turn it into a GBIF
+//! `taxon_key`: GBIF URIs carry the key directly; iNaturalist / Wikidata URIs
+//! cross-walk to one via Wikidata's external-ID properties.
+//!
+//! Pure and network-free — all the I/O lives in the caller.
+
+/// A `taxonID` URI classified by source.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TaxonRef {
+    /// GBIF backbone usage key (e.g. from `https://www.gbif.org/species/2880791`).
+    Gbif(i64),
+    /// iNaturalist taxon id (e.g. from `https://www.inaturalist.org/taxa/12345`).
+    INaturalist(String),
+    /// Wikidata entity id, including the leading `Q` (e.g. `Q158746`).
+    Wikidata(String),
+    /// Anything we don't recognize; carries the original string for logging.
+    Unknown(String),
+}
+
+/// Classify a `taxonID` URI. Tolerates a trailing slash and a `?query`/`#frag`
+/// suffix, and matches hosts case-insensitively.
+pub fn parse(uri: &str) -> TaxonRef {
+    let trimmed = uri.trim();
+
+    // `gbif:2880791` shorthand.
+    if let Some(rest) = trimmed.strip_prefix("gbif:") {
+        return match rest.parse::<i64>() {
+            Ok(key) => TaxonRef::Gbif(key),
+            Err(_) => TaxonRef::Unknown(uri.to_string()),
+        };
+    }
+
+    // Strip scheme + a `www.` prefix, then split off any query/fragment so the
+    // last path segment is clean.
+    let no_scheme = trimmed
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(trimmed);
+    let path = no_scheme
+        .split(['?', '#'])
+        .next()
+        .unwrap_or(no_scheme)
+        .trim_end_matches('/');
+
+    let Some((host, rest)) = path.split_once('/') else {
+        return TaxonRef::Unknown(uri.to_string());
+    };
+    let host = host.to_ascii_lowercase();
+    let host = host.strip_prefix("www.").unwrap_or(&host);
+    let last = rest.rsplit('/').next().unwrap_or(rest);
+
+    match host {
+        "gbif.org" if rest.starts_with("species/") => match last.parse::<i64>() {
+            Ok(key) => TaxonRef::Gbif(key),
+            Err(_) => TaxonRef::Unknown(uri.to_string()),
+        },
+        "api.gbif.org" if rest.contains("/species/") => match last.parse::<i64>() {
+            Ok(key) => TaxonRef::Gbif(key),
+            Err(_) => TaxonRef::Unknown(uri.to_string()),
+        },
+        "inaturalist.org" if rest.starts_with("taxa/") => {
+            if last.chars().all(|c| c.is_ascii_digit()) && !last.is_empty() {
+                TaxonRef::INaturalist(last.to_string())
+            } else {
+                TaxonRef::Unknown(uri.to_string())
+            }
+        }
+        // Wikidata exposes both `/wiki/Q…` (human) and `/entity/Q…` (data) URIs.
+        "wikidata.org" if rest.starts_with("wiki/") || rest.starts_with("entity/") => {
+            if is_wikidata_qid(last) {
+                TaxonRef::Wikidata(last.to_string())
+            } else {
+                TaxonRef::Unknown(uri.to_string())
+            }
+        }
+        _ => TaxonRef::Unknown(uri.to_string()),
+    }
+}
+
+/// A Wikidata item id is `Q` followed by at least one digit.
+fn is_wikidata_qid(s: &str) -> bool {
+    matches!(s.strip_prefix('Q'), Some(digits)
+        if !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_gbif_web_url() {
+        assert_eq!(
+            parse("https://www.gbif.org/species/2880791"),
+            TaxonRef::Gbif(2880791)
+        );
+    }
+
+    #[test]
+    fn parses_gbif_api_url() {
+        assert_eq!(
+            parse("https://api.gbif.org/v1/species/2880791"),
+            TaxonRef::Gbif(2880791)
+        );
+    }
+
+    #[test]
+    fn parses_gbif_shorthand() {
+        assert_eq!(parse("gbif:2880791"), TaxonRef::Gbif(2880791));
+    }
+
+    #[test]
+    fn tolerates_trailing_slash_and_query() {
+        assert_eq!(
+            parse("https://www.gbif.org/species/2880791/"),
+            TaxonRef::Gbif(2880791)
+        );
+        assert_eq!(
+            parse("https://www.gbif.org/species/2880791?foo=bar"),
+            TaxonRef::Gbif(2880791)
+        );
+    }
+
+    #[test]
+    fn parses_inaturalist_url() {
+        assert_eq!(
+            parse("https://www.inaturalist.org/taxa/12345"),
+            TaxonRef::INaturalist("12345".to_string())
+        );
+        assert_eq!(
+            parse("inaturalist.org/taxa/12345"),
+            TaxonRef::INaturalist("12345".to_string())
+        );
+    }
+
+    #[test]
+    fn parses_wikidata_urls() {
+        assert_eq!(
+            parse("https://www.wikidata.org/wiki/Q158746"),
+            TaxonRef::Wikidata("Q158746".to_string())
+        );
+        assert_eq!(
+            parse("http://www.wikidata.org/entity/Q158746"),
+            TaxonRef::Wikidata("Q158746".to_string())
+        );
+    }
+
+    #[test]
+    fn host_matching_is_case_insensitive() {
+        assert_eq!(parse("https://WWW.GBIF.ORG/species/42"), TaxonRef::Gbif(42));
+    }
+
+    #[test]
+    fn rejects_junk() {
+        assert_eq!(
+            parse("https://example.com/foo/1"),
+            TaxonRef::Unknown("https://example.com/foo/1".to_string())
+        );
+        assert_eq!(
+            parse("gbif:notanumber"),
+            TaxonRef::Unknown("gbif:notanumber".to_string())
+        );
+        assert_eq!(
+            parse("https://www.gbif.org/species/abc"),
+            TaxonRef::Unknown("https://www.gbif.org/species/abc".to_string())
+        );
+        assert_eq!(
+            parse("https://www.wikidata.org/wiki/P31"),
+            TaxonRef::Unknown("https://www.wikidata.org/wiki/P31".to_string())
+        );
+        assert_eq!(parse(""), TaxonRef::Unknown("".to_string()));
+    }
+}

--- a/crates/observing-taxonomy-gbif/src/lib.rs
+++ b/crates/observing-taxonomy-gbif/src/lib.rs
@@ -92,15 +92,49 @@ impl TaxonomyUpstream for GbifUpstream {
     }
 
     async fn get_by_key(&self, taxon_key: i64) -> Result<Option<UpstreamMatch>, ResolveError> {
-        // GBIF's species-detail endpoint lacks the keyed classification chain
-        // that `match_name` returns, so we'd need follow-up calls per ancestor
-        // to construct anything resolver-shaped. Until that's wired up,
-        // by-key lookups always miss the upstream — callers will fall back
-        // to whatever's cached. This is fine for now: by-key lookups today
-        // come from `accepted_taxon_key` chases on synonym rows we haven't
-        // finished plumbing.
-        let _ = taxon_key;
-        Ok(None)
+        // The v2 `/species/match` endpoint accepts a `usageKey` and returns the
+        // same `NameUsageMatch` (usage + classification chain) as a name match,
+        // so a by-key lookup reuses the exact response shape `match_name` does.
+        let usage_key = taxon_key.to_string();
+        let result = self
+            .api
+            .match_names(
+                None,             //  1 class
+                None,             //  2 exclude
+                None,             //  3 family
+                None,             //  4 generic_name
+                None,             //  5 genus
+                None,             //  6 infraspecific_epithet
+                None,             //  7 kingdom
+                None,             //  8 order
+                None,             //  9 phylum
+                None,             // 10 scientific_name
+                None,             // 11 scientific_name_authorship
+                None,             // 12 scientific_name_id
+                None,             // 13 species
+                None,             // 14 specific_epithet
+                None,             // 15 strict
+                None,             // 16 subfamily
+                None,             // 17 subgenus
+                None,             // 18 subtribe
+                None,             // 19 superfamily
+                None,             // 20 taxon_concept_id
+                None,             // 21 taxon_id
+                None,             // 22 taxon_rank
+                None,             // 23 tribe
+                Some(&usage_key), // 24 usage_key
+                None,             // 25 verbatim_taxon_rank
+                None,             // 26 verbose
+            )
+            .await;
+
+        let m: NameUsageMatch = match result {
+            Ok(rv) => rv.into_inner(),
+            Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => return Ok(None),
+            Err(e) => return Err(ResolveError::Upstream(e.to_string())),
+        };
+
+        Ok(build_upstream_match(m))
     }
 }
 

--- a/crates/wikidata-client/src/lib.rs
+++ b/crates/wikidata-client/src/lib.rs
@@ -154,6 +154,57 @@ impl WikidataClient {
         result
     }
 
+    /// Cross-walk an external taxon identifier to a GBIF backbone usage key.
+    ///
+    /// Finds the Wikidata item carrying `external_id` on `source_property`
+    /// (e.g. `P3151` for iNaturalist taxon id) and reads its GBIF ID
+    /// (`P846`). Returns `None` if no item matches, the item has no GBIF ID,
+    /// the GBIF ID isn't an integer, or the query fails.
+    pub async fn gbif_key_for(&self, source_property: &str, external_id: &str) -> Option<i64> {
+        let query = format!(
+            r#"SELECT ?gbif WHERE {{
+    ?item wdt:{source_property} "{external_id}" .
+    ?item wdt:P846 ?gbif .
+}} LIMIT 1"#,
+        );
+        self.first_gbif_key(&query).await
+    }
+
+    /// Cross-walk a Wikidata entity id (e.g. `Q158746`) to a GBIF backbone
+    /// usage key by reading its GBIF ID (`P846`). Returns `None` on a
+    /// non-Q-id, a missing/ non-integer GBIF ID, or a query failure.
+    pub async fn gbif_key_for_entity(&self, qid: &str) -> Option<i64> {
+        // `qid` is interpolated unquoted as `wd:{qid}`, so guard against
+        // anything that isn't a bare item id before it reaches the query.
+        let is_qid = matches!(qid.strip_prefix('Q'), Some(d)
+            if !d.is_empty() && d.chars().all(|c| c.is_ascii_digit()));
+        if !is_qid {
+            return None;
+        }
+        let query = format!(
+            r#"SELECT ?gbif WHERE {{
+    wd:{qid} wdt:P846 ?gbif .
+}} LIMIT 1"#,
+        );
+        self.first_gbif_key(&query).await
+    }
+
+    /// Run a SPARQL query whose first binding exposes a `?gbif` literal and
+    /// parse it as a GBIF usage key.
+    async fn first_gbif_key(&self, query: &str) -> Option<i64> {
+        let bindings = match self.sparql_query(query).await {
+            Ok(b) => b,
+            Err(e) => {
+                warn!(error = ?e, "Wikidata GBIF cross-walk failed");
+                return None;
+            }
+        };
+        bindings
+            .first()
+            .and_then(|b| b.get("gbif"))
+            .and_then(|v| v.value.parse::<i64>().ok())
+    }
+
     /// Fetch images (Wikidata property P18) for items matching external IDs.
     ///
     /// Returns a map of external ID to Wikimedia Commons thumbnail URL, with the


### PR DESCRIPTION
Closes #523.

## What

When an identification has a `taxonID` URI but name-based resolution couldn't produce an `accepted_taxon_key` (i.e. no usable plain-text taxa data), resolve the URI to a GBIF key and stamp it. Wikidata acts as a universal cross-walk so GBIF, **iNaturalist**, and **Wikidata** URLs all funnel into the existing GBIF-keyed `taxa` cache. **No migrations / schema changes.**

Builds on the `taxonID` field added in lexicons.bio#30.

## How

- **`GbifUpstream::get_by_key`** — was a `Ok(None)` stub; now calls the GBIF v2 `/species/match` endpoint with the `usageKey` param and reuses the existing, tested `build_upstream_match` (usage + ancestor chain). No new response mapping.
- **`taxon_uri` parser** (new, pure, unit-tested) — classifies a `taxonID` into `Gbif(i64)` / `INaturalist` / `Wikidata` / `Unknown`. Handles `gbif:N`, `gbif.org/species/N`, `api.gbif.org/v1/species/N`, `inaturalist.org/taxa/N`, Wikidata `/wiki/Q…` + `/entity/Q…`; tolerant of trailing slashes/queries, case-insensitive host.
- **`WikidataClient::gbif_key_for` / `gbif_key_for_entity`** — read the GBIF ID (`P846`) for a taxon identified on a source property (e.g. iNaturalist `P3151`) or a Wikidata Q-id.
- **Second pass in `resolve_taxa`** — `run_taxon_id_pass` runs *after* the name pass and only touches rows still `accepted_taxon_key IS NULL`, so it's a strict fallback (per the precedence decision). One `community_ids` matview refresh covers both passes. `--dry-run` / `--limit` / rate-limiting carry over.

## Precedence (decided with author)

taxonID is a **fallback**: name-based resolution runs first and is unchanged; the URI pass only mops up what's left.

## Testing

- Unit tests: `observing-resolve-taxa` (parser), `observing-taxonomy-gbif`, `wikidata-client` — all green. `cargo fmt --check` + `clippy` clean.
- **Live smoke test** against dev DB (70 identifications, 64 with iNat `taxon_id`, 0 resolved, empty taxa cache):
  - Name pass resolved 41/47 pairs; the taxon_id pass then saw only the 5 remaining rows (fallback ordering confirmed), resolving 2 via iNat→Wikidata→GBIF and gracefully skipping 3 (no `P846`, or a key GBIF didn't return). 0 errors.
  - taxa cache went 0 → 128 rows (targets + ancestor chains).
  - A controlled row (`Zzzznotarealtaxonname` + iNat `49807`) confirmed the isolated path: name pass skipped it, URI pass cross-walked to GBIF `5189989` (*Bulla gouldiana*, full classification). Cleaned up after.

## Out of scope (follow-ups)

- **Occurrence `taxonID`** — the vendored `occurrence.json` doesn't carry the field yet, and occurrence taxon derives from the accepted identification; resolution stays at the identification level.
- **Synonym → accepted redirect** — pre-existing follow-up; a taxonID pointing at a synonym stamps the synonym's own key, exactly as the name path does today.