### PR TITLE
chore(deps): bump jacquard to 0.12

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,12 +28,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aliasable"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "250f629c0161ad8107cf89319e990051fae62832fd343083bea452d93e2205fd"
-
-[[package]]
 name = "alloc-no-stdlib"
 version = "2.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,7 +741,7 @@ version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "proc-macro2",
  "quote",
  "syn",
@@ -1752,12 +1746,6 @@ dependencies = [
 
 [[package]]
 name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
@@ -2249,9 +2237,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jacquard-common"
-version = "0.12.0-beta.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e830579811d60e29209c9466d034225d5e045ecdc2b3c55282709bd07da97869"
+checksum = "82e9239b4bf08cf6b3e9d9d420be8b17bd09ee34228b52b884089cbcf67d23bf"
 dependencies = [
  "base64",
  "bon",
@@ -2271,7 +2259,6 @@ dependencies = [
  "miette",
  "multibase",
  "multihash",
- "ouroboros",
  "oxilangtag",
  "p256",
  "phf",
@@ -2299,11 +2286,11 @@ dependencies = [
 
 [[package]]
 name = "jacquard-derive"
-version = "0.12.0-beta.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f83b8049e4e7916e0f6764c3deaf5e55a7ffbab26c379415e9b1d4d645d957"
+checksum = "7bea6f33da422d272cb09a2571fb65f88aed13612774f2eb635716ce71d1e742"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "jacquard-lexicon",
  "proc-macro2",
  "quote",
@@ -2312,13 +2299,13 @@ dependencies = [
 
 [[package]]
 name = "jacquard-lexicon"
-version = "0.12.0-beta.2"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64935ef85dd24f60f467082c21ad52f739a02dd402a2adf40e5794e3de949e1f"
+checksum = "3bf8be274eb0af89ece99b56cbbc837748f62d44af8ab8280acafdfcafe84db7"
 dependencies = [
  "cid",
  "dashmap",
- "heck 0.5.0",
+ "heck",
  "inventory",
  "jacquard-common",
  "miette",
@@ -3125,30 +3112,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ouroboros"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e0f050db9c44b97a94723127e6be766ac5c340c48f2c4bb3ffa11713744be59"
-dependencies = [
- "aliasable",
- "ouroboros_macro",
- "static_assertions",
-]
-
-[[package]]
-name = "ouroboros_macro"
-version = "0.18.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c7028bdd3d43083f6d8d4d5187680d0d3560d54df4cc9d752005268b41e64d0"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "proc-macro2-diagnostics",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "oxilangtag"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3415,19 +3378,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro2-diagnostics"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af066a9c399a26e020ada66a034357a868728e72cd426f3adcd35f80d88d88c8"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
- "version_check",
- "yansi",
-]
-
-[[package]]
 name = "progenitor"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3459,7 +3409,7 @@ version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6e349eed84b9a1a6a5dbe478d335e3df73d32a93c5eefe571c9b8cb298aab5d"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "http",
  "indexmap",
  "openapiv3",
@@ -4533,7 +4483,7 @@ dependencies = [
  "cfg-if",
  "dotenvy",
  "either",
- "heck 0.5.0",
+ "heck",
  "hex",
  "proc-macro2",
  "quote",
@@ -4643,12 +4593,6 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
-
-[[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "stringprep"
@@ -5228,7 +5172,7 @@ version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa7b026f540b148b81043c720889dbb942b08659aa8a43f624ac4f04dbfc1861"
 dependencies = [
- "heck 0.5.0",
+ "heck",
  "log",
  "proc-macro2",
  "quote",
@@ -5938,7 +5882,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "wit-parser",
 ]
 
@@ -5949,7 +5893,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
- "heck 0.5.0",
+ "heck",
  "indexmap",
  "prettyplease",
  "syn",
@@ -6015,12 +5959,6 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
-
-[[package]]
-name = "yansi"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"

--- a/crates/observing-appview/Cargo.toml
+++ b/crates/observing-appview/Cargo.toml
@@ -25,7 +25,7 @@ observing-species-id-protocol = { path = "../observing-species-id-protocol" }
 pg-url-env = { path = "../pg-url-env" }
 
 # AT Protocol types (for record construction)
-jacquard-common = "0.12.0-beta.2"
+jacquard-common = "0.12"
 
 # Async runtime
 tokio = { workspace = true }

--- a/crates/observing-collections/Cargo.toml
+++ b/crates/observing-collections/Cargo.toml
@@ -10,4 +10,4 @@ license = "MIT OR Apache-2.0"
 # associated const, so the collection constants below cannot drift from the
 # lexicon schemas (e.g. during the lexicons.bio migration).
 observing-lexicons = { path = "../observing-lexicons" }
-jacquard-common = "0.12.0-beta.2"
+jacquard-common = "0.12"

--- a/crates/observing-db/Cargo.toml
+++ b/crates/observing-db/Cargo.toml
@@ -34,5 +34,5 @@ observing-lexicons = { path = "../observing-lexicons", optional = true }
 
 # Test-only: lexicon constraint validation in processing tests
 [dev-dependencies]
-jacquard-lexicon = "0.12.0-beta.2"
+jacquard-lexicon = "0.12"
 tokio = { workspace = true, features = ["rt", "macros"] }

--- a/crates/observing-lexicons/Cargo.toml
+++ b/crates/observing-lexicons/Cargo.toml
@@ -19,8 +19,8 @@ unused_imports = "allow"
 all = "allow"
 
 [dependencies]
-jacquard-common = "0.12.0-beta.2"
-jacquard-derive = "0.12.0-beta.2"
-jacquard-lexicon = "0.12.0-beta.2"
+jacquard-common = "0.12"
+jacquard-derive = "0.12"
+jacquard-lexicon = "0.12"
 rustversion = "1"
 serde = { workspace = true }


### PR DESCRIPTION
Updates `jacquard-common`, `jacquard-derive`, and `jacquard-lexicon` from `0.12.0-beta.2` to the `0.12.0` release.

Picks up https://tangled.org/nonbinary.computer/jacquard/pulls/9/round/0

Closes #649