### PR TITLE
feat(brand): refresh logo, typefaces, and colors

### DIFF
--- a/frontend/src/assets/logo.svg
+++ b/frontend/src/assets/logo.svg
@@ -1,9 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="40 40 120 120">
   <g transform="translate(100,100) rotate(-45)">
-    <path d="M-60,0 Q0,-70 60,0" fill="#4CAF50"/>
-    <path d="M-60,0 Q0,70 60,0" fill="#2E7D32"/>
-    <circle cx="0" cy="0" r="20" fill="white"/>
-    <circle cx="0" cy="0" r="10" fill="#1B5E20"/>
-    <circle cx="4" cy="-4" r="3" fill="white" opacity="0.7"/>
+    <path d="M-60,0 Q0,-70 60,0 Q0,70 -60,0Z" fill="#1e5631"/>
+    <circle cx="0" cy="0" r="18" fill="#ffffff"/>
+    <circle cx="0" cy="0" r="9" fill="#1e5631"/>
+    <circle cx="3.5" cy="-3.5" r="2.5" fill="#ffffff" opacity="0.65"/>
   </g>
 </svg>

--- a/frontend/src/components/common/ImageWithSkeleton.tsx
+++ b/frontend/src/components/common/ImageWithSkeleton.tsx
@@ -23,7 +23,9 @@ export function ImageWithSkeleton({
     return (
       <Box
         sx={{
-          bgcolor: "action.hover",
+          // Warm parchment fill rather than MUI's cool black-alpha grey, so
+          // empty tiles sit in the bone/forest palette instead of clashing.
+          bgcolor: "placeholder",
           display: "flex",
           alignItems: "center",
           justifyContent: "center",

--- a/frontend/src/components/common/Logo.stories.tsx
+++ b/frontend/src/components/common/Logo.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { Logo } from "./Logo";
+
+const meta = {
+  title: "Common/Logo",
+  component: Logo,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    // The mark is drawn with `currentColor`, so it inherits the accent green
+    // from its parent — mirror how the app renders it (color: primary.main).
+    // Switch the Storybook theme (light/dark) to see it adapt.
+    (Story) => (
+      <Box sx={{ color: "primary.main", display: "inline-flex" }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  argTypes: {
+    size: { control: { type: "number" } },
+  },
+} satisfies Meta<typeof Logo>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: { size: 64 },
+};
+
+export const Favicon: Story = {
+  args: { size: 16 },
+  parameters: {
+    docs: {
+      description: {
+        story: "The mark holds up at favicon scale — flat fill, no fine detail to lose.",
+      },
+    },
+  },
+};
+
+export const Hero: Story = {
+  args: { size: 128 },
+};

--- a/frontend/src/components/common/Logo.tsx
+++ b/frontend/src/components/common/Logo.tsx
@@ -1,0 +1,27 @@
+interface LogoProps {
+  size?: number;
+}
+
+// The Observ.ing mark: a leaf that doubles as an eye — "observing" nature.
+// Flat single-color treatment (the brand-exploration recommendation): cleaner
+// at small sizes and more versatile than the old two-tone version. The leaf and
+// pupil use `currentColor`, so the mark inherits the accent green from its
+// parent — forest green in light mode, the brighter accent in dark mode.
+export function Logo({ size = 32 }: LogoProps) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="40 40 120 120"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden="true"
+    >
+      <g transform="translate(100,100) rotate(-45)">
+        <path d="M-60,0 Q0,-70 60,0 Q0,70 -60,0Z" fill="currentColor" />
+        <circle cx="0" cy="0" r="18" fill="#ffffff" />
+        <circle cx="0" cy="0" r="9" fill="currentColor" />
+        <circle cx="3.5" cy="-3.5" r="2.5" fill="#ffffff" opacity="0.65" />
+      </g>
+    </svg>
+  );
+}

--- a/frontend/src/components/common/Wordmark.stories.tsx
+++ b/frontend/src/components/common/Wordmark.stories.tsx
@@ -1,0 +1,45 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { Wordmark } from "./Wordmark";
+import { Logo } from "./Logo";
+
+const meta = {
+  title: "Common/Wordmark",
+  component: Wordmark,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof Wordmark>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "DM Sans 600, with the dot in accent green — the brand moment that highlights the domain structure (observ + .ing).",
+      },
+    },
+  },
+};
+
+export const Lockup: Story = {
+  render: () => (
+    <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
+      <Box sx={{ color: "primary.main", display: "inline-flex" }}>
+        <Logo size={32} />
+      </Box>
+      <Wordmark />
+    </Box>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "The full brand lockup as used in the top bar: leaf-eye mark + wordmark.",
+      },
+    },
+  },
+};

