### PR TITLE
refactor(upload): build observation payload once for create/update

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -364,6 +364,28 @@ export function UploadModal() {
       toast.error(`Failed to ${isEditMode ? "update" : "submit"}: ${getErrorMessage(error)}`);
     };
 
+    // Fields shared by create and update; the update path adds `uri` and
+    // `retainedBlobCids` on top. Conditional spreads omit empty/unset values
+    // so we never send blank taxonomy or quantity fields.
+    const commonPayload = {
+      ...(trimmedSpecies ? { scientificName: trimmedSpecies } : {}),
+      ...(trimmedSpecies && kingdom ? { kingdom } : {}),
+      ...(trimmedSpecies && !matchedTaxon && rank ? { taxonRank: rank } : {}),
+      ...(trimmedSpecies && matchedTaxon?.taxonId ? { taxonId: matchedTaxon.taxonId } : {}),
+      latitude: parseFloat(lat),
+      longitude: parseFloat(lng),
+      coordinateUncertaintyInMeters: uncertaintyMeters,
+      ...(organismQuantity.trim()
+        ? {
+            organismQuantity: organismQuantity.trim(),
+            ...(organismQuantityType ? { organismQuantityType } : {}),
+          }
+        : {}),
+      license,
+      eventDate: new Date(observationDate).toISOString(),
+      ...(imageData.length > 0 ? { images: imageData } : {}),
+    };
+
     if (isEditMode && editingObservation) {
       // Extract CIDs from retained existing image URLs (/media/blob/{did}/{cid})
       const retainedBlobCids = existingImages.map((url) => {
@@ -371,50 +393,11 @@ export function UploadModal() {
       });
 
       updateObs.mutate(
-        {
-          uri: editingObservation.uri,
-          ...(trimmedSpecies ? { scientificName: trimmedSpecies } : {}),
-          ...(trimmedSpecies && kingdom ? { kingdom } : {}),
-          ...(trimmedSpecies && !matchedTaxon && rank ? { taxonRank: rank } : {}),
-          ...(trimmedSpecies && matchedTaxon?.taxonId ? { taxonId: matchedTaxon.taxonId } : {}),
-          latitude: parseFloat(lat),
-          longitude: parseFloat(lng),
-          coordinateUncertaintyInMeters: uncertaintyMeters,
-          ...(organismQuantity.trim()
-            ? {
-                organismQuantity: organismQuantity.trim(),
-                ...(organismQuantityType ? { organismQuantityType } : {}),
-              }
-            : {}),
-          license,
-          eventDate: new Date(observationDate).toISOString(),
-          ...(imageData.length > 0 ? { images: imageData } : {}),
-          retainedBlobCids,
-        },
+        { uri: editingObservation.uri, ...commonPayload, retainedBlobCids },
         { onSuccess, onError },
       );
     } else {
-      submitObs.mutate(
-        {
-          ...(trimmedSpecies ? { scientificName: trimmedSpecies } : {}),
-          ...(trimmedSpecies && kingdom ? { kingdom } : {}),
-          ...(trimmedSpecies && !matchedTaxon && rank ? { taxonRank: rank } : {}),
-          ...(trimmedSpecies && matchedTaxon?.taxonId ? { taxonId: matchedTaxon.taxonId } : {}),
-          latitude: parseFloat(lat),
-          longitude: parseFloat(lng),
-          coordinateUncertaintyInMeters: uncertaintyMeters,
-          ...(organismQuantity.trim()
-            ? {
-                organismQuantity: organismQuantity.trim(),
-                ...(organismQuantityType ? { organismQuantityType } : {}),
-              }
-            : {}),
-          license,
-          eventDate: new Date(observationDate).toISOString(),
-          ...(imageData.length > 0 ? { images: imageData } : {}),
-        },
-        { onSuccess, onError },
-      );
+      submitObs.mutate(commonPayload, { onSuccess, onError });
     }
   };
 


### PR DESCRIPTION
## What

The submit handler's create and update branches each spelled out the **same** ~15 conditionally-spread payload fields (scientificName / kingdom / taxonRank / taxonId, latitude, longitude, coordinateUncertaintyInMeters, organismQuantity (+type), license, eventDate, images). Only `uri` and `retainedBlobCids` were unique to the update path.

This builds the shared fields once as `commonPayload` and spreads it into both `submitObs.mutate` and `updateObs.mutate`, so the two paths can't drift.

## Notes

- Behavior-preserving; the conditional-spread semantics (omit empty/unset fields) are unchanged.
- `tsc --noEmit` clean — the extracted const infers a type compatible with both mutations.