### PR TITLE
feat(explore): add a dense table view to the explore feed

### DIFF
--- a/frontend/src/components/feed/ExploreTable.stories.tsx
+++ b/frontend/src/components/feed/ExploreTable.stories.tsx
@@ -1,0 +1,77 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { ExploreTable } from "./ExploreTable";
+import { OAK_OBSERVATION, FERN_OBSERVATION } from "../../../.storybook/fixtures";
+import type { Occurrence } from "../../services/types";
+
+// A row exercising the "needs work" path: quality issues (rendered as the
+// warning chip), an organism quantity, and an imprecise location.
+const PARTIAL_OBSERVATION: Occurrence = {
+  ...FERN_OBSERVATION,
+  uri: "at://did:plc:bob/app.observ.occurrence/fern2",
+  cid: "bafyreifern2",
+  organismQuantity: "12",
+  organismQuantityType: "individuals",
+  location: { latitude: 51.51, longitude: -0.13, uncertaintyMeters: 4000 },
+  likeCount: 8,
+  qualityIssues: ["MISSING_MEDIA", "COORDINATES_IMPRECISE"],
+};
+
+// A barely-identified row: no taxonomy and no location, so most cells fall
+// back to the em-dash placeholder.
+const {
+  effectiveTaxonomy: _dropTax,
+  location: _dropLoc,
+  ...UNIDENTIFIED_OBSERVATION
+} = {
+  ...OAK_OBSERVATION,
+  uri: "at://did:plc:alice/app.observ.occurrence/oak2",
+  cid: "bafyreioak2",
+  identificationCount: 0,
+  qualityIssues: ["MISSING_MEDIA", "NO_CONSENSUS_ID"],
+} satisfies Occurrence;
+void _dropTax;
+void _dropLoc;
+
+const meta = {
+  title: "Feed/ExploreTable",
+  component: ExploreTable,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <Box sx={{ overflowX: "auto", bgcolor: "background.default", p: 2 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof ExploreTable>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    observations: [
+      OAK_OBSERVATION,
+      FERN_OBSERVATION,
+      PARTIAL_OBSERVATION,
+      UNIDENTIFIED_OBSERVATION,
+    ],
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    observations: [],
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "With no observations the table renders just its header row.",
+      },
+    },
+  },
+};

