### PR TITLE
fix(taxon): don't select a tree node when collapsing its arrow

### DIFF
--- a/frontend/src/components/taxon/TaxonTreePanel.tsx
+++ b/frontend/src/components/taxon/TaxonTreePanel.tsx
@@ -31,6 +31,11 @@ function renderTreeItems(
       <TreeItem
         key={item.id}
         itemId={item.id}
+        // The expand/collapse arrow lives inside the selectable content, so a
+        // click on it bubbles up and selects (navigates to) the item. Stop the
+        // arrow click from reaching the content handler; MUI runs this before
+        // its own expansion logic, so collapsing/expanding still works.
+        slotProps={{ iconContainer: { onClick: (event) => event.stopPropagation() } }}
         label={
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, py: 0.25 }}>
             <Box


### PR DESCRIPTION
## Problem

In the taxonomy tree (e.g. `/taxon/Plantae/Magnoliopsida`), clicking the expand/collapse **arrow** on an entry you don't have selected navigates to (selects) that entry.

## Root cause

The tree uses MUI `SimpleTreeView`, where the selected item drives navigation. Reading the `@mui/x-tree-view` v9 source, the click wiring is:

- the **content** root's handler always runs `handleSelection`;
- the **iconContainer** (arrow) handler only runs `handleExpansion` — it never selects.

But the iconContainer is a DOM **child** of content, so an arrow click bubbles up to the content handler and selects. `expansionTrigger="iconContainer"` (added in #410) only stops *content* clicks from *expanding* — it does nothing about this bubble-to-select, which is why #410 didn't fully fix it.

## Fix

Stop the arrow click from propagating to the content handler, via the `iconContainer` **slot** (no class-name lookups):

```tsx
slotProps={{ iconContainer: { onClick: (event) => event.stopPropagation() } }}
```

MUI invokes the slot's `onClick` *before* its own expansion logic and only skips expansion when `event.defaultMuiPrevented` is set — so `stopPropagation()` suppresses the bubble-to-select while leaving expand/collapse fully intact.

## Verification

Ran the frontend locally against live backend data with Playwright:

- ✅ Collapse arrow on an unselected, expanded ancestor — collapses, URL/selection unchanged.
- ✅ Expand arrow — expands, URL/selection unchanged.
- ✅ Row label click — still navigates to the taxon (no regression).
- ✅ No console errors.