### PR TITLE
refactor(routes): extract AT-URI collection/rkey parse helper

### DIFF
--- a/crates/observing-appview/src/auth.rs
+++ b/crates/observing-appview/src/auth.rs
@@ -71,6 +71,29 @@ pub fn build_strong_ref(uri: &str, cid: &str) -> Result<StrongRef, AppError> {
         .build())
 }
 
+/// Parse the `collection` and `rkey` segments of a parsed [`at_uri_parser::AtUri`]
+/// into the strongly-typed atproto values needed for repo `deleteRecord` /
+/// `putRecord` calls, wrapping parse failures in a consistent `AppError`.
+pub fn parse_collection_and_rkey(
+    at_uri: &at_uri_parser::AtUri,
+) -> Result<
+    (
+        atrium_api::types::string::Nsid,
+        atrium_api::types::string::RecordKey,
+    ),
+    AppError,
+> {
+    let collection = at_uri
+        .collection
+        .parse()
+        .map_err(|e| AppError::Internal(format!("Invalid collection: {e}")))?;
+    let rkey = at_uri
+        .rkey
+        .parse()
+        .map_err(|e| AppError::Internal(format!("Invalid rkey: {e}")))?;
+    Ok((collection, rkey))
+}
+
 /// Restore an OAuth session and return an AT Protocol agent for the given DID.
 pub async fn require_agent(
     oauth_client: &OAuthClientType,

--- a/crates/observing-appview/src/routes/identifications.rs
+++ b/crates/observing-appview/src/routes/identifications.rs
@@ -126,6 +126,7 @@ pub async fn delete_identification(
     }
 
     let (agent, did_parsed) = auth::require_agent(&state.oauth_client, &user.did).await?;
+    let (collection, rkey) = auth::parse_collection_and_rkey(&at_uri)?;
     agent
         .api
         .com
@@ -133,15 +134,9 @@ pub async fn delete_identification(
         .repo
         .delete_record(
             atrium_api::com::atproto::repo::delete_record::InputData {
-                collection: at_uri
-                    .collection
-                    .parse()
-                    .map_err(|e| AppError::Internal(format!("Invalid collection: {e}")))?,
+                collection,
                 repo: atrium_api::types::string::AtIdentifier::Did(did_parsed),
-                rkey: at_uri
-                    .rkey
-                    .parse()
-                    .map_err(|e| AppError::Internal(format!("Invalid rkey: {e}")))?,
+                rkey,
                 swap_commit: None,
                 swap_record: None,
             }

--- a/crates/observing-appview/src/routes/occurrences/write.rs
+++ b/crates/observing-appview/src/routes/occurrences/write.rs
@@ -218,6 +218,7 @@ pub async fn delete_occurrence(
     }
 
     let (agent, did_parsed) = auth::require_agent(&state.oauth_client, &user.did).await?;
+    let (collection, rkey) = auth::parse_collection_and_rkey(&at_uri)?;
     agent
         .api
         .com
@@ -225,15 +226,9 @@ pub async fn delete_occurrence(
         .repo
         .delete_record(
             atrium_api::com::atproto::repo::delete_record::InputData {
-                collection: at_uri
-                    .collection
-                    .parse()
-                    .map_err(|e| AppError::Internal(format!("Invalid collection: {e}")))?,
+                collection,
                 repo: atrium_api::types::string::AtIdentifier::Did(did_parsed),
-                rkey: at_uri
-                    .rkey
-                    .parse()
-                    .map_err(|e| AppError::Internal(format!("Invalid rkey: {e}")))?,
+                rkey,
                 swap_commit: None,
                 swap_record: None,
             }
@@ -283,14 +278,7 @@ pub async fn update_occurrence(
         ));
     }
 
-    let collection_nsid: atrium_api::types::string::Nsid = at_uri
-        .collection
-        .parse()
-        .map_err(|e| AppError::Internal(format!("Invalid collection: {e}")))?;
-    let rkey_parsed: atrium_api::types::string::RecordKey = at_uri
-        .rkey
-        .parse()
-        .map_err(|e| AppError::Internal(format!("Invalid rkey: {e}")))?;
+    let (collection_nsid, rkey_parsed) = auth::parse_collection_and_rkey(&at_uri)?;
 
     let (agent, did_parsed) = auth::require_agent(&state.oauth_client, &user.did).await?;
 


### PR DESCRIPTION
## What

Three record-deletion / update handlers — `delete_occurrence`, `update_occurrence` (in `routes/occurrences/write.rs`) and `delete_identification` (in `routes/identifications.rs`) — each repeated the same boilerplate to turn an `AtUri`'s `collection` / `rkey` strings into typed `Nsid` / `RecordKey` values:

```rust
collection: at_uri.collection.parse()
    .map_err(|e| AppError::Internal(format!("Invalid collection: {e}")))?,
rkey: at_uri.rkey.parse()
    .map_err(|e| AppError::Internal(format!("Invalid rkey: {e}")))?,
```

This extracts a single `auth::parse_collection_and_rkey(&AtUri) -> Result<(Nsid, RecordKey), AppError>` helper (placed next to the analogous `build_strong_ref`) and routes all three call sites through it.

## Notes

- Behavior-preserving: same parse targets, same error messages.
- No new dependencies.