### PR TITLE
fix(upload): label full coordinate-uncertainty slider range

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -56,6 +56,8 @@ function sliderToValue(slider: number): number {
 const SLIDER_MIN = valueToSlider(1);
 const SLIDER_MAX = valueToSlider(500000);
 const SLIDER_MARKS = [
+  { value: valueToSlider(1), label: "1m" },
+  { value: valueToSlider(10), label: "10m" },
   { value: valueToSlider(100), label: "100m" },
   { value: valueToSlider(1000), label: "1km" },
   { value: valueToSlider(10000), label: "10km" },


### PR DESCRIPTION
## What
Adds `1m` and `10m` tick labels to the coordinate-uncertainty slider in the New/Edit Observation form (`LocationPicker.tsx`).

## Why
The slider is a **log10 meters scale** (min `1m`, max `500km`), but the tick labels started at `100m` — leaving the entire `1m`–`100m` segment (~35% of the track, the leftmost portion) unlabeled. The **50 m default** sits inside that unlabeled region, so the readout "Coordinate Uncertainty: 50m" appeared *to the left* of the first `100m` tick with no reference point, looking like a scale/label mismatch.

Labeling the slider's true low end fixes it: ticks now read `1m · 10m · 100m · 1km · 10km · 100km`, and 50 m falls clearly between `10m` and `100m`.

## Notes
- No change to the slider min/max, scale math, or default — purely adds two labels.
- Verified live in the browser (Playwright): the New Observation modal now shows all six ticks with the 50 m handle between 10m and 100m. fmt/oxlint/tsc all pass.