### PR TITLE
refactor(frontend): share a single fileToBase64 helper

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -37,7 +37,7 @@ import { ConfirmDialog } from "../common/ConfirmDialog";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { VisualId } from "../identification/VisualId";
 import { PhotoLightbox } from "../observation/PhotoLightbox";
-import { getErrorMessage } from "../../lib/utils";
+import { getErrorMessage, fileToBase64 } from "../../lib/utils";
 import { KINGDOMS } from "../../lib/kingdoms";
 import { TAXON_RANKS } from "../../lib/taxonRanks";
 import { pickPhotos } from "../../lib/photoPicker";
@@ -416,26 +416,6 @@ export function UploadModal() {
         { onSuccess, onError },
       );
     }
-  };
-
-  const fileToBase64 = (file: File): Promise<string> => {
-    return new Promise((resolve, reject) => {
-      const reader = new FileReader();
-      reader.onload = () => {
-        if (typeof reader.result !== "string") {
-          reject(new Error("Expected string result"));
-          return;
-        }
-        const base64 = reader.result.split(",")[1];
-        if (!base64) {
-          reject(new Error("Invalid data URL format"));
-          return;
-        }
-        resolve(base64);
-      };
-      reader.onerror = reject;
-      reader.readAsDataURL(file);
-    });
   };
 
   const handleLocationChange = (newLat: number, newLng: number) => {

--- a/frontend/src/hooks/useVisualId.ts
+++ b/frontend/src/hooks/useVisualId.ts
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { identifySpecies, type SpeciesSuggestion } from "../services/api";
 import { useAppDispatch } from "../store";
 import { addToast } from "../store/uiSlice";
+import { fileToBase64 } from "../lib/utils";
 
 interface UseVisualIdOptions {
   imageUrl: string;
@@ -33,11 +34,7 @@ export function useVisualId({
     try {
       const response = await fetch(imageUrl);
       const blob = await response.blob();
-      const base64 = await new Promise<string>((resolve) => {
-        const reader = new FileReader();
-        reader.onloadend = () => resolve(String(reader.result ?? "").split(",")[1] ?? "");
-        reader.readAsDataURL(blob);
-      });
+      const base64 = await fileToBase64(blob);
 
       const params: Parameters<typeof identifySpecies>[0] = {
         image: base64,

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -104,3 +104,28 @@ export function getDisplayName(
 export function getErrorMessage(error: unknown, fallback = "Unknown error"): string {
   return error instanceof Error ? error.message : fallback;
 }
+
+/**
+ * Read a file/blob and return just the base64 payload (the part after the
+ * `data:...;base64,` prefix of a data URL). Rejects if the result isn't a
+ * usable data URL.
+ */
+export function fileToBase64(file: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      if (typeof reader.result !== "string") {
+        reject(new Error("Expected string result"));
+        return;
+      }
+      const base64 = reader.result.split(",")[1];
+      if (!base64) {
+        reject(new Error("Invalid data URL format"));
+        return;
+      }
+      resolve(base64);
+    };
+    reader.onerror = reject;
+    reader.readAsDataURL(file);
+  });
+}


### PR DESCRIPTION
## What

`UploadModal` had a robust File→base64 reader (rejects on a non-string/empty result) and `useVisualId` had its own inline `FileReader` doing the same `data:...;base64,` split (resolving `""` on failure). Both are now a single `fileToBase64(file: Blob)` helper in `lib/utils`.

## Notes

- `readAsDataURL` accepts any `Blob` (and `File` extends `Blob`), so one signature covers both call sites.
- `useVisualId.handleFetch` already wraps the read in `try/catch`, so the unified helper *rejecting* on a malformed blob (rather than sending an empty base64 string the server would reject anyway) is handled gracefully — it surfaces the existing "identification unavailable" toast.
- `tsc` / `oxfmt` clean (no new lint warnings).