### PR TITLE
fix(feed): stop home feed serving stale explore data during auth check

### DIFF
--- a/frontend/src/lib/query/hooks.test.tsx
+++ b/frontend/src/lib/query/hooks.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { ReactNode } from "react";
+import { configureStore } from "@reduxjs/toolkit";
+import { Provider } from "react-redux";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor, act } from "@testing-library/react";
+import authReducer, { checkAuth } from "../../store/authSlice";
+import feedReducer from "../../store/feedSlice";
+import type { User } from "../../services/types";
+import type * as ApiModule from "../../services/api";
+
+// `useFeed` picks its endpoint from auth state, so the api layer is mocked to
+// observe which one it calls under each auth condition. `importOriginal` keeps
+// every other export intact (hooks.ts pulls many names from this module).
+const fetchHomeFeed = vi.fn(async () => ({ occurrences: [], cursor: undefined }));
+const fetchExploreFeed = vi.fn(async () => ({ occurrences: [], cursor: undefined }));
+vi.mock("../../services/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof ApiModule>()),
+  fetchHomeFeed: (...args: unknown[]) => fetchHomeFeed(...args),
+  fetchExploreFeed: (...args: unknown[]) => fetchExploreFeed(...args),
+}));
+
+// Imported after the mock is registered so the hook closes over the stubs.
+import { useFeed } from "./hooks";
+import { qk } from "./keys";
+
+const TEST_USER: User = { did: "did:plc:tester", handle: "tester.example" };
+
+// A fresh store starts at { user: null, isLoading: true } — exactly the
+// startup state before the `checkAuth` round-trip resolves.
+function makeStore() {
+  return configureStore({ reducer: { auth: authReducer, feed: feedReducer } });
+}
+
+type Store = ReturnType<typeof makeStore>;
+
+// `checkAuth.fulfilled(payload)` is the same action the real thunk dispatches
+// when the session check returns: it sets `user` and clears `isLoading`.
+function resolveAuth(store: Store, user: User | null) {
+  act(() => {
+    store.dispatch(checkAuth.fulfilled(user, "req"));
+  });
+}
+
+function wrapper(store: Store, client: QueryClient) {
+  return ({ children }: { children: ReactNode }) => (
+    <Provider store={store}>
+      <QueryClientProvider client={client}>{children}</QueryClientProvider>
+    </Provider>
+  );
+}
+
+function makeClient() {
+  // Retries off so a rejected query fails fast instead of stalling the test.
+  return new QueryClient({ defaultOptions: { queries: { retry: false } } });
+}
+
+describe("useFeed", () => {
+  beforeEach(() => {
+    fetchHomeFeed.mockClear();
+    fetchExploreFeed.mockClear();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it("fetches nothing until the startup auth check resolves", async () => {
+    const store = makeStore(); // isLoading: true
+    renderHook(() => useFeed("home"), { wrapper: wrapper(store, makeClient()) });
+
+    // Give React Query a turn; the query must stay disabled while auth loads,
+    // so a logged-in user never fires a throwaway explore request that would
+    // get cached under the home key.
+    await Promise.resolve();
+    expect(fetchHomeFeed).not.toHaveBeenCalled();
+    expect(fetchExploreFeed).not.toHaveBeenCalled();
+  });
+
+  it("fetches the home endpoint for a signed-in home tab", async () => {
+    const store = makeStore();
+    resolveAuth(store, TEST_USER);
+    renderHook(() => useFeed("home"), { wrapper: wrapper(store, makeClient()) });
+
+    await waitFor(() => expect(fetchHomeFeed).toHaveBeenCalledTimes(1));
+    expect(fetchExploreFeed).not.toHaveBeenCalled();
+  });
+
+  it("falls back to the explore endpoint for a signed-out home tab", async () => {
+    const store = makeStore();
+    resolveAuth(store, null);
+    renderHook(() => useFeed("home"), { wrapper: wrapper(store, makeClient()) });
+
+    await waitFor(() => expect(fetchExploreFeed).toHaveBeenCalledTimes(1));
+    expect(fetchHomeFeed).not.toHaveBeenCalled();
+  });
+
+  // The core regression: when auth flips false -> true the home tab must
+  // refetch the home endpoint, not keep serving the explore data it cached
+  // during the unauthenticated window. This only holds because the query key
+  // includes `isAuthenticated`.
+  it("refetches the home endpoint when auth flips from out to in", async () => {
+    const store = makeStore();
+    const client = makeClient();
+    resolveAuth(store, null); // resolved, signed out
+    renderHook(() => useFeed("home"), { wrapper: wrapper(store, client) });
+
+    await waitFor(() => expect(fetchExploreFeed).toHaveBeenCalledTimes(1));
+    expect(fetchHomeFeed).not.toHaveBeenCalled();
+
+    resolveAuth(store, TEST_USER); // now signed in
+
+    await waitFor(() => expect(fetchHomeFeed).toHaveBeenCalledTimes(1));
+    // The explore response is NOT reused for the signed-in home view.
+    expect(fetchExploreFeed).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys home feeds separately by auth state", () => {
+    // Same tab + filters but different auth => distinct cache entries, so an
+    // explore response can never masquerade as the signed-in home feed.
+    const signedOut = qk.feed("home", {}, false);
+    const signedIn = qk.feed("home", {}, true);
+    expect(signedOut).not.toEqual(signedIn);
+    // The shared "feed" tag is preserved so the like-patcher still matches.
+    expect(signedOut[0]).toBe("feed");
+    expect(signedIn[0]).toBe("feed");
+  });
+});

--- a/frontend/src/lib/query/hooks.ts
+++ b/frontend/src/lib/query/hooks.ts
@@ -29,20 +29,31 @@ const nextCursor = (last: { cursor?: string }): Cursor => last.cursor ?? undefin
 
 /**
  * Home/explore feed. The active tab comes from the route (passed by the
- * caller); filters + auth are read from Redux. All three form the query key.
+ * caller); filters + auth are read from Redux. All form the query key.
+ *
+ * `isAuthenticated` drives the endpoint choice (signed-in home vs. explore
+ * fallback) AND is part of the query key, so the two responses never share a
+ * cache entry and an auth flip refetches. We also wait for the startup auth
+ * check (`isLoading`) to settle before fetching: otherwise the home tab would
+ * fire an explore request during the brief window where a logged-in user still
+ * reads as unauthenticated, cache it under the home key, and — since auth isn't
+ * a refetch trigger on its own — leave the wrong feed showing until the next
+ * stale refetch.
  */
 export function useFeed(tab: FeedTab) {
   const filters = useAppSelector((s) => s.feed.filters);
   const isAuthenticated = useAppSelector((s) => s.auth.user !== null);
+  const authResolved = useAppSelector((s) => !s.auth.isLoading);
 
   return useInfiniteQuery({
-    queryKey: qk.feed(tab, filters),
+    queryKey: qk.feed(tab, filters, isAuthenticated),
     queryFn: ({ pageParam }: { pageParam: Cursor }) =>
       tab === "home" && isAuthenticated
         ? fetchHomeFeed(pageParam)
         : fetchExploreFeed(pageParam, filters),
     initialPageParam: initialCursor,
     getNextPageParam: nextCursor,
+    enabled: authResolved,
   });
 }
 

--- a/frontend/src/lib/query/keys.ts
+++ b/frontend/src/lib/query/keys.ts
@@ -6,7 +6,15 @@ import type { FeedFilters, FeedTab } from "../../services/types";
 // The first element of each key is a stable string tag we match on.
 export const qk = {
   // Occurrence-bearing caches (the ones likes must patch) -------------------
-  feed: (tab: FeedTab, filters: FeedFilters) => ["feed", tab, filters] as const,
+  // `isAuthenticated` is part of the key because `useFeed` fetches a different
+  // endpoint for the signed-in home tab (`/feeds/home`, quality-filtered) vs.
+  // the signed-out / explore fallback (`/feeds/explore`, unfiltered). Leaving
+  // it out let an explore response fetched during the startup auth-check window
+  // get cached under the home key and never refetch once auth resolved, so the
+  // home feed nondeterministically showed explore posts. Keying on it makes the
+  // two states distinct caches and forces a refetch when auth flips.
+  feed: (tab: FeedTab, filters: FeedFilters, isAuthenticated: boolean) =>
+    ["feed", tab, filters, isAuthenticated] as const,
   profileFeed: (did: string, type: "observations" | "identifications") =>
     ["profileFeed", did, type] as const,
   taxonOccurrences: (kingdomOrId: string, name?: string) =>


### PR DESCRIPTION
## Problem

The home feed nondeterministically showed different posts at the top across reloads — sometimes incomplete/low-quality observations that should have been filtered out.

Root cause is a frontend cache-key bug in `useFeed` (`frontend/src/lib/query/hooks.ts`):

- The `queryFn` chooses between two endpoints based on `isAuthenticated`:
  - `/api/feeds/home` — always `quality=complete` (a subset)
  - `/api/feeds/explore` — no quality filter by default (the full set)
- But the React Query key (`qk.feed(tab, filters)`) **did not include `isAuthenticated`**.

On startup `auth.user` is `null` until the async `/oauth/me` check resolves (~50–300ms). The feed query and the auth check race:

1. Query fires first → `isAuthenticated` false → fetches **explore** data, cached under the home key.
2. Auth resolves first → fetches **home** data.

Because auth wasn't in the key, the flip to authenticated produced no key change and therefore **no refetch** — a feed fetched as "explore" stayed cached under the home tab until the next stale refetch (1 min). Persisted cache widened the window.

The backend ordering itself is deterministic (`created_at DESC, uri DESC` with a tuple cursor); the nondeterminism was entirely this client-side key/endpoint mismatch.

## Fix

- Add `isAuthenticated` to `qk.feed` so signed-in and signed-out feeds are distinct cache entries and an auth flip refetches. The `"feed"` tag stays first, so the like-patcher (`occurrenceCache.ts`) still matches by prefix.
- Gate the query with `enabled: !isLoading` so it waits for the startup auth check to settle instead of firing a throwaway explore request during the window.

## Tests

New `frontend/src/lib/query/hooks.test.tsx` (5 cases):
- no fetch while the auth check is loading,
- signed-in home tab → home endpoint,
- signed-out home tab → explore endpoint,
- **regression:** auth flip false→true refetches the home endpoint instead of reusing cached explore data,
- key is partitioned by auth while preserving the `"feed"` tag.

## Verification

- New tests pass; full unit suite 147 → 152 passing.
- `npm run fmt`, lint (clean for changed files), and `tsc --noEmit` (whole project) all pass.

## Related

- #624 — feed ordering trusts the client-supplied `createdAt` timestamp (separate ranking-integrity concern surfaced during this investigation; not the cause of this race).