### PR TITLE
fix(pwa): add standard mobile-web-app-capable meta tag

### DIFF
--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -12,6 +12,7 @@
       content="A decentralized platform for biodiversity observations, built on the AT Protocol. Record what you see, keep what you create."
     />
     <meta name="theme-color" content="#3a7d44" />
+    <meta name="mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="apple-mobile-web-app-title" content="Observ.ing" />


### PR DESCRIPTION
## What

Adds the standard `<meta name="mobile-web-app-capable" content="yes">` to `frontend/src/index.html`, alongside the existing `apple-mobile-web-app-capable` tag.

## Why

Chrome logs a console warning on every page load:

> `<meta name="apple-mobile-web-app-capable" content="yes">` is deprecated. Please include `<meta name="mobile-web-app-capable" content="yes">`

The `apple-` prefixed tag is **kept** because iOS Safari still relies on it for add-to-home-screen / standalone behavior; the standard tag is what Chromium browsers now expect. Including both satisfies all engines and silences the warning.

## Testing

- Verified the warning originates from this tag while driving the app locally with Playwright (it fired on every route).
- One-line, static-markup change; no runtime/logic impact.