--- a/frontend/src/components/common/Wordmark.tsx
+++ b/frontend/src/components/common/Wordmark.tsx
@@ -1,0 +1,32 @@
+import { Box, Typography, type SxProps, type Theme } from "@mui/material";
+
+interface WordmarkProps {
+  /** Hide the wordmark text below this breakpoint (icon-only). */
+  sx?: SxProps<Theme>;
+}
+
+// The "Observ.ing" wordmark. Set in DM Sans, weight 600. The dot is the brand
+// moment — colored in the accent green to draw the eye to the domain structure
+// (observ + .ing) — while the rest of the word sits in the primary text color.
+export function Wordmark({ sx }: WordmarkProps) {
+  return (
+    <Typography
+      component="span"
+      sx={{
+        fontFamily: '"DM Sans", sans-serif',
+        fontWeight: 600,
+        fontSize: "1.125rem",
+        lineHeight: 1,
+        letterSpacing: "-0.02em",
+        color: "text.primary",
+        ...sx,
+      }}
+    >
+      Observ
+      <Box component="span" sx={{ color: "primary.main" }}>
+        .
+      </Box>
+      ing
+    </Typography>
+  );
+}

--- a/frontend/src/components/landing/LandingPage.tsx
+++ b/frontend/src/components/landing/LandingPage.tsx
@@ -3,7 +3,7 @@ import { Box, Button, Card, CardContent, Container, Typography } from "@mui/mate
 import { Explore, GitHub, Schema } from "@mui/icons-material";
 import { useAppDispatch } from "../../store";
 import { openLoginModal } from "../../store/uiSlice";
-import logoSvg from "../../assets/logo.svg";
+import { Logo } from "../common/Logo";
 
 const features = [
   {
@@ -52,8 +52,8 @@ export function LandingPage() {
         }}
       >
         <Container maxWidth="sm">
-          <Box sx={{ mb: 3 }}>
-            <img src={logoSvg} alt="" width={64} height={64} />
+          <Box sx={{ mb: 3, color: "primary.main", display: "inline-flex" }}>
+            <Logo size={64} />
           </Box>
           <Typography
             variant="h1"

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -8,10 +8,10 @@ import {
   ListItemText,
   Box,
   Divider,
-  Typography,
 } from "@mui/material";
 import { Login, Logout, MenuBook } from "@mui/icons-material";
-import logoSvg from "../../assets/logo.svg";
+import { Logo } from "../common/Logo";
+import { Wordmark } from "../common/Wordmark";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
 
@@ -53,18 +53,10 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
           textDecoration: "none",
         }}
       >
-        <img src={logoSvg} alt="" width={28} height={28} />
-        <Typography
-          variant="h6"
-          component="span"
-          sx={{
-            fontWeight: 800,
-            color: "primary.main",
-            letterSpacing: "-0.02em",
-          }}
-        >
-          Observ.ing
-        </Typography>
+        <Box sx={{ color: "primary.main", display: "inline-flex" }}>
+          <Logo size={28} />
+        </Box>
+        <Wordmark />
       </Box>
 
       <Divider />

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -22,7 +22,8 @@ import {
 } from "@mui/material";
 import { Person, Login, Logout, MenuBook, Settings, Menu as MenuIcon } from "@mui/icons-material";
 import { getDisplayName } from "../../lib/utils";
