### PR TITLE
feat(atproto): env overrides for PLC directory, handle resolution, an…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,18 @@ SPECIES_ID_SERVICE_URL=http://localhost:3005
 # Comma-separated allowed CORS origins.
 # CORS_ORIGINS=
 
+# Override the PLC directory used to resolve did:plc identities (appview OAuth,
+# identity resolver, and blob resolver). Defaults to https://plc.directory.
+# Point this at a local @atproto/dev-env PLC for isolated e2e tests.
+# PLC_DIRECTORY_URL=https://plc.directory
+
+# Override handle (handle -> DID) resolution. Unset = spec-default decentralized
+# resolution (DNS TXT + .well-known), which is what production uses. When set,
+# both the OAuth client and the identity resolver resolve handles via this URL's
+# com.atproto.identity.resolveHandle instead. Point at a local @atproto/dev-env
+# PDS for isolated e2e, where `.test` handles cannot resolve via DNS.
+# HANDLE_RESOLVER_URL=
+
 # Override where the appview serves built static files from. Default:
 # `dist/public`. If the directory is empty, appview proxies frontend
 # requests to the Vite dev server instead.
@@ -112,6 +124,12 @@ TAP_DATABASE_URL=sqlite:./.tap-ingester/tap.db
 # Set to skip spawning Tap and connect to an existing instance (e.g. one
 # you're running in Docker).
 # TAP_URL=
+
+# Override the upstream firehose Tap subscribes to (a relay or, for e2e, a
+# single PDS's com.atproto.sync.subscribeRepos). Unset = Tap's built-in public
+# relay default. Pair with PLC_DIRECTORY_URL to point Tap at a local
+# @atproto/dev-env network. The lag probe tracks this automatically.
+# TAP_RELAY_URL=
 
 # Basic-auth password for Tap's admin endpoints. Optional locally.
 # TAP_ADMIN_PASSWORD=

--- a/crates/atproto-blob-resolver/src/resolver.rs
+++ b/crates/atproto-blob-resolver/src/resolver.rs
@@ -3,28 +3,30 @@
 use crate::error::{BlobResolverError, Result};
 use crate::types::PlcDirectoryResponse;
 use at_uri_parser::AtUri;
-use atproto_identity::{Did, DidMethod};
+use atproto_identity::{plc_directory_url, Did, DidMethod};
 use reqwest::Client;
 use tracing::{debug, warn};
 
 /// Resolves AT Protocol DIDs to PDS endpoints and fetches blobs
 pub struct BlobResolver {
     client: Client,
+    plc_directory_url: String,
 }
 
 impl BlobResolver {
     /// Create a new blob resolver
     pub fn new() -> Self {
-        Self {
-            client: Client::new(),
-        }
+        Self::with_client(Client::new())
     }
 
     /// Create a resolver using a caller-provided HTTP client — e.g. one
     /// configured with a request timeout. [`BlobResolver::new`] uses a default
     /// client with no timeout.
     pub fn with_client(client: Client) -> Self {
-        Self { client }
+        Self {
+            client,
+            plc_directory_url: plc_directory_url(),
+        }
     }
 
     /// Resolve a DID to its PDS URL
@@ -35,9 +37,9 @@ impl BlobResolver {
         }
     }
 
