### PR TITLE
refactor(jobs): shared batch-job harness + dedupe PDS record fetch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -198,6 +198,7 @@ checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 name = "atproto-blob-resolver"
 version = "0.1.0"
 dependencies = [
+ "at-uri-parser",
  "atproto-identity",
  "reqwest 0.13.3",
  "serde",
@@ -445,15 +446,12 @@ dependencies = [
 name = "backfill-occurrences"
 version = "0.1.0"
 dependencies = [
- "at-uri-parser",
  "atproto-blob-resolver",
- "atproto-identity",
  "chrono",
  "clap",
- "futures",
+ "observing-bootstrap",
  "observing-db",
  "reqwest 0.13.3",
- "serde_json",
  "sqlx",
  "tokio",
  "tracing",
@@ -2915,6 +2913,9 @@ name = "observing-bootstrap"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "clap",
+ "futures",
+ "sqlx",
  "tokio",
  "tracing",
 ]
@@ -3750,6 +3751,7 @@ version = "0.1.0"
 dependencies = [
  "chrono",
  "clap",
+ "observing-bootstrap",
  "observing-collections",
  "observing-db",
  "serde_json",

--- a/crates/atproto-blob-resolver/Cargo.toml
+++ b/crates/atproto-blob-resolver/Cargo.toml
@@ -12,6 +12,9 @@ reqwest = { workspace = true }
 # DID newtype
 atproto-identity = { path = "../atproto-identity" }
 
+# AT-URI parsing, for `fetch_record_by_aturi`
+at-uri-parser = { path = "../at-uri-parser" }
+
 # Serialization
 serde = { workspace = true }
 serde_json = { workspace = true }

--- a/crates/atproto-blob-resolver/src/resolver.rs
+++ b/crates/atproto-blob-resolver/src/resolver.rs
@@ -2,6 +2,7 @@
 
 use crate::error::{BlobResolverError, Result};
 use crate::types::PlcDirectoryResponse;
+use at_uri_parser::AtUri;
 use atproto_identity::{Did, DidMethod};
 use reqwest::Client;
 use tracing::{debug, warn};
@@ -157,6 +158,26 @@ impl BlobResolver {
         body.get("value").cloned().ok_or_else(|| {
             BlobResolverError::RecordFetch("getRecord response missing `value` field".to_string())
         })
+    }
+
+    /// Fetch a record straight from its `at://…` URI: parse the URI, resolve
+    /// the author's PDS, and [`fetch_record`](Self::fetch_record) the
+    /// referenced record's `value`.
+    ///
+    /// Consolidates the parse-URI → resolve-DID → `getRecord` dance that every
+    /// caller (the ingester's media resolver, backfill jobs) would otherwise
+    /// repeat. URI/DID parse failures surface as
+    /// [`BlobResolverError::RecordFetch`] / [`BlobResolverError::DidResolution`].
+    pub async fn fetch_record_by_aturi(&self, at_uri: &str) -> Result<serde_json::Value> {
+        let parsed = AtUri::parse(at_uri).ok_or_else(|| {
+            BlobResolverError::RecordFetch(format!("unparseable AT-URI: {at_uri}"))
+        })?;
+        let did = Did::parse(&parsed.did).map_err(|e| {
+            BlobResolverError::DidResolution(format!("unparseable DID in {at_uri}: {e}"))
+        })?;
+        let pds_url = self.resolve_pds_url(&did).await?;
+        self.fetch_record(&pds_url, &parsed.did, &parsed.collection, &parsed.rkey)
+            .await
     }
 }
 

--- a/crates/backfill-occurrences/Cargo.toml
+++ b/crates/backfill-occurrences/Cargo.toml
@@ -8,17 +8,17 @@ license = "MIT OR Apache-2.0"
 [dependencies]
 # `processing::occurrence_from_json` (feature-gated) + the occurrences upsert.
 observing-db = { path = "../observing-db", features = ["processing"] }
-# DID -> PDS resolution and `com.atproto.repo.getRecord`, shared with the ingester.
+# DID -> PDS resolution + `getRecord` (via fetch_record_by_aturi).
 atproto-blob-resolver = { path = "../atproto-blob-resolver" }
-atproto-identity = { path = "../atproto-identity" }
-at-uri-parser = { path = "../at-uri-parser" }
+# Shared batch-job scaffolding: CLI flags, pool setup, the drive loop.
+observing-bootstrap = { path = "../observing-bootstrap", default-features = false, features = [
+    "job",
+] }
 
 tokio = { workspace = true }
 sqlx = { workspace = true }
-serde_json = { workspace = true }
 chrono = { workspace = true }
 reqwest = { workspace = true }
-futures = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 clap = { version = "4", features = ["derive", "env"] }

--- a/crates/backfill-occurrences/src/main.rs
+++ b/crates/backfill-occurrences/src/main.rs
@@ -12,26 +12,23 @@
 //! Approach: iterate the `occurrences` table (we already hold every `uri` +
 //! `did`), resolve each author's PDS, `getRecord` the live occurrence,
 //! re-parse it via `processing::occurrence_from_json` (which now extracts the
-//! quantity fields), and `occurrences::upsert` the result.
+//! quantity fields), and `occurrences::upsert` the result. The shared
+//! `observing_bootstrap::job` harness supplies the CLI flags, pool setup, and
+//! the bounded-concurrency drive loop; this binary supplies the query and the
+//! per-row fetch/parse/upsert.
 //!
 //! Safe to re-run: the upsert COALESCEs the backfilled columns
 //! (`organism_quantity = COALESCE($n, occurrences.organism_quantity)`), so a
 //! second pass never clobbers a value with NULL, and `associated_media` is
 //! likewise preserved. Records that have been deleted from their PDS, or whose
 //! PDS is unreachable, are skipped rather than failing the run.
-//!
-//! This deliberately mirrors `replay-failed-records`: a small, restartable,
-//! operator-driven job that bypasses the live-firehose wrappers (media
-//! resolution, notifications) and talks to the parser + upsert directly.
 
-use at_uri_parser::AtUri;
 use atproto_blob_resolver::BlobResolver;
-use atproto_identity::Did;
 use chrono::{DateTime, Utc};
 use clap::Parser;
-use futures::stream::{self, StreamExt};
+use observing_bootstrap::job::{self, JobOpts, Outcome};
 use observing_db::{occurrences, processing};
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::PgPool;
 use std::process::ExitCode;
 use std::time::Duration;
 use tracing::{error, info, warn};
@@ -40,14 +37,8 @@ use tracing_subscriber::{prelude::*, EnvFilter};
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Re-fetch and parse, but don't write to the database. Reports what would
-    /// be filled.
-    #[arg(long)]
-    dry_run: bool,
-
-    /// Cap on rows to process this run. Unbounded if omitted.
-    #[arg(long)]
-    limit: Option<i64>,
+    #[command(flatten)]
+    job: JobOpts,
 
     /// Only process occurrences authored by this DID. Useful for verifying
     /// behavior on one repo before the full sweep.
@@ -86,23 +77,10 @@ async fn main() -> ExitCode {
 
     let args = Args::parse();
 
-    let database_url = match std::env::var("DATABASE_URL") {
-        Ok(v) => v,
-        Err(_) => {
-            error!("DATABASE_URL is required");
-            return ExitCode::from(2);
-        }
-    };
-
-    let pool = match PgPoolOptions::new()
-        .max_connections(args.concurrency.max(1) as u32 + 1)
-        .acquire_timeout(Duration::from_secs(30))
-        .connect(&database_url)
-        .await
-    {
+    let pool = match job::connect_pool(args.concurrency).await {
         Ok(p) => p,
         Err(e) => {
-            error!(error = %e, "failed to connect");
+            error!("{e}");
             return ExitCode::from(1);
         }
     };
@@ -114,38 +92,32 @@ async fn main() -> ExitCode {
         .expect("reqwest client build should not fail with defaults");
     let resolver = BlobResolver::with_client(http);
 
-    match run(&pool, &resolver, &args).await {
-        Ok(summary) => {
-            info!(
-                scanned = summary.scanned,
-                upserted = summary.upserted,
-                filled = summary.filled,
-                skipped = summary.skipped,
-                failed = summary.failed,
-                "done"
-            );
-            ExitCode::SUCCESS
-        }
+    let rows = match fetch_rows(&pool, &args).await {
+        Ok(r) => r,
         Err(e) => {
-            error!(error = %e, "fatal error");
-            ExitCode::from(1)
+            error!(error = %e, "failed to list occurrences");
+            return ExitCode::from(1);
         }
-    }
+    };
+    info!(candidates = rows.len(), "occurrences to re-fetch");
+
+    let summary = job::drive(rows, args.concurrency, |row| {
+        backfill_one(&pool, &resolver, row, args.job.dry_run)
+    })
+    .await;
+
+    info!(
+        scanned = summary.scanned(),
+        done = ?summary.done,
+        skipped = summary.skipped,
+        failed = summary.failed,
+        "done"
+    );
+    ExitCode::SUCCESS
 }
 
-#[derive(Default, Debug)]
-struct Summary {
-    scanned: u64,
-    /// Rows successfully re-upserted (or that would be, under --dry-run).
-    upserted: u64,
-    /// Subset of `upserted` whose re-parsed record carried a quantity value.
-    filled: u64,
-    skipped: u64,
-    failed: u64,
-}
-
-async fn run(pool: &PgPool, resolver: &BlobResolver, args: &Args) -> Result<Summary, sqlx::Error> {
-    let rows = sqlx::query_as!(
+async fn fetch_rows(pool: &PgPool, args: &Args) -> Result<Vec<OccurrenceRef>, sqlx::Error> {
+    sqlx::query_as!(
         OccurrenceRef,
         r#"
         SELECT uri, did, cid, created_at as "created_at!: DateTime<Utc>"
@@ -157,82 +129,26 @@ async fn run(pool: &PgPool, resolver: &BlobResolver, args: &Args) -> Result<Summ
         "#,
         args.all,
         args.did.as_deref(),
-        args.limit,
+        args.job.limit,
     )
     .fetch_all(pool)
-    .await?;
-
-    info!(candidates = rows.len(), "occurrences to re-fetch");
-
-    let outcomes = stream::iter(rows.iter())
-        .map(|row| backfill_one(pool, resolver, row, args.dry_run))
-        .buffer_unordered(args.concurrency.max(1))
-        .collect::<Vec<_>>()
-        .await;
-
-    let mut summary = Summary {
-        scanned: outcomes.len() as u64,
-        ..Default::default()
-    };
-    for outcome in outcomes {
-        match outcome {
-            Outcome::Upserted { filled } => {
-                summary.upserted += 1;
-                if filled {
-                    summary.filled += 1;
-                }
-            }
-            Outcome::Skipped => summary.skipped += 1,
-            Outcome::Failed => summary.failed += 1,
-        }
-    }
-
-    Ok(summary)
-}
-
-enum Outcome {
-    Upserted { filled: bool },
-    Skipped,
-    Failed,
+    .await
 }
 
 async fn backfill_one(
     pool: &PgPool,
     resolver: &BlobResolver,
-    row: &OccurrenceRef,
+    row: OccurrenceRef,
     dry_run: bool,
 ) -> Outcome {
-    let Some(at_uri) = AtUri::parse(&row.uri) else {
-        warn!(uri = %row.uri, "skipped: unparseable AT-URI");
-        return Outcome::Skipped;
-    };
-    let did = match Did::parse(&at_uri.did) {
-        Ok(d) => d,
-        Err(e) => {
-            warn!(uri = %row.uri, error = %e, "skipped: unparseable DID");
-            return Outcome::Skipped;
-        }
-    };
-
-    let pds_url = match resolver.resolve_pds_url(&did).await {
-        Ok(url) => url,
-        Err(e) => {
-            warn!(uri = %row.uri, error = %e, "skipped: DID resolution failed");
-            return Outcome::Skipped;
-        }
-    };
-
     // A fetch failure here is expected for records that have since been
     // deleted, or whose PDS is temporarily unreachable. Treat it as a skip so
     // the sweep completes; `failed` stays reserved for parse/write errors,
     // which point at a real bug rather than transient/network state.
-    let record = match resolver
-        .fetch_record(&pds_url, &at_uri.did, &at_uri.collection, &at_uri.rkey)
-        .await
-    {
+    let record = match resolver.fetch_record_by_aturi(&row.uri).await {
         Ok(v) => v,
         Err(e) => {
-            warn!(uri = %row.uri, error = %e, "skipped: getRecord failed");
+            warn!(uri = %row.uri, error = %e, "skipped: could not fetch record");
             return Outcome::Skipped;
         }
     };
@@ -253,16 +169,11 @@ async fn backfill_one(
 
     let filled =
         parsed.params.organism_quantity.is_some() || parsed.params.organism_quantity_type.is_some();
+    let label = if filled { "filled" } else { "unchanged" };
 
     if dry_run {
-        info!(
-            uri = %row.uri,
-            filled,
-            organism_quantity = ?parsed.params.organism_quantity,
-            organism_quantity_type = ?parsed.params.organism_quantity_type,
-            "would upsert"
-        );
-        return Outcome::Upserted { filled };
+        info!(uri = %row.uri, filled, "would upsert");
+        return Outcome::Done(label);
     }
 
     match occurrences::upsert(pool, &parsed.params).await {
@@ -275,7 +186,7 @@ async fn backfill_one(
                     "backfilled quantity"
                 );
             }
-            Outcome::Upserted { filled }
+            Outcome::Done(label)
         }
         Err(e) => {
             warn!(uri = %row.uri, error = %e, "failed: upsert");

--- a/crates/observing-bootstrap/Cargo.toml
+++ b/crates/observing-bootstrap/Cargo.toml
@@ -5,7 +5,18 @@ edition = "2021"
 description = "Shared service-bootstrap helpers for observ.ing binaries"
 license = "MIT OR Apache-2.0"
 
+[features]
+default = ["http"]
+# HTTP service scaffolding (`serve`). Pulls axum.
+http = ["dep:axum", "dep:tokio"]
+# One-shot batch-job scaffolding (`job` module): shared CLI flags, a
+# bounded-concurrency drive loop, and pool setup. Pulls sqlx/clap/futures.
+job = ["dep:sqlx", "dep:clap", "dep:futures"]
+
 [dependencies]
-axum = { workspace = true }
-tokio = { workspace = true }
 tracing = { workspace = true }
+axum = { workspace = true, optional = true }
+tokio = { workspace = true, optional = true }
+sqlx = { workspace = true, optional = true }
+futures = { workspace = true, optional = true }
+clap = { version = "4", features = ["derive"], optional = true }

--- a/crates/observing-bootstrap/src/http.rs
+++ b/crates/observing-bootstrap/src/http.rs
@@ -1,0 +1,19 @@
+//! HTTP service scaffolding.
+
+use std::net::SocketAddr;
+
+/// Bind an axum app to `0.0.0.0:<port>` and serve it until the process exits.
+///
+/// Centralizes the `SocketAddr::from(([0, 0, 0, 0], port))` →
+/// `TcpListener::bind` → `axum::serve` sequence that every HTTP service
+/// repeated. Binding to `0.0.0.0` (all interfaces) is required for the Cloud
+/// Run TCP startup probe to reach the container.
+///
+/// Returns the bind/serve [`std::io::Error`] to the caller; the message logged
+/// on startup includes the resolved address.
+pub async fn serve(router: axum::Router, port: u16) -> std::io::Result<()> {
+    let addr = SocketAddr::from(([0, 0, 0, 0], port));
+    tracing::info!("Starting HTTP server on {addr}");
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, router).await
+}

--- a/crates/observing-bootstrap/src/job.rs
+++ b/crates/observing-bootstrap/src/job.rs
@@ -1,0 +1,106 @@
+//! Scaffolding for one-shot batch jobs — data backfills, ledger replays, and
+//! similar operator-driven sweeps that iterate rows and process each one.
+//!
+//! A job binary supplies the two things that actually differ between jobs — a
+//! query that yields the work and an async closure that processes one item —
+//! and this module handles the parts that don't: the shared CLI flags
+//! ([`JobOpts`]), pool setup ([`connect_pool`]), and a bounded-concurrency
+//! drive loop with a labeled tally ([`drive`] → [`Summary`]).
+//!
+//! The closure owns its own dry-run handling (capture [`JobOpts::dry_run`]) and
+//! logs its own per-row detail; the harness only counts outcomes. See
+//! `backfill-occurrences` and `replay-failed-records` for the two callers.
+
+use std::collections::BTreeMap;
+use std::future::Future;
+use std::time::Duration;
+
+use futures::stream::{self, StreamExt};
+use sqlx::postgres::{PgPool, PgPoolOptions};
+
+/// CLI flags shared by every batch job. Flatten into a binary's own `Args`
+/// with `#[command(flatten)]`, then add job-specific flags alongside.
+///
+/// Concurrency is deliberately *not* here: some jobs must run strictly
+/// sequentially (e.g. parents before children), others want it tunable, so
+/// each binary passes its own value to [`drive`].
+#[derive(clap::Args, Debug, Clone)]
+pub struct JobOpts {
+    /// Do everything except write to the database.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Cap on rows to process this run. Unbounded if omitted.
+    #[arg(long)]
+    pub limit: Option<i64>,
+}
+
+/// What happened to one row.
+///
+/// `Done` carries a `&'static str` bucket so a job can split its success count
+/// into named tallies (e.g. `"filled"` vs `"unchanged"`) that show up in the
+/// [`Summary`]. Jobs that don't care can pass a single constant label.
+pub enum Outcome {
+    Done(&'static str),
+    Skipped,
+    Failed,
+}
+
+/// Tally returned by [`drive`]. Log it as structured fields on completion.
+#[derive(Default, Debug)]
+pub struct Summary {
+    /// Successful rows, bucketed by the label each returned.
+    pub done: BTreeMap<&'static str, u64>,
+    pub skipped: u64,
+    pub failed: u64,
+}
+
+impl Summary {
+    /// Total rows processed across all outcomes.
+    pub fn scanned(&self) -> u64 {
+        self.done.values().sum::<u64>() + self.skipped + self.failed
+    }
+}
+
+/// Connect a pool sized for `concurrency` in-flight queries, reading
+/// `DATABASE_URL` from the environment.
+///
+/// Returns a human-readable error string suitable for logging immediately
+/// before a non-zero exit.
+pub async fn connect_pool(concurrency: usize) -> Result<PgPool, String> {
+    let url = std::env::var("DATABASE_URL").map_err(|_| "DATABASE_URL is required".to_string())?;
+    PgPoolOptions::new()
+        .max_connections(concurrency.max(1) as u32 + 1)
+        .acquire_timeout(Duration::from_secs(30))
+        .connect(&url)
+        .await
+        .map_err(|e| format!("failed to connect: {e}"))
+}
+
+/// Run `process` over `rows` with up to `concurrency` items in flight,
+/// collecting a [`Summary`].
+///
+/// Pass `concurrency = 1` for strict in-order, one-at-a-time processing (the
+/// drive then completes items in the order `rows` yields them — important when
+/// later rows depend on earlier ones).
+pub async fn drive<Row, Proc, Fut>(rows: Vec<Row>, concurrency: usize, process: Proc) -> Summary
+where
+    Proc: Fn(Row) -> Fut,
+    Fut: Future<Output = Outcome>,
+{
+    let outcomes = stream::iter(rows)
+        .map(process)
+        .buffer_unordered(concurrency.max(1))
+        .collect::<Vec<_>>()
+        .await;
+
+    let mut summary = Summary::default();
+    for outcome in outcomes {
+        match outcome {
+            Outcome::Done(label) => *summary.done.entry(label).or_default() += 1,
+            Outcome::Skipped => summary.skipped += 1,
+            Outcome::Failed => summary.failed += 1,
+        }
+    }
+    summary
+}

--- a/crates/observing-bootstrap/src/lib.rs
+++ b/crates/observing-bootstrap/src/lib.rs
@@ -1,19 +1,18 @@
-//! Shared bootstrap helpers for observ.ing service binaries.
+//! Shared bootstrap helpers for observ.ing binaries.
+//!
+//! Two independent, feature-gated halves:
+//! - [`serve`] (feature `http`) — bind + serve an axum app, for HTTP services.
+//! - [`job`] (feature `job`) — scaffolding for one-shot batch jobs (data
+//!   backfills, replays).
+//!
+//! Note: tracing/log initialization is intentionally *not* centralized here —
+//! services and jobs configure their own subscribers (structured Stackdriver
+//! vs. plain fmt), so that decision stays at the binary.
 
-use std::net::SocketAddr;
+#[cfg(feature = "http")]
+mod http;
+#[cfg(feature = "http")]
+pub use http::serve;
 
-/// Bind an axum app to `0.0.0.0:<port>` and serve it until the process exits.
-///
-/// Centralizes the `SocketAddr::from(([0, 0, 0, 0], port))` →
-/// `TcpListener::bind` → `axum::serve` sequence that every HTTP service
-/// repeated. Binding to `0.0.0.0` (all interfaces) is required for the Cloud
-/// Run TCP startup probe to reach the container.
-///
-/// Returns the bind/serve [`std::io::Error`] to the caller; the message logged
-/// on startup includes the resolved address.
-pub async fn serve(router: axum::Router, port: u16) -> std::io::Result<()> {
-    let addr = SocketAddr::from(([0, 0, 0, 0], port));
-    tracing::info!("Starting HTTP server on {addr}");
-    let listener = tokio::net::TcpListener::bind(addr).await?;
-    axum::serve(listener, router).await
-}
+#[cfg(feature = "job")]
+pub mod job;

--- a/crates/replay-failed-records/Cargo.toml
+++ b/crates/replay-failed-records/Cargo.toml
@@ -11,6 +11,10 @@ license = "MIT OR Apache-2.0"
 observing-db = { path = "../observing-db", features = ["processing"] }
 # Canonical collection NSIDs, shared with tap-ingester (no more hand-kept copy).
 observing-collections = { path = "../observing-collections" }
+# Shared batch-job scaffolding: CLI flags, pool setup, the drive loop.
+observing-bootstrap = { path = "../observing-bootstrap", default-features = false, features = [
+    "job",
+] }
 
 tokio = { workspace = true }
 sqlx = { workspace = true }

--- a/crates/replay-failed-records/src/main.rs
+++ b/crates/replay-failed-records/src/main.rs
@@ -12,7 +12,9 @@
 //! Approach: read each row's `record_json`, dispatch by `collection` through
 //! the matching `observing_db::processing::*_from_json` parser, hand the
 //! result to the per-table `upsert` helper, and DELETE the ledger row on
-//! success. Failures are logged and left in the ledger for inspection.
+//! success. Failures are logged and left in the ledger for inspection. The
+//! shared `observing_bootstrap::job` harness supplies the CLI flags, pool
+//! setup, and drive loop; this binary supplies the query and per-row logic.
 //!
 //! Intentionally bypasses the tap-ingester wrappers: skips media resolution
 //! and notification creation. Those are live-firehose concerns, not replay
@@ -22,11 +24,11 @@
 
 use chrono::{DateTime, Utc};
 use clap::Parser;
+use observing_bootstrap::job::{self, JobOpts, Outcome};
 use observing_db::{comments, identifications, interactions, likes, occurrences, processing};
 use serde_json::Value;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::PgPool;
 use std::process::ExitCode;
-use std::time::Duration;
 use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
@@ -38,13 +40,8 @@ use observing_collections::{
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Args {
-    /// Print what would be replayed without writing to the database.
-    #[arg(long)]
-    dry_run: bool,
-
-    /// Cap on rows to process this run. Unbounded if omitted.
-    #[arg(long)]
-    limit: Option<i64>,
+    #[command(flatten)]
+    job: JobOpts,
 
     /// Only replay rows whose `collection` matches this NSID exactly.
     /// Useful for verifying behavior on one collection before running the
@@ -74,57 +71,54 @@ async fn main() -> ExitCode {
 
     let args = Args::parse();
 
-    let database_url = match std::env::var("DATABASE_URL") {
-        Ok(v) => v,
-        Err(_) => {
-            error!("DATABASE_URL is required");
-            return ExitCode::from(2);
-        }
-    };
-
-    let pool = match PgPoolOptions::new()
-        .max_connections(2)
-        .acquire_timeout(Duration::from_secs(30))
-        .connect(&database_url)
-        .await
-    {
+    let pool = match job::connect_pool(2).await {
         Ok(p) => p,
         Err(e) => {
-            error!(error = %e, "failed to connect");
+            error!("{e}");
             return ExitCode::from(1);
         }
     };
 
-    match run(&pool, &args).await {
-        Ok(summary) => {
-            info!(
-                replayed = summary.replayed,
-                failed = summary.failed,
-                skipped = summary.skipped,
-                "done"
-            );
-            ExitCode::SUCCESS
-        }
+    let rows = match fetch_rows(&pool, &args).await {
+        Ok(r) => r,
         Err(e) => {
-            error!(error = %e, "fatal error");
-            ExitCode::from(1)
+            error!(error = %e, "failed to read failed_records");
+            return ExitCode::from(1);
+        }
+    };
+    info!(candidates = rows.len(), "rows to consider");
+
+    // Strictly sequential (concurrency 1): the query orders occurrences first
+    // so children referencing them via subject_uri don't FK-violate, and
+    // multiple updates to one URI must replay in order. buffer_unordered(1)
+    // preserves that submission order.
+    let summary = job::drive(rows, 1, |row| replay_one(&pool, row, args.job.dry_run)).await;
+
+    // `identifications::upsert` no longer refreshes the `community_ids` matview
+    // per row (it aggregates the whole table — O(n²) across a batch). Refresh
+    // once after the batch drains so replayed identifications are reflected.
+    if !args.job.dry_run && summary.done.values().sum::<u64>() > 0 {
+        if let Err(e) = identifications::refresh_community_ids(&pool).await {
+            warn!(error = %e, "failed to refresh community_ids after replay");
         }
     }
+
+    info!(
+        scanned = summary.scanned(),
+        done = ?summary.done,
+        skipped = summary.skipped,
+        failed = summary.failed,
+        "done"
+    );
+    ExitCode::SUCCESS
 }
 
-#[derive(Default, Debug)]
-struct Summary {
-    replayed: u64,
-    failed: u64,
-    skipped: u64,
-}
-
-async fn run(pool: &PgPool, args: &Args) -> Result<Summary, sqlx::Error> {
+async fn fetch_rows(pool: &PgPool, args: &Args) -> Result<Vec<FailedRow>, sqlx::Error> {
     // Occurrences first so children referencing them via subject_uri don't
     // FK-violate within this same run. Within each group, oldest first so
     // multiple updates to the same URI replay in chronological order
     // (upserts are idempotent, but ordering keeps the final state honest).
-    let rows = sqlx::query_as!(
+    sqlx::query_as!(
         FailedRow,
         r#"
         SELECT uri, collection, did, cid, action,
@@ -138,56 +132,24 @@ async fn run(pool: &PgPool, args: &Args) -> Result<Summary, sqlx::Error> {
         LIMIT COALESCE($2, 9223372036854775807)
         "#,
         args.collection.as_deref(),
-        args.limit,
+        args.job.limit,
     )
     .fetch_all(pool)
-    .await?;
-
-    info!(candidates = rows.len(), "rows to consider");
-
-    let mut summary = Summary::default();
-    for row in rows {
-        match replay_one(pool, &row, args.dry_run).await {
-            ReplayOutcome::Replayed => summary.replayed += 1,
-            ReplayOutcome::Skipped(reason) => {
-                info!(uri = %row.uri, %reason, "skipped");
-                summary.skipped += 1;
-            }
-            ReplayOutcome::Failed(err) => {
-                warn!(uri = %row.uri, error = %err, "replay failed");
-                summary.failed += 1;
-            }
-        }
-    }
-
-    // `identifications::upsert` no longer refreshes the `community_ids` matview
-    // per row (it aggregates the whole table — O(n²) across a batch). Refresh
-    // once after the batch drains so replayed identifications are reflected.
-    if !args.dry_run && summary.replayed > 0 {
-        if let Err(e) = identifications::refresh_community_ids(pool).await {
-            warn!(error = %e, "failed to refresh community_ids after replay");
-        }
-    }
-
-    Ok(summary)
+    .await
 }
 
-enum ReplayOutcome {
-    Replayed,
-    Skipped(String),
-    Failed(String),
-}
-
-async fn replay_one(pool: &PgPool, row: &FailedRow, dry_run: bool) -> ReplayOutcome {
+async fn replay_one(pool: &PgPool, row: FailedRow, dry_run: bool) -> Outcome {
     // Deletes don't carry a record_json and don't need parsing — replaying
     // them is just re-issuing the DELETE, which is idempotent. Worth doing
     // if we ever ledger delete failures, but for now treat as skipped so
     // the operator can spot them.
     if row.action == "delete" {
-        return ReplayOutcome::Skipped("action=delete".into());
+        info!(uri = %row.uri, reason = "action=delete", "skipped");
+        return Outcome::Skipped;
     }
     let Some(record_json) = row.record_json.as_ref() else {
-        return ReplayOutcome::Skipped("record_json is NULL".into());
+        info!(uri = %row.uri, reason = "record_json is NULL", "skipped");
+        return Outcome::Skipped;
     };
     let cid = row.cid.clone().unwrap_or_default();
 
@@ -299,7 +261,8 @@ async fn replay_one(pool: &PgPool, row: &FailedRow, dry_run: bool) -> ReplayOutc
             }
         }
         other => {
-            return ReplayOutcome::Skipped(format!("unsupported collection: {other}"));
+            info!(uri = %row.uri, reason = %format!("unsupported collection: {other}"), "skipped");
+            return Outcome::Skipped;
         }
     };
 
@@ -307,7 +270,7 @@ async fn replay_one(pool: &PgPool, row: &FailedRow, dry_run: bool) -> ReplayOutc
         Ok(()) => {
             if dry_run {
                 info!(uri = %row.uri, collection = %row.collection, "would replay");
-                return ReplayOutcome::Replayed;
+                return Outcome::Done("replayed");
             }
             // Drop the ledger row only after the upsert lands, so a crash
             // mid-run leaves the row queued for the next pass.
@@ -320,13 +283,17 @@ async fn replay_one(pool: &PgPool, row: &FailedRow, dry_run: bool) -> ReplayOutc
             {
                 Ok(_) => {
                     info!(uri = %row.uri, collection = %row.collection, "replayed");
-                    ReplayOutcome::Replayed
+                    Outcome::Done("replayed")
                 }
                 Err(e) => {
-                    ReplayOutcome::Failed(format!("upsert succeeded but ledger delete failed: {e}"))
+                    warn!(uri = %row.uri, error = %e, "upsert succeeded but ledger delete failed");
+                    Outcome::Failed
                 }
             }
         }
-        Err(e) => ReplayOutcome::Failed(e),
+        Err(e) => {
+            warn!(uri = %row.uri, error = %e, "replay failed");
+            Outcome::Failed
+        }
     }
 }

--- a/crates/tap-ingester/src/media_resolver.rs
+++ b/crates/tap-ingester/src/media_resolver.rs
@@ -12,9 +12,7 @@
 //! records arrive on the firehose before the occurrence that references them
 //! — the appview uploads them first — so this typically succeeds.
 
-use at_uri_parser::AtUri;
 use atproto_blob_resolver::BlobResolver;
-use atproto_identity::Did;
 use observing_db::processing::AssociatedMediaRef;
 use observing_db::types::{BlobEntry, BlobImage, BlobRef};
 use reqwest::Client;
@@ -54,12 +52,9 @@ impl MediaResolver {
     }
 
     async fn resolve_one(&self, r: &AssociatedMediaRef) -> Option<BlobEntry> {
-        let at_uri = AtUri::parse(&r.uri)?;
-        let did = Did::parse(&at_uri.did).ok()?;
-        let pds_url = self.blob_resolver.resolve_pds_url(&did).await.ok()?;
         let record = self
             .blob_resolver
-            .fetch_record(&pds_url, &at_uri.did, &at_uri.collection, &at_uri.rkey)
+            .fetch_record_by_aturi(&r.uri)
             .await
             .ok()?;
         media_record_to_blob_entry(&record)


### PR DESCRIPTION
## What

Extracts the scaffolding that the two one-shot jobs — `replay-failed-records` and `backfill-occurrences` (#602) — had copied between them, so the *next* data backfill is mostly its query + per-row logic instead of a fresh ~250-line crate. Pure refactor; no behavior change.

This is the "A + B" from the data-migration patterns discussion.

## A — shared batch-job harness in `observing-bootstrap`

Feature-gated so HTTP services and DB jobs don't drag in each other's deps:

- `default = ["http"]` → existing consumers (`observing-appview`, `observing-species-id`, `tap-ingester`) are untouched; `serve` moves behind the `http` feature.
- new **`job`** feature/module:
  - `JobOpts` — flatten-able `--dry-run` / `--limit` (`#[command(flatten)]`).
  - `connect_pool(concurrency)` — `DATABASE_URL` → sized pool.
  - `Outcome` / `Summary` — `Outcome::Done(&'static str)` lets a job bucket its successes into named tallies (e.g. `filled` vs `unchanged`).
  - `drive(rows, concurrency, process)` — the bounded-concurrency loop + tally. `concurrency = 1` ⇒ strict in-order, one-at-a-time (replay relies on this for FK ordering).
- Tracing/log init stays **per-binary** — deliberately not unified (services use structured Stackdriver, jobs use plain fmt).

## B — dedupe the PDS-fetch dance

`atproto-blob-resolver` gains `fetch_record_by_aturi(at_uri)`, consolidating the `parse-URI → resolve-DID → getRecord` sequence that was duplicated. `tap-ingester`'s `MediaResolver::resolve_one` drops from 8 lines to 2; the backfill job uses the same helper.

## Both jobs reworked onto the harness

Each `main` is now `arg-parse → connect_pool → fetch_rows → drive(...)`. **SQL is byte-identical**, so the `.sqlx` offline cache is unchanged. Net `-244 / +282` across the PR, but that includes two new *shared* modules — the binaries themselves shrank a lot (`backfill` `main.rs` ~169→~60 effective, `replay` similar).

## Testing

- `cargo build --workspace` clean in **offline** mode (CI parity); existing `.sqlx` cache still valid (no SQL changed).
- `cargo fmt --check` + `cargo clippy` (bootstrap `job` feature, blob-resolver, both jobs) clean.
- Smoke-tested both `--dry-run` against the dev DB:
  - `backfill-occurrences` drives 5 rows → `done={"unchanged": 5}` (exercises `fetch_record_by_aturi` + the drive loop).
  - `replay-failed-records` drives 218 rows sequentially → `done={"replayed": 218}`.

## Follow-ups (not here)

The patterns discussion also floated (C) using runtime sqlx queries in one-off jobs to skip cache churn, (D) a written "writing a data migration" convention, and (E) a run-once Rust data-migration registry for in-DB Tier-2 transforms. Left for separate change(s).