### PR TITLE
fix(pwa): make the "new version available" Reload button always reload

### DIFF
--- a/frontend/src/components/common/UpdatePrompt.tsx
+++ b/frontend/src/components/common/UpdatePrompt.tsx
@@ -31,6 +31,15 @@ export function UpdatePrompt() {
 
   const close = () => setNeedRefresh(false);
 
+  const reload = async () => {
+    // updateServiceWorker(true) only reloads via the SW's "controlling" event,
+    // which never fires if there's no waiting worker (already activated in
+    // another tab, reclaimed by the browser) or no prior controller (first
+    // uncontrolled load). Force a reload afterward so the button always works.
+    await updateServiceWorker(true);
+    window.location.reload();
+  };
+
   return (
     <Snackbar
       open={needRefresh}
@@ -39,7 +48,7 @@ export function UpdatePrompt() {
       anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
       action={
         <>
-          <Button color="inherit" size="small" onClick={() => updateServiceWorker(true)}>
+          <Button color="inherit" size="small" onClick={reload}>
             Reload
           </Button>
           <Button color="inherit" size="small" onClick={close}>


### PR DESCRIPTION
## Problem

Sometimes the "A new version is available." Snackbar's **Reload** button does nothing.

The button called `updateServiceWorker(true)` (from vite-plugin-pwa). That function does **not** reload the page itself — it sends `SKIP_WAITING` to the waiting service worker, and the actual reload only happens when Workbox fires its `controlling` event. That event never fires when:

- there is **no waiting worker** — it was already activated in another tab or reclaimed by the browser (our aggressive `registration.update()` on every `visibilitychange` makes this race more likely), or
- there is **no prior controller** (first uncontrolled page load, where vite-plugin-pwa intentionally skips the reload).

In those cases the user clicks Reload and nothing happens.

## Fix

Force `window.location.reload()` after `updateServiceWorker(true)` resolves, so the button always reloads regardless of service-worker state. When a waiting worker does exist, it is still activated first, so the new version is picked up; the explicit reload just removes the dependency on the `controlling` event.

## Test plan

- `tsc --noEmit` passes; formatted with oxfmt.
- Manual: trigger the update prompt and confirm Reload reloads the page in both the waiting-worker and no-waiting-worker cases.