### PR TITLE
refactor(taxon): extract shared TaxonHeroCard component

### DIFF
--- a/frontend/src/components/taxon/TaxonDetail.tsx
+++ b/frontend/src/components/taxon/TaxonDetail.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   Stack,
   IconButton,
-  Chip,
   Divider,
   Link as MuiLink,
   List,
@@ -18,13 +17,12 @@ import {
   AccordionDetails,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { slugToName } from "../../lib/taxonSlug";
 import { useTaxon, useTaxonOccurrences } from "../../lib/query/hooks";
-import { ConservationStatus } from "../common/ConservationStatus";
 import { LoadMoreButton } from "../common/LoadMoreButton";
 import { TaxonLink, shouldItalicizeTaxonName } from "../common/TaxonLink";
+import { TaxonHeroCard } from "./TaxonHeroCard";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useWikidataThumbnails } from "../../hooks/useWikidataThumbnails";
 import { WikiTaxonThumbnail } from "../common/WikiTaxonThumbnail";
@@ -111,10 +109,6 @@ export function TaxonDetail() {
     );
   }
 
-  // Use external URLs from the API response
-  const gbifUrl = taxon.gbifUrl;
-  const wikidataUrl = taxon.wikidataUrl;
-
   // Hero image: prefer photoUrl, fall back to larger Wikidata thumbnail
   const heroUrl =
     taxon.photoUrl ||
@@ -190,129 +184,7 @@ export function TaxonDetail() {
             </Stack>
           )}
 