-    /// Resolve a did:plc: DID via plc.directory
+    /// Resolve a did:plc: DID via the PLC directory
     async fn resolve_plc_did(&self, did: &Did) -> Result<String> {
-        let url = format!("https://plc.directory/{}", did.as_str());
+        let url = format!("{}/{}", self.plc_directory_url, did.as_str());
         debug!(did = %did, url = %url, "Resolving PLC DID");
 
         let response = self.client.get(&url).send().await?;

--- a/crates/atproto-identity/src/lib.rs
+++ b/crates/atproto-identity/src/lib.rs
@@ -11,3 +11,17 @@ mod types;
 pub use did::{Did, DidMethod, DidParseError};
 pub use resolver::IdentityResolver;
 pub use types::{Profile, ResolveResult};
+
+/// Base URL of the PLC directory used to resolve `did:plc:` documents.
+///
+/// Overridable via the `PLC_DIRECTORY_URL` env var so the stack can be pointed
+/// at a local `@atproto/dev-env` PLC for isolated e2e tests; falls back to the
+/// public directory. The returned value never has a trailing slash, so callers
+/// can build URLs as `format!("{base}/{did}")`.
+pub fn plc_directory_url() -> String {
+    std::env::var("PLC_DIRECTORY_URL")
+        .ok()
+        .map(|s| s.trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "https://plc.directory".to_string())
+}

--- a/crates/atproto-identity/src/resolver.rs
+++ b/crates/atproto-identity/src/resolver.rs
@@ -19,6 +19,7 @@ const BATCH_SIZE: usize = 25;
 pub struct IdentityResolver {
     client: Client,
     service_url: String,
+    plc_directory_url: String,
     identity_cache: Cache<String, ResolveResult>,
     profile_cache: Cache<String, Arc<Profile>>,
 }
@@ -27,6 +28,22 @@ impl IdentityResolver {
     /// Create a new resolver with default settings
     pub fn new() -> Self {
         Self::with_service_url(DEFAULT_SERVICE_URL)
+    }
+
+    /// Create a resolver, honoring `HANDLE_RESOLVER_URL` as an override for the
+    /// service base used to resolve handles (point this at a local
+    /// `@atproto/dev-env` PDS for isolated e2e). Falls back to the public
+    /// Bluesky API. did:plc resolution is governed separately by
+    /// [`crate::plc_directory_url`].
+    pub fn from_env() -> Self {
+        match std::env::var("HANDLE_RESOLVER_URL")
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+        {
+            Some(url) => Self::with_service_url(&url),
+            None => Self::new(),
+        }
     }
 
     /// Create a new resolver with a custom Bluesky API URL
@@ -49,6 +66,7 @@ impl IdentityResolver {
         Self {
             client,
             service_url: service_url.to_string(),
+            plc_directory_url: crate::plc_directory_url(),
             identity_cache,
             profile_cache,
         }
@@ -168,7 +186,7 @@ impl IdentityResolver {
     /// Get the DID document for a DID
     async fn get_did_document(&self, did: &Did) -> Option<DidDocument> {
         let url = match did.method() {
-            DidMethod::Plc(_) => format!("https://plc.directory/{}", did.as_str()),
+            DidMethod::Plc(_) => format!("{}/{}", self.plc_directory_url, did.as_str()),
             DidMethod::Web(host) => {
                 let domain = host.replace("%3A", ":");
                 format!("https://{domain}/.well-known/did.json")

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -73,7 +73,7 @@ async fn main() {
 
     let state = AppState {
         pool,
-        resolver: Arc::new(atproto_identity::IdentityResolver::new()),
+        resolver: Arc::new(atproto_identity::IdentityResolver::from_env()),
         taxonomy: Arc::new(TaxonomyClient::new()),
         species_id,
         oauth_client: Arc::new(oauth_client),

--- a/crates/observing-appview/src/state.rs
+++ b/crates/observing-appview/src/state.rs
@@ -25,7 +25,9 @@ use atrium_oauth::{DefaultHttpClient, OAuthClient};
 /// stack is pointed at a local `@atproto/dev-env` PDS for isolated e2e, where
 /// `.test` handles cannot resolve via DNS.
 pub enum AppHandleResolver {
-    Dns(AtprotoHandleResolver<HickoryDnsTxtResolver, DefaultHttpClient>),
+    // Boxed: the DNS resolver is ~10x larger than the AppView variant
+    // (clippy::large_enum_variant).
+    Dns(Box<AtprotoHandleResolver<HickoryDnsTxtResolver, DefaultHttpClient>>),
     AppView(AppViewHandleResolver<DefaultHttpClient>),
 }
 
@@ -58,10 +60,12 @@ fn build_handle_resolver(http_client: Arc<DefaultHttpClient>) -> AppHandleResolv
                 http_client,
             }))
         }
-        None => AppHandleResolver::Dns(AtprotoHandleResolver::new(AtprotoHandleResolverConfig {
-            dns_txt_resolver: HickoryDnsTxtResolver::default(),
-            http_client,
-        })),
+        None => AppHandleResolver::Dns(Box::new(AtprotoHandleResolver::new(
+            AtprotoHandleResolverConfig {
+                dns_txt_resolver: HickoryDnsTxtResolver::default(),
+                http_client,
+            },
+        ))),
     }
 }
 

--- a/crates/observing-appview/src/state.rs
+++ b/crates/observing-appview/src/state.rs
@@ -8,23 +8,76 @@ use crate::resolver::HickoryDnsTxtResolver;
 use crate::species_id_client::SpeciesIdClient;
 use crate::taxonomy_client::TaxonomyClient;
 
-use atrium_identity::did::{CommonDidResolver, CommonDidResolverConfig, DEFAULT_PLC_DIRECTORY_URL};
-use atrium_identity::handle::{AtprotoHandleResolver, AtprotoHandleResolverConfig};
+use atrium_api::types::string::{Did, Handle};
+use atrium_common::resolver::Resolver;
+use atrium_identity::did::{CommonDidResolver, CommonDidResolverConfig};
+use atrium_identity::handle::{
+    AppViewHandleResolver, AppViewHandleResolverConfig, AtprotoHandleResolver,
+    AtprotoHandleResolverConfig, HandleResolver,
+};
 use atrium_oauth::{DefaultHttpClient, OAuthClient};
+
+/// Handle→DID resolver chosen at startup.
+///
+/// Production uses the spec-default decentralized resolver (DNS TXT +
+/// `.well-known`). Setting `HANDLE_RESOLVER_URL` switches to an AppView-style
+/// `com.atproto.identity.resolveHandle` call against that URL — this is how the
+/// stack is pointed at a local `@atproto/dev-env` PDS for isolated e2e, where
+/// `.test` handles cannot resolve via DNS.
+pub enum AppHandleResolver {
+    Dns(AtprotoHandleResolver<HickoryDnsTxtResolver, DefaultHttpClient>),
+    AppView(AppViewHandleResolver<DefaultHttpClient>),
+}
+
+impl Resolver for AppHandleResolver {
+    type Input = Handle;
+    type Output = Did;
+    type Error = atrium_identity::Error;
+
+    async fn resolve(&self, handle: &Handle) -> Result<Did, atrium_identity::Error> {
+        match self {
+            Self::Dns(r) => r.resolve(handle).await,
+            Self::AppView(r) => r.resolve(handle).await,
+        }
+    }
+}
+
+impl HandleResolver for AppHandleResolver {}
+
+/// Build the handle resolver from `HANDLE_RESOLVER_URL` (AppView-style when set,
+/// decentralized DNS/well-known otherwise).
+fn build_handle_resolver(http_client: Arc<DefaultHttpClient>) -> AppHandleResolver {
+    match std::env::var("HANDLE_RESOLVER_URL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+    {
+        Some(service_url) => {
+            AppHandleResolver::AppView(AppViewHandleResolver::new(AppViewHandleResolverConfig {
+                service_url,
+                http_client,
+            }))
+        }
+        None => AppHandleResolver::Dns(AtprotoHandleResolver::new(AtprotoHandleResolverConfig {
+            dns_txt_resolver: HickoryDnsTxtResolver::default(),
+            http_client,
+        })),
+    }
+}
 
 /// The concrete OAuthClient type with PostgreSQL stores and DNS resolution.
 pub type OAuthClientType = OAuthClient<
     PgStateStore,
     PgSessionStore,
     CommonDidResolver<DefaultHttpClient>,
-    AtprotoHandleResolver<HickoryDnsTxtResolver, DefaultHttpClient>,
+    AppHandleResolver,
 >;
 
 /// The concrete OAuth session type returned by `OAuthClientType::restore()`.
 pub type OAuthSessionType = atrium_oauth::OAuthSession<
     DefaultHttpClient,
     CommonDidResolver<DefaultHttpClient>,
-    AtprotoHandleResolver<HickoryDnsTxtResolver, DefaultHttpClient>,
+    AppHandleResolver,
     PgSessionStore,
 >;
 
@@ -62,13 +115,10 @@ pub fn create_oauth_client(pool: PgPool, public_url: Option<&str>, port: u16) ->
 
     let resolver = atrium_oauth::OAuthResolverConfig {
         did_resolver: CommonDidResolver::new(CommonDidResolverConfig {
-            plc_directory_url: DEFAULT_PLC_DIRECTORY_URL.to_string(),
+            plc_directory_url: atproto_identity::plc_directory_url(),
             http_client: http_client.clone(),
         }),
-        handle_resolver: AtprotoHandleResolver::new(AtprotoHandleResolverConfig {
-            dns_txt_resolver: HickoryDnsTxtResolver::default(),
-            http_client: http_client.clone(),
-        }),
+        handle_resolver: build_handle_resolver(http_client.clone()),
         authorization_server_metadata: Default::default(),
         protected_resource_metadata: Default::default(),
     };

--- a/crates/tap-ingester/src/main.rs
+++ b/crates/tap-ingester/src/main.rs
@@ -141,6 +141,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             if let Some(pw) = admin_password.as_deref() {
                 builder = builder.admin_password(pw.to_string());
             }
+            // dev-env override: point Tap's DID resolution + firehose at a local
+            // @atproto/dev-env network so e2e test records never touch the
+            // public firehose. Both no-op in production (vars unset); Tap then
+            // uses its built-in plc.directory + public relay defaults.
+            if let Some(url) = parse_url_env("PLC_DIRECTORY_URL") {
+                info!(plc_url = %url, "overriding Tap PLC directory");
+                builder = builder.plc_url(url);
+            }
+            if let Some(url) = parse_url_env("TAP_RELAY_URL") {
+                info!(relay_url = %url, "overriding Tap relay/firehose source");
+                builder = builder.relay_url(url);
+            }
             // tapped defaults Tap's stdio to /dev/null. In CI we want
             // Tap's startup logs visible so failures are debuggable.
             if std::env::var("TAP_INHERIT_STDIO").is_ok() {
@@ -349,13 +361,34 @@ fn resolve_tap_database_url() -> String {
         .unwrap_or_else(|| "sqlite:///data/tap.db".to_string())
 }
 
-/// Relay the heartbeat's lag probe connects to. Must match the relay Tap
-/// consumes from (sequence numbers are relay-specific) — Tap is left on its
-/// default `relay1.us-east.bsky.network`, so this default matches. Override
-/// with `LAG_PROBE_RELAY_URL`; set it empty to disable the probe.
+/// Relay the heartbeat's lag probe connects to. Must match the firehose Tap
+/// consumes from (sequence numbers are source-specific). Resolution order:
+/// `LAG_PROBE_RELAY_URL` (explicit; set empty to disable the probe), else
+/// `TAP_RELAY_URL` (so a dev-env override is tracked automatically), else the
+/// public relay that matches Tap's built-in default.
 fn resolve_lag_probe_relay() -> String {
-    std::env::var("LAG_PROBE_RELAY_URL")
+    if let Ok(url) = std::env::var("LAG_PROBE_RELAY_URL") {
+        return url;
+    }
+    std::env::var("TAP_RELAY_URL")
         .unwrap_or_else(|_| "wss://relay1.us-east.bsky.network".to_string())
+}
+
+/// Parse an optional URL env var, warning (and treating as unset) on a bad
+/// value rather than failing startup.
+fn parse_url_env(name: &str) -> Option<url::Url> {
+    let raw = std::env::var(name).ok()?;
+    let raw = raw.trim();
+    if raw.is_empty() {
+        return None;
+    }
+    match raw.parse() {
+        Ok(url) => Some(url),
+        Err(e) => {
+            warn!(var = name, value = raw, error = %e, "ignoring unparseable URL env var");
+            None
+        }
+    }
 }
 
 /// Build a Postgres connection string from either DATABASE_URL directly


### PR DESCRIPTION
…d Tap firehose source

Three env vars let the Rust stack be pointed at a local ATProto network (e.g. @atproto/dev-env) for isolated e2e tests. All no-op in production when unset:

- PLC_DIRECTORY_URL: shared atproto_identity::plc_directory_url() threaded through appview OAuth, IdentityResolver, and the blob resolver; also forwarded to Tap's spawn path.
- HANDLE_RESOLVER_URL: AppHandleResolver enum keeps spec-default DNS/well-known handle resolution in prod, swaps to an AppView-style resolveHandle resolver when set (.test handles can't resolve via DNS). IdentityResolver::from_env() honors the same var.
- TAP_RELAY_URL: overrides the upstream firehose Tap subscribes to (tapped already exposes relay_url); the heartbeat lag probe tracks it automatically.

Extracted from the dev-env e2e spike (#623) — these overrides are useful independent of the TS harness.