### PR TITLE
fix(ui): close FAB after action, silence map sprite warnings, stop deleted-observation refetch

### DIFF
--- a/frontend/src/components/common/FAB.tsx
+++ b/frontend/src/components/common/FAB.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
@@ -9,16 +10,22 @@ import { pickPhotos } from "../../lib/photoPicker";
 export function FAB() {
   const dispatch = useAppDispatch();
   const user = useAppSelector((state) => state.auth.user);
+  // Controlled open state so we can force the speed-dial closed when an action
+  // opens a modal, and keep it closed when focus returns to the FAB after that
+  // modal closes (see onOpen below).
+  const [open, setOpen] = useState(false);
 
   if (!user) {
     return null;
   }
 
   const handleNewObservation = () => {
+    setOpen(false);
     dispatch(openUploadModal());
   };
 
   const handleQuickPhoto = async () => {
+    setOpen(false);
     const files = await pickPhotos({ source: "camera" });
     if (files.length > 0) {
       setPendingUploadFiles(files);
@@ -36,6 +43,14 @@ export function FAB() {
       ariaLabel="Create actions"
       icon={<SpeedDialIcon icon={<AddIcon />} />}
       direction="up"
+      open={open}
+      // Ignore the "focus" reason: MUI re-opens the dial when focus returns to
+      // it after a modal we launched closes, which is the reopen bug. Click
+      // ("toggle") and hover ("mouseEnter") still open it.
+      onOpen={(_event, reason) => {
+        if (reason !== "focus") setOpen(true);
+      }}
+      onClose={() => setOpen(false)}
       sx={{
         position: "fixed",
         bottom: 16,

--- a/frontend/src/components/map/mapUtils.test.ts
+++ b/frontend/src/components/map/mapUtils.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi } from "vitest";
+import { suppressMissingImages, type StyleImageMissingMap } from "./mapUtils";
+
+// maplibre-gl is a heavy WebGL module and `suppressMissingImages` only needs
+// the `on`/`hasImage`/`addImage` surface of the map it's handed, so stub the
+// package to keep this a pure unit test (mapUtils default-imports it).
+vi.mock("maplibre-gl", () => ({ default: {} }));
+
+describe("suppressMissingImages", () => {
+  function makeFakeMap(hasImage = false) {
+    const handlers: Record<string, (e: { id: string }) => void> = {};
+    const addImage =
+      vi.fn<(id: string, image: { width: number; height: number; data: Uint8Array }) => void>();
+    const map: StyleImageMissingMap = {
+      on: (type, listener) => {
+        handlers[type] = listener;
+      },
+      hasImage: () => hasImage,
+      addImage,
+    };
+    return {
+      map,
+      addImage,
+      fire: (id: string) => handlers["styleimagemissing"]?.({ id }),
+    };
+  }
+
+  it("registers a styleimagemissing handler that handles missing ids", () => {
+    const { map, addImage, fire } = makeFakeMap(false);
+    suppressMissingImages(map);
+
+    fire("artwork");
+    expect(addImage).toHaveBeenCalledTimes(1);
+  });
+
+  it("adds a 1x1 fully-transparent placeholder for a missing image id", () => {
+    const { map, addImage, fire } = makeFakeMap(false);
+    suppressMissingImages(map);
+
+    fire("artwork");
+
+    const [id, image] = addImage.mock.calls[0];
+    expect(id).toBe("artwork");
+    expect(image.width).toBe(1);
+    expect(image.height).toBe(1);
+    expect(image.data).toBeInstanceOf(Uint8Array);
+    expect([...image.data]).toEqual([0, 0, 0, 0]); // RGBA, fully transparent
+  });
+
+  it("does not re-add an image that already exists", () => {
+    const { map, addImage, fire } = makeFakeMap(true);
+    suppressMissingImages(map);
+
+    fire("artwork");
+
+    expect(addImage).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/components/map/mapUtils.ts
+++ b/frontend/src/components/map/mapUtils.ts
@@ -49,13 +49,25 @@ export function createMap(
  * placeholder for any missing id so the warning stops. The handler persists
  * across `setStyle` (basemap/theme swaps), so it only needs to be wired once.
  */
-function suppressMissingImages(map: maplibregl.Map): void {
+export function suppressMissingImages(map: StyleImageMissingMap): void {
   map.on("styleimagemissing", (e) => {
     const id = e.id;
     // Guard against double-add: the event can fire repeatedly for the same id.
     if (map.hasImage(id)) return;
     map.addImage(id, { width: 1, height: 1, data: new Uint8Array(4) });
   });
+}
+
+/**
+ * The minimal slice of a maplibre map that {@link suppressMissingImages}
+ * touches. A real `maplibregl.Map` satisfies it; declaring it as a structural
+ * type lets the handler be unit-tested with a lightweight fake instead of a
+ * real WebGL map.
+ */
+export interface StyleImageMissingMap {
+  on(type: "styleimagemissing", listener: (e: { id: string }) => void): unknown;
+  hasImage(id: string): boolean | undefined;
+  addImage(id: string, image: { width: number; height: number; data: Uint8Array }): void;
 }
 
 /**

--- a/frontend/src/components/map/mapUtils.ts
+++ b/frontend/src/components/map/mapUtils.ts
@@ -26,6 +26,8 @@ export function createMap(
     style: basemapStyleUrl(basemap, mode),
   });
 
+  suppressMissingImages(map);
+
   map.addControl(new maplibregl.NavigationControl({ showCompass: false }), "top-right");
 
   let geolocateControl: maplibregl.GeolocateControl | undefined;
@@ -37,6 +39,23 @@ export function createMap(
   }
 
   return { map, geolocateControl };
+}
+
+/**
+ * Silence MapLibre's `styleimagemissing` warnings. The MapTiler outdoor style
+ * references sprite icons for many OSM POI subclasses (artwork, gallery,
+ * arts_centre, tenrikyo, ...) that aren't in our sprite sheet; without a handler
+ * MapLibre logs a warning per missing id. We register a tiny transparent
+ * placeholder for any missing id so the warning stops. The handler persists
+ * across `setStyle` (basemap/theme swaps), so it only needs to be wired once.
+ */
+function suppressMissingImages(map: maplibregl.Map): void {
+  map.on("styleimagemissing", (e) => {
+    const id = e.id;
+    // Guard against double-add: the event can fire repeatedly for the same id.
+    if (map.hasImage(id)) return;
+    map.addImage(id, { width: 1, height: 1, data: new Uint8Array(4) });
+  });
 }
 
 /**

--- a/frontend/src/components/modals/DeleteConfirmDialog.tsx
+++ b/frontend/src/components/modals/DeleteConfirmDialog.tsx
@@ -2,7 +2,11 @@ import { useNavigate, useLocation } from "react-router-dom";
 import { Typography } from "@mui/material";
 import { ConfirmDialog } from "../common/ConfirmDialog";
 import { useAppDispatch, useAppSelector } from "../../store";
-import { closeDeleteConfirm } from "../../store/uiSlice";
+import {
+  closeDeleteConfirm,
+  startDeletingObservation,
+  clearDeletingObservation,
+} from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
 import { useDeleteObservation } from "../../lib/query/mutations";
 import { getErrorMessage } from "../../lib/utils";
@@ -28,9 +32,15 @@ export function DeleteConfirmDialog() {
   const handleConfirmDelete = () => {
     if (!observation) return;
 
+    // Disable the detail query for this uri up front so the still-mounted detail
+    // page doesn't refetch the row (a 404) once the mutation removes it from the
+    // cache, in the gap before we navigate home.
+    const uri = observation.uri;
+    dispatch(startDeletingObservation(uri));
+
     // The hook waits for the ingester to drop the row, then drops the detail
     // cache and refetches the feeds so the observation disappears everywhere.
-    deleteObs.mutate(observation.uri, {
+    deleteObs.mutate(uri, {
       onSuccess: () => {
         toast.success("Observation deleted successfully");
         dispatch(closeDeleteConfirm());
@@ -39,8 +49,12 @@ export function DeleteConfirmDialog() {
         if (location.pathname.includes("/observation/")) {
           navigate("/");
         }
+        dispatch(clearDeletingObservation());
       },
       onError: (error) => {
+        // Re-enable the query: the row still exists, so the detail page should
+        // recover its data.
+        dispatch(clearDeletingObservation());
         const message = getErrorMessage(error, "Failed to delete observation");
         toast.error(message);
         if (message.includes("Session expired")) {

--- a/frontend/src/lib/query/hooks.test.tsx
+++ b/frontend/src/lib/query/hooks.test.tsx
@@ -14,15 +14,18 @@ import type * as ApiModule from "../../services/api";
 // every other export intact (hooks.ts pulls many names from this module).
 const fetchHomeFeed = vi.fn(async () => ({ occurrences: [], cursor: undefined }));
 const fetchExploreFeed = vi.fn(async () => ({ occurrences: [], cursor: undefined }));
+const fetchObservation = vi.fn(async () => null);
 vi.mock("../../services/api", async (importOriginal) => ({
   ...(await importOriginal<typeof ApiModule>()),
   fetchHomeFeed: (...args: unknown[]) => fetchHomeFeed(...args),
   fetchExploreFeed: (...args: unknown[]) => fetchExploreFeed(...args),
+  fetchObservation: (...args: unknown[]) => fetchObservation(...args),
 }));
 
 // Imported after the mock is registered so the hook closes over the stubs.
-import { useFeed } from "./hooks";
+import { useFeed, useObservation } from "./hooks";
 import { qk } from "./keys";
+import uiReducer, { startDeletingObservation } from "../../store/uiSlice";
 
 const TEST_USER: User = { did: "did:plc:tester", handle: "tester.example" };
 
@@ -124,5 +127,60 @@ describe("useFeed", () => {
     // The shared "feed" tag is preserved so the like-patcher still matches.
     expect(signedOut[0]).toBe("feed");
     expect(signedIn[0]).toBe("feed");
+  });
+});
+
+// The detail query must go quiet the instant a delete for that observation
+// starts. Otherwise the delete mutation's `removeQueries` runs while this
+// query still has an active observer, React Query refetches to repopulate it,
+// and the request hits the now-deleted row -> a 404 in the gap before the
+// detail page navigates away. `useObservation` gates `enabled` on
+// `ui.deletingObservationUri`.
+describe("useObservation", () => {
+  const URI = "at://did:plc:tester/bio.lexicons.temp.v0-1.occurrence/abc";
+
+  function makeUiStore() {
+    return configureStore({ reducer: { ui: uiReducer } });
+  }
+
+  function uiWrapper(store: ReturnType<typeof makeUiStore>, client: QueryClient) {
+    return ({ children }: { children: ReactNode }) => (
+      <Provider store={store}>
+        <QueryClientProvider client={client}>{children}</QueryClientProvider>
+      </Provider>
+    );
+  }
+
+  beforeEach(() => {
+    fetchObservation.mockClear();
+  });
+
+  it("fetches the observation when no delete is in progress", async () => {
+    const store = makeUiStore();
+    renderHook(() => useObservation(URI), { wrapper: uiWrapper(store, makeClient()) });
+
+    await waitFor(() => expect(fetchObservation).toHaveBeenCalledTimes(1));
+    expect(fetchObservation).toHaveBeenCalledWith(URI);
+  });
+
+  it("does not fetch while that observation is being deleted", async () => {
+    const store = makeUiStore();
+    store.dispatch(startDeletingObservation(URI));
+    renderHook(() => useObservation(URI), { wrapper: uiWrapper(store, makeClient()) });
+
+    // Give React Query a turn; the query must stay disabled, so no refetch of
+    // the row the delete is about to remove.
+    await Promise.resolve();
+    expect(fetchObservation).not.toHaveBeenCalled();
+  });
+
+  it("still fetches when a different observation is being deleted", async () => {
+    const store = makeUiStore();
+    store.dispatch(
+      startDeletingObservation("at://did:plc:other/bio.lexicons.temp.v0-1.occurrence/zzz"),
+    );
+    renderHook(() => useObservation(URI), { wrapper: uiWrapper(store, makeClient()) });
+
+    await waitFor(() => expect(fetchObservation).toHaveBeenCalledTimes(1));
   });
 });

--- a/frontend/src/lib/query/hooks.ts
+++ b/frontend/src/lib/query/hooks.ts
@@ -82,10 +82,14 @@ export function useTaxonOccurrences(kingdomOrId: string, name?: string) {
 // ── Single reads ─────────────────────────────────────────────────────────────
 
 export function useObservation(uri: string | undefined) {
+  // Once a delete for this observation starts, stop fetching it: the mutation
+  // removes the detail cache, and without this the still-mounted detail page
+  // would refetch the now-deleted row (a 404) before navigating away.
+  const isDeleting = useAppSelector((s) => s.ui.deletingObservationUri === uri);
   return useQuery({
     queryKey: qk.observation(uri ?? ""),
     queryFn: () => fetchObservation(uri ?? ""),
-    enabled: !!uri,
+    enabled: !!uri && !isDeleting,
   });
 }
 

--- a/frontend/src/store/uiSlice.test.ts
+++ b/frontend/src/store/uiSlice.test.ts
@@ -8,6 +8,8 @@ import uiReducer, {
   closeUploadModal,
   openDeleteConfirm,
   closeDeleteConfirm,
+  startDeletingObservation,
+  clearDeletingObservation,
   addToast,
   removeToast,
   setCurrentLocation,
@@ -146,6 +148,28 @@ describe("uiSlice", () => {
       store.dispatch(closeDeleteConfirm());
 
       expect(store.getState().ui.deleteConfirmObservation).toBeNull();
+    });
+  });
+
+  describe("deleting observation", () => {
+    it("defaults to no observation being deleted", () => {
+      const store = createTestStore();
+      expect(store.getState().ui.deletingObservationUri).toBeNull();
+    });
+
+    it("records the uri whose delete is in progress", () => {
+      const store = createTestStore();
+      store.dispatch(startDeletingObservation(mockOccurrence.uri));
+
+      expect(store.getState().ui.deletingObservationUri).toBe(mockOccurrence.uri);
+    });
+
+    it("clears the in-progress uri", () => {
+      const store = createTestStore();
+      store.dispatch(startDeletingObservation(mockOccurrence.uri));
+      store.dispatch(clearDeletingObservation());
+
+      expect(store.getState().ui.deletingObservationUri).toBeNull();
     });
   });
 

--- a/frontend/src/store/uiSlice.ts
+++ b/frontend/src/store/uiSlice.ts
@@ -35,6 +35,10 @@ interface UIState {
   uploadModalOpen: boolean;
   editingObservation: Occurrence | null;
   deleteConfirmObservation: Occurrence | null;
+  // AT URI of an observation whose delete is in progress / just completed. The
+  // detail query is disabled for it so it doesn't refetch the now-removed row
+  // (a 404) in the gap before the detail page navigates away.
+  deletingObservationUri: string | null;
   toasts: Toast[];
   currentLocation: { lat: number; lng: number } | null;
   themeMode: ThemeMode;
@@ -48,6 +52,7 @@ const initialState: UIState = {
   uploadModalOpen: false,
   editingObservation: null,
   deleteConfirmObservation: null,
+  deletingObservationUri: null,
   toasts: [],
   currentLocation: null,
   themeMode: storedTheme,
@@ -81,6 +86,12 @@ const uiSlice = createSlice({
     },
     closeDeleteConfirm: (state) => {
       state.deleteConfirmObservation = null;
+    },
+    startDeletingObservation: (state, action: PayloadAction<string>) => {
+      state.deletingObservationUri = action.payload;
+    },
+    clearDeletingObservation: (state) => {
+      state.deletingObservationUri = null;
     },
     addToast: (state, action: PayloadAction<{ message: string; type: "success" | "error" }>) => {
       state.toasts.push({
@@ -117,6 +128,8 @@ export const {
   closeUploadModal,
   openDeleteConfirm,
   closeDeleteConfirm,
+  startDeletingObservation,
+  clearDeletingObservation,
   addToast,
   removeToast,
   setCurrentLocation,

--- a/frontend/tests/upload.spec.ts
+++ b/frontend/tests/upload.spec.ts
@@ -40,6 +40,23 @@ authTest.describe("Upload Modal - Logged In", () => {
     await authExpect(page.getByLabel(/Taxon/i)).not.toBeVisible();
   });
 
+  // Regression: the create speed-dial must stay closed after an action opens
+  // and then closes the upload modal. The SpeedDial used to re-open when focus
+  // returned to the FAB on modal close (MUI opens the dial on focus).
+  authTest(
+    "create FAB menu stays closed after the modal closes",
+    async ({ authenticatedPage: page }) => {
+      await page.goto("/");
+      await openUploadModal(page); // opens the dial, picks New Observation, opens modal
+      await page.getByRole("button", { name: "Cancel" }).click();
+      await authExpect(page.getByLabel(/Taxon/i)).not.toBeVisible();
+
+      // Focus has returned to the FAB; the dial must not have re-opened.
+      await authExpect(page.getByRole("menuitem", { name: "New Observation" })).not.toBeVisible();
+      await authExpect(page.locator(FAB)).toHaveAttribute("aria-expanded", "false");
+    },
+  );
+
   // TC-UPLOAD-003: Authenticated mode banner
   authTest("upload modal shows posting as handle", async ({ authenticatedPage: page }) => {
     await page.goto("/");


### PR DESCRIPTION
Three small UX/console-noise fixes found while polishing the app.

## 1. Create-FAB menu reopens after submit
`FAB.tsx`. The MUI `SpeedDial` was uncontrolled and opens on focus. Choosing an action (New Observation / Quick Photo) opened a modal; when the modal closed, focus returned to the FAB and the speed-dial **re-opened**. Fix: make it controlled and ignore the `"focus"` open reason — click (`toggle`) and hover (`mouseEnter`) still open it; the post-modal focus return no longer does.
**Verified live** (Playwright): menu now stays closed after the modal closes.

## 2. MapLibre `styleimagemissing` console warnings
`mapUtils.ts`. The MapTiler outdoor basemap references sprite icons for OSM POI subclasses (`artwork`, `gallery`, `arts_centre`, `tenrikyo`, …) that aren't in our sprite sheet, logging one warning per id on every map. Fix: a shared `styleimagemissing` handler in `createMap()` registers a 1×1 transparent placeholder (guarded by `hasImage`), persisting across basemap/theme `setStyle` swaps.
**Verified live**: the 5 warnings are gone (0 remaining).

## 3. Transient 404 refetch of a just-deleted observation
`DeleteConfirmDialog.tsx` / `hooks.ts` / `uiSlice.ts`. On delete, the mutation's `removeQueries(["observation", uri])` runs while the detail page's `useObservation` still has an active observer, so React Query immediately refetches → `GET /api/occurrences/<uri>` → 404, in the gap before navigating home. Fix: a new `deletingObservationUri` UI-state flag disables the detail query the moment delete starts (cleared on success-after-navigate and on error), so there's no active fetch to repopulate.
Verified by code review + full `tsc`; a clean live repro was blocked by the local env (occurrence rows require the tap-ingester, which wasn't running), but the refetch path is eliminated deterministically.

## Checks
`npm run fmt:check`, `npm run lint` (0 errors; 3 pre-existing warnings in UploadModal.tsx, untouched), and `npx tsc --noEmit` all pass.