### PR TITLE
fix(db): add (created_at, uri) tiebreaker to profile feed queries

### DIFF
--- a/.sqlx/query-399b33fe5e9815027a179beeaf52e981e33975175d48b3bb71172af95a6f656a.json
+++ b/.sqlx/query-399b33fe5e9815027a179beeaf52e981e33975175d48b3bb71172af95a6f656a.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date,\n                    ST_Y(location::geometry) as latitude,\n                    ST_X(location::geometry) as longitude,\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    organism_quantity, organism_quantity_type,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
+  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date,\n                    ST_Y(location::geometry) as latitude,\n                    ST_X(location::geometry) as longitude,\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    organism_quantity, organism_quantity_type,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1\n                ORDER BY created_at DESC, uri DESC\n                LIMIT $2\n                ",
   "describe": {
     "columns": [
       {
@@ -269,5 +269,5 @@
       null
     ]
   },
-  "hash": "5b48bc6aa4d50ec21a9f35d7e9c6729503c88d249dccfcb1e700d75247f8cf99"
+  "hash": "399b33fe5e9815027a179beeaf52e981e33975175d48b3bb71172af95a6f656a"
 }

--- a/.sqlx/query-880a34ae7525d0ab28bb38987dd326f5d1a11cf76176a02a5a5fc06b469e5f4f.json
+++ b/.sqlx/query-880a34ae7525d0ab28bb38987dd326f5d1a11cf76176a02a5a5fc06b469e5f4f.json
@@ -1,6 +1,6 @@
 {
   "db_name": "PostgreSQL",
-  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date,\n                    ST_Y(location::geometry) as latitude,\n                    ST_X(location::geometry) as longitude,\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    organism_quantity, organism_quantity_type,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1 AND created_at < ($3::text)::timestamptz\n                ORDER BY created_at DESC\n                LIMIT $2\n                ",
+  "query": "\n                SELECT\n                    uri, cid, did, scientific_name,\n                    event_date,\n                    ST_Y(location::geometry) as latitude,\n                    ST_X(location::geometry) as longitude,\n                    coordinate_uncertainty_meters,\n                    associated_media, recorded_by,\n                    taxon_id, taxon_rank, kingdom, phylum, class, \"order\" as order_, family, genus,\n                    organism_quantity, organism_quantity_type,\n                    created_at,\n                    NULL::float8 as distance_meters,\n                    NULL::text as source\n                FROM occurrences\n                WHERE did = $1 AND created_at < ($3::text)::timestamptz\n                ORDER BY created_at DESC, uri DESC\n                LIMIT $2\n                ",
   "describe": {
     "columns": [
       {
@@ -270,5 +270,5 @@
       null
     ]
   },
-  "hash": "38b8578794bea02954d8788ba0a2e2b166a4613af0bb009f59eba105ec146754"
+  "hash": "880a34ae7525d0ab28bb38987dd326f5d1a11cf76176a02a5a5fc06b469e5f4f"
 }

--- a/crates/observing-db/src/feeds.rs
+++ b/crates/observing-db/src/feeds.rs
@@ -163,7 +163,7 @@ pub async fn get_profile_feed(
                     NULL::text as source
                 FROM occurrences
                 WHERE did = $1 AND created_at < ($3::text)::timestamptz
-                ORDER BY created_at DESC
+                ORDER BY created_at DESC, uri DESC
                 LIMIT $2
                 "#,
                 did,
@@ -190,7 +190,7 @@ pub async fn get_profile_feed(
                     NULL::text as source
                 FROM occurrences
                 WHERE did = $1
-                ORDER BY created_at DESC
+                ORDER BY created_at DESC, uri DESC
                 LIMIT $2
                 "#,
                 did,


### PR DESCRIPTION
## Summary

Follow-up to #581. That PR stabilized feed ordering by adding a `uri` secondary sort key to the `QueryBuilder`-based feeds (home / explore / taxon), but it missed the two `query_as!` profile-feed queries in `get_profile_feed` (cursor and first-page variants), which still ordered by `created_at` alone.

Because `created_at` is authoring-time set by the appview, observations posted in the same second share a timestamp. Without a tiebreaker, Postgres can return tied rows in a different order between two executions of the same query — so a profile page's observation list could reorder nondeterministically between fetches (e.g. the persisted react-query cache restore vs. the background revalidation).

## Changes

- `crates/observing-db/src/feeds.rs` — add `, uri DESC` to both `get_profile_feed` queries, matching the home/explore/taxon feeds.
- Regenerate the sqlx offline cache (`.sqlx/`) for the changed query hashes.

## Notes

While investigating the reported home-feed reorder, the home/explore/taxon feeds already carry the tiebreaker from #581 — so if that symptom is still visible in production, it points to a deploy lag rather than a code gap. This PR closes the remaining profile-feed gap.

## Test plan

- [x] `cargo sqlx prepare --workspace` succeeds against a local DB; workspace compiles clean.