### PR TITLE
chore(lexicons): sync latest bio.lexicons.temp.v0-1 + regenerate types

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -529,7 +529,7 @@ fn build_occurrence_record_json(
         .parse()
         .map_err(|_| AppError::BadRequest("Invalid eventDate format".into()))?;
 
-    let associated_media = if media_refs.is_empty() {
+    let media = if media_refs.is_empty() {
         None
     } else {
         Some(media_refs)
@@ -543,7 +543,7 @@ fn build_occurrence_record_json(
                 as i64,
         )
         .event_date(event_date)
-        .maybe_associated_media(associated_media)
+        .maybe_media(media)
         .build();
 
     auth::serialize_at_record(&record)

--- a/crates/observing-db/src/processing.rs
+++ b/crates/observing-db/src/processing.rs
@@ -49,9 +49,9 @@ pub fn parse_naive_datetime(s: &str) -> Option<NaiveDateTime> {
 }
 
 /// A strong reference to a `bio.lexicons.temp.v0-1.media` record, as it appears
-/// in an occurrence's `associatedMedia` array. Callers (the ingester) resolve
-/// these by fetching the referenced record from the author's PDS to build
-/// `BlobEntry` values for `associated_media`.
+/// in an occurrence's `media` array (legacy: `associatedMedia`). Callers (the
+/// ingester) resolve these by fetching the referenced record from the author's
+/// PDS to build `BlobEntry` values for `associated_media`.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct AssociatedMediaRef {
     pub uri: String,
@@ -138,8 +138,11 @@ pub fn occurrence_from_json(
         .and_then(parse_datetime)
         .unwrap_or(fallback_time);
 
+    // The lexicon renamed `associatedMedia` → `media`; read the current key,
+    // falling back to the legacy one for already-published records.
     let associated_media_refs: Vec<AssociatedMediaRef> = record_json
-        .get("associatedMedia")
+        .get("media")
+        .or_else(|| record_json.get("associatedMedia"))
         .and_then(|v| v.as_array())
         .map(|arr| {
             arr.iter()
@@ -170,7 +173,7 @@ pub fn occurrence_from_json(
                 })
                 .map(|v| v as i32),
             // Try legacy "blobs" field first (inline image embeds), then skip
-            // "associatedMedia" (strong refs that require media record resolution).
+            // "media" (strong refs that require media record resolution).
             // The appview write path provides blob entries directly via parsed.params.
             associated_media: record_json.get("blobs").and_then(|v| {
                 // Borrow-deserialize to validate shape without cloning the Value.
@@ -837,7 +840,7 @@ mod tests {
     /// the ingester use to turn a PDS occurrence record into a DB row. The
     /// appview's create path writes occurrences in the
     /// `bio.lexicons.temp.v0-1.occurrence` shape, where images are referenced via
-    /// `associatedMedia` strong refs to separate `bio.lexicons.temp.v0-1.media`
+    /// `media` strong refs to separate `bio.lexicons.temp.v0-1.media`
     /// records — there is no inline `blobs` field on the occurrence itself.
     ///
     /// Resolving those strong refs requires HTTP calls to the author's PDS,
@@ -846,14 +849,14 @@ mod tests {
     /// covers the first half of that pipeline: the parser must surface the
     /// strong refs so the ingester has something to resolve.
     #[test]
-    fn test_occurrence_from_json_extracts_associated_media_refs() {
+    fn test_occurrence_from_json_extracts_media_refs() {
         let record = serde_json::json!({
             "$type": "bio.lexicons.temp.v0-1.occurrence",
             "decimalLatitude": "37.7749",
             "decimalLongitude": "-122.4194",
             "coordinateUncertaintyInMeters": 10,
             "eventDate": "2024-06-15T08:30:45.123Z",
-            "associatedMedia": [
+            "media": [
                 {
                     "uri": "at://did:plc:author/bio.lexicons.temp.v0-1.media/abc123",
                     "cid": "bafyreiabc123"
@@ -891,7 +894,7 @@ mod tests {
                     cid: "bafyreidef456".into(),
                 },
             ],
-            "occurrence_from_json must surface associatedMedia strong refs so the \
+            "occurrence_from_json must surface media strong refs so the \
              ingester can resolve them; without this, ingester-only writes lose \
              every photo on new observations"
         );
@@ -899,6 +902,42 @@ mod tests {
             parsed.params.associated_media.is_none(),
             "synchronous parser should not populate associated_media from strong \
              refs — that is the ingester's async job"
+        );
+    }
+
+    /// Records published before the `associatedMedia` → `media` lexicon rename
+    /// still carry the legacy key; the parser must keep resolving their photos.
+    #[test]
+    fn test_occurrence_from_json_falls_back_to_legacy_associated_media() {
+        let record = serde_json::json!({
+            "$type": "bio.lexicons.temp.v0-1.occurrence",
+            "decimalLatitude": "37.7749",
+            "decimalLongitude": "-122.4194",
+            "eventDate": "2024-06-15T08:30:45.123Z",
+            "associatedMedia": [
+                {
+                    "uri": "at://did:plc:author/bio.lexicons.temp.v0-1.media/abc123",
+                    "cid": "bafyreiabc123"
+                }
+            ]
+        });
+
+        let parsed = occurrence_from_json(
+            &record,
+            "at://did:plc:author/bio.lexicons.temp.v0-1.occurrence/xyz".to_string(),
+            "bafyreioccurrence".to_string(),
+            "did:plc:author".to_string(),
+            Utc::now(),
+        )
+        .expect("record should parse");
+
+        assert_eq!(
+            parsed.associated_media_refs,
+            vec![AssociatedMediaRef {
+                uri: "at://did:plc:author/bio.lexicons.temp.v0-1.media/abc123".into(),
+                cid: "bafyreiabc123".into(),
+            }],
+            "legacy associatedMedia strong refs must still resolve after the rename"
         );
     }
 

--- a/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/occurrence.rs
+++ b/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/occurrence.rs
@@ -16,7 +16,7 @@ use jacquard_common::{BosStr, CowStr, DefaultStr, FromStaticStr};
 use jacquard_common::deps::codegen::unicode_segmentation::UnicodeSegmentation;
 use jacquard_common::deps::smol_str::SmolStr;
 use jacquard_common::types::collection::{Collection, RecordError};
-use jacquard_common::types::string::{AtUri, Cid, Datetime};
+use jacquard_common::types::string::{AtUri, Cid, Datetime, UriValue};
 use jacquard_common::types::uri::{RecordUri, UriError};
 use jacquard_common::types::value::Data;
 use jacquard_common::xrpc::XrpcResp;
@@ -38,9 +38,9 @@ use serde::{Deserialize, Serialize};
     bound(deserialize = "S: Deserialize<'de> + BosStr")
 )]
 pub struct Occurrence<S: BosStr = DefaultStr> {
-    ///Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia).
+    ///Identification accepted by the occurrence user as the source of taxonID. Must be accompanied by taxonID. Indirectly maps to Darwin Core dwc:isAcceptedIdentification.
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub associated_media: Option<Vec<StrongRef<S>>>,
+    pub accepted_identification_id: Option<StrongRef<S>>,
     ///The horizontal distance (in meters) from the given coordinates describing the smallest circle containing the whole of the Location (Darwin Core dwc:coordinateUncertaintyInMeters).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub coordinate_uncertainty_in_meters: Option<i64>,
@@ -53,8 +53,105 @@ pub struct Occurrence<S: BosStr = DefaultStr> {
     ///The date-time when the observation occurred, in ISO 8601 format (Darwin Core dwc:eventDate).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub event_date: Option<Datetime>,
+    ///Strong references to media records documenting the observation. Conceptually maps to the DwC-DP Occurrence Media table (https://gbif.github.io/dwc-dp/qrg/#Occurrence%20Media), which replaced the legacy dwc:associatedMedia term.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub media: Option<Vec<StrongRef<S>>>,
+    ///The quantity of the organism present at the time of the Occurrence. Generally an integer or float but may be categorical, e.g. 'many' or '10-100' (Darwin Core dwc:organismQuantity).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organism_quantity: Option<S>,
+    ///The type of quantification system used for the quantity of organisms (Darwin Core dwc:organismQuantityType).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub organism_quantity_type: Option<OccurrenceOrganismQuantityType<S>>,
+    ///Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by acceptedIdentificationID. Must be accompanied by acceptedIdentificationID. Represents a more specific version of the DarwinCore equivalent (Darwin Core dwc:taxonID).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub taxon_id: Option<UriValue<S>>,
     #[serde(flatten, default, skip_serializing_if = "Option::is_none")]
     pub extra_data: Option<BTreeMap<SmolStr, Data<S>>>,
+}
+
+/// The type of quantification system used for the quantity of organisms (Darwin Core dwc:organismQuantityType).
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum OccurrenceOrganismQuantityType<S: BosStr = DefaultStr> {
+    Individuals,
+    PercentCover,
+    Other(S),
+}
+
+impl<S: BosStr> OccurrenceOrganismQuantityType<S> {
+    pub fn as_str(&self) -> &str {
+        match self {
+            Self::Individuals => "individuals",
+            Self::PercentCover => "percent-cover",
+            Self::Other(s) => s.as_ref(),
+        }
+    }
+    /// Construct from a string-like value, matching known values.
+    pub fn from_value(s: S) -> Self {
+        match s.as_ref() {
+            "individuals" => Self::Individuals,
+            "percent-cover" => Self::PercentCover,
+            _ => Self::Other(s),
+        }
+    }
+}
+
+impl<S: BosStr> core::fmt::Display for OccurrenceOrganismQuantityType<S> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+impl<S: BosStr> AsRef<str> for OccurrenceOrganismQuantityType<S> {
+    fn as_ref(&self) -> &str {
+        self.as_str()
+    }
+}
+
+impl<S: BosStr> Serialize for OccurrenceOrganismQuantityType<S> {
+    fn serialize<Ser>(&self, serializer: Ser) -> Result<Ser::Ok, Ser::Error>
+    where
+        Ser: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de, S: Deserialize<'de> + BosStr> Deserialize<'de> for OccurrenceOrganismQuantityType<S> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = S::deserialize(deserializer)?;
+        Ok(Self::from_value(s))
+    }
+}
+
+impl<S: BosStr + Default> Default for OccurrenceOrganismQuantityType<S> {
+    fn default() -> Self {
+        Self::Other(Default::default())
+    }
+}
+
+impl<S: BosStr> jacquard_common::IntoStatic for OccurrenceOrganismQuantityType<S>
+where
+    S: BosStr + jacquard_common::IntoStatic,
+    S::Output: BosStr,
+{
+    type Output = OccurrenceOrganismQuantityType<S::Output>;
+    fn into_static(self) -> Self::Output {
+        match self {
+            OccurrenceOrganismQuantityType::Individuals => {
+                OccurrenceOrganismQuantityType::Individuals
+            }
+            OccurrenceOrganismQuantityType::PercentCover => {
+                OccurrenceOrganismQuantityType::PercentCover
+            }
+            OccurrenceOrganismQuantityType::Other(v) => {
+                OccurrenceOrganismQuantityType::Other(v.into_static())
+            }
+        }
+    }
 }
 
 /// Typed wrapper for GetRecord response with this collection's record type.
@@ -112,22 +209,22 @@ impl<S: BosStr> LexiconSchema for Occurrence<S> {
         lexicon_doc_bio_lexicons_temp_v0_1_occurrence()
     }
     fn validate(&self) -> Result<(), ConstraintError> {
-        if let Some(ref value) = self.associated_media {
-            #[allow(unused_comparisons)]
-            if value.len() > 10usize {
-                return Err(ConstraintError::MaxLength {
-                    path: ValidationPath::from_field("associated_media"),
-                    max: 10usize,
-                    actual: value.len(),
-                });
-            }
-        }
         if let Some(ref value) = self.coordinate_uncertainty_in_meters {
             if *value < 0i64 {
                 return Err(ConstraintError::Minimum {
                     path: ValidationPath::from_field("coordinate_uncertainty_in_meters"),
                     min: 0i64,
                     actual: *value,
+                });
+            }
+        }
+        if let Some(ref value) = self.media {
+            #[allow(unused_comparisons)]
+            if value.len() > 10usize {
+                return Err(ConstraintError::MaxLength {
+                    path: ValidationPath::from_field("media"),
+                    max: 10usize,
+                    actual: value.len(),
                 });
             }
         }
@@ -158,11 +255,15 @@ pub mod occurrence_state {
 pub struct OccurrenceBuilder<S: BosStr, St: occurrence_state::State> {
     _state: PhantomData<fn() -> St>,
     _fields: (
-        Option<Vec<StrongRef<S>>>,
+        Option<StrongRef<S>>,
         Option<i64>,
         Option<S>,
         Option<S>,
         Option<Datetime>,
+        Option<Vec<StrongRef<S>>>,
+        Option<S>,
+        Option<OccurrenceOrganismQuantityType<S>>,
+        Option<UriValue<S>>,
     ),
     _type: PhantomData<fn() -> S>,
 }
@@ -179,20 +280,20 @@ impl<S: BosStr> OccurrenceBuilder<S, occurrence_state::Empty> {
     pub fn new() -> Self {
         OccurrenceBuilder {
             _state: PhantomData,
-            _fields: (None, None, None, None, None),
+            _fields: (None, None, None, None, None, None, None, None, None),
             _type: PhantomData,
         }
     }
 }
 
 impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
-    /// Set the `associatedMedia` field (optional)
-    pub fn associated_media(mut self, value: impl Into<Option<Vec<StrongRef<S>>>>) -> Self {
+    /// Set the `acceptedIdentificationID` field (optional)
+    pub fn accepted_identification_id(mut self, value: impl Into<Option<StrongRef<S>>>) -> Self {
         self._fields.0 = value.into();
         self
     }
-    /// Set the `associatedMedia` field to an Option value (optional)
-    pub fn maybe_associated_media(mut self, value: Option<Vec<StrongRef<S>>>) -> Self {
+    /// Set the `acceptedIdentificationID` field to an Option value (optional)
+    pub fn maybe_accepted_identification_id(mut self, value: Option<StrongRef<S>>) -> Self {
         self._fields.0 = value;
         self
     }
@@ -250,6 +351,64 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
+impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+    /// Set the `media` field (optional)
+    pub fn media(mut self, value: impl Into<Option<Vec<StrongRef<S>>>>) -> Self {
+        self._fields.5 = value.into();
+        self
+    }
+    /// Set the `media` field to an Option value (optional)
+    pub fn maybe_media(mut self, value: Option<Vec<StrongRef<S>>>) -> Self {
+        self._fields.5 = value;
+        self
+    }
+}
+
+impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+    /// Set the `organismQuantity` field (optional)
+    pub fn organism_quantity(mut self, value: impl Into<Option<S>>) -> Self {
+        self._fields.6 = value.into();
+        self
+    }
+    /// Set the `organismQuantity` field to an Option value (optional)
+    pub fn maybe_organism_quantity(mut self, value: Option<S>) -> Self {
+        self._fields.6 = value;
+        self
+    }
+}
+
+impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+    /// Set the `organismQuantityType` field (optional)
+    pub fn organism_quantity_type(
+        mut self,
+        value: impl Into<Option<OccurrenceOrganismQuantityType<S>>>,
+    ) -> Self {
+        self._fields.7 = value.into();
+        self
+    }
+    /// Set the `organismQuantityType` field to an Option value (optional)
+    pub fn maybe_organism_quantity_type(
+        mut self,
+        value: Option<OccurrenceOrganismQuantityType<S>>,
+    ) -> Self {
+        self._fields.7 = value;
+        self
+    }
+}
+
+impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+    /// Set the `taxonID` field (optional)
+    pub fn taxon_id(mut self, value: impl Into<Option<UriValue<S>>>) -> Self {
+        self._fields.8 = value.into();
+        self
+    }
+    /// Set the `taxonID` field to an Option value (optional)
+    pub fn maybe_taxon_id(mut self, value: Option<UriValue<S>>) -> Self {
+        self._fields.8 = value;
+        self
+    }
+}
+
 impl<S: BosStr, St> OccurrenceBuilder<S, St>
 where
     St: occurrence_state::State,
@@ -257,22 +416,30 @@ where
     /// Build the final struct.
     pub fn build(self) -> Occurrence<S> {
         Occurrence {
-            associated_media: self._fields.0,
+            accepted_identification_id: self._fields.0,
             coordinate_uncertainty_in_meters: self._fields.1,
             decimal_latitude: self._fields.2,
             decimal_longitude: self._fields.3,
             event_date: self._fields.4,
+            media: self._fields.5,
+            organism_quantity: self._fields.6,
+            organism_quantity_type: self._fields.7,
+            taxon_id: self._fields.8,
             extra_data: Default::default(),
         }
     }
     /// Build the final struct with custom extra_data.
     pub fn build_with_data(self, extra_data: BTreeMap<SmolStr, Data<S>>) -> Occurrence<S> {
         Occurrence {
-            associated_media: self._fields.0,
+            accepted_identification_id: self._fields.0,
             coordinate_uncertainty_in_meters: self._fields.1,
             decimal_latitude: self._fields.2,
             decimal_longitude: self._fields.3,
             event_date: self._fields.4,
+            media: self._fields.5,
+            organism_quantity: self._fields.6,
+            organism_quantity_type: self._fields.7,
+            taxon_id: self._fields.8,
             extra_data: Some(extra_data),
         }
     }
@@ -302,18 +469,9 @@ fn lexicon_doc_bio_lexicons_temp_v0_1_occurrence() -> LexiconDoc<'static> {
                             #[allow(unused_mut)]
                             let mut map = BTreeMap::new();
                             map.insert(
-                                SmolStr::new_static("associatedMedia"),
-                                LexObjectProperty::Array(LexArray {
-                                    description: Some(
-                                        CowStr::new_static(
-                                            "Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia).",
-                                        ),
-                                    ),
-                                    items: LexArrayItem::Ref(LexRef {
-                                        r#ref: CowStr::new_static("com.atproto.repo.strongRef"),
-                                        ..Default::default()
-                                    }),
-                                    max_length: Some(10usize),
+                                SmolStr::new_static("acceptedIdentificationID"),
+                                LexObjectProperty::Ref(LexRef {
+                                    r#ref: CowStr::new_static("com.atproto.repo.strongRef"),
                                     ..Default::default()
                                 }),
                             );
@@ -355,6 +513,56 @@ fn lexicon_doc_bio_lexicons_temp_v0_1_occurrence() -> LexiconDoc<'static> {
                                         ),
                                     ),
                                     format: Some(LexStringFormat::Datetime),
+                                    ..Default::default()
+                                }),
+                            );
+                            map.insert(
+                                SmolStr::new_static("media"),
+                                LexObjectProperty::Array(LexArray {
+                                    description: Some(
+                                        CowStr::new_static(
+                                            "Strong references to media records documenting the observation. Conceptually maps to the DwC-DP Occurrence Media table (https://gbif.github.io/dwc-dp/qrg/#Occurrence%20Media), which replaced the legacy dwc:associatedMedia term.",
+                                        ),
+                                    ),
+                                    items: LexArrayItem::Ref(LexRef {
+                                        r#ref: CowStr::new_static("com.atproto.repo.strongRef"),
+                                        ..Default::default()
+                                    }),
+                                    max_length: Some(10usize),
+                                    ..Default::default()
+                                }),
+                            );
+                            map.insert(
+                                SmolStr::new_static("organismQuantity"),
+                                LexObjectProperty::String(LexString {
+                                    description: Some(
+                                        CowStr::new_static(
+                                            "The quantity of the organism present at the time of the Occurrence. Generally an integer or float but may be categorical, e.g. 'many' or '10-100' (Darwin Core dwc:organismQuantity).",
+                                        ),
+                                    ),
+                                    ..Default::default()
+                                }),
+                            );
+                            map.insert(
+                                SmolStr::new_static("organismQuantityType"),
+                                LexObjectProperty::String(LexString {
+                                    description: Some(
+                                        CowStr::new_static(
+                                            "The type of quantification system used for the quantity of organisms (Darwin Core dwc:organismQuantityType).",
+                                        ),
+                                    ),
+                                    ..Default::default()
+                                }),
+                            );
+                            map.insert(
+                                SmolStr::new_static("taxonID"),
+                                LexObjectProperty::String(LexString {
+                                    description: Some(
+                                        CowStr::new_static(
+                                            "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by acceptedIdentificationID. Must be accompanied by acceptedIdentificationID. Represents a more specific version of the DarwinCore equivalent (Darwin Core dwc:taxonID).",
+                                        ),
+                                    ),
+                                    format: Some(LexStringFormat::Uri),
                                     ..Default::default()
                                 }),
                             );

--- a/frontend/src/lib/uploader.ts
+++ b/frontend/src/lib/uploader.ts
@@ -82,7 +82,7 @@ export class OccurrenceUploader {
       decimalLatitude: String(data.location.decimalLatitude),
       decimalLongitude: String(data.location.decimalLongitude),
       eventDate: data.eventDate,
-      associatedMedia: mediaRefs,
+      media: mediaRefs,
     };
     if (data.location.coordinateUncertaintyInMeters != null) {
       record["coordinateUncertaintyInMeters"] = data.location.coordinateUncertaintyInMeters;

--- a/lexicons/bio/lexicons/temp/v0-1/occurrence.json
+++ b/lexicons/bio/lexicons/temp/v0-1/occurrence.json
@@ -27,14 +27,33 @@
             "description": "The horizontal distance (in meters) from the given coordinates describing the smallest circle containing the whole of the Location (Darwin Core dwc:coordinateUncertaintyInMeters).",
             "minimum": 0
           },
-          "associatedMedia": {
+          "media": {
             "type": "array",
-            "description": "Strong references to media records documenting the observation (Darwin Core dwc:associatedMedia).",
+            "description": "Strong references to media records documenting the observation. Conceptually maps to the DwC-DP Occurrence Media table (https://gbif.github.io/dwc-dp/qrg/#Occurrence%20Media), which replaced the legacy dwc:associatedMedia term.",
             "items": {
               "type": "ref",
               "ref": "com.atproto.repo.strongRef"
             },
             "maxLength": 10
+          },
+          "organismQuantity": {
+            "type": "string",
+            "description": "The quantity of the organism present at the time of the Occurrence. Generally an integer or float but may be categorical, e.g. 'many' or '10-100' (Darwin Core dwc:organismQuantity)."
+          },
+          "organismQuantityType": {
+            "type": "string",
+            "description": "The type of quantification system used for the quantity of organisms (Darwin Core dwc:organismQuantityType).",
+            "knownValues": ["individuals", "percent-cover"]
+          },
+          "taxonID": {
+            "type": "string",
+            "format": "uri",
+            "description": "Identified taxon the occurrence user has accepted, preferably a stable URI (e.g. a GBIF species URI). Derived from identification specified by acceptedIdentificationID. Must be accompanied by acceptedIdentificationID. Represents a more specific version of the DarwinCore equivalent (Darwin Core dwc:taxonID)."
+          },
+          "acceptedIdentificationID": {
+            "type": "ref",
+            "ref": "com.atproto.repo.strongRef",
+            "description": "Identification accepted by the occurrence user as the source of taxonID. Must be accompanied by taxonID. Indirectly maps to Darwin Core dwc:isAcceptedIdentification."
           }
         }
       }


### PR DESCRIPTION
## What

Pulls the latest `bio.lexicons.temp.v0-1` lexicons from [lexicons.bio](https://github.com/lexicons-bio/lexicons.bio) (@`e3370bb`) and regenerates the Rust types via `scripts/generate-rust-types.sh`.

Only **`occurrence`** changed upstream (`identification` / `media` were already in sync):
- `associatedMedia` → **`media`** (rename)
- added **`taxonID`** (uri) and **`acceptedIdentificationID`** (strongRef)
- added **`organismQuantity`** + **`organismQuantityType`** (`individuals` / `percent-cover`)

## How

- Synced `lexicons/bio/lexicons/temp/v0-1/occurrence.json` from upstream.
- Ran the pinned codegen (`jacquard-lexgen@0.12.0-beta.2`) then `cargo fmt` — the only generated diff is `occurrence.rs` (the rest was just unformatted generator churn that rustfmt collapses).

### Fallout from the `media` rename
The wire field rename touched every place that reads/writes that key:
- **appview write path** (`write.rs`): builder `.maybe_associated_media` → `.maybe_media`.
- **frontend** (`uploader.ts`): direct PDS write now emits `media`.
- **ingest** (`processing.rs`): reads the new `media` key, **falling back to legacy `associatedMedia`** so already-published records keep resolving their photos. Added a regression test for the fallback; updated the existing test to the `media` shape.

Internal names (`associated_media` DB column, `associated_media_refs`, `MediaResolver`) are unchanged — only the on-the-wire lexicon key moved.

## Not in this PR (follow-up)

The new occurrence fields (`taxonID`, `acceptedIdentificationID`, `organismQuantity`, `organismQuantityType`) are now **exposed by the generated types but not yet consumed**. Wiring occurrence `taxonID`/`acceptedIdentificationID` through ingest + resolution is the natural follow-up to #523 (whose taxonID resolution currently lives at the identification level).

## Testing

- `cargo build --workspace` clean; `cargo fmt --check` clean.
- `cargo test -p observing-db --features processing` — 53 pass, incl. the updated `..._extracts_media_refs` and new `..._falls_back_to_legacy_associated_media`.
- Frontend `uploader.ts` passes oxfmt/oxlint (no new warnings).