### PR TITLE
fix(map): keep uncertainty circle radius when picking a new point

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -87,29 +87,31 @@ export function LocationPicker({
   modeRef.current = mode;
   const basemapRef = useRef(basemap);
   basemapRef.current = basemap;
+  // Latest uncertainty radius for stable callbacks (e.g. the map "click"
+  // handler, which is bound once on init); reading the prop directly would
+  // capture a stale value and reset the circle to the old radius on click.
+  const uncertaintyMetersRef = useRef(uncertaintyMeters);
+  uncertaintyMetersRef.current = uncertaintyMeters;
 
-  const updateMarker = useCallback(
-    (lng: number, lat: number, radius?: number) => {
-      if (!map.current) return;
+  const updateMarker = useCallback((lng: number, lat: number, radius?: number) => {
+    if (!map.current) return;
 
-      if (marker.current) {
-        marker.current.setLngLat([lng, lat]);
-      } else {
-        marker.current = new maplibregl.Marker({ color: MAP_MARKER_COLOR })
-          .setLngLat([lng, lat])
-          .addTo(map.current);
-      }
+    if (marker.current) {
+      marker.current.setLngLat([lng, lat]);
+    } else {
+      marker.current = new maplibregl.Marker({ color: MAP_MARKER_COLOR })
+        .setLngLat([lng, lat])
+        .addTo(map.current);
+    }
 
-      // Update uncertainty circle
-      const effectiveRadius = radius ?? uncertaintyMeters;
-      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- maplibre getSource has no generic overload
-      const source = map.current.getSource("uncertainty") as maplibregl.GeoJSONSource | undefined;
-      if (source) {
-        source.setData(createCircleGeoJSON(lng, lat, effectiveRadius));
-      }
-    },
-    [uncertaintyMeters],
-  );
+    // Update uncertainty circle
+    const effectiveRadius = radius ?? uncertaintyMetersRef.current;
+    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- maplibre getSource has no generic overload
+    const source = map.current.getSource("uncertainty") as maplibregl.GeoJSONSource | undefined;
+    if (source) {
+      source.setData(createCircleGeoJSON(lng, lat, effectiveRadius));
+    }
+  }, []);
 
   const flyToLocation = useCallback(
     (lat: number, lng: number) => {


### PR DESCRIPTION
## Problem

In the new observation modal, if you change the uncertainty radius slider and then click on the map to select a new point, the radius circle reverts to the original/default size instead of keeping the radius you just set.

## Root cause

The map's `click` handler is registered once inside the init effect (deps `[]`), so it permanently captures the `updateMarker` closure from the first render. `updateMarker` read `uncertaintyMeters` from that stale closure (the initial `50`), so clicking the map redrew the circle at the old radius.

## Fix

Added a `uncertaintyMetersRef` kept in sync with the prop on every render, and have `updateMarker` read `uncertaintyMetersRef.current` instead of the closed-over prop. This makes `updateMarker` a stable callback (`[]` deps) that always uses the latest radius. The slider's own immediate-redraw path was already correct and is unchanged.

This also makes `flyToLocation`, the geolocate handler, and the external-prop sync effect use a non-stale `updateMarker`.