-import logoSvg from "../../assets/logo.svg";
+import { Logo } from "../common/Logo";
+import { Wordmark } from "../common/Wordmark";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
 import { PendingIndicator } from "./PendingIndicator";
@@ -99,19 +100,10 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
                 "&:hover": { opacity: 0.8 },
               }}
             >
-              <img src={logoSvg} alt="" width={32} height={32} />
-              <Typography
-                variant="h6"
-                component="span"
-                sx={{
-                  fontWeight: 800,
-                  color: "primary.main",
-                  display: { xs: "none", sm: "block" },
-                  letterSpacing: "-0.02em",
-                }}
-              >
-                Observ.ing
-              </Typography>
+              <Box sx={{ color: "primary.main", display: "inline-flex" }}>
+                <Logo size={32} />
+              </Box>
+              <Wordmark sx={{ display: { xs: "none", sm: "block" } }} />
             </Box>
 
             {/* Desktop Nav */}

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -11,7 +11,7 @@
       name="description"
       content="A decentralized platform for biodiversity observations, built on the AT Protocol. Record what you see, keep what you create."
     />
-    <meta name="theme-color" content="#15803d" />
+    <meta name="theme-color" content="#1e5631" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Observ.ing" />

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,17 @@ import { createRoot } from "react-dom/client";
 import { Capacitor } from "@capacitor/core";
 import { App } from "./App";
 
+// Self-hosted brand fonts (bundled, so they work offline in the PWA / native
+// shell). DM Sans for UI, JetBrains Mono for data/numerals.
+import "@fontsource/dm-sans/400.css";
+import "@fontsource/dm-sans/500.css";
+import "@fontsource/dm-sans/600.css";
+import "@fontsource/dm-sans/700.css";
+import "@fontsource/jetbrains-mono/400.css";
+import "@fontsource/jetbrains-mono/500.css";
+import "@fontsource/jetbrains-mono/600.css";
+import "@fontsource/jetbrains-mono/700.css";
+
 // After OAuth, the appview redirects to /?just-authed=1. In a Capacitor
 // build that means the WebView is sitting on observ.ing — the user logged
 // in, but they're now viewing the website rather than the bundled app.

--- a/frontend/src/public/favicon.svg
+++ b/frontend/src/public/favicon.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="6 6 20 20">
   <g transform="translate(16,16) rotate(-45)">
-    <path d="M-12,0 Q0,-14 12,0" fill="#4CAF50"/>
-    <path d="M-12,0 Q0,14 12,0" fill="#2E7D32"/>
-    <circle cx="0" cy="0" r="4" fill="white"/>
-    <circle cx="0" cy="0" r="2" fill="#1B5E20"/>
+    <path d="M-12,0 Q0,-14 12,0 Q0,14 -12,0Z" fill="#1e5631"/>
+    <circle cx="0" cy="0" r="3.6" fill="#ffffff"/>
+    <circle cx="0" cy="0" r="1.8" fill="#1e5631"/>
+    <circle cx="0.7" cy="-0.7" r="0.5" fill="#ffffff" opacity="0.65"/>
   </g>
 </svg>

--- a/frontend/src/public/manifest.webmanifest
+++ b/frontend/src/public/manifest.webmanifest
@@ -6,8 +6,8 @@
   "scope": "/",
   "display": "standalone",
   "orientation": "portrait",
