### PR TITLE
fix(feed): stop home/explore feed from swapping content after load

### DIFF
--- a/frontend/src/lib/query/QueryProvider.tsx
+++ b/frontend/src/lib/query/QueryProvider.tsx
@@ -2,6 +2,7 @@
 // replay. Mount this INSIDE the Redux <Provider> so query hooks can still read
 // UI state (filters, viewer DID) from Redux.
 import type { ReactNode } from "react";
+import { defaultShouldDehydrateQuery } from "@tanstack/react-query";
 import { PersistQueryClientProvider } from "@tanstack/react-query-persist-client";
 import { queryClient, persister, PERSIST_MAX_AGE } from "./queryClient";
 // Side-effect import: registers write-mutation defaults (e.g. likes) on the
@@ -19,6 +20,15 @@ export function QueryProvider({ children }: { children: ReactNode }) {
         // like tapped offline is replayed after a reload + reconnect.
         dehydrateOptions: {
           shouldDehydrateMutation: (mutation) => mutation.state.isPaused,
+          // Persist successful queries by default, but NOT the home/explore feed.
+          // The feed is fast-moving, newest-first, online-only content: a restored
+          // snapshot has no real offline value and is almost always older than its
+          // 1-min staleTime, so it renders instantly on load and then visibly
+          // swaps when the background refetch returns fresher results. Skipping
+          // dehydration makes the feed start clean (one skeleton → content) instead
+          // of flashing stale → fresh. Detail caches (observations, taxa) still persist.
+          shouldDehydrateQuery: (query) =>
+            query.queryKey[0] !== "feed" && defaultShouldDehydrateQuery(query),
         },
         // Bump when cached shapes change incompatibly to discard stale caches.
         buster: "v1",

--- a/frontend/src/lib/query/hooks.ts
+++ b/frontend/src/lib/query/hooks.ts
@@ -54,6 +54,13 @@ export function useFeed(tab: FeedTab) {
     initialPageParam: initialCursor,
     getNextPageParam: nextCursor,
     enabled: authResolved,
+    // The feed is an infinite query showing fast-moving, newest-first content.
+    // A background refetch re-pulls every loaded page and can reorder/duplicate
+    // rows under the reader, so we don't auto-refresh it on tab focus, and we
+    // give it a longer staleTime so re-entering the feed mid-session doesn't
+    // swap content either. Fresh data still loads on a real reload / pull-to-refresh.
+    refetchOnWindowFocus: false,
+    staleTime: 5 * 60 * 1000,
   });
 }
 


### PR DESCRIPTION
## Problem

The home and explore feeds often render instantly on load, then visibly **swap to different results a couple seconds later**. Three things combined to cause it:

1. **Persisted stale snapshot (the main one).** The query cache is persisted to IndexedDB for 7 days (`gcTime: PERSIST_MAX_AGE`), but feeds have a 1-minute `staleTime`. On load, the old feed snapshot is restored from IndexedDB and rendered immediately, then — because it's older than 1 min — refetched in the background and replaced. For a newest-first feed, "fresh" is genuinely different, so you see a reshuffle.
2. **`refetchOnWindowFocus`.** Tabbing back re-ran the *infinite* feed query, re-pulling all loaded pages and reordering/duplicating rows under the reader.
3. **Short `staleTime`.** Re-entering the feed mid-session re-swapped it too.

The root mismatch: feeds are the worst thing to persist — a 7-day-old feed snapshot has no offline value but guarantees a stale→fresh flash on every load. Persistence makes sense for detail data (observations, taxa), not the feed.

## Fix (scoped to the feed only)

- **Exclude `["feed", …]` queries from IndexedDB dehydration** (`shouldDehydrateQuery` in `QueryProvider.tsx`). The feed now starts clean — one skeleton → content — instead of flashing stale → fresh. Detail caches and offline-mutation replay still persist exactly as before.
- **Disable `refetchOnWindowFocus`** for the feed query.
- **Raise the feed `staleTime` to 5 minutes** so re-entering it mid-session doesn't swap either.

Intended tradeoff: a cold load now does one fresh fetch (brief skeleton) instead of instantly painting a stale snapshot — the correct behavior for a newest-first feed.

| Trigger | Before | After |
|---|---|---|
| Cold load | snapshot → background refetch swap | skeleton → content, one clean transition |
| Tab refocus | refetch reshuffles | no auto-refetch |
| Re-enter feed mid-session | stale after 1 min → swap | stable for 5 min |

## Verification

Ran the dev server and drove it headless against the live backend:

- Explore feed loads (`/api/feeds/explore` → 200) and renders 20 observations.
- After loading the feed **and** an observation, the persisted IndexedDB cache contains **only** the `observation` query — the feed query is excluded (`feedPersisted: 0`).
- Tabbing away and back triggers **0** feed refetches.

`oxfmt` clean, `tsc --noEmit` clean, `oxlint` 0 errors.