### PR TITLE
feat(backfill): one-shot job to re-fetch occurrences from PDS and backfill organismQuantity

### DIFF
--- a/.sqlx/query-b10aca3d81383915ea27c394adee13a6dc21c2b005396ed69969a35671c3435d.json
+++ b/.sqlx/query-b10aca3d81383915ea27c394adee13a6dc21c2b005396ed69969a35671c3435d.json
@@ -1,0 +1,66 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT uri, did, cid, created_at as \"created_at!: DateTime<Utc>\"\n        FROM occurrences\n        WHERE ($1::bool OR organism_quantity IS NULL)\n          AND ($2::text IS NULL OR did = $2)\n        ORDER BY created_at ASC\n        LIMIT COALESCE($3, 9223372036854775807)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uri",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "did",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "did"
+          }
+        }
+      },
+      {
+        "ordinal": 2,
+        "name": "cid",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "cid"
+          }
+        }
+      },
+      {
+        "ordinal": 3,
+        "name": "created_at!: DateTime<Utc>",
+        "type_info": "Timestamptz",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "created_at"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      false,
+      false,
+      false
+    ]
+  },
+  "hash": "b10aca3d81383915ea27c394adee13a6dc21c2b005396ed69969a35671c3435d"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -442,6 +442,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "backfill-occurrences"
+version = "0.1.0"
+dependencies = [
+ "at-uri-parser",
+ "atproto-blob-resolver",
+ "atproto-identity",
+ "chrono",
+ "clap",
+ "futures",
+ "observing-db",
+ "reqwest 0.13.3",
+ "serde_json",
+ "sqlx",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "base-x"
 version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/crates/backfill-occurrences/Cargo.toml
+++ b/crates/backfill-occurrences/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "backfill-occurrences"
+version = "0.1.0"
+edition = "2021"
+description = "One-shot CLI that re-fetches occurrence records from their authoring PDS and re-runs the upsert, to backfill newly-extracted columns (organismQuantity/organismQuantityType)"
+license = "MIT OR Apache-2.0"
+
+[dependencies]
+# `processing::occurrence_from_json` (feature-gated) + the occurrences upsert.
+observing-db = { path = "../observing-db", features = ["processing"] }
+# DID -> PDS resolution and `com.atproto.repo.getRecord`, shared with the ingester.
+atproto-blob-resolver = { path = "../atproto-blob-resolver" }
+atproto-identity = { path = "../atproto-identity" }
+at-uri-parser = { path = "../at-uri-parser" }
+
+tokio = { workspace = true }
+sqlx = { workspace = true }
+serde_json = { workspace = true }
+chrono = { workspace = true }
+reqwest = { workspace = true }
+futures = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+clap = { version = "4", features = ["derive", "env"] }

--- a/crates/backfill-occurrences/src/main.rs
+++ b/crates/backfill-occurrences/src/main.rs
@@ -1,0 +1,285 @@
+//! One-shot CLI that re-fetches occurrence records from their authoring PDS
+//! and re-runs them through the normal occurrence upsert.
+//!
+//! Why this exists: extracted columns are populated from the lexicon record at
+//! ingest time. When a new field is added to the schema (e.g.
+//! `organism_quantity` / `organism_quantity_type`, added in #600/#601) the
+//! columns are NULL for every row that was ingested before the change — the
+//! source value was never persisted in the DB, only on the author's PDS. A
+//! SQL migration can't recover it; the only way to fill those columns is to
+//! re-fetch each record and re-run the parser.
+//!
+//! Approach: iterate the `occurrences` table (we already hold every `uri` +
+//! `did`), resolve each author's PDS, `getRecord` the live occurrence,
+//! re-parse it via `processing::occurrence_from_json` (which now extracts the
+//! quantity fields), and `occurrences::upsert` the result.
+//!
+//! Safe to re-run: the upsert COALESCEs the backfilled columns
+//! (`organism_quantity = COALESCE($n, occurrences.organism_quantity)`), so a
+//! second pass never clobbers a value with NULL, and `associated_media` is
+//! likewise preserved. Records that have been deleted from their PDS, or whose
+//! PDS is unreachable, are skipped rather than failing the run.
+//!
+//! This deliberately mirrors `replay-failed-records`: a small, restartable,
+//! operator-driven job that bypasses the live-firehose wrappers (media
+//! resolution, notifications) and talks to the parser + upsert directly.
+
+use at_uri_parser::AtUri;
+use atproto_blob_resolver::BlobResolver;
+use atproto_identity::Did;
+use chrono::{DateTime, Utc};
+use clap::Parser;
+use futures::stream::{self, StreamExt};
+use observing_db::{occurrences, processing};
+use sqlx::postgres::{PgPool, PgPoolOptions};
+use std::process::ExitCode;
+use std::time::Duration;
+use tracing::{error, info, warn};
+use tracing_subscriber::{prelude::*, EnvFilter};
+
+#[derive(Parser, Debug)]
+#[command(version, about, long_about = None)]
+struct Args {
+    /// Re-fetch and parse, but don't write to the database. Reports what would
+    /// be filled.
+    #[arg(long)]
+    dry_run: bool,
+
+    /// Cap on rows to process this run. Unbounded if omitted.
+    #[arg(long)]
+    limit: Option<i64>,
+
+    /// Only process occurrences authored by this DID. Useful for verifying
+    /// behavior on one repo before the full sweep.
+    #[arg(long)]
+    did: Option<String>,
+
+    /// Re-fetch every occurrence, not just rows still missing
+    /// `organism_quantity`. The upsert is idempotent either way; this just
+    /// widens the candidate set (and the number of PDS round trips).
+    #[arg(long)]
+    all: bool,
+
+    /// Number of PDS fetches to run concurrently.
+    #[arg(long, default_value_t = 8)]
+    concurrency: usize,
+}
+
+struct OccurrenceRef {
+    uri: String,
+    did: String,
+    cid: String,
+    /// `created_at` is never touched by the ON CONFLICT branch of the upsert;
+    /// it's passed only as the `fallback_time` the parser would use if this
+    /// row had somehow been deleted between SELECT and upsert (INSERT branch).
+    created_at: DateTime<Utc>,
+}
+
+#[tokio::main]
+async fn main() -> ExitCode {
+    let env_filter = EnvFilter::try_from_default_env()
+        .unwrap_or_else(|_| EnvFilter::new("backfill_occurrences=info"));
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer())
+        .init();
+
+    let args = Args::parse();
+
+    let database_url = match std::env::var("DATABASE_URL") {
+        Ok(v) => v,
+        Err(_) => {
+            error!("DATABASE_URL is required");
+            return ExitCode::from(2);
+        }
+    };
+
+    let pool = match PgPoolOptions::new()
+        .max_connections(args.concurrency.max(1) as u32 + 1)
+        .acquire_timeout(Duration::from_secs(30))
+        .connect(&database_url)
+        .await
+    {
+        Ok(p) => p,
+        Err(e) => {
+            error!(error = %e, "failed to connect");
+            return ExitCode::from(1);
+        }
+    };
+
+    // A bounded timeout keeps a single slow/hanging PDS from stalling the run.
+    let http = reqwest::Client::builder()
+        .timeout(Duration::from_secs(10))
+        .build()
+        .expect("reqwest client build should not fail with defaults");
+    let resolver = BlobResolver::with_client(http);
+
+    match run(&pool, &resolver, &args).await {
+        Ok(summary) => {
+            info!(
+                scanned = summary.scanned,
+                upserted = summary.upserted,
+                filled = summary.filled,
+                skipped = summary.skipped,
+                failed = summary.failed,
+                "done"
+            );
+            ExitCode::SUCCESS
+        }
+        Err(e) => {
+            error!(error = %e, "fatal error");
+            ExitCode::from(1)
+        }
+    }
+}
+
+#[derive(Default, Debug)]
+struct Summary {
+    scanned: u64,
+    /// Rows successfully re-upserted (or that would be, under --dry-run).
+    upserted: u64,
+    /// Subset of `upserted` whose re-parsed record carried a quantity value.
+    filled: u64,
+    skipped: u64,
+    failed: u64,
+}
+
+async fn run(pool: &PgPool, resolver: &BlobResolver, args: &Args) -> Result<Summary, sqlx::Error> {
+    let rows = sqlx::query_as!(
+        OccurrenceRef,
+        r#"
+        SELECT uri, did, cid, created_at as "created_at!: DateTime<Utc>"
+        FROM occurrences
+        WHERE ($1::bool OR organism_quantity IS NULL)
+          AND ($2::text IS NULL OR did = $2)
+        ORDER BY created_at ASC
+        LIMIT COALESCE($3, 9223372036854775807)
+        "#,
+        args.all,
+        args.did.as_deref(),
+        args.limit,
+    )
+    .fetch_all(pool)
+    .await?;
+
+    info!(candidates = rows.len(), "occurrences to re-fetch");
+
+    let outcomes = stream::iter(rows.iter())
+        .map(|row| backfill_one(pool, resolver, row, args.dry_run))
+        .buffer_unordered(args.concurrency.max(1))
+        .collect::<Vec<_>>()
+        .await;
+
+    let mut summary = Summary {
+        scanned: outcomes.len() as u64,
+        ..Default::default()
+    };
+    for outcome in outcomes {
+        match outcome {
+            Outcome::Upserted { filled } => {
+                summary.upserted += 1;
+                if filled {
+                    summary.filled += 1;
+                }
+            }
+            Outcome::Skipped => summary.skipped += 1,
+            Outcome::Failed => summary.failed += 1,
+        }
+    }
+
+    Ok(summary)
+}
+
+enum Outcome {
+    Upserted { filled: bool },
+    Skipped,
+    Failed,
+}
+
+async fn backfill_one(
+    pool: &PgPool,
+    resolver: &BlobResolver,
+    row: &OccurrenceRef,
+    dry_run: bool,
+) -> Outcome {
+    let Some(at_uri) = AtUri::parse(&row.uri) else {
+        warn!(uri = %row.uri, "skipped: unparseable AT-URI");
+        return Outcome::Skipped;
+    };
+    let did = match Did::parse(&at_uri.did) {
+        Ok(d) => d,
+        Err(e) => {
+            warn!(uri = %row.uri, error = %e, "skipped: unparseable DID");
+            return Outcome::Skipped;
+        }
+    };
+
+    let pds_url = match resolver.resolve_pds_url(&did).await {
+        Ok(url) => url,
+        Err(e) => {
+            warn!(uri = %row.uri, error = %e, "skipped: DID resolution failed");
+            return Outcome::Skipped;
+        }
+    };
+
+    // A fetch failure here is expected for records that have since been
+    // deleted, or whose PDS is temporarily unreachable. Treat it as a skip so
+    // the sweep completes; `failed` stays reserved for parse/write errors,
+    // which point at a real bug rather than transient/network state.
+    let record = match resolver
+        .fetch_record(&pds_url, &at_uri.did, &at_uri.collection, &at_uri.rkey)
+        .await
+    {
+        Ok(v) => v,
+        Err(e) => {
+            warn!(uri = %row.uri, error = %e, "skipped: getRecord failed");
+            return Outcome::Skipped;
+        }
+    };
+
+    let parsed = match processing::occurrence_from_json(
+        &record,
+        row.uri.clone(),
+        row.cid.clone(),
+        row.did.clone(),
+        row.created_at,
+    ) {
+        Ok(p) => p,
+        Err(e) => {
+            warn!(uri = %row.uri, error = %e, "failed: parse");
+            return Outcome::Failed;
+        }
+    };
+
+    let filled =
+        parsed.params.organism_quantity.is_some() || parsed.params.organism_quantity_type.is_some();
+
+    if dry_run {
+        info!(
+            uri = %row.uri,
+            filled,
+            organism_quantity = ?parsed.params.organism_quantity,
+            organism_quantity_type = ?parsed.params.organism_quantity_type,
+            "would upsert"
+        );
+        return Outcome::Upserted { filled };
+    }
+
+    match occurrences::upsert(pool, &parsed.params).await {
+        Ok(()) => {
+            if filled {
+                info!(
+                    uri = %row.uri,
+                    organism_quantity = ?parsed.params.organism_quantity,
+                    organism_quantity_type = ?parsed.params.organism_quantity_type,
+                    "backfilled quantity"
+                );
+            }
+            Outcome::Upserted { filled }
+        }
+        Err(e) => {
+            warn!(uri = %row.uri, error = %e, "failed: upsert");
+            Outcome::Failed
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a `backfill-occurrences` one-shot binary that recovers `organism_quantity` / `organism_quantity_type` for occurrence rows ingested **before** #601 added those columns.

Follow-up to #601. Those extracted columns are NULL on every pre-existing row because the source value was never stored in the DB — it lives only on the author's PDS — so a SQL migration can't recover it. The only way to fill them is to re-fetch each record and re-run the parser.

## How

Mirrors the existing `replay-failed-records` job (small, restartable, operator-driven, bypasses the live-firehose media/notification wrappers):

1. Iterate the `occurrences` table — we already hold every `uri` + `did`.
2. Resolve each author's PDS (`BlobResolver::resolve_pds_url`) and `getRecord` the live occurrence (`fetch_record`).
3. Re-parse via `processing::occurrence_from_json` (which #601 updated to extract the quantity fields).
4. Re-run `occurrences::upsert`.

**Safety / resilience**
- **Idempotent** — the upsert COALESCEs the backfilled columns (`organism_quantity = COALESCE($n, occurrences.organism_quantity)`), so a re-run never clobbers a value with NULL; `associated_media` is likewise preserved.
- Records **deleted from / unreachable on** their PDS are *skipped*, not failed. `failed` is reserved for parse/write bugs that warrant a look.
- Bounded `--concurrency` of PDS fetches. Flags: `--dry-run`, `--limit`, `--did`, `--all`.

## Not in this PR

No Cloud Run Job / deploy wiring yet (cf. `observing-migrate`, `replay-failed-records`) — added when there's actually a need to run it in prod. Note that today a sweep fills ~nothing: `organismQuantity` is brand-new in the lexicon, so existing PDS records predate the field.

## Testing

- `cargo build --workspace` clean in **offline** mode (CI parity); regenerated `.sqlx` cache for the new query.
- `cargo fmt --check` + `cargo clippy -p backfill-occurrences` clean.
- Smoke-tested against the dev DB — both `--dry-run` and a real run re-fetch live PDS records and re-upsert cleanly; row count unchanged (307); `filled=0` (existing records predate the field, as expected).