-  "theme_color": "#15803d",
-  "background_color": "#ffffff",
+  "theme_color": "#1e5631",
+  "background_color": "#faf6ec",
   "icons": [
     {
       "src": "/icons/icon-192.png",

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,8 +1,26 @@
 import { createTheme, type Theme, type PaletteMode } from "@mui/material/styles";
 
+// Custom palette token for the warm neutral used by empty/loading placeholder
+// surfaces (the "No image" tile and the loading skeleton), so the color lives
+// in one place instead of being duplicated as raw hex in components.
+declare module "@mui/material/styles" {
+  interface Palette {
+    placeholder: string;
+  }
+  interface PaletteOptions {
+    placeholder?: string;
+  }
+}
+
+// Brand type stack: DM Sans for UI (geometric, friendly, reads well at every
+// size), JetBrains Mono for data/numerals. System fonts remain as fallbacks.
+const sansStack =
+  '"DM Sans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif';
+export const monoStack = '"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace';
+
 const sharedConfig = {
   typography: {
-    fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu, sans-serif',
+    fontFamily: sansStack,
     h1: { fontSize: "1.5rem", fontWeight: 700, letterSpacing: "-0.02em" },
     h2: { fontSize: "1.25rem", fontWeight: 700, letterSpacing: "-0.01em" },
     h3: { fontSize: "1.1rem", fontWeight: 700 },
@@ -21,12 +39,14 @@ const sharedConfig = {
 const darkPalette = {
   mode: "dark" as const,
   primary: {
-    main: "#22c55e",
-    dark: "#16a34a",
-    contrastText: "#0a0a0a",
+    // Brighter accent green for legibility against the dark background —
+    // the old #22c55e didn't hold enough contrast next to the off-white text.
+    main: "#8ab87a",
+    dark: "#6fa05f",
+    contrastText: "#0e0e0d",
   },
   background: {
-    default: "#0a0a0a",
+    default: "#0e0e0d",
     paper: "#1a1a1a",
   },
   text: {
@@ -41,23 +61,26 @@ const darkPalette = {
     main: "#ef4444",
   },
   divider: "#333",
+  placeholder: "#211f1b",
 };
 
 const lightPalette = {
   mode: "light" as const,
   primary: {
-    main: "#15803d",
-    dark: "#166534",
+    // Forest green — more ownable than the previous Material Design green.
+    main: "#1e5631",
+    dark: "#143d22",
     contrastText: "#ffffff",
   },
   background: {
-    default: "#f5f5f5",
+    // Warm bone paper, in keeping with the naturalist / field-guide feel.
+    default: "#faf6ec",
     paper: "#ffffff",
   },
   text: {
-    primary: "#171717",
-    secondary: "#525252",
-    disabled: "#737373",
+    primary: "#1a1a18",
+    secondary: "#5b5445",
+    disabled: "#8c836d",
   },
   warning: {
     main: "#b45309",
@@ -65,7 +88,8 @@ const lightPalette = {
   error: {
     main: "#b91c1c",
   },
-  divider: "#d4d4d4",
+  divider: "#e2dbca",
+  placeholder: "#efe7d4",
 };
 
 const createAppTheme = (mode: PaletteMode): Theme => {
@@ -88,6 +112,10 @@ const createAppTheme = (mode: PaletteMode): Theme => {
             display: "flex",
             flexDirection: "column",
           },
+          // JetBrains Mono is the brand's data/numerals typeface.
+          "code, pre, kbd, samp": {
+            fontFamily: monoStack,
+          },
         },
       },
       MuiButton: {
@@ -95,6 +123,15 @@ const createAppTheme = (mode: PaletteMode): Theme => {
           root: {
             textTransform: "none",
           },
+        },
+      },
+      // Warm the loading shimmer to the bone palette (the default is a cool
+      // black-alpha grey that clashes with the warm background).
+      MuiSkeleton: {
+        styleOverrides: {
+          root: ({ theme }) => ({
+            backgroundColor: theme.palette.placeholder,
+          }),
         },
       },
       MuiTab: {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
       workbox: {
         navigateFallback: "/index.html",
         navigateFallbackDenylist: [/^\/api/, /^\/oauth/, /^\/media/, /^\/admin/],
-        globPatterns: ["**/*.{js,css,html,ico,png,svg,webmanifest}"],
+        globPatterns: ["**/*.{js,css,html,ico,png,svg,webmanifest,woff2}"],
         cleanupOutdatedCaches: true,
         // Only cache routes whose responses are independent of the viewer.
         // /api/taxa/{...}/occurrences and other enrichment-touched routes
@@ -75,7 +75,14 @@ export default defineConfig({
   },
   server: {
     fs: {
-      allow: [path.resolve(__dirname, "../lexicons"), "."],
+      // `../node_modules` so the dev server can serve dependency assets that
+      // live outside the `src` root — e.g. the self-hosted @fontsource woff2
+      // files (otherwise they 403 and the brand fonts fall back to system sans).
+      allow: [
+        path.resolve(__dirname, "../lexicons"),
+        path.resolve(__dirname, "../node_modules"),
+        ".",
+      ],
     },
     hmr: {
       // When accessed via the Rust proxy on port 3000, HMR WebSocket must still

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,8 @@
         "@capacitor/core": "^8.3.4",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
+        "@fontsource/dm-sans": "^5.2.8",
+        "@fontsource/jetbrains-mono": "^5.2.8",
         "@mui/icons-material": "9.0.1",
         "@mui/material": "9.0.1",
         "@mui/x-date-pickers": "^9.2.0",
@@ -2741,6 +2743,24 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
       "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
       "license": "MIT"
+    },
+    "node_modules/@fontsource/dm-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-sans/-/dm-sans-5.2.8.tgz",
+      "integrity": "sha512-tlovG42m9ESG28WiHpLq3F5umAlm64rv0RkqTbYowRn70e9OlRr5a3yTJhrhrY+k5lftR/OFJjPzOLQzk8EfCA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
     },
     "node_modules/@inquirer/ansi": {
       "version": "2.0.5",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "@capacitor/core": "^8.3.4",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",
+    "@fontsource/dm-sans": "^5.2.8",
+    "@fontsource/jetbrains-mono": "^5.2.8",
     "@mui/icons-material": "9.0.1",
     "@mui/material": "9.0.1",
     "@mui/x-date-pickers": "^9.2.0",


### PR DESCRIPTION
## Summary

Implements the **Brand Exploration** design handoff, focused on the three things called out — **logo, typefaces, and colors**. The design moves Observ.ing off the generic Material-Design green toward a more ownable forest green with a warm field-guide palette, and adopts DM Sans as the wordmark/UI face.

### Logo
- New theme-adaptive `Logo` component: the **flat single-color** leaf-eye mark (the design's recommended treatment), drawn with `currentColor` so it renders forest-green in light mode and the brighter accent in dark mode.
- Updated the static `logo.svg` and `favicon.svg` assets to the flat mark.

### Typefaces
- Self-hosted **DM Sans** (UI) and **JetBrains Mono** (data/numerals) via `@fontsource` — bundled rather than via CDN so they work offline in the PWA / Capacitor shell.
- New `Wordmark` component: "Observ**.**ing" in DM Sans 600 with the **dot in accent green** (the brand moment from the design).
- JetBrains Mono applied to `code/pre/kbd/samp`.

### Colors
- Forest green primary: `#1e5631` (light) / `#8ab87a` (dark — brighter for contrast, which the design explicitly fixed).
- Warm bone background `#faf6ec`, warmer text/divider tones, dark bg `#0e0e0d`. Updated `theme-color` meta + web manifest.
- Warmed the "No image" placeholder + loading skeleton to a shared `placeholder` palette token (previously a cool grey that clashed with the bone palette).

### Fixes found while verifying in-browser
- **Dev fonts were 403'ing**: `vite.config.ts` `server.fs.allow` didn't include the repo-root `node_modules`, so the `@fontsource` woff2 files were forbidden in dev and fonts silently fell back to system sans. Added `../node_modules`.
- Added `woff2` to the PWA precache glob so fonts are cached for offline use.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `oxlint` / `oxfmt` clean (no new warnings)
- [x] `vite build` succeeds; 24 woff2 emitted and precached in `sw.js`
- [x] Verified in browser: DM Sans 400–700 load (200 OK), wordmark dot = `#1e5631`, logo fill theme-adaptive, `placeholder` token resolves to `#efe7d4`
- [ ] Visual check of dark mode (follows OS appearance)

## Design source
`Brand Exploration.html` handoff from Claude Design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
