### PR TITLE
feat(taxon): show common names and tidy rank in classification tree

### DIFF
--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -17,6 +17,7 @@ const TREE_WIDTH = 300;
 interface TreeNode {
   id: string;
   name: string;
+  commonName?: string | undefined;
   rank: string;
   kingdom: string;
   childrenLoaded: boolean;
@@ -30,6 +31,7 @@ function nodeId(kingdom: string, name: string): string {
 
 export interface TaxonTreeItem extends TreeViewDefaultItemModelProperties {
   rank: string;
+  commonName?: string | undefined;
   children?: TaxonTreeItem[];
 }
 
@@ -45,6 +47,7 @@ function buildItems(id: string, nodes: Map<string, TreeNode>): TaxonTreeItem[] {
     id: node.id,
     label: node.name,
     rank: node.rank,
+    commonName: node.commonName,
   };
   if (children.length > 0) {
     item.children = children;
@@ -170,6 +173,7 @@ export function TaxonExplorer() {
       const existing = nodes.get(currentId);
       if (existing) {
         existing.childrenLoaded = true;
+        if (!existing.commonName) existing.commonName = detail.commonName;
         // Merge children (union)
         for (const cid of currentChildren) {
           if (!existing.childIds.includes(cid)) {
@@ -180,6 +184,7 @@ export function TaxonExplorer() {
         nodes.set(currentId, {
           id: currentId,
           name: detail.scientificName,
+          commonName: detail.commonName,
           rank: detail.rank,
           kingdom: k,
           childrenLoaded: true,
@@ -194,6 +199,7 @@ export function TaxonExplorer() {
           nodes.set(childId, {
             id: childId,
             name: child.scientificName,
+            commonName: child.commonName,
             rank: child.rank,
             kingdom: k,
             childrenLoaded: false,
@@ -241,6 +247,7 @@ export function TaxonExplorer() {
         nodes.set(childId, {
           id: childId,
           name: child.scientificName,
+          commonName: child.commonName,
           rank: child.rank,
           kingdom: parent.kingdom,
           childrenLoaded: false,

--- a/frontend/src/components/taxon/TaxonTreePanel.tsx
+++ b/frontend/src/components/taxon/TaxonTreePanel.tsx
@@ -29,7 +29,7 @@ function renderTreeItems(
         key={item.id}
         itemId={item.id}
         label={
-          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, py: 0.25 }}>
+          <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, py: 0.5 }}>
             <Box
               sx={{
                 width: 20,
@@ -50,24 +50,44 @@ function renderTreeItems(
                 />
               )}
             </Box>
-            <Typography
-              variant="body2"
-              component="span"
-              sx={{
-                fontStyle: shouldItalicizeTaxonName(String(item.label), item.rank)
-                  ? "italic"
-                  : "normal",
-                fontWeight: item.id === selectedId ? 700 : 400,
-              }}
-            >
-              {item.label}
-            </Typography>
+            <Box sx={{ display: "flex", flexDirection: "column", minWidth: 0, flexGrow: 1 }}>
+              <Typography
+                variant="body2"
+                component="span"
+                noWrap
+                sx={{
+                  fontStyle: shouldItalicizeTaxonName(String(item.label), item.rank)
+                    ? "italic"
+                    : "normal",
+                  fontWeight: item.id === selectedId ? 700 : 400,
+                }}
+              >
+                {item.label}
+              </Typography>
+              {item.commonName && (
+                <Typography
+                  variant="caption"
+                  component="span"
+                  noWrap
+                  sx={{
+                    color: "text.secondary",
+                    lineHeight: 1.2,
+                  }}
+                >
+                  {item.commonName}
+                </Typography>
+              )}
+            </Box>
             <Typography
               variant="caption"
               component="span"
               sx={{
-                color: "text.disabled",
+                ml: 1,
                 flexShrink: 0,
+                color: "text.disabled",
+                fontSize: "0.65rem",
+                letterSpacing: "0.04em",
+                textTransform: "uppercase",
               }}
             >
               {item.rank}

--- a/frontend/tests/taxon-explorer.spec.ts
+++ b/frontend/tests/taxon-explorer.spec.ts
@@ -149,19 +149,23 @@ test.describe("Taxon Explorer - Classification tree", () => {
     const tree = page.getByRole("tree");
     await expect(tree).toBeVisible();
 
-    // Tree items are named "<scientificName> <rank>" (e.g. "Quercus genus").
+    // Tree items are named "<scientificName> <rank>" (e.g. "Quercus genus"),
+    // or "<scientificName> <commonName> <rank>" when a common name is present.
     // Anchoring on the rank suffix makes assertions unambiguous when a name
     // is a prefix of another (e.g. "Quercus" vs "Quercus agrifolia").
-    const treeitem = (name: string, rank: string) =>
-      tree.getByRole("treeitem", { name: `${name} ${rank}`, exact: true });
+    const treeitem = (name: string, rank: string, commonName?: string) =>
+      tree.getByRole("treeitem", {
+        name: commonName ? `${name} ${commonName} ${rank}` : `${name} ${rank}`,
+        exact: true,
+      });
 
     // The full ancestor chain must be present as tree items.
     for (const ancestor of QUERCUS_AGRIFOLIA_ANCESTORS) {
       await expect(treeitem(ancestor.name, ancestor.rank)).toBeVisible();
     }
 
-    // The current taxon itself.
-    await expect(treeitem("Quercus agrifolia", "species")).toBeVisible();
+    // The current taxon itself (its detail fixture carries a common name).
+    await expect(treeitem("Quercus agrifolia", "species", "Coast Live Oak")).toBeVisible();
 
     // Aunts/uncles: at least one sibling must appear at each ancestor level.
     // These names are distinct from anything on the ancestor path, so their


### PR DESCRIPTION
## What

Adds vernacular (common) names to the taxon classification tree and reworks each row so the extra line doesn't crowd the panel.

- **Common names**: shown as a muted caption under each scientific name in the tree, sourced from the existing `commonName` field on the taxa API (no backend change).
- **Rank, tidied**: pinned to a steady right-aligned, uppercase, letter-spaced column instead of floating mid-row, so it reads as quiet structure rather than scattered repeated tags.
- **Spacing**: a touch more vertical room per row so the two-line name block breathes.

## Why

The classification tree only showed scientific names. Common names make taxa far easier to recognize for non-experts. The rank styling/spacing tweaks keep the panel from feeling noisy now that each row carries two lines.

## Verification

Built the frontend and ran appview locally on :3000; confirmed the tree renders common names (e.g. Arthropoda → "arthropod") with rank aligned in a clean right-hand column.