-          {/* Image card + title block */}
-          <Stack
-            direction={{ xs: "column", sm: "row" }}
-            spacing={2}
-            sx={{ alignItems: { xs: "stretch", sm: "flex-start" } }}
-          >
-            {heroUrl && (
-              <Box
-                sx={{
-                  width: 240,
-                  height: 240,
-                  maxWidth: "100%",
-                  flexShrink: 0,
-                  borderRadius: 1,
-                  overflow: "hidden",
-                  backgroundColor: "action.hover",
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                  mx: { xs: "auto", sm: 0 },
-                }}
-              >
-                <Box
-                  component="img"
-                  src={heroUrl}
-                  alt={taxon.scientificName}
-                  sx={{
-                    width: "100%",
-                    height: "100%",
-                    objectFit: "contain",
-                    display: "block",
-                  }}
-                />
-              </Box>
-            )}
-            <Box sx={{ flex: 1, minWidth: 0 }}>
-              {/* Scientific Name */}
-              <Typography
-                variant="h5"
-                sx={{
-                  fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
-                    ? "italic"
-                    : "normal",
-                  color: "primary.main",
-                  fontWeight: 600,
-                }}
-              >
-                {taxon.scientificName}
-              </Typography>
-
-              {/* Common Name */}
-              {taxon.commonName && (
-                <Typography
-                  variant="h6"
-                  component="p"
-                  sx={{
-                    color: "text.secondary",
-                    mt: 0.5,
-                  }}
-                >
-                  {taxon.commonName}
-                </Typography>
-              )}
-
-              {/* Stats + External Links */}
-              <Stack
-                direction="row"
-                spacing={1}
-                sx={{
-                  alignItems: "center",
-                  mt: 2,
-                  flexWrap: "wrap",
-                }}
-              >
-                {taxon.conservationStatus && (
-                  <ConservationStatus status={taxon.conservationStatus} showLabel />
-                )}
-                {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
-                <Typography
-                  variant="body2"
-                  sx={{
-                    color: "text.secondary",
-                  }}
-                >
-                  {taxon.observationCount} observation{taxon.observationCount !== 1 ? "s" : ""} on
-                  Observ.ing
-                  {taxon.numDescendants !== undefined && taxon.numDescendants > 0 && (
-                    <> &middot; {taxon.numDescendants.toLocaleString()} descendant taxa</>
-                  )}
-                </Typography>
-                {(gbifUrl || wikidataUrl) && (
-                  <>
-                    {gbifUrl && (
-                      <Chip
-                        component="a"
-                        href={gbifUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        label="GBIF"
-                        size="small"
-                        variant="outlined"
-                        clickable
-                        icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                      />
-                    )}
-                    {wikidataUrl && (
-                      <Chip
-                        component="a"
-                        href={wikidataUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        label="Wikidata"
-                        size="small"
-                        variant="outlined"
-                        clickable
-                        icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                      />
-                    )}
-                  </>
-                )}
-              </Stack>
-            </Box>
-          </Stack>
+          <TaxonHeroCard taxon={taxon} heroUrl={heroUrl} />
 
           {/* Taxonomy Tree */}
           {((taxon.ancestors?.length ?? 0) > 0 || (taxon.children?.length ?? 0) > 0) && (

--- a/frontend/src/components/taxon/TaxonDetailPanel.tsx
+++ b/frontend/src/components/taxon/TaxonDetailPanel.tsx
@@ -6,7 +6,6 @@ import {
   Button,
   Stack,
   IconButton,
-  Chip,
   Divider,
   Link as MuiLink,
   Accordion,
@@ -15,14 +14,12 @@ import {
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import AccountTreeIcon from "@mui/icons-material/AccountTree";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import type { TaxonDetail as TaxonDetailType, Occurrence } from "../../services/types";
-import { ConservationStatus } from "../common/ConservationStatus";
 import { LoadMoreButton } from "../common/LoadMoreButton";
-import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { WikiCommonsGallery } from "../common/WikiCommonsGallery";
 import { FeedItem } from "../feed/FeedItem";
+import { TaxonHeroCard } from "./TaxonHeroCard";
 
 interface TaxonDetailPanelProps {
   taxon: TaxonDetailType;
@@ -47,9 +44,6 @@ export function TaxonDetailPanel({
 }: TaxonDetailPanelProps) {
   const [descExpanded, setDescExpanded] = useState(false);
   const [galleryMounted, setGalleryMounted] = useState(false);
-
-  const gbifUrl = taxon.gbifUrl;
-  const wikidataUrl = taxon.wikidataUrl;
 
   return (
     <Box sx={{ flex: 1, overflow: "auto", minHeight: 0 }}>
@@ -83,129 +77,7 @@ export function TaxonDetailPanel({
       </Box>
       {/* Main Content */}
       <Box sx={{ p: 3 }}>
-        {/* Image card + title block */}
-        <Stack
-          direction={{ xs: "column", sm: "row" }}
-          spacing={2}
-          sx={{ alignItems: { xs: "stretch", sm: "flex-start" } }}
-        >
-          {heroUrl && (
-            <Box
-              sx={{
-                width: 240,
-                height: 240,
-                maxWidth: "100%",
-                flexShrink: 0,
-                borderRadius: 1,
-                overflow: "hidden",
-                backgroundColor: "action.hover",
-                display: "flex",
-                alignItems: "center",
-                justifyContent: "center",
-                mx: { xs: "auto", sm: 0 },
-              }}
-            >
-              <Box
-                component="img"
-                src={heroUrl}
-                alt={taxon.scientificName}
-                sx={{
-                  width: "100%",
-                  height: "100%",
-                  objectFit: "contain",
-                  display: "block",
-                }}
-              />
-            </Box>
-          )}
-          <Box sx={{ flex: 1, minWidth: 0 }}>
-            {/* Scientific Name */}
-            <Typography
-              variant="h5"
-              sx={{
-                fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
-                  ? "italic"
-                  : "normal",
-                color: "primary.main",
-                fontWeight: 600,
-              }}
-            >
-              {taxon.scientificName}
-            </Typography>
-
-            {/* Common Name */}
-            {taxon.commonName && (
-              <Typography
-                variant="h6"
-                component="p"
-                sx={{
-                  color: "text.secondary",
-                  mt: 0.5,
-                }}
-              >
-                {taxon.commonName}
-              </Typography>
-            )}
-
-            {/* Stats + External Links */}
-            <Stack
-              direction="row"
-              spacing={1}
-              sx={{
-                alignItems: "center",
-                mt: 2,
-                flexWrap: "wrap",
-              }}
-            >
-              {taxon.conservationStatus && (
-                <ConservationStatus status={taxon.conservationStatus} showLabel />
-              )}
-              {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
-              <Typography
-                variant="body2"
-                sx={{
-                  color: "text.secondary",
-                }}
-              >
-                {taxon.observationCount} observation{taxon.observationCount !== 1 ? "s" : ""} on
-                Observ.ing
-                {taxon.numDescendants !== undefined && taxon.numDescendants > 0 && (
-                  <> &middot; {taxon.numDescendants.toLocaleString()} descendant taxa</>
-                )}
-              </Typography>
-              {(gbifUrl || wikidataUrl) && (
-                <>
-                  {gbifUrl && (
-                    <Chip
-                      component="a"
-                      href={gbifUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      label="GBIF"
-                      size="small"
-                      variant="outlined"
-                      clickable
-                      icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                    />
-                  )}
-                  {wikidataUrl && (
-                    <Chip
-                      component="a"
-                      href={wikidataUrl}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      label="Wikidata"
-                      size="small"
-                      variant="outlined"
-                      clickable
-                      icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
-                    />
-                  )}
-                </>
-              )}
-            </Stack>
-          </Box>
-        </Stack>
+        <TaxonHeroCard taxon={taxon} heroUrl={heroUrl} />
 
         {/* Media Gallery — lazy-loaded */}
         <Accordion

--- a/frontend/src/components/taxon/TaxonHeroCard.stories.tsx
+++ b/frontend/src/components/taxon/TaxonHeroCard.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { TaxonHeroCard } from "./TaxonHeroCard";
+import { OAK_TAXON_DETAIL } from "../../../.storybook/fixtures";
+
+const meta = {
+  title: "Taxon/TaxonHeroCard",
+  component: TaxonHeroCard,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof TaxonHeroCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const WithHeroImage: Story = {
+  args: {
+    taxon: OAK_TAXON_DETAIL,
+    heroUrl: OAK_TAXON_DETAIL.photoUrl,
+  },
+};
+
+export const NoHeroImage: Story = {
+  args: {
+    taxon: OAK_TAXON_DETAIL,
+  },
+};

--- a/frontend/src/components/taxon/TaxonHeroCard.tsx
+++ b/frontend/src/components/taxon/TaxonHeroCard.tsx
@@ -1,0 +1,147 @@
+import { Box, Typography, Chip, Stack } from "@mui/material";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import type { TaxonDetail } from "../../services/types";
+import { ConservationStatus } from "../common/ConservationStatus";
+import { shouldItalicizeTaxonName } from "../common/TaxonLink";
+
+export interface TaxonHeroCardProps {
+  taxon: TaxonDetail;
+  /** Large hero image URL; the image card is omitted when absent. */
+  heroUrl?: string | undefined;
+}
+
+/**
+ * The taxon hero block: an optional 240×240 image card alongside the scientific
+ * name, common name, conservation/extinct chips, observation count, and
+ * GBIF/Wikidata links. Shared by the full-page `TaxonDetail` and the
+ * `TaxonDetailPanel` side panel.
+ */
+export function TaxonHeroCard({ taxon, heroUrl }: TaxonHeroCardProps) {
+  const gbifUrl = taxon.gbifUrl;
+  const wikidataUrl = taxon.wikidataUrl;
+
+  return (
+    <Stack
+      direction={{ xs: "column", sm: "row" }}
+      spacing={2}
+      sx={{ alignItems: { xs: "stretch", sm: "flex-start" } }}
+    >
+      {heroUrl && (
+        <Box
+          sx={{
+            width: 240,
+            height: 240,
+            maxWidth: "100%",
+            flexShrink: 0,
+            borderRadius: 1,
+            overflow: "hidden",
+            backgroundColor: "action.hover",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            mx: { xs: "auto", sm: 0 },
+          }}
+        >
+          <Box
+            component="img"
+            src={heroUrl}
+            alt={taxon.scientificName}
+            sx={{
+              width: "100%",
+              height: "100%",
+              objectFit: "contain",
+              display: "block",
+            }}
+          />
+        </Box>
+      )}
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        {/* Scientific Name */}
+        <Typography
+          variant="h5"
+          sx={{
+            fontStyle: shouldItalicizeTaxonName(taxon.scientificName, taxon.rank)
+              ? "italic"
+              : "normal",
+            color: "primary.main",
+            fontWeight: 600,
+          }}
+        >
+          {taxon.scientificName}
+        </Typography>
+
+        {/* Common Name */}
+        {taxon.commonName && (
+          <Typography
+            variant="h6"
+            component="p"
+            sx={{
+              color: "text.secondary",
+              mt: 0.5,
+            }}
+          >
+            {taxon.commonName}
+          </Typography>
+        )}
+
+        {/* Stats + External Links */}
+        <Stack
+          direction="row"
+          spacing={1}
+          sx={{
+            alignItems: "center",
+            mt: 2,
+            flexWrap: "wrap",
+          }}
+        >
+          {taxon.conservationStatus && (
+            <ConservationStatus status={taxon.conservationStatus} showLabel />
+          )}
+          {taxon.extinct && <Chip label="Extinct" size="small" color="error" />}
+          <Typography
+            variant="body2"
+            sx={{
+              color: "text.secondary",
+            }}
+          >
+            {taxon.observationCount} observation{taxon.observationCount !== 1 ? "s" : ""} on
+            Observ.ing
+            {taxon.numDescendants !== undefined && taxon.numDescendants > 0 && (
+              <> &middot; {taxon.numDescendants.toLocaleString()} descendant taxa</>
+            )}
+          </Typography>
+          {(gbifUrl || wikidataUrl) && (
+            <>
+              {gbifUrl && (
+                <Chip
+                  component="a"
+                  href={gbifUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  label="GBIF"
+                  size="small"
+                  variant="outlined"
+                  clickable
+                  icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                />
+              )}
+              {wikidataUrl && (
+                <Chip
+                  component="a"
+                  href={wikidataUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  label="Wikidata"
+                  size="small"
+                  variant="outlined"
+                  clickable
+                  icon={<OpenInNewIcon sx={{ fontSize: 14 }} />}
+                />
+              )}
+            </>
+          )}
+        </Stack>
+      </Box>
+    </Stack>
+  );
+}


### PR DESCRIPTION
## What

`TaxonDetail` (full page) and `TaxonDetailPanel` (side panel) rendered a **byte-identical** ~120-line "image card + title block":

- the optional 240×240 hero image card,
- the scientific name (italicized via `shouldItalicizeTaxonName`),
- the common name,
- the conservation-status + "Extinct" chips,
- the observation count (+ descendant-taxa suffix),
- the GBIF / Wikidata external-link chips.

This extracts a `TaxonHeroCard` component (with a Storybook story, as `check:stories` requires) and renders it in both, dropping each file's now-unused `Chip` / `OpenInNewIcon` / `ConservationStatus` imports and `gbifUrl`/`wikidataUrl` locals.

## Notes

- Pure presentational extraction — identical markup; both call sites already had the same `taxon: TaxonDetail` + `heroUrl` inputs.
- The surrounding chrome that *differs* (TaxonDetail's breadcrumb, the Panel's tree-toggle header) is intentionally left in each component.
- `tsc`, `oxlint`, `oxfmt`, and `check:stories` all clean.