--- a/frontend/src/components/feed/ExploreTable.tsx
+++ b/frontend/src/components/feed/ExploreTable.tsx
@@ -1,0 +1,216 @@
+import { memo } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  Box,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableRow,
+  Tooltip,
+  Chip,
+} from "@mui/material";
+import type { Occurrence } from "../../services/types";
+import type { QualityIssue } from "../../bindings/QualityIssue";
+import { getImageUrl } from "../../services/api";
+import { getObservationUrl, getDisplayName } from "../../lib/utils";
+import { shouldItalicizeTaxonName } from "../common/TaxonLink";
+
+interface ExploreTableProps {
+  observations: Occurrence[];
+}
+
+// Short, human-readable labels for the quality-issue codes surfaced per row.
+// (QualityIssue is the inverse of the filter's QualityCriterion — these are the
+// problems an observation *has*, not the criteria it meets.)
+const QUALITY_ISSUE_LABELS: Record<QualityIssue, string> = {
+  MISSING_DATE: "No date",
+  MISSING_LOCATION: "No location",
+  MISSING_MEDIA: "No media",
+  COORDINATES_IMPRECISE: "Imprecise coords",
+  NO_CONSENSUS_ID: "No community ID",
+};
+
+// Column definitions, declared once so the header and the empty placeholder
+// stay in sync with the body. `numeric` right-aligns and uses a tabular font.
+const COLUMNS: ReadonlyArray<{ label: string; numeric?: boolean }> = [
+  { label: "" }, // thumbnail
+  { label: "Scientific name" },
+  { label: "Common name" },
+  { label: "Rank" },
+  { label: "Kingdom" },
+  { label: "Phylum" },
+  { label: "Class" },
+  { label: "Order" },
+  { label: "Family" },
+  { label: "Genus" },
+  { label: "Observer" },
+  { label: "Date" },
+  { label: "Lat", numeric: true },
+  { label: "Lng", numeric: true },
+  { label: "± m", numeric: true },
+  { label: "Qty" },
+  { label: "IDs", numeric: true },
+  { label: "Likes", numeric: true },
+  { label: "Quality" },
+  { label: "Posted" },
+];
+
+// Render the date portion of an ISO timestamp as YYYY-MM-DD (CSV-friendly,
+// locale-stable). Falls back to an em dash when absent or unparseable.
+function formatDate(iso?: string): string {
+  if (!iso) return "—";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "—";
+  return d.toISOString().slice(0, 10);
+}
+
+function formatCoord(n?: number): string {
+  return typeof n === "number" ? n.toFixed(5) : "—";
+}
+
+function text(v?: string | null): string {
+  return v && v.length > 0 ? v : "—";
+}
+
+const numericSx = { fontVariantNumeric: "tabular-nums", textAlign: "right" } as const;
+
+const ExploreTableRow = memo(function ExploreTableRow({
+  observation: obs,
+}: {
+  observation: Occurrence;
+}) {
+  const navigate = useNavigate();
+  const tax = obs.effectiveTaxonomy;
+  const sciName = obs.communityId || tax?.scientificName || "Unknown";
+  const italic = shouldItalicizeTaxonName(sciName, tax?.rank);
+  const issues = obs.qualityIssues ?? [];
+
+  const quantity =
+    obs.organismQuantity != null
+      ? [obs.organismQuantity, obs.organismQuantityType].filter(Boolean).join(" ")
+      : "—";
+
+  return (
+    <TableRow
+      hover
+      onClick={() => navigate(getObservationUrl(obs.uri))}
+      sx={{ cursor: "pointer", "& td": { whiteSpace: "nowrap" } }}
+    >
+      <TableCell sx={{ p: 0.5 }}>
+        <Box
+          component="img"
+          src={obs.images[0] ? getImageUrl(obs.images[0].url) : undefined}
+          alt=""
+          loading="lazy"
+          sx={{
+            width: 36,
+            height: 36,
+            borderRadius: 0.5,
+            objectFit: "cover",
+            display: "block",
+            bgcolor: "action.hover",
+          }}
+        />
+      </TableCell>
+      <TableCell sx={{ fontStyle: italic ? "italic" : "normal", fontWeight: 500 }}>
+        {sciName}
+      </TableCell>
+      <TableCell>{text(tax?.vernacularName)}</TableCell>
+      <TableCell sx={{ color: "text.secondary" }}>{text(tax?.rank)}</TableCell>
+      <TableCell sx={{ color: "text.secondary" }}>{text(tax?.kingdom)}</TableCell>
+      <TableCell sx={{ color: "text.secondary" }}>{text(tax?.phylum)}</TableCell>
+      <TableCell sx={{ color: "text.secondary" }}>{text(tax?.class)}</TableCell>
+      <TableCell sx={{ color: "text.secondary" }}>{text(tax?.order)}</TableCell>
+      <TableCell sx={{ color: "text.secondary" }}>{text(tax?.family)}</TableCell>
+      <TableCell sx={{ color: "text.secondary", fontStyle: "italic" }}>
+        {text(tax?.genus)}
+      </TableCell>
+      <TableCell>{getDisplayName(obs.observer)}</TableCell>
+      <TableCell>{formatDate(obs.eventDate)}</TableCell>
+      <TableCell sx={numericSx}>{formatCoord(obs.location?.latitude)}</TableCell>
+      <TableCell sx={numericSx}>{formatCoord(obs.location?.longitude)}</TableCell>
+      <TableCell sx={numericSx}>
+        {typeof obs.location?.uncertaintyMeters === "number"
+          ? Math.round(obs.location.uncertaintyMeters)
+          : "—"}
+      </TableCell>
+      <TableCell>{quantity}</TableCell>
+      <TableCell sx={numericSx}>{obs.identificationCount}</TableCell>
+      <TableCell sx={numericSx}>{obs.likeCount ?? 0}</TableCell>
+      <TableCell>
+        {issues.length === 0 ? (
+          <Chip size="small" color="success" variant="outlined" label="Verifiable" />
+        ) : (
+          <Tooltip title={issues.map((i) => QUALITY_ISSUE_LABELS[i]).join(", ")}>
+            <Chip
+              size="small"
+              color="warning"
+              variant="outlined"
+              label={`${issues.length} issue${issues.length === 1 ? "" : "s"}`}
+            />
+          </Tooltip>
+        )}
+      </TableCell>
+      <TableCell sx={{ color: "text.secondary" }}>{formatDate(obs.createdAt)}</TableCell>
+    </TableRow>
+  );
+});
+
+/**
+ * Dense, CSV-style table view of the explore feed. Surfaces the full taxonomy
+ * ladder, coordinates, quantities and quality state per observation in one
+ * horizontally-scrollable grid. Rows link to the observation detail page.
+ *
+ * The table sits on a raised `background.paper` surface to lift it off the page
+ * background, and the header row is sticky. Crucially this component owns NO
+ * scroll container of its own: both axes scroll on the ancestor in FeedView, so
+ * (a) the infinite-scroll trigger keeps firing and (b) `stickyHeader` can pin
+ * the header to the top of that same scroller. An intermediate `overflow` box
+ * here would capture the scroll and break both.
+ */
+export const ExploreTable = memo(function ExploreTable({ observations }: ExploreTableProps) {
+  return (
+    <Paper
+      variant="outlined"
+      sx={{ width: "max-content", minWidth: "100%", my: 1.5, overflow: "visible" }}
+    >
+      <Table
+        stickyHeader
+        size="small"
+        sx={{
+          "& th, & td": { fontSize: "0.8rem", py: 0.75, px: 1 },
+        }}
+      >
+        <TableHead>
+          <TableRow>
+            {COLUMNS.map((col, i) => (
+              <TableCell
+                key={col.label || `col-${i}`}
+                sx={{
+                  fontWeight: 700,
+                  whiteSpace: "nowrap",
+                  color: "text.secondary",
+                  // Opaque header so rows don't bleed through while pinned. A
+                  // touch lighter than the body via the elevation overlay.
+                  bgcolor: "background.paper",
+                  backgroundImage: (theme) =>
+                    `linear-gradient(${theme.palette.action.hover}, ${theme.palette.action.hover})`,
+                  ...(col.numeric ? { textAlign: "right" } : {}),
+                }}
+              >
+                {col.label}
+              </TableCell>
+            ))}
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {observations.map((obs) => (
+            <ExploreTableRow key={obs.uri} observation={obs} />
+          ))}
+        </TableBody>
+      </Table>
+    </Paper>
+  );
+});

