### PR TITLE
perf(db): index feed sort + debounce community_ids matview refresh

### DIFF
--- a/crates/observing-db/Cargo.toml
+++ b/crates/observing-db/Cargo.toml
@@ -23,6 +23,9 @@ ts-rs = { workspace = true }
 # Logging
 tracing = { workspace = true }
 
+# Async runtime: background community_ids refresh debouncer
+tokio = { workspace = true, features = ["rt", "sync", "time"] }
+
 # Time
 chrono = { workspace = true }
 

--- a/crates/observing-db/migrations/20260606120000_occurrences_created_at_index.sql
+++ b/crates/observing-db/migrations/20260606120000_occurrences_created_at_index.sql
@@ -1,0 +1,17 @@
+-- Index the feed sort/keyset on `occurrences`.
+--
+-- Every feed (home / explore / profile / taxon) sorts by
+-- `(created_at DESC, uri DESC)` and paginates with the keyset cursor
+-- `(created_at, uri) < ($cursor_ts, $cursor_uri)`. The only occurrence
+-- indexes were on `location`, `scientific_name`, `did`, and `event_date`, so
+-- without a `created_at` index every feed page did a full sort of the whole
+-- table to return ~20 rows — cost grows with the table.
+--
+-- This composite index matches both the ORDER BY and the keyset tuple
+-- comparison, turning each page into a backwards index range scan.
+--
+-- Built non-concurrently: sqlx runs each migration inside a transaction, which
+-- precludes CREATE INDEX CONCURRENTLY. The build takes a lock that blocks
+-- writes (but not reads) on `occurrences` for its duration.
+CREATE INDEX IF NOT EXISTS occurrences_created_at_uri_idx
+    ON ingester.occurrences (created_at DESC, uri DESC);

--- a/crates/observing-db/src/identifications.rs
+++ b/crates/observing-db/src/identifications.rs
@@ -1,11 +1,19 @@
 use crate::types::{IdentificationRow, UpsertIdentificationParams};
 use sqlx::PgPool;
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Notify;
+use tracing::{error, trace};
 
-/// Upsert an identification record and refresh the community ID materialized view.
+/// Upsert an identification record.
 ///
-/// NOTE: Must take `&PgPool` because `REFRESH MATERIALIZED VIEW CONCURRENTLY`
-/// cannot be executed within a transaction block.
+/// Does NOT refresh the `community_ids` matview — the matview aggregates the
+/// whole identifications⋈occurrences tables, so refreshing per record is
+/// O(table) work per call. Callers signal a debounced
+/// [`CommunityIdsRefresher`] instead (or, for batch jobs, call
+/// [`refresh_community_ids`] once when the batch drains).
 ///
 /// Uses the dynamic query API rather than the `query!` macro so the new
 /// `accepted_taxon_key` column doesn't require regenerating the offline
@@ -41,19 +49,18 @@ pub async fn upsert(pool: &PgPool, p: &UpsertIdentificationParams) -> Result<(),
     .execute(pool)
     .await?;
 
-    refresh_community_ids(pool).await?;
     Ok(())
 }
 
-/// Delete an identification and refresh the community ID materialized view.
+/// Delete an identification.
 ///
-/// NOTE: Must take `&PgPool` because `REFRESH MATERIALIZED VIEW CONCURRENTLY`
-/// cannot be executed within a transaction block.
+/// Like [`upsert`], does NOT refresh the `community_ids` matview; callers
+/// drive that via a debounced [`CommunityIdsRefresher`] or a batch-end
+/// [`refresh_community_ids`].
 pub async fn delete(pool: &PgPool, uri: &str) -> Result<(), sqlx::Error> {
     sqlx::query!("DELETE FROM identifications WHERE uri = $1", uri)
         .execute(pool)
         .await?;
-    refresh_community_ids(pool).await?;
     Ok(())
 }
 
@@ -162,10 +169,85 @@ pub async fn get_community_ids_for_occurrences(
         .collect())
 }
 
