### PR TITLE
feat(taxon): add search to the taxon explorer sidebar

### DIFF
--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -6,7 +6,7 @@ import { ConservationStatus } from "./ConservationStatus";
 import { renderAutocompleteInput } from "./autocompleteInput";
 import { nameToSlug } from "../../lib/taxonSlug";
 
-function taxonUrlFor(option: TaxaResult): string | null {
+export function taxonUrlFor(option: TaxaResult): string | null {
   if (option.rank?.toLowerCase() === "kingdom") {
     return `/taxon/${nameToSlug(option.scientificName)}`;
   }

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -373,6 +373,7 @@ export function TaxonExplorer() {
     onExpandedItemsChange: setExpandedItems,
     onSelectedItemsChange: handleTreeSelect,
     onItemExpansionToggle: handleTreeExpansionToggle,
+    onSearchNavigate: () => setMobileTreeOpen(false),
   };
 
   // Only show the skeleton on the very first load. On subsequent navigations

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -58,6 +58,10 @@ export function TaxonExplorer() {
 
   // Tree state
   const nodesRef = useRef<Map<string, TreeNode>>(new Map());
+  // Kingdom whose classification currently populates nodesRef. The explorer
+  // shows one kingdom at a time, so a change means we've jumped kingdoms (e.g.
+  // via search) and must drop the old nodes.
+  const treeKingdomRef = useRef<string>("");
   const [treeItems, setTreeItems] = useState<TaxonTreeItem[]>([]);
   const [expandedItems, setExpandedItems] = useState<string[]>([]);
   const [selectedItem, setSelectedItem] = useState<string>("");
@@ -129,8 +133,16 @@ export function TaxonExplorer() {
   /** Merge a taxon detail's ancestors + children into the tree node map */
   const mergeIntoTree = useCallback(
     (detail: TaxonDetail) => {
-      const nodes = nodesRef.current;
       const k = detail.kingdom || lookupKingdom || "";
+      // Jumped to a different kingdom — drop the previous kingdom's nodes so a
+      // stale root can't win in rebuildTreeFromRoot (which picks the first root
+      // it finds). Within a kingdom we keep nodes so the tree stays expanded
+      // across navigation.
+      if (k && treeKingdomRef.current && treeKingdomRef.current !== k) {
+        nodesRef.current = new Map();
+      }
+      if (k) treeKingdomRef.current = k;
+      const nodes = nodesRef.current;
       const ancestors = detail.ancestors ?? [];
 
       // Add ancestor nodes (linked parent → child along the path)

--- a/frontend/src/components/taxon/TaxonSearchBox.stories.tsx
+++ b/frontend/src/components/taxon/TaxonSearchBox.stories.tsx
@@ -1,0 +1,63 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
+import { Box } from "@mui/material";
+import { TaxonSearchBox } from "./TaxonSearchBox";
+import type { TaxaResult } from "../../services/types";
+
+const SAMPLE_RESULTS: TaxaResult[] = [
+  {
+    id: "Plantae/Quercus-robur",
+    scientificName: "Quercus robur",
+    commonName: "English oak",
+    rank: "species",
+    kingdom: "Plantae",
+    source: "gbif",
+  },
+  {
+    id: "Plantae/Quercus-alba",
+    scientificName: "Quercus alba",
+    commonName: "White oak",
+    rank: "species",
+    kingdom: "Plantae",
+    source: "gbif",
+  },
+  {
+    id: "Plantae/Quercus",
+    scientificName: "Quercus",
+    commonName: "Oaks",
+    rank: "genus",
+    kingdom: "Plantae",
+    source: "gbif",
+  },
+];
+
+const meta = {
+  title: "Taxon/TaxonSearchBox",
+  component: TaxonSearchBox,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: 300 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof TaxonSearchBox>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithResults: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get("/api/taxa/search", () => HttpResponse.json({ results: SAMPLE_RESULTS })),
+      ],
+    },
+  },
+};

--- a/frontend/src/components/taxon/TaxonSearchBox.tsx
+++ b/frontend/src/components/taxon/TaxonSearchBox.tsx
@@ -1,0 +1,52 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { searchTaxa } from "../../services/api";
+import type { TaxaResult } from "../../services/types";
+import { useAutocomplete } from "../../hooks/useAutocomplete";
+import { MAX_AUTOCOMPLETE_RESULTS } from "../../lib/utils";
+import { TaxaAutocompleteView, taxonUrlFor } from "../common/TaxaAutocompleteView";
+
+interface TaxonSearchBoxProps {
+  /** Called after a successful navigation (e.g. to close the mobile tree drawer). */
+  onNavigate?: (() => void) | undefined;
+}
+
+/**
+ * Search box for the taxon explorer's classification sidebar. Reuses the
+ * shared taxa autocomplete query; picking a suggestion navigates to that
+ * taxon's page.
+ */
+export function TaxonSearchBox({ onNavigate }: TaxonSearchBoxProps) {
+  const navigate = useNavigate();
+  const [value, setValue] = useState("");
+  const { options, loading, handleSearch, clearOptions } = useAutocomplete<TaxaResult>({
+    searchFn: searchTaxa,
+    filterResults: (results) => results.slice(0, MAX_AUTOCOMPLETE_RESULTS),
+  });
+
+  const handleMatch = (match: TaxaResult | null) => {
+    if (!match) return;
+    const url = taxonUrlFor(match);
+    if (!url) return;
+    setValue("");
+    clearOptions();
+    onNavigate?.();
+    navigate(url);
+  };
+
+  return (
+    <TaxaAutocompleteView
+      value={value}
+      onChange={setValue}
+      onMatchChange={handleMatch}
+      label="Search taxa"
+      placeholder="Search by common or scientific name..."
+      size="small"
+      margin="none"
+      options={options}
+      loading={loading}
+      onSearch={handleSearch}
+      onClear={clearOptions}
+    />
+  );
+}

--- a/frontend/src/components/taxon/TaxonTreePanel.tsx
+++ b/frontend/src/components/taxon/TaxonTreePanel.tsx
@@ -2,6 +2,7 @@ import { Box, CircularProgress, Typography } from "@mui/material";
 import { SimpleTreeView } from "@mui/x-tree-view/SimpleTreeView";
 import { TreeItem } from "@mui/x-tree-view/TreeItem";
 import type { TaxonTreeItem } from "./TaxonExplorer";
+import { TaxonSearchBox } from "./TaxonSearchBox";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 
 interface TaxonTreePanelProps {
@@ -14,6 +15,8 @@ interface TaxonTreePanelProps {
   onExpandedItemsChange: (ids: string[]) => void;
   onSelectedItemsChange: (id: string) => void;
   onItemExpansionToggle: (id: string, isExpanded: boolean) => void;
+  /** Called after the search box navigates (e.g. to close the mobile drawer). */
+  onSearchNavigate?: (() => void) | undefined;
 }
 
 function renderTreeItems(
@@ -92,6 +95,7 @@ export function TaxonTreePanel({
   onExpandedItemsChange,
   onSelectedItemsChange,
   onItemExpansionToggle,
+  onSearchNavigate,
 }: TaxonTreePanelProps) {
   return (
     <Box
@@ -99,33 +103,42 @@ export function TaxonTreePanel({
         p: 1,
         height: "100%",
         overflow: "auto",
-        pointerEvents: disabled ? "none" : "auto",
-        opacity: disabled ? 0.5 : 1,
         transition: "opacity 0.15s",
       }}
     >
-      <Typography
-        variant="subtitle2"
+      <Box sx={{ px: 1, pt: 1, pb: 0.5 }}>
+        <TaxonSearchBox onNavigate={onSearchNavigate} />
+      </Box>
+      <Box
         sx={{
-          color: "text.secondary",
-          px: 1,
-          py: 1,
+          pointerEvents: disabled ? "none" : "auto",
+          opacity: disabled ? 0.5 : 1,
+          transition: "opacity 0.15s",
         }}
       >
-        Classification
-      </Typography>
-      <SimpleTreeView
-        expansionTrigger="iconContainer"
-        expandedItems={expandedItems}
-        selectedItems={selectedItems}
-        onExpandedItemsChange={(_e, ids) => onExpandedItemsChange(ids)}
-        onSelectedItemsChange={(_e, id) => {
-          if (id) onSelectedItemsChange(id);
-        }}
-        onItemExpansionToggle={(_e, id, isExpanded) => onItemExpansionToggle(id, isExpanded)}
-      >
-        {renderTreeItems(items, selectedItems, loadingNodeId, thumbnails)}
-      </SimpleTreeView>
+        <Typography
+          variant="subtitle2"
+          sx={{
+            color: "text.secondary",
+            px: 1,
+            py: 1,
+          }}
+        >
+          Classification
+        </Typography>
+        <SimpleTreeView
+          expansionTrigger="iconContainer"
+          expandedItems={expandedItems}
+          selectedItems={selectedItems}
+          onExpandedItemsChange={(_e, ids) => onExpandedItemsChange(ids)}
+          onSelectedItemsChange={(_e, id) => {
+            if (id) onSelectedItemsChange(id);
+          }}
+          onItemExpansionToggle={(_e, id, isExpanded) => onItemExpansionToggle(id, isExpanded)}
+        >
+          {renderTreeItems(items, selectedItems, loadingNodeId, thumbnails)}
+        </SimpleTreeView>
+      </Box>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary

Adds a search box to the taxon explorer page (`/taxon/...`), as requested in #430. Previously the page only let you navigate the taxonomy via the **Classification** tree or direct URLs — there was no way to search.

The search box sits at the top of the classification sidebar and is powered by the existing taxa autocomplete query (`/api/taxa/search` → `searchTaxa`), as the ticket suggested. Picking a suggestion navigates to that taxon's page; on mobile it also closes the tree drawer.

## Changes

- **`TaxonSearchBox.tsx`** (new) — wraps the shared `TaxaAutocompleteView` with the `useAutocomplete` hook + `searchTaxa`; navigates to the picked taxon and resets the input.
- **`TaxonTreePanel.tsx`** — renders the search box above the "Classification" heading. The in-flight `disabled` dimming now wraps only the tree, so search stays usable while the tree is frozen during a load.
- **`TaxonExplorer.tsx`** — passes `onSearchNavigate` to close the mobile tree drawer after a search jump.
- **`TaxaAutocompleteView.tsx`** — exports the existing `taxonUrlFor` helper for reuse.
- **`TaxonSearchBox.stories.tsx`** (new) — required sibling story (Default + WithResults via MSW).

## Testing

- `tsc`, `oxlint`, `oxfmt`, `check:stories` pass; 142 unit tests pass.
- Verified in Storybook with Playwright: typing a query populates the dropdown with results linking to the correct `/taxon/...` URLs.

Closes #430