--- a/frontend/src/components/feed/FeedView.tsx
+++ b/frontend/src/components/feed/FeedView.tsx
@@ -1,5 +1,7 @@
-import { useRef, useCallback } from "react";
-import { Box, Container } from "@mui/material";
+import { useRef, useCallback, useState } from "react";
+import { Box, Container, ToggleButton, ToggleButtonGroup, Tooltip } from "@mui/material";
+import GridViewIcon from "@mui/icons-material/GridView";
+import TableRowsIcon from "@mui/icons-material/TableRows";
 import { useAppDispatch } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useFeed } from "../../lib/query/hooks";
@@ -10,6 +12,7 @@ import { FeedSkeletonList } from "./FeedItemSkeleton";
 import { ProfileObservationCardSkeleton } from "../profile/ProfileObservationCardSkeleton";
 import { ExploreFilterPanel } from "./ExploreFilterPanel";
 import { ExploreGridCard } from "./ExploreGridCard";
+import { ExploreTable } from "./ExploreTable";
 import { FeedEndIndicator } from "./FeedEndIndicator";
 import { observationGridSx } from "../common/observationGridLayout";
 import { CenteredSpinner } from "../common/CenteredSpinner";
@@ -23,6 +26,10 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
   usePageTitle(tab === "explore" ? "Explore" : "Home");
   const dispatch = useAppDispatch();
   const contentRef = useRef<HTMLDivElement>(null);
+
+  // Explore results layout: dense card grid (default) or a CSV-style table.
+  // Presentation-only state — no need to share it beyond this component.
+  const [viewMode, setViewMode] = useState<"grid" | "table">("grid");
 
   const { data, isLoading, isFetchingNextPage, hasNextPage, fetchNextPage } = useFeed(tab);
   const observations = data?.pages.flatMap((page) => page.occurrences) ?? [];
@@ -58,6 +65,28 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
         <Box sx={{ flexShrink: 0 }}>
           <Container maxWidth="sm" disableGutters>
             <Box sx={{ px: 2, pt: 2 }}>
