### PR TITLE
refactor(taxon): extract shared LoadMoreButton component

### DIFF
--- a/frontend/src/components/common/LoadMoreButton.stories.tsx
+++ b/frontend/src/components/common/LoadMoreButton.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LoadMoreButton } from "./LoadMoreButton";
+
+const meta = {
+  title: "Common/LoadMoreButton",
+  component: LoadMoreButton,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  args: {
+    onClick: () => {},
+  },
+} satisfies Meta<typeof LoadMoreButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    loading: false,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    loading: true,
+  },
+};

--- a/frontend/src/components/common/LoadMoreButton.tsx
+++ b/frontend/src/components/common/LoadMoreButton.tsx
@@ -1,0 +1,24 @@
+import { Box, Button, CircularProgress } from "@mui/material";
+
+export interface LoadMoreButtonProps {
+  /** Whether the next page is currently being fetched (shows a spinner and disables the button). */
+  loading: boolean;
+  /** Invoked when the button is clicked to fetch the next page. */
+  onClick: () => void;
+}
+
+/**
+ * Centered "Load more" pagination button with an inline spinner while loading,
+ * matching the look used by the taxon detail observation lists. Render it
+ * behind a `hasMore` guard at the call site.
+ */
+export function LoadMoreButton({ loading, onClick }: LoadMoreButtonProps) {
+  return (
+    <Box sx={{ p: 2, textAlign: "center" }}>
+      <Button variant="text" onClick={onClick} disabled={loading}>
+        {loading ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
+        Load more
+      </Button>
+    </Box>
+  );
+}

--- a/frontend/src/components/taxon/TaxonDetail.tsx
+++ b/frontend/src/components/taxon/TaxonDetail.tsx
@@ -6,7 +6,6 @@ import {
   Container,
   Typography,
   Button,
-  CircularProgress,
   Stack,
   IconButton,
   Chip,
@@ -24,6 +23,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { slugToName } from "../../lib/taxonSlug";
 import { useTaxon, useTaxonOccurrences } from "../../lib/query/hooks";
 import { ConservationStatus } from "../common/ConservationStatus";
+import { LoadMoreButton } from "../common/LoadMoreButton";
 import { TaxonLink, shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useWikidataThumbnails } from "../../hooks/useWikidataThumbnails";
@@ -602,14 +602,7 @@ export function TaxonDetail() {
               <FeedItem key={obs.uri} observation={obs} />
             ))}
 
-            {hasMore && (
-              <Box sx={{ p: 2, textAlign: "center" }}>
-                <Button variant="text" onClick={loadMoreObservations} disabled={loadingMore}>
-                  {loadingMore ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
-                  Load more
-                </Button>
-              </Box>
-            )}
+            {hasMore && <LoadMoreButton loading={loadingMore} onClick={loadMoreObservations} />}
           </Box>
         )}
       </Container>

--- a/frontend/src/components/taxon/TaxonDetailPanel.tsx
+++ b/frontend/src/components/taxon/TaxonDetailPanel.tsx
@@ -4,7 +4,6 @@ import {
   Box,
   Typography,
   Button,
-  CircularProgress,
   Stack,
   IconButton,
   Chip,
@@ -20,6 +19,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import type { TaxonDetail as TaxonDetailType, Occurrence } from "../../services/types";
 import { ConservationStatus } from "../common/ConservationStatus";
+import { LoadMoreButton } from "../common/LoadMoreButton";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { WikiCommonsGallery } from "../common/WikiCommonsGallery";
 import { FeedItem } from "../feed/FeedItem";
@@ -371,14 +371,7 @@ export function TaxonDetailPanel({
             <FeedItem key={obs.uri} observation={obs} />
           ))}
 
-          {hasMore && (
-            <Box sx={{ p: 2, textAlign: "center" }}>
-              <Button variant="text" onClick={onLoadMore} disabled={loadingMore}>
-                {loadingMore ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
-                Load more
-              </Button>
-            </Box>
-          )}
+          {hasMore && <LoadMoreButton loading={loadingMore} onClick={onLoadMore} />}
         </Box>
       )}
     </Box>


### PR DESCRIPTION
## What

`TaxonDetail` and `TaxonDetailPanel` rendered an identical centered "Load more" pagination button with an inline spinner:

```tsx
{hasMore && (
  <Box sx={{ p: 2, textAlign: "center" }}>
    <Button variant="text" onClick={...} disabled={loadingMore}>
      {loadingMore ? <CircularProgress size={20} sx={{ mr: 1 }} /> : null}
      Load more
    </Button>
  </Box>
)}
```

This extracts `common/LoadMoreButton` (with a Storybook story, as required by `check:stories`) and uses it in both, dropping the now-unused `CircularProgress` imports.

## Notes

- Scoped to the two taxon views, which were byte-identical. `ProfileView`'s "Load more" is intentionally left alone — it's a different variant (`outlined`, no spinner).
- `tsc`, `oxlint`, `oxfmt`, and `check:stories` all clean.