### PR TITLE
feat(observation): add organism quantity to the new observation form

### DIFF
--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -6,7 +6,9 @@ use jacquard_common::types::collection::Collection;
 use jacquard_common::types::string::Datetime;
 use observing_db::types::{BlobEntry, BlobImage, BlobRef as DbBlobRef};
 use observing_lexicons::bio_lexicons::temp::v0_1::media::MediaRecord;
-use observing_lexicons::bio_lexicons::temp::v0_1::occurrence::{Occurrence, OccurrenceRecord};
+use observing_lexicons::bio_lexicons::temp::v0_1::occurrence::{
+    Occurrence, OccurrenceOrganismQuantityType, OccurrenceRecord,
+};
 use observing_lexicons::com_atproto::repo::strong_ref::StrongRef;
 use serde::Deserialize;
 use serde_json::json;
@@ -31,6 +33,14 @@ pub struct CreateOccurrenceRequest {
     longitude: f64,
     #[ts(optional)]
     coordinate_uncertainty_in_meters: Option<i32>,
+    /// Darwin Core dwc:organismQuantity — free text (a count, a range like
+    /// "10-100", or a categorical value like "many"). Written verbatim.
+    #[ts(optional)]
+    organism_quantity: Option<String>,
+    /// Darwin Core dwc:organismQuantityType — the quantification system the
+    /// quantity uses ("individuals", "percent-cover", or an open-vocab value).
+    #[ts(optional)]
+    organism_quantity_type: Option<String>,
     #[ts(optional)]
     event_date: Option<String>,
     #[ts(optional)]
@@ -74,6 +84,13 @@ pub struct UpdateOccurrenceRequest {
     longitude: f64,
     #[ts(optional)]
     coordinate_uncertainty_in_meters: Option<i32>,
+    /// See `CreateOccurrenceRequest::organism_quantity`. Omitting it clears the
+    /// value on the record, so the edit form sends back the existing value.
+    #[ts(optional)]
+    organism_quantity: Option<String>,
+    /// See `CreateOccurrenceRequest::organism_quantity_type`.
+    #[ts(optional)]
+    organism_quantity_type: Option<String>,
     #[ts(optional)]
     event_date: Option<String>,
     /// Newly-added images to upload and attach, in addition to any retained ones.
@@ -134,6 +151,8 @@ pub async fn create_occurrence(
         body.latitude,
         body.longitude,
         body.coordinate_uncertainty_in_meters,
+        body.organism_quantity.as_deref(),
+        body.organism_quantity_type.as_deref(),
         body.event_date.as_deref(),
         media_refs,
     )?;
@@ -355,6 +374,8 @@ pub async fn update_occurrence(
         body.latitude,
         body.longitude,
         body.coordinate_uncertainty_in_meters,
+        body.organism_quantity.as_deref(),
+        body.organism_quantity_type.as_deref(),
         body.event_date.as_deref(),
         media_refs,
     )?;
@@ -532,6 +553,8 @@ fn build_occurrence_record_json(
     latitude: f64,
     longitude: f64,
     coordinate_uncertainty_in_meters: Option<i32>,
+    organism_quantity: Option<&str>,
+    organism_quantity_type: Option<&str>,
     event_date: Option<&str>,
     media_refs: Vec<StrongRef>,
 ) -> Result<serde_json::Value, AppError> {
@@ -556,6 +579,16 @@ fn build_occurrence_record_json(
                 as i64,
         )
         .event_date(event_date)
+        .maybe_organism_quantity(
+            organism_quantity
+                .filter(|s| !s.is_empty())
+                .map(SmolStr::from),
+        )
+        .maybe_organism_quantity_type(
+            organism_quantity_type
+                .filter(|s| !s.is_empty())
+                .map(|s| OccurrenceOrganismQuantityType::from_value(SmolStr::from(s))),
+        )
         .maybe_media(media)
         .build();
 

--- a/frontend/src/bindings/CreateOccurrenceRequest.ts
+++ b/frontend/src/bindings/CreateOccurrenceRequest.ts
@@ -5,6 +5,16 @@ export type CreateOccurrenceRequest = {
   latitude: number;
   longitude: number;
   coordinateUncertaintyInMeters?: number;
+  /**
+   * Darwin Core dwc:organismQuantity — free text (a count, a range like
+   * "10-100", or a categorical value like "many"). Written verbatim.
+   */
+  organismQuantity?: string;
+  /**
+   * Darwin Core dwc:organismQuantityType — the quantification system the
+   * quantity uses ("individuals", "percent-cover", or an open-vocab value).
+   */
+  organismQuantityType?: string;
   eventDate?: string;
   images?: Array<ImageUpload>;
   /**

--- a/frontend/src/bindings/UpdateOccurrenceRequest.ts
+++ b/frontend/src/bindings/UpdateOccurrenceRequest.ts
@@ -6,6 +6,15 @@ export type UpdateOccurrenceRequest = {
   latitude: number;
   longitude: number;
   coordinateUncertaintyInMeters?: number;
+  /**
+   * See `CreateOccurrenceRequest::organism_quantity`. Omitting it clears the
+   * value on the record, so the edit form sends back the existing value.
+   */
+  organismQuantity?: string;
+  /**
+   * See `CreateOccurrenceRequest::organism_quantity_type`.
+   */
+  organismQuantityType?: string;
   eventDate?: string;
   /**
    * Newly-added images to upload and attach, in addition to any retained ones.

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -14,8 +14,12 @@ import {
   InputLabel,
   Select,
   MenuItem,
+  Accordion,
+  AccordionSummary,
+  AccordionDetails,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
@@ -55,6 +59,15 @@ function toDatetimeLocal(date: Date): string {
   return `${date.getFullYear()}-${pad(date.getMonth() + 1)}-${pad(date.getDate())}T${pad(date.getHours())}:${pad(date.getMinutes())}`;
 }
 
+// Darwin Core dwc:organismQuantityType values the backend lexicon recognizes.
+// "individuals" is the default for a plain count; the observation view renders
+// the chosen type next to the number (e.g. "12 (individuals)").
+const ORGANISM_QUANTITY_TYPES = [
+  { value: "individuals", label: "Individuals" },
+  { value: "percent-cover", label: "Percent cover" },
+] as const;
+const DEFAULT_ORGANISM_QUANTITY_TYPE = "individuals";
+
 export function UploadModal() {
   const dispatch = useAppDispatch();
   const toast = useToast();
@@ -80,6 +93,14 @@ export function UploadModal() {
   const [existingImages, setExistingImages] = useState<string[]>([]);
   const [observationDate, setObservationDate] = useState(() => toDatetimeLocal(new Date()));
   const [uncertaintyMeters, setUncertaintyMeters] = useState(50);
+  // Darwin Core organismQuantity (+ its type). Kept out of the default flow in a
+  // collapsed "More details" section — most users identifying a single organism
+  // never touch it.
+  const [organismQuantity, setOrganismQuantity] = useState("");
+  const [organismQuantityType, setOrganismQuantityType] = useState<string>(
+    DEFAULT_ORGANISM_QUANTITY_TYPE,
+  );
+  const [moreDetailsOpen, setMoreDetailsOpen] = useState(false);
   const [visualIdImageUrl, setVisualIdImageUrl] = useState<string | null>(null);
   const [isDirty, setIsDirty] = useState(false);
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
@@ -92,6 +113,9 @@ export function UploadModal() {
   useEffect(() => {
     if (!isOpen) return undefined;
     setIsDirty(false);
+    setOrganismQuantity("");
+    setOrganismQuantityType(DEFAULT_ORGANISM_QUANTITY_TYPE);
+    setMoreDetailsOpen(false);
     if (!editingObservation) {
       setLicense(defaultLicense ?? DEFAULT_LICENSE);
       if (currentLocation) {
@@ -122,6 +146,15 @@ export function UploadModal() {
       }
     }
     setExistingImages((editingObservation.images || []).map((img) => img.url));
+    // Pre-fill quantity and expand the section so an existing value is visible
+    // (and not silently wiped) when editing.
+    if (editingObservation.organismQuantity) {
+      setOrganismQuantity(editingObservation.organismQuantity);
+      setOrganismQuantityType(
+        editingObservation.organismQuantityType || DEFAULT_ORGANISM_QUANTITY_TYPE,
+      );
+      setMoreDetailsOpen(true);
+    }
 
     // Resolve the existing taxon name back to a TaxaResult so the form
     // shows "Existing taxon" instead of incorrectly flagging it as new.
@@ -152,6 +185,9 @@ export function UploadModal() {
     setExistingImages([]);
     setObservationDate(toDatetimeLocal(new Date()));
     setUncertaintyMeters(50);
+    setOrganismQuantity("");
+    setOrganismQuantityType(DEFAULT_ORGANISM_QUANTITY_TYPE);
+    setMoreDetailsOpen(false);
     setVisualIdImageUrl(null);
     setIsDirty(false);
   };
@@ -344,6 +380,12 @@ export function UploadModal() {
           latitude: parseFloat(lat),
           longitude: parseFloat(lng),
           coordinateUncertaintyInMeters: uncertaintyMeters,
+          ...(organismQuantity.trim()
+            ? {
+                organismQuantity: organismQuantity.trim(),
+                ...(organismQuantityType ? { organismQuantityType } : {}),
+              }
+            : {}),
           license,
           eventDate: new Date(observationDate).toISOString(),
           ...(imageData.length > 0 ? { images: imageData } : {}),
@@ -361,6 +403,12 @@ export function UploadModal() {
           latitude: parseFloat(lat),
           longitude: parseFloat(lng),
           coordinateUncertaintyInMeters: uncertaintyMeters,
+          ...(organismQuantity.trim()
+            ? {
+                organismQuantity: organismQuantity.trim(),
+                ...(organismQuantityType ? { organismQuantityType } : {}),
+              }
+            : {}),
           license,
           eventDate: new Date(observationDate).toISOString(),
           ...(imageData.length > 0 ? { images: imageData } : {}),
@@ -737,6 +785,61 @@ export function UploadModal() {
               inputLabel: { shrink: true },
             }}
           />
+
+          <Accordion
+            expanded={moreDetailsOpen}
+            onChange={(_, expanded) => setMoreDetailsOpen(expanded)}
+            disableGutters
+            elevation={0}
+            square
+            sx={{
+              mt: 1,
+              bgcolor: "transparent",
+              "&:before": { display: "none" },
+            }}
+          >
+            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 0, minHeight: "auto" }}>
+              <Typography variant="body2" color="text.secondary">
+                More details (optional)
+              </Typography>
+            </AccordionSummary>
+            <AccordionDetails sx={{ px: 0, pt: 0 }}>
+              <Stack direction="row" spacing={1}>
+                <TextField
+                  label="Quantity"
+                  value={organismQuantity}
+                  onChange={(e) => {
+                    setOrganismQuantity(e.target.value);
+                    setIsDirty(true);
+                  }}
+                  margin="normal"
+                  placeholder="e.g. 1, 12, or 10–100"
+                  sx={{ flex: 1 }}
+                />
+                <FormControl margin="normal" sx={{ minWidth: 150 }}>
+                  <InputLabel id="organism-quantity-type-label">Type</InputLabel>
+                  <Select
+                    labelId="organism-quantity-type-label"
+                    value={organismQuantityType}
+                    label="Type"
+                    onChange={(e) => {
+                      setOrganismQuantityType(e.target.value);
+                      setIsDirty(true);
+                    }}
+                  >
+                    {ORGANISM_QUANTITY_TYPES.map((opt) => (
+                      <MenuItem key={opt.value} value={opt.value}>
+                        {opt.label}
+                      </MenuItem>
+                    ))}
+                  </Select>
+                </FormControl>
+              </Stack>
+              <Typography variant="caption" color="text.secondary">
+                How many organisms you observed. Optional — leave blank if unsure.
+              </Typography>
+            </AccordionDetails>
+          </Accordion>
 
           <Stack
             direction="row"

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -231,6 +231,8 @@ export async function submitObservation(data: {
   latitude: number;
   longitude: number;
   coordinateUncertaintyInMeters?: number;
+  organismQuantity?: string;
+  organismQuantityType?: string;
   license?: string;
   eventDate: string;
   images?: Array<{ data: string; mimeType: string }>;
@@ -259,6 +261,8 @@ export async function updateObservation(data: {
   latitude: number;
   longitude: number;
   coordinateUncertaintyInMeters?: number;
+  organismQuantity?: string;
+  organismQuantityType?: string;
   license?: string;
   eventDate: string;
   images?: Array<{ data: string; mimeType: string }>;


### PR DESCRIPTION
## What

Adds the ability to **enter and edit** Darwin Core `organismQuantity` (+ `organismQuantityType`) in the new-observation / edit form.

The read side already landed in #601/#602 — the lexicon, DB columns, ingester, and observation view all surface quantity (e.g. *12 (individuals)*) — but there was **no way to set it** except the one-shot backfill. The create/edit form and the appview write path ignored both fields.

## Changes

- **`write.rs`** — `organismQuantity` + `organismQuantityType` added to `CreateOccurrenceRequest`/`UpdateOccurrenceRequest`, threaded into `build_occurrence_record_json`, and written onto the `Occurrence` record (type parsed via the lexicon's open-vocab enum, so unknown values fall through to `Other`).
- **ts-rs bindings** — regenerated `CreateOccurrenceRequest.ts` / `UpdateOccurrenceRequest.ts`.
- **`api.ts`** — both fields added to the submit/update payloads.
- **`UploadModal.tsx`** — a collapsed **"More details (optional)"** section below the date field, with a free-text **Quantity** input and a **Type** dropdown (*Individuals* / *Percent cover*, default Individuals).

## UX

- Hidden by default, so the basic photo → location → taxon → submit flow is untouched.
- Auto-expands and pre-fills when editing an observation that already has a quantity, so the value is visible and isn't silently wiped on save.
- Omitting the quantity clears it on the record (edit sends the existing value back).

## Notes

- No DB/migration changes — main's `20260606000000` migration already added the columns.

## Verification

- `cargo check -p observing-appview`, bindings export test, `cargo fmt --check`
- `oxfmt --check`, `tsc --noEmit`, `oxlint` (0 errors)