### PR TITLE
refactor(frontend): centralize coordinate formatting

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -27,6 +27,7 @@ import {
 } from "./mapUtils";
 import { useBasemap } from "./useBasemap";
 import { BasemapSelector } from "./BasemapSelector";
+import { formatCoordinate } from "../../lib/utils";
 
 interface LocationPickerProps {
   latitude: number | null;
@@ -75,8 +76,8 @@ export function LocationPicker({
   const [searchQuery, setSearchQuery] = useState("");
   const [searchResults, setSearchResults] = useState<NominatimResult[]>([]);
   const [isSearching, setIsSearching] = useState(false);
-  const [latInput, setLatInput] = useState(latitude?.toFixed(6) ?? "");
-  const [lngInput, setLngInput] = useState(longitude?.toFixed(6) ?? "");
+  const [latInput, setLatInput] = useState(latitude != null ? formatCoordinate(latitude) : "");
+  const [lngInput, setLngInput] = useState(longitude != null ? formatCoordinate(longitude) : "");
   const [showCoordinates, setShowCoordinates] = useState(false);
   const theme = useTheme();
   const mode = theme.palette.mode;
@@ -120,8 +121,8 @@ export function LocationPicker({
       }
       updateMarker(lng, lat);
       onChange(lat, lng);
-      setLatInput(lat.toFixed(6));
-      setLngInput(lng.toFixed(6));
+      setLatInput(formatCoordinate(lat));
+      setLngInput(formatCoordinate(lng));
     },
     [onChange, updateMarker],
   );
@@ -186,8 +187,8 @@ export function LocationPicker({
       const { latitude: lat, longitude: lng } = e.coords;
       updateMarker(lng, lat);
       onChange(lat, lng);
-      setLatInput(lat.toFixed(6));
-      setLngInput(lng.toFixed(6));
+      setLatInput(formatCoordinate(lat));
+      setLngInput(formatCoordinate(lng));
     });
 
     mapInstance.on("load", () => {
@@ -218,8 +219,8 @@ export function LocationPicker({
       const { lng, lat } = e.lngLat;
       updateMarker(lng, lat);
       onChange(lat, lng);
-      setLatInput(lat.toFixed(6));
-      setLngInput(lng.toFixed(6));
+      setLatInput(formatCoordinate(lat));
+      setLngInput(formatCoordinate(lng));
     });
 
     map.current = mapInstance;
@@ -257,8 +258,8 @@ export function LocationPicker({
     ) {
       updateMarker(longitude, latitude);
       map.current.setCenter([longitude, latitude]);
-      setLatInput(latitude.toFixed(6));
-      setLngInput(longitude.toFixed(6));
+      setLatInput(formatCoordinate(latitude));
+      setLngInput(formatCoordinate(longitude));
     }
   }, [latitude, longitude, updateMarker]);
 

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -37,7 +37,7 @@ import { ConfirmDialog } from "../common/ConfirmDialog";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { VisualId } from "../identification/VisualId";
 import { PhotoLightbox } from "../observation/PhotoLightbox";
-import { getErrorMessage, fileToBase64 } from "../../lib/utils";
+import { getErrorMessage, fileToBase64, formatCoordinate } from "../../lib/utils";
 import { KINGDOMS } from "../../lib/kingdoms";
 import { TAXON_RANKS } from "../../lib/taxonRanks";
 import { pickPhotos } from "../../lib/photoPicker";
@@ -119,8 +119,8 @@ export function UploadModal() {
     if (!editingObservation) {
       setLicense(defaultLicense ?? DEFAULT_LICENSE);
       if (currentLocation) {
-        setLat(currentLocation.lat.toFixed(6));
-        setLng(currentLocation.lng.toFixed(6));
+        setLat(formatCoordinate(currentLocation.lat));
+        setLng(formatCoordinate(currentLocation.lng));
       }
       const pending = consumePendingUploadFiles();
       if (pending.length > 0) {
@@ -139,8 +139,8 @@ export function UploadModal() {
       setObservationDate(toDatetimeLocal(new Date(editingObservation.eventDate)));
     }
     if (editingObservation.location) {
-      setLat(editingObservation.location.latitude.toFixed(6));
-      setLng(editingObservation.location.longitude.toFixed(6));
+      setLat(formatCoordinate(editingObservation.location.latitude));
+      setLng(formatCoordinate(editingObservation.location.longitude));
       if (editingObservation.location.uncertaintyMeters) {
         setUncertaintyMeters(editingObservation.location.uncertaintyMeters);
       }
@@ -287,8 +287,8 @@ export function UploadModal() {
           if (latRefValue === "S") latitude = -Math.abs(latitude);
           if (lngRefValue === "W") longitude = -Math.abs(longitude);
 
-          setLat(latitude.toFixed(6));
-          setLng(longitude.toFixed(6));
+          setLat(formatCoordinate(latitude));
+          setLng(formatCoordinate(longitude));
           toast.success("Location extracted from photo EXIF data");
         }
       }
@@ -402,8 +402,8 @@ export function UploadModal() {
   };
 
   const handleLocationChange = (newLat: number, newLng: number) => {
-    setLat(newLat.toFixed(6));
-    setLng(newLng.toFixed(6));
+    setLat(formatCoordinate(newLat));
+    setLng(formatCoordinate(newLng));
     setIsDirty(true);
   };
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -5,6 +5,14 @@
 /** Maximum number of results shown in autocomplete dropdowns. */
 export const MAX_AUTOCOMPLETE_RESULTS = 5;
 
+/** Decimal places used when formatting latitude/longitude for display and inputs. */
+export const COORDINATE_PRECISION = 6;
+
+/** Format a latitude or longitude to the standard coordinate precision. */
+export function formatCoordinate(value: number): string {
+  return value.toFixed(COORDINATE_PRECISION);
+}
+
 /**
  * Format a Date as a compact relative time string (e.g., "now", "5m", "2h", "3d")
  * For dates older than a week, returns a formatted date string.


### PR DESCRIPTION
## What

The 6-decimal latitude/longitude format was spelled out as `.toFixed(6)` in ~18 places across `UploadModal` and `LocationPicker` — a magic number with no shared intent.

This adds `COORDINATE_PRECISION` and a `formatCoordinate(value: number)` helper to `lib/utils` and routes all coordinate formatting through it (including the `latitude?.toFixed(6) ?? ""` input-seed cases, rewritten as `latitude != null ? formatCoordinate(latitude) : ""`).

## Notes

- Behavior-preserving; output is identical.
- `tsc` / `oxfmt` clean; no new lint warnings.