+              <Box sx={{ display: "flex", justifyContent: "flex-end", mb: 1 }}>
+                <ToggleButtonGroup
+                  size="small"
+                  exclusive
+                  value={viewMode}
+                  onChange={(_, value) => {
+                    if (value) setViewMode(value);
+                  }}
+                  aria-label="Results layout"
+                >
+                  <ToggleButton value="grid" aria-label="Grid view">
+                    <Tooltip title="Grid">
+                      <GridViewIcon fontSize="small" />
+                    </Tooltip>
+                  </ToggleButton>
+                  <ToggleButton value="table" aria-label="Table view">
+                    <Tooltip title="Table">
+                      <TableRowsIcon fontSize="small" />
+                    </Tooltip>
+                  </ToggleButton>
+                </ToggleButtonGroup>
+              </Box>
               <ExploreFilterPanel />
             </Box>
           </Container>
@@ -74,22 +103,32 @@ export function FeedView({ tab = "home" }: FeedViewProps) {
           "&::-webkit-scrollbar": { display: "none" },
         }}
       >
-        <Container maxWidth={tab === "explore" ? "md" : "sm"} disableGutters>
+        <Container
+          maxWidth={tab !== "explore" ? "sm" : viewMode === "table" ? false : "md"}
+          disableGutters
+        >
           {tab === "explore" ? (
             <>
-              <Box sx={observationGridSx(4)}>
-                {observations.map((obs) => (
-                  <ExploreGridCard key={obs.uri} observation={obs} />
-                ))}
+              {viewMode === "table" ? (
+                <>
+                  {observations.length > 0 && <ExploreTable observations={observations} />}
+                  {isLoading && observations.length === 0 && <CenteredSpinner color="primary" />}
+                </>
+              ) : (
+                <Box sx={observationGridSx(4)}>
+                  {observations.map((obs) => (
+                    <ExploreGridCard key={obs.uri} observation={obs} />
+                  ))}
 
-                {isLoading && observations.length === 0 && (
-                  <>
-                    {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
-                      <ProfileObservationCardSkeleton key={i} />
-                    ))}
-                  </>
-                )}
-              </Box>
+                  {isLoading && observations.length === 0 && (
+                    <>
+                      {[1, 2, 3, 4, 5, 6, 7, 8].map((i) => (
+                        <ProfileObservationCardSkeleton key={i} />
+                      ))}
+                    </>
+                  )}
+                </Box>
+              )}
 
               {isFetchingNextPage && <CenteredSpinner color="primary" />}
 


### PR DESCRIPTION
## Summary

Adds a **grid/table view toggle** to the Explore page and a new dense, CSV-style table view for browsing observations with much more detail than the card grid.

A small toggle (grid / table icons) sits above the filter panel. Grid is the default; switching to table swaps in `ExploreTable` and widens the results container to full width.

## The table

One row per observation, ~20 columns:

- Thumbnail
- Scientific name (italicized for species/genus), Common name, Rank
- Full taxonomy ladder: Kingdom · Phylum · Class · Order · Family · Genus
- Observer, Event date (`YYYY-MM-DD`)
- Latitude / Longitude (5-decimal, tabular figures), uncertainty (± m)
- Quantity (organism quantity + type), Identification count, Likes
- Data quality — "Verifiable" chip when clean, else a warning chip (`N issues`) with a tooltip listing them
- Posted date

Rows link through to the observation detail page. Missing values render as `—`.

## Layout / scrolling notes

- The table sits on a raised `background.paper` surface (lifts it off the page background) with a **sticky header**.
- It deliberately owns **no scroll container of its own** — both axes scroll on `FeedView`'s existing ancestor scroller. This keeps the infinite-scroll trigger firing *and* lets `stickyHeader` pin to the top of that same scroller. An intermediate `overflow` box would have broken both.
- View mode is local `FeedView` component state (presentation-only; resets on navigation). Easy to promote to a URL param / localStorage later.

## Test plan

- [x] `tsc --noEmit`, `oxfmt --check`, `oxlint` all clean
- [x] Verified in-browser (Playwright): toggle switches grid ↔ table, all columns populate with real data, taxonomy/observer/quality render correctly
- [ ] Reviewer: confirm sticky header + infinite scroll behave together while scrolling a long feed

## Notes for reviewers

- `QualityIssue` is imported directly from `bindings/` (it isn't re-exported from `services/types`). Happy to add a re-export if preferred.
- No backend changes — reuses the existing `useFeed` / `fetchExploreFeed` data with no new fields.