### PR TITLE
refactor(identification): use MuiLink for profile name link

### DIFF
--- a/frontend/src/components/identification/IdentificationHistory.tsx
+++ b/frontend/src/components/identification/IdentificationHistory.tsx
@@ -8,6 +8,7 @@ import {
   Paper,
   Chip,
   IconButton,
+  Link as MuiLink,
   Menu,
   MenuItem,
 } from "@mui/material";
@@ -176,9 +177,11 @@ export function IdentificationHistory({
                       flexWrap: "wrap",
                     }}
                   >
-                    <RouterLink
+                    <MuiLink
+                      component={RouterLink}
                       to={`/profile/${encodeURIComponent(id.identifier?.did || id.did)}`}
-                      style={{ textDecoration: "none" }}
+                      underline="none"
+                      color="inherit"
                     >
                       <Typography
                         variant="body2"
@@ -189,7 +192,7 @@ export function IdentificationHistory({
                       >
                         {id.identifier?.displayName || id.identifier?.handle || "Unknown"}
                       </Typography>
-                    </RouterLink>
+                    </MuiLink>
                     <Typography
                       variant="caption"
                       sx={{


### PR DESCRIPTION
## What

The profile-name link in `IdentificationHistory` was a `RouterLink` with an inline `style={{ textDecoration: "none" }}`. This switches it to MUI's `Link` via `component={RouterLink}`, using `underline="none"` / `color="inherit"` to preserve the exact current appearance.

## Why

- Matches the idiomatic pattern already used elsewhere (e.g. `WikiCommonsGallery` uses `Link as MuiLink`).
- `sx` / inline `style` on a raw router `<a>` doesn't get MUI's focus-visible and theming behavior; `MuiLink` does.
- No visual change: `underline="none"` + `color="inherit"` reproduce the prior styling (the child `Typography` still owns weight/color).

## Scope

One line of imports + the single link element. The sibling avatar `RouterLink` (no inline style) is intentionally left as-is.