-/// Refresh the community IDs materialized view
+/// Refresh the community IDs materialized view.
+///
+/// `REFRESH MATERIALIZED VIEW CONCURRENTLY` cannot run inside a transaction,
+/// so the executor must be a real connection/pool, not a transaction handle.
+/// On the firehose hot path prefer [`CommunityIdsRefresher`], which coalesces
+/// these calls; use this directly only for one-shot/batch refreshes.
 pub async fn refresh_community_ids(executor: impl sqlx::PgExecutor<'_>) -> Result<(), sqlx::Error> {
     sqlx::query!("REFRESH MATERIALIZED VIEW CONCURRENTLY community_ids")
         .execute(executor)
         .await?;
     Ok(())
+}
+
+/// Coalesces `REFRESH MATERIALIZED VIEW CONCURRENTLY community_ids`.
+///
+/// The `community_ids` matview aggregates the *entire* identifications⋈occurrences
+/// tables, so refreshing it once per ingested identification (the old behavior
+/// of [`upsert`]/[`delete`]) is O(table) work per firehose event and serializes
+/// ingest under any identification backlog or replay. Instead, the ingest path
+/// calls the cheap, non-blocking [`request_refresh`](Self::request_refresh); a
+/// single background task runs at most one refresh per `debounce` window and
+/// always performs a trailing refresh after the last request, so the view
+/// converges.
+///
+/// The trade-off is up to `debounce` of staleness in the consensus view, which
+/// is acceptable for an eventually-consistent aggregate. Every committed
+/// identification is still eventually reflected: callers invoke
+/// `request_refresh` *after* their write commits, so the row is visible to the
+/// snapshot of any refresh that observes the request.
+#[derive(Clone)]
+pub struct CommunityIdsRefresher {
+    dirty: Arc<AtomicBool>,
+    notify: Arc<Notify>,
+}
+
+impl CommunityIdsRefresher {
+    /// Spawn the background refresh task. Must be called within a Tokio runtime.
+    pub fn spawn(pool: PgPool, debounce: Duration) -> Self {
+        let dirty = Arc::new(AtomicBool::new(false));
+        let notify = Arc::new(Notify::new());
+        let this = Self {
+            dirty: Arc::clone(&dirty),
+            notify: Arc::clone(&notify),
+        };
+
+        tokio::spawn(async move {
+            loop {
+                // Park until something marks the view dirty. `notify_one`
+                // stores a permit when no task is waiting, so a request that
+                // races this check is not lost.
+                while !dirty.swap(false, Ordering::SeqCst) {
+                    notify.notified().await;
+                }
+
+                // Absorb a burst of further requests into this one refresh.
+                tokio::time::sleep(debounce).await;
+
+                // Requests that landed during the window have already committed
+                // (callers signal post-commit), so the upcoming refresh covers
+                // them — clear the flag to avoid a redundant trailing pass. A
+                // request that races the refresh re-sets the flag and gets its
+                // own pass: correctness over a possible extra refresh.
+                dirty.store(false, Ordering::SeqCst);
+
+                if let Err(e) = refresh_community_ids(&pool).await {
+                    error!(error = %e, "failed to refresh community_ids matview");
+                } else {
+                    trace!("refreshed community_ids matview");
+                }
+            }
+        });
+
+        this
+    }
+
+    /// Mark the matview stale. Cheap and non-blocking — safe on the firehose
+    /// hot path. Call it *after* the identification write commits.
+    pub fn request_refresh(&self) {
+        self.dirty.store(true, Ordering::SeqCst);
+        self.notify.notify_one();
+    }
 }

--- a/crates/replay-failed-records/src/main.rs
+++ b/crates/replay-failed-records/src/main.rs
@@ -160,6 +160,15 @@ async fn run(pool: &PgPool, args: &Args) -> Result<Summary, sqlx::Error> {
         }
     }
 
+    // `identifications::upsert` no longer refreshes the `community_ids` matview
+    // per row (it aggregates the whole table — O(n²) across a batch). Refresh
+    // once after the batch drains so replayed identifications are reflected.
+    if !args.dry_run && summary.replayed > 0 {
+        if let Err(e) = identifications::refresh_community_ids(pool).await {
+            warn!(error = %e, "failed to refresh community_ids after replay");
+        }
+    }
+
     Ok(summary)
 }
 

--- a/crates/tap-ingester/src/database.rs
+++ b/crates/tap-ingester/src/database.rs
@@ -8,10 +8,17 @@
 use crate::error::{IngesterError, Result};
 use crate::media_resolver::MediaResolver;
 use chrono::{DateTime, Utc};
+use observing_db::identifications::CommunityIdsRefresher;
 use observing_db::processing;
 use serde_json::Value;
 use sqlx::postgres::{PgPool, PgPoolOptions};
+use std::time::Duration;
 use tracing::{debug, info, warn};
+
+/// Debounce window for coalescing `community_ids` matview refreshes. Trades up
+/// to this much staleness in the consensus view for bounded refresh cost on
+/// the firehose hot path.
+const COMMUNITY_IDS_REFRESH_DEBOUNCE: Duration = Duration::from_secs(2);
 
 /// Look up the occurrence owner and create a notification (skips self-notifications)
 async fn notify_occurrence_owner(
@@ -66,6 +73,7 @@ macro_rules! process_or_fail {
 pub struct Database {
     pool: PgPool,
     media_resolver: MediaResolver,
+    community_ids_refresher: CommunityIdsRefresher,
 }
 
 impl Database {
@@ -78,9 +86,12 @@ impl Database {
             .connect(database_url)
             .await?;
         info!("Database connection established");
+        let community_ids_refresher =
+            CommunityIdsRefresher::spawn(pool.clone(), COMMUNITY_IDS_REFRESH_DEBOUNCE);
         Ok(Self {
             pool,
             media_resolver: MediaResolver::new(),
+            community_ids_refresher,
         })
     }
 
@@ -164,6 +175,9 @@ impl Database {
         );
 
         observing_db::identifications::upsert(&self.pool, &params).await?;
+        // Signal post-commit; the background debouncer coalesces the matview
+        // refresh so we don't re-aggregate the whole table per firehose event.
+        self.community_ids_refresher.request_refresh();
         notify_occurrence_owner(&self.pool, did, "identification", &params.subject_uri, uri).await;
         Ok(())
     }
@@ -171,6 +185,7 @@ impl Database {
     pub async fn delete_identification(&self, uri: &str) -> Result<()> {
         debug!("Deleting identification: {}", uri);
         observing_db::identifications::delete(&self.pool, uri).await?;
+        self.community_ids_refresher.request_refresh();
         Ok(())
     }
 


### PR DESCRIPTION
Two backend performance fixes on the hottest read and ingest paths, found while auditing the backend.

## 1. Feed sort index (read path)
Every feed (home / explore / profile / taxon) sorts by `(created_at DESC, uri DESC)` and paginates with the keyset cursor `(created_at, uri) < ($ts, $uri)`. The `occurrences` table was indexed on `location`, `scientific_name`, `did`, and `event_date` — but **not** `created_at`, so each feed page did a full-table sort to return ~20 rows, getting worse as the table grows.

Adds a composite index `occurrences_created_at_uri_idx (created_at DESC, uri DESC)` that serves both the `ORDER BY` and the keyset tuple comparison as a backwards index range scan.

> ⚠️ Built non-concurrently — sqlx wraps each migration in a transaction, which precludes `CREATE INDEX CONCURRENTLY`. The build takes a lock that blocks **writes (not reads)** on `occurrences` for its duration. Worth applying on staging first and watching the build time before prod.

## 2. Debounce the `community_ids` matview refresh (ingest path)
`identifications::upsert`/`delete` ran `REFRESH MATERIALIZED VIEW CONCURRENTLY community_ids` **per record**. The matview aggregates the *entire* `identifications ⋈ occurrences` tables, so this is O(table) work on every firehose identification event — and O(n²) across a replay backlog. This is a direct contributor to the known firehose-lag failure mode.

Replaces it with `CommunityIdsRefresher`: a single background task that coalesces refreshes to **at most one per 2s window**, with a guaranteed trailing refresh after the last request.

- `upsert`/`delete` no longer refresh.
- tap-ingester signals the refresher post-commit via a lock-free `request_refresh()` (`AtomicBool` store + `Notify`), safe on the hot path.
- replay-failed-records refreshes **once** after the batch drains (skipped on dry-run / zero replays).
- `observing-resolve-taxa` already refreshed once after its batch — unchanged.

**Trade-off:** the consensus view is now eventually consistent with up to ~2s of staleness (the debounce window, a single `const`) rather than synchronously fresh. Appropriate for a firehose-driven aggregate. Correctness — every committed identification is eventually reflected — is argued on the `CommunityIdsRefresher` doc comment (callers signal post-commit, so the row is visible to any refresh snapshot that observes the request).

## Verification
- `observing-db`, `tap-ingester`, `replay-failed-records`, `observing-appview` all build (`SQLX_OFFLINE=true`).
- 34 `observing-db` tests pass; clippy clean on changed crates; `cargo fmt` applied.
- No `.sqlx` cache regen needed (no query macros changed).
- Migration SQL not yet run against a live DB — apply on staging first (see write-lock note above).