### PR TITLE
chore(uploader): remove unused compressImage method

### DIFF
--- a/frontend/src/lib/uploader.test.ts
+++ b/frontend/src/lib/uploader.test.ts
@@ -428,21 +428,4 @@ describe("OccurrenceUploader", () => {
       expect(result).toBeDefined();
     });
   });
-
-  describe("compressImage", () => {
-    // Note: compressImage uses browser APIs (Image, canvas) which aren't available in Node
-    // These tests verify the method exists and document expected behavior
-    // Full testing would require jsdom or a browser environment
-
-    it("method exists on uploader", () => {
-      expect(typeof uploader.compressImage).toBe("function");
-    });
-
-    // In a browser environment, we would test:
-    // - Image scaling when width > maxWidth
-    // - Quality parameter affects output size
-    // - Returns a File with type image/jpeg
-    // - Rejects when image fails to load
-    // - Rejects when canvas.toBlob returns null
-  });
 });

--- a/frontend/src/lib/uploader.ts
+++ b/frontend/src/lib/uploader.ts
@@ -258,46 +258,6 @@ export class OccurrenceUploader {
 
     return exifData;
   }
-
-  /**
-   * Compress an image for upload
-   */
-  async compressImage(file: File, maxWidth = 2048, quality = 0.85): Promise<File> {
-    return new Promise((resolve, reject) => {
-      const img = new Image();
-      const canvas = document.createElement("canvas");
-      const ctx = canvas.getContext("2d");
-
-      img.onload = () => {
-        let { width, height } = img;
-
-        // Scale down if necessary
-        if (width > maxWidth) {
-          height = (height * maxWidth) / width;
-          width = maxWidth;
-        }
-
-        canvas.width = width;
-        canvas.height = height;
-        ctx?.drawImage(img, 0, 0, width, height);
-
-        canvas.toBlob(
-          (blob) => {
-            if (blob) {
-              resolve(new File([blob], file.name, { type: "image/jpeg" }));
-            } else {
-              reject(new Error("Failed to compress image"));
-            }
-          },
-          "image/jpeg",
-          quality,
-        );
-      };
-
-      img.onerror = () => reject(new Error("Failed to load image"));
-      img.src = URL.createObjectURL(file);
-    });
-  }
 }
 
 export type { OccurrenceData, UploadResult, ExifData };


### PR DESCRIPTION
## Summary

Removes the dead `compressImage` method from `OccurrenceUploader`. It was never called — the upload path (`uploadImages`) sends the original file's `arrayBuffer()` directly, so `compressImage` was unreachable code. Its only reference was a trivial "method exists on uploader" test, removed alongside it.

As a side benefit, this also drops a latent object-URL leak: the method did `img.src = URL.createObjectURL(file)` and never called `revokeObjectURL`.

## Context

Surfaced during a frontend performance audit. Note this does **not** add image compression to uploads — it removes code that *claimed* to but was never wired in. Actually compressing uploads (cap longest edge, re-encode) before `uploadBlob` remains a worthwhile follow-up, ideally paired with real thumbnail downscaling server-side.

## Testing

- `npm run fmt` ✅
- `npm run lint` ✅ (no new warnings)
- Unit tests not run locally (vitest not installed in this worktree); change is a pure deletion with no remaining references — CI will cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)