### PR TITLE
refactor(common): render Wikimedia thumbnails via Box component="img"

### DIFF
--- a/frontend/src/components/common/WikiCommonsGallery.tsx
+++ b/frontend/src/components/common/WikiCommonsGallery.tsx
@@ -141,11 +141,12 @@ export function WikiCommonsGallery({ taxonName, limit = 12 }: WikiCommonsGallery
         {images.map((img, idx) => (
           <ImageListItem key={idx}>
             <MuiLink href={img.pageUrl} target="_blank" rel="noopener noreferrer">
-              <img
+              <Box
+                component="img"
                 src={img.thumbUrl}
                 alt={`Wikimedia Commons image ${idx + 1}`}
                 loading="lazy"
-                style={{ borderRadius: 4, display: "block", width: "100%" }}
+                sx={{ borderRadius: 0.5, display: "block", width: "100%" }}
                 onError={(e) => {
                   if (e.target instanceof HTMLImageElement) {
                     e.target.style.display = "none";


### PR DESCRIPTION
## What

In `WikiCommonsGallery`, the thumbnail `<img>` used a raw `style={{ borderRadius: 4, ... }}`. This switches it to MUI's `Box component="img"` with `sx`.

## Why

- `sx` only works on MUI/emotion components — a raw `<img>` can't use it. `Box component="img"` gives the element `sx` + theme access while still rendering a real `<img>` (so `loading="lazy"`, `src`, `alt`, and the `onError` fallback are unchanged).
- `borderRadius: 0.5` = `theme.shape.borderRadius * 0.5` = 4px, so this is a **no-op visually** — it just routes the radius through the theme instead of a hard-coded pixel value.

## Scope

Single element; the `onError` handler (which hides broken thumbnails) is preserved verbatim.