### PR TITLE
fix(map): blank map in prod — size container by width/height, not absolute inset

### DIFF
--- a/frontend/src/components/map/LocationMap.tsx
+++ b/frontend/src/components/map/LocationMap.tsx
@@ -125,7 +125,11 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
 
   return (
     <Box sx={[{ position: "relative" }, mapContainerSx]}>
-      <Box ref={mapContainer} sx={{ position: "absolute", inset: 0 }} />
+      {/* Fill the parent via width/height, NOT position:absolute+inset — maplibre
+          adds `.maplibregl-map { position: relative }`, which ties on specificity
+          with emotion's `position:absolute` and wins by load order in the prod CSS
+          bundle, collapsing the container to height 0 (a blank map). */}
+      <Box ref={mapContainer} sx={{ width: "100%", height: "100%" }} />
       {MAPTILER_ENABLED && <BasemapSelector />}
     </Box>
   );

--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -346,7 +346,11 @@ export function LocationPicker({
         }}
       />
       <Box sx={[{ position: "relative" }, mapContainerSx]}>
-        <Box ref={mapContainer} sx={{ position: "absolute", inset: 0 }} />
+        {/* Fill the parent via width/height, NOT position:absolute+inset — maplibre
+            adds `.maplibregl-map { position: relative }`, which ties on specificity
+            with emotion's `position:absolute` and wins by load order in the prod CSS
+            bundle, collapsing the container to height 0 (a blank map). */}
+        <Box ref={mapContainer} sx={{ width: "100%", height: "100%" }} />
         {MAPTILER_ENABLED && <BasemapSelector />}
       </Box>
       <Button


### PR DESCRIPTION
## Problem

The map was blank in production (the New Observation modal and the observation detail page) despite all MapTiler tiles returning 200. It rendered fine in local dev, which masked the bug.

## Root cause

A CSS cascade bug, **not** a key/network issue. The inner map container filled its parent via `position: absolute; inset: 0`. maplibre adds `.maplibregl-map { position: relative }` to that same element. The two rules tie on specificity, so **load order** decides — and in the **prod** CSS bundle maplibre's rule wins, flipping the container to `position: relative`. With `relative`, `inset: 0` is a no-op and the container collapses to **height 0** → blank map. Local dev injects the stylesheets in the opposite order, so it only broke in prod.

Confirmed live on prod: the inner div measured `814×0` while its parent was `816×200`; patching it to fill by width/height gave it `198px` and the map rendered immediately.

## Fix

```diff
-<Box ref={mapContainer} sx={{ position: "absolute", inset: 0 }} />
+<Box ref={mapContainer} sx={{ width: "100%", height: "100%" }} />
```

Sizing by width/height fills the parent regardless of `position`, so it's immune to which stylesheet wins. Applied to both `LocationPicker` (New Observation modal) and `LocationMap` (observation detail).

## Verification

- Reproduced and fix-validated against live prod via DOM patch (map went from `0px`/blank to `198px`/rendered).
- `fmt:check`, `oxlint`, and `tsc --noEmit` all pass.