### PR TITLE
feat(identify): live camera species identification

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -64,6 +64,9 @@ const TransparencyPage = lazy(() =>
 const NotFound = lazy(() =>
   import("./components/common/NotFound").then((m) => ({ default: m.NotFound })),
 );
+const LiveIdView = lazy(() =>
+  import("./components/identification/LiveIdView").then((m) => ({ default: m.LiveIdView })),
+);
 
 function AppContent() {
   const dispatch = useAppDispatch();
@@ -158,6 +161,7 @@ function AppContent() {
               <Route path="/lexicons" element={<LexiconView />} />
               <Route path="/docs" element={<DocsPage />} />
               <Route path="/settings" element={<SettingsPage />} />
+              <Route path="/identify" element={<LiveIdView />} />
               <Route path="/transparency" element={<TransparencyPage />} />
               <Route path="*" element={<NotFound />} />
             </Routes>

--- a/frontend/src/components/common/FAB.tsx
+++ b/frontend/src/components/common/FAB.tsx
@@ -2,12 +2,15 @@ import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import AddAPhotoIcon from "@mui/icons-material/AddAPhoto";
+import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
+import { useNavigate } from "react-router-dom";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { openUploadModal, setPendingUploadFiles } from "../../store/uiSlice";
 import { pickPhotos } from "../../lib/photoPicker";
 
 export function FAB() {
   const dispatch = useAppDispatch();
+  const navigate = useNavigate();
   const user = useAppSelector((state) => state.auth.user);
 
   if (!user) {
@@ -26,9 +29,14 @@ export function FAB() {
     }
   };
 
+  const handleLiveId = () => {
+    navigate("/identify");
+  };
+
   const actions = [
     { icon: <CameraAltIcon />, name: "New Observation", action: handleNewObservation },
     { icon: <AddAPhotoIcon />, name: "Quick Photo", action: handleQuickPhoto },
+    { icon: <CenterFocusStrongIcon />, name: "Live ID", action: handleLiveId },
   ];
 
   return (

--- a/frontend/src/components/common/FAB.tsx
+++ b/frontend/src/components/common/FAB.tsx
@@ -4,6 +4,7 @@ import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import AddAPhotoIcon from "@mui/icons-material/AddAPhoto";
 import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
 import { useNavigate } from "react-router-dom";
+import { Capacitor } from "@capacitor/core";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { openUploadModal, setPendingUploadFiles } from "../../store/uiSlice";
 import { pickPhotos } from "../../lib/photoPicker";
@@ -36,7 +37,12 @@ export function FAB() {
   const actions = [
     { icon: <CameraAltIcon />, name: "New Observation", action: handleNewObservation },
     { icon: <AddAPhotoIcon />, name: "Quick Photo", action: handleQuickPhoto },
-    { icon: <CenterFocusStrongIcon />, name: "Live ID", action: handleLiveId },
+    // Live ID relies on getUserMedia, which only works on web/PWA. Native
+    // builds would open a broken viewfinder, so hide the entry point there
+    // until a Capacitor camera-preview plugin is wired up.
+    ...(Capacitor.isNativePlatform()
+      ? []
+      : [{ icon: <CenterFocusStrongIcon />, name: "Live ID", action: handleLiveId }]),
   ];
 
   return (

--- a/frontend/src/components/identification/LiveIdView.stories.tsx
+++ b/frontend/src/components/identification/LiveIdView.stories.tsx
@@ -1,0 +1,153 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { http, HttpResponse } from "msw";
+import { LiveIdView } from "./LiveIdView";
+import type { SpeciesSuggestion } from "../../services/api";
+
+const SUGGESTIONS: SpeciesSuggestion[] = [
+  {
+    scientificName: "Quercus robur",
+    confidence: 0.92,
+    commonName: "English Oak",
+    kingdom: "Plantae",
+    family: "Fagaceae",
+    genus: "Quercus",
+    inRange: true,
+  },
+  {
+    scientificName: "Quercus alba",
+    confidence: 0.61,
+    commonName: "White Oak",
+    kingdom: "Plantae",
+    family: "Fagaceae",
+    genus: "Quercus",
+    inRange: false,
+  },
+  {
+    scientificName: "Acer rubrum",
+    confidence: 0.38,
+    commonName: "Red Maple",
+    kingdom: "Plantae",
+    family: "Sapindaceae",
+    genus: "Acer",
+  },
+];
+
+const speciesIdHandler = http.post("/api/species-id", () =>
+  HttpResponse.json({ suggestions: SUGGESTIONS, modelVersion: "story", inferenceTimeMs: 120 }),
+);
+
+// --- browser API mocks ------------------------------------------------------
+// LiveIdView gates on geolocation before starting the camera, then samples the
+// live <video> stream. These stubs let each state be viewed without real
+// hardware; they're installed in beforeEach (so they're in place before the
+// component's mount effect runs) and restored by the returned cleanup.
+
+type GeoBehavior = "granted" | "denied" | "pending";
+
+function mockGeolocation(behavior: GeoBehavior): () => void {
+  const original = navigator.geolocation;
+  Object.defineProperty(navigator, "geolocation", {
+    configurable: true,
+    value: {
+      // Typed with the minimal shapes LiveIdView actually consumes (it only
+      // reads coords.latitude/longitude and ignores the error payload), so the
+      // literal needs no full GeolocationPosition / ...PositionError cast.
+      getCurrentPosition(
+        success: (position: { coords: { latitude: number; longitude: number } }) => void,
+        error?: (err: { code: number; message: string }) => void,
+      ): void {
+        if (behavior === "granted") {
+          success({ coords: { latitude: 40.015, longitude: -105.2705 } });
+        } else if (behavior === "denied") {
+          error?.({ code: 1, message: "User denied Geolocation" });
+        }
+        // "pending": never invoke a callback, leaving the prompt on screen.
+      },
+    },
+  });
+  return () =>
+    Object.defineProperty(navigator, "geolocation", { configurable: true, value: original });
+}
+
+// Feed the camera a self-drawn, animating canvas so the <video> actually plays
+// (firing `onPlaying`) and the identification loop has frames to sample.
+function mockCamera(): () => void {
+  const original = navigator.mediaDevices;
+  const canvas = document.createElement("canvas");
+  canvas.width = 1280;
+  canvas.height = 720;
+  const ctx = canvas.getContext("2d");
+  let raf = 0;
+  let t = 0;
+  const draw = () => {
+    if (ctx) {
+      ctx.fillStyle = "#2e5d34";
+      ctx.fillRect(0, 0, canvas.width, canvas.height);
+      ctx.fillStyle = "#7cb342";
+      ctx.beginPath();
+      ctx.arc(640 + Math.sin(t / 30) * 120, 360, 140, 0, Math.PI * 2);
+      ctx.fill();
+    }
+    t += 1;
+    raf = requestAnimationFrame(draw);
+  };
+  draw();
+  const stream = canvas.captureStream(15);
+  Object.defineProperty(navigator, "mediaDevices", {
+    configurable: true,
+    value: { getUserMedia: async () => stream },
+  });
+  return () => {
+    cancelAnimationFrame(raf);
+    stream.getTracks().forEach((track) => track.stop());
+    Object.defineProperty(navigator, "mediaDevices", { configurable: true, value: original });
+  };
+}
+
+/**
+ * Full-screen live camera identifier. Stories stub `navigator.geolocation` and
+ * `getUserMedia`, since the real component needs a granted location and a rear
+ * camera before it shows anything.
+ */
+const meta = {
+  title: "Identification/LiveIdView",
+  component: LiveIdView,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+  // Default to the location-prompt state so the autodocs preview is stable.
+  beforeEach: () => mockGeolocation("pending"),
+} satisfies Meta<typeof LiveIdView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+/** Location permission is still pending — the camera hasn't started yet. */
+export const RequestingLocation: Story = {
+  beforeEach: () => mockGeolocation("pending"),
+};
+
+/** Location was denied — show the blocking gate with a retry. */
+export const LocationDenied: Story = {
+  beforeEach: () => mockGeolocation("denied"),
+};
+
+/**
+ * Location granted and the camera running: the live overlay shows the top guess
+ * (with an in-range 📍), its percentage, common name, and runner-ups, updating
+ * as the mocked `/api/species-id` endpoint responds.
+ */
+export const Live: Story = {
+  parameters: {
+    msw: { handlers: [speciesIdHandler] },
+  },
+  beforeEach: () => {
+    const restoreGeo = mockGeolocation("granted");
+    const restoreCamera = mockCamera();
+    return () => {
+      restoreCamera();
+      restoreGeo();
+    };
+  },
+};

--- a/frontend/src/components/identification/LiveIdView.tsx
+++ b/frontend/src/components/identification/LiveIdView.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Box, CircularProgress, IconButton, Stack, Typography } from "@mui/material";
+import { Box, Button, CircularProgress, IconButton, Stack, Typography } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import PlaceIcon from "@mui/icons-material/Place";
@@ -23,10 +23,37 @@ export function LiveIdView() {
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [coords, setCoords] = useState<{ latitude: number; longitude: number } | null>(null);
+  // Location is a hard requirement: it drives the geo range filtering, so the
+  // camera doesn't start until it's granted (rather than best-effort).
+  const [locationState, setLocationState] = useState<"prompting" | "granted" | "denied">(
+    "prompting",
+  );
 
-  // Acquire the rear camera. Cleanup stops every track so the camera light
-  // goes off the moment we leave the view.
+  const requestLocation = useCallback(() => {
+    if (!navigator.geolocation) {
+      setLocationState("denied");
+      return;
+    }
+    setLocationState("prompting");
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        setCoords({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
+        setLocationState("granted");
+      },
+      () => setLocationState("denied"),
+      { enableHighAccuracy: false, timeout: 10_000, maximumAge: 60_000 },
+    );
+  }, []);
+
+  // Ask for location up front, before the camera or any identification starts.
   useEffect(() => {
+    requestLocation();
+  }, [requestLocation]);
+
+  // Acquire the rear camera only once location is granted. Cleanup stops every
+  // track so the camera light goes off the moment we leave the view.
+  useEffect(() => {
+    if (locationState !== "granted") return;
     let stream: MediaStream | null = null;
     let cancelled = false;
 
@@ -54,25 +81,7 @@ export function LiveIdView() {
       stream?.getTracks().forEach((t) => t.stop());
       streamRef.current = null;
     };
-  }, []);
-
-  // Best-effort location for the geo range boost; identification works without it.
-  useEffect(() => {
-    if (!navigator.geolocation) return;
-    let cancelled = false;
-    navigator.geolocation.getCurrentPosition(
-      (pos) => {
-        if (!cancelled) {
-          setCoords({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
-        }
-      },
-      () => {},
-      { enableHighAccuracy: false, timeout: 5000, maximumAge: 60_000 },
-    );
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  }, [locationState]);
 
   const { suggestions, isInferring } = useLiveId({
     videoRef,
@@ -113,6 +122,58 @@ export function LiveIdView() {
   const sorted = [...suggestions].sort((a, b) => b.confidence - a.confidence);
   const top = sorted[0];
   const rest = sorted.slice(1);
+
+  // Location gate — the camera never starts until we have coordinates.
+  if (locationState !== "granted") {
+    return (
+      <Box
+        sx={{
+          position: "fixed",
+          inset: 0,
+          zIndex: 1300,
+          bgcolor: "black",
+          color: "white",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          textAlign: "center",
+          gap: 2,
+          p: 3,
+        }}
+      >
+        <IconButton
+          onClick={handleClose}
+          aria-label="Close"
+          sx={{ position: "absolute", top: 8, left: 8, color: "white" }}
+        >
+          <CloseIcon />
+        </IconButton>
+        <PlaceIcon sx={{ fontSize: 48, opacity: 0.85 }} />
+        {locationState === "prompting" ? (
+          <>
+            <Typography variant="h6">Allow location access</Typography>
+            <Typography variant="body2" sx={{ opacity: 0.8, maxWidth: 320 }}>
+              Live identification uses your location to narrow suggestions to species found near
+              you. Allow location access to continue.
+            </Typography>
+            <CircularProgress size={20} sx={{ color: "white", mt: 1 }} />
+          </>
+        ) : (
+          <>
+            <Typography variant="h6">Location required</Typography>
+            <Typography variant="body2" sx={{ opacity: 0.8, maxWidth: 320 }}>
+              Live identification needs your location. Enable location access for this site in your
+              browser settings, then try again.
+            </Typography>
+            <Button variant="contained" color="primary" onClick={requestLocation} sx={{ mt: 1 }}>
+              Try again
+            </Button>
+          </>
+        )}
+      </Box>
+    );
+  }
 
   return (
     <Box sx={{ position: "fixed", inset: 0, zIndex: 1300, bgcolor: "black" }}>

--- a/frontend/src/components/identification/LiveIdView.tsx
+++ b/frontend/src/components/identification/LiveIdView.tsx
@@ -1,0 +1,235 @@
+import { useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { Box, CircularProgress, IconButton, Stack, Typography } from "@mui/material";
+import CloseIcon from "@mui/icons-material/Close";
+import CameraAltIcon from "@mui/icons-material/CameraAlt";
+import PlaceIcon from "@mui/icons-material/Place";
+import { useLiveId } from "../../hooks/useLiveId";
+import { useAppDispatch } from "../../store";
+import { openUploadModal, setPendingUploadFiles, addToast } from "../../store/uiSlice";
+
+/**
+ * Full-screen live camera identifier — point the camera at something and the
+ * top species guess updates continuously (Seek-style), backed by the same
+ * `/api/species-id` endpoint the upload flow uses. Web/PWA only for now; it
+ * relies on `getUserMedia` rather than the native Capacitor camera.
+ */
+export function LiveIdView() {
+  const navigate = useNavigate();
+  const dispatch = useAppDispatch();
+  const videoRef = useRef<HTMLVideoElement | null>(null);
+  const streamRef = useRef<MediaStream | null>(null);
+
+  const [ready, setReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [coords, setCoords] = useState<{ latitude: number; longitude: number } | null>(null);
+
+  // Acquire the rear camera. Cleanup stops every track so the camera light
+  // goes off the moment we leave the view.
+  useEffect(() => {
+    let stream: MediaStream | null = null;
+    let cancelled = false;
+
+    navigator.mediaDevices
+      .getUserMedia({ video: { facingMode: "environment" }, audio: false })
+      .then((s) => {
+        if (cancelled) {
+          s.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        stream = s;
+        streamRef.current = s;
+        const video = videoRef.current;
+        if (video) {
+          video.srcObject = s;
+          void video.play();
+        }
+      })
+      .catch(() => {
+        if (!cancelled) setError("Camera access is required for live identification.");
+      });
+
+    return () => {
+      cancelled = true;
+      stream?.getTracks().forEach((t) => t.stop());
+      streamRef.current = null;
+    };
+  }, []);
+
+  // Best-effort location for the geo range boost; identification works without it.
+  useEffect(() => {
+    if (!navigator.geolocation) return;
+    let cancelled = false;
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        if (!cancelled) {
+          setCoords({ latitude: pos.coords.latitude, longitude: pos.coords.longitude });
+        }
+      },
+      () => {},
+      { enableHighAccuracy: false, timeout: 5000, maximumAge: 60_000 },
+    );
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const { suggestions, isInferring } = useLiveId({
+    videoRef,
+    active: ready,
+    latitude: coords?.latitude,
+    longitude: coords?.longitude,
+  });
+
+  const handleClose = () => navigate(-1);
+
+  // Capture the current frame at native resolution and hand it to the existing
+  // upload flow — the upload modal will re-run a full identification on it.
+  const handleCapture = () => {
+    const video = videoRef.current;
+    if (!video || video.videoWidth === 0) return;
+    const canvas = document.createElement("canvas");
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+    ctx.drawImage(video, 0, 0);
+    canvas.toBlob(
+      (blob) => {
+        if (!blob) {
+          dispatch(addToast({ message: "Couldn't capture photo", type: "error" }));
+          return;
+        }
+        const file = new File([blob], `live-${Date.now()}.jpg`, { type: "image/jpeg" });
+        setPendingUploadFiles([file]);
+        dispatch(openUploadModal());
+        navigate("/");
+      },
+      "image/jpeg",
+      0.92,
+    );
+  };
+
+  const sorted = [...suggestions].sort((a, b) => b.confidence - a.confidence);
+  const top = sorted[0];
+  const rest = sorted.slice(1);
+
+  return (
+    <Box sx={{ position: "fixed", inset: 0, zIndex: 1300, bgcolor: "black" }}>
+      <Box
+        component="video"
+        ref={videoRef}
+        playsInline
+        muted
+        autoPlay
+        onPlaying={() => setReady(true)}
+        sx={{ width: "100%", height: "100%", objectFit: "cover" }}
+      />
+
+      {/* Top gradient + close button */}
+      <Box
+        sx={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          p: 1,
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          background: "linear-gradient(to bottom, rgba(0,0,0,0.5), transparent)",
+        }}
+      >
+        <IconButton onClick={handleClose} sx={{ color: "white" }} aria-label="Close">
+          <CloseIcon />
+        </IconButton>
+        {isInferring && <CircularProgress size={18} sx={{ color: "white", mr: 1 }} />}
+      </Box>
+
+      {error && (
+        <Box
+          sx={{
+            position: "absolute",
+            inset: 0,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            p: 3,
+            textAlign: "center",
+          }}
+        >
+          <Typography sx={{ color: "white" }}>{error}</Typography>
+        </Box>
+      )}
+
+      {/* Bottom overlay: current best guess + shutter */}
+      <Box
+        sx={{
+          position: "absolute",
+          bottom: 0,
+          left: 0,
+          right: 0,
+          pt: 6,
+          pb: 3,
+          px: 2,
+          background: "linear-gradient(to top, rgba(0,0,0,0.7), transparent)",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          gap: 2,
+        }}
+      >
+        <Box sx={{ minHeight: 56, textAlign: "center", color: "white" }}>
+          {top ? (
+            <>
+              <Stack
+                direction="row"
+                spacing={1}
+                sx={{ alignItems: "baseline", justifyContent: "center", flexWrap: "wrap" }}
+              >
+                <Typography sx={{ fontStyle: "italic", fontWeight: 600 }}>
+                  {top.scientificName}
+                </Typography>
+                {top.inRange === true && (
+                  <PlaceIcon sx={{ fontSize: 16, color: "success.light" }} aria-label="In range" />
+                )}
+                <Typography variant="body2" sx={{ opacity: 0.8 }}>
+                  {Math.round(top.confidence * 100)}%
+                </Typography>
+              </Stack>
+              {top.commonName && (
+                <Typography variant="body2" sx={{ opacity: 0.85 }}>
+                  {top.commonName}
+                </Typography>
+              )}
+              {rest.length > 0 && (
+                <Typography variant="caption" sx={{ opacity: 0.6 }}>
+                  also: {rest.map((s) => s.commonName ?? s.scientificName).join(", ")}
+                </Typography>
+              )}
+            </>
+          ) : (
+            <Typography variant="body2" sx={{ opacity: 0.7 }}>
+              {ready ? "Point at a plant or animal…" : "Starting camera…"}
+            </Typography>
+          )}
+        </Box>
+
+        <IconButton
+          onClick={handleCapture}
+          aria-label="Capture photo"
+          sx={{
+            width: 68,
+            height: 68,
+            bgcolor: "white",
+            color: "black",
+            border: "4px solid rgba(255,255,255,0.5)",
+            "&:hover": { bgcolor: "white" },
+          }}
+        >
+          <CameraAltIcon />
+        </IconButton>
+      </Box>
+    </Box>
+  );
+}

--- a/frontend/src/hooks/useLiveId.ts
+++ b/frontend/src/hooks/useLiveId.ts
@@ -26,8 +26,64 @@ const FRAME_JPEG_QUALITY = 0.7;
  */
 const MIN_GAP_MS = 700;
 
-/** How many candidates to show in the live overlay. */
-const LIVE_LIMIT = 3;
+/**
+ * How many candidates to request per frame. A few more than we display gives
+ * the temporal aggregation more signal (a species ranked 4th one frame and 1st
+ * the next still accumulates).
+ */
+const LIVE_LIMIT = 5;
+
+/**
+ * Temporal smoothing: a single frame's top guess is noisy, so we aggregate the
+ * recent ones. We keep at most `AGG_MAX_SAMPLES` inferences from the last
+ * `AGG_WINDOW_MS`, and rank species by their *mean* confidence across that
+ * window — counting frames where a species didn't appear as 0. That rewards
+ * species detected consistently over ones that flicker in for a single frame.
+ *
+ * At ~2.4s per inference (latency + gap) an 8s window holds ~3–4 frames — enough
+ * to average out noise while still re-converging quickly when you pan to a new
+ * subject. The sample cap is a backstop in case inference gets much faster.
+ */
+const AGG_WINDOW_MS = 8000;
+const AGG_MAX_SAMPLES = 10;
+
+/** How many aggregated candidates to surface to the overlay. */
+const DISPLAY_LIMIT = 4;
+
+interface Sample {
+  t: number;
+  suggestions: SpeciesSuggestion[];
+}
+
+/**
+ * Collapse a window of per-frame results into a single ranked list. Each
+ * species' score is the sum of its confidences across the window divided by the
+ * frame count, so a strong-every-frame detection outranks a strong-once one.
+ * Metadata (common name, range, taxonomy) is taken from its latest appearance.
+ */
+function aggregate(samples: Sample[]): SpeciesSuggestion[] {
+  const frameCount = samples.length;
+  if (frameCount === 0) return [];
+
+  const acc = new Map<string, { sum: number; latest: SpeciesSuggestion }>();
+  // Oldest-to-newest, so `latest` ends up holding the most recent appearance.
+  for (const sample of samples) {
+    for (const s of sample.suggestions) {
+      const cur = acc.get(s.scientificName);
+      if (cur) {
+        cur.sum += s.confidence;
+        cur.latest = s;
+      } else {
+        acc.set(s.scientificName, { sum: s.confidence, latest: s });
+      }
+    }
+  }
+
+  return [...acc.values()]
+    .map(({ sum, latest }) => ({ ...latest, confidence: sum / frameCount }))
+    .sort((a, b) => b.confidence - a.confidence)
+    .slice(0, DISPLAY_LIMIT);
+}
 
 function captureFrame(video: HTMLVideoElement, canvas: HTMLCanvasElement): string | null {
   const { videoWidth, videoHeight } = video;
@@ -53,6 +109,7 @@ export function useLiveId({ videoRef, active, latitude, longitude }: UseLiveIdOp
   const [suggestions, setSuggestions] = useState<SpeciesSuggestion[]>([]);
   const [isInferring, setIsInferring] = useState(false);
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const samplesRef = useRef<Sample[]>([]);
 
   useEffect(() => {
     if (!active) return;
@@ -61,6 +118,7 @@ export function useLiveId({ videoRef, active, latitude, longitude }: UseLiveIdOp
       canvasRef.current = document.createElement("canvas");
     }
     const canvas = canvasRef.current;
+    samplesRef.current = [];
 
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | undefined;
@@ -82,7 +140,17 @@ export function useLiveId({ videoRef, active, latitude, longitude }: UseLiveIdOp
             if (longitude != null && Number.isFinite(longitude)) params.longitude = longitude;
 
             const result = await identifySpecies(params);
-            if (!cancelled) setSuggestions(result.suggestions);
+            if (!cancelled) {
+              // Append this frame, then drop anything older than the window or
+              // beyond the sample cap, and republish the smoothed ranking.
+              const now = Date.now();
+              const cutoff = now - AGG_WINDOW_MS;
+              const next = [...samplesRef.current, { t: now, suggestions: result.suggestions }]
+                .filter((s) => s.t >= cutoff)
+                .slice(-AGG_MAX_SAMPLES);
+              samplesRef.current = next;
+              setSuggestions(aggregate(next));
+            }
           } catch {
             // Transient failures (offline, server hiccup) are expected in a
             // continuous loop — keep the last result and try again next tick.

--- a/frontend/src/hooks/useLiveId.ts
+++ b/frontend/src/hooks/useLiveId.ts
@@ -1,0 +1,106 @@
+import { useEffect, useRef, useState } from "react";
+import { identifySpecies, type SpeciesSuggestion } from "../services/api";
+
+interface UseLiveIdOptions {
+  /** The live preview element to sample frames from. */
+  videoRef: React.RefObject<HTMLVideoElement | null>;
+  /** Run the loop only while true (e.g. once the stream is playing). */
+  active: boolean;
+  latitude?: number | undefined;
+  longitude?: number | undefined;
+}
+
+/**
+ * Longest edge (px) of the JPEG we send per frame. The server resizes to
+ * 224x224 anyway, so anything much larger just wastes bandwidth and inference
+ * setup; ~384 keeps small subjects legible after downscale.
+ */
+const FRAME_MAX_EDGE = 384;
+const FRAME_JPEG_QUALITY = 0.7;
+
+/**
+ * Minimum gap between the *end* of one inference and the *start* of the next.
+ * We never have more than one request in flight (each is a full BioCLIP pass),
+ * so the effective cadence is inference latency + this gap. Keeps server load
+ * and battery bounded while still feeling responsive.
+ */
+const MIN_GAP_MS = 700;
+
+/** How many candidates to show in the live overlay. */
+const LIVE_LIMIT = 3;
+
+function captureFrame(video: HTMLVideoElement, canvas: HTMLCanvasElement): string | null {
+  const { videoWidth, videoHeight } = video;
+  if (videoWidth === 0 || videoHeight === 0) return null;
+
+  const scale = Math.min(1, FRAME_MAX_EDGE / Math.max(videoWidth, videoHeight));
+  canvas.width = Math.round(videoWidth * scale);
+  canvas.height = Math.round(videoHeight * scale);
+
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return null;
+  ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+
+  // Strip the `data:image/jpeg;base64,` prefix — the API wants raw base64.
+  return canvas.toDataURL("image/jpeg", FRAME_JPEG_QUALITY).split(",")[1] ?? null;
+}
+
+/**
+ * Continuously identifies whatever the camera is pointed at by sampling frames
+ * and calling the existing `/api/species-id` endpoint, one request at a time.
+ */
+export function useLiveId({ videoRef, active, latitude, longitude }: UseLiveIdOptions) {
+  const [suggestions, setSuggestions] = useState<SpeciesSuggestion[]>([]);
+  const [isInferring, setIsInferring] = useState(false);
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    if (!active) return;
+
+    if (!canvasRef.current) {
+      canvasRef.current = document.createElement("canvas");
+    }
+    const canvas = canvasRef.current;
+
+    let cancelled = false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+
+    const tick = async () => {
+      if (cancelled) return;
+      const video = videoRef.current;
+      // HAVE_CURRENT_DATA — there's a decoded frame to sample.
+      if (video && video.readyState >= 2) {
+        const base64 = captureFrame(video, canvas);
+        if (base64) {
+          setIsInferring(true);
+          try {
+            const params: Parameters<typeof identifySpecies>[0] = {
+              image: base64,
+              limit: LIVE_LIMIT,
+            };
+            if (latitude != null && Number.isFinite(latitude)) params.latitude = latitude;
+            if (longitude != null && Number.isFinite(longitude)) params.longitude = longitude;
+
+            const result = await identifySpecies(params);
+            if (!cancelled) setSuggestions(result.suggestions);
+          } catch {
+            // Transient failures (offline, server hiccup) are expected in a
+            // continuous loop — keep the last result and try again next tick.
+          } finally {
+            if (!cancelled) setIsInferring(false);
+          }
+        }
+      }
+      if (!cancelled) timer = setTimeout(() => void tick(), MIN_GAP_MS);
+    };
+
+    void tick();
+
+    return () => {
+      cancelled = true;
+      if (timer) clearTimeout(timer);
+    };
+  }, [active, latitude, longitude, videoRef]);
+
+  return { suggestions, isInferring };
+}


### PR DESCRIPTION
## Summary

Adds a full-screen **live camera identifier** (Path A: server-polling). Point the rear camera at a plant or animal and the top species guess updates continuously, backed by the existing `/api/species-id` pipeline — **no model or backend changes**.

Entry point: FAB → **Live ID** → `/identify`.

## What's included

- **`useLiveId` hook** — samples the live `<video>` to an offscreen canvas, downscales each frame to a 384px JPEG (the server resizes to 224×224 anyway), and calls `identifySpecies`. Safety properties:
  - **one inference in flight at a time** (each is a full BioCLIP ViT-H/14 pass)
  - 700ms gap after each completes, so cadence self-adapts to latency
  - unmount cancellation drops stale results
  - passes lat/lon through for the geo-range boost
- **`LiveIdView`** — `getUserMedia({ facingMode: "environment" })` preview, best-effort geolocation, a live overlay (top guess + common name + % match + in-range 📍, plus runner-ups), and a shutter that captures the current frame at native resolution and hands it to the existing upload flow (which re-runs a full ID). Stops all camera tracks on exit.
- Lazy **`/identify`** route + **Live ID** FAB action (web/PWA only — hidden on native Capacitor builds).
- **Storybook stories** for `LiveIdView` covering the location-prompt, location-denied, and live-overlay states (stubbing `navigator.geolocation` / `getUserMedia`).

Reuses `identifySpecies` / `SpeciesSuggestion` and existing conventions (the `Parameters<>` conditional-param pattern from `useVisualId`, lazy routing, MUI).

## Notes / follow-ons

- **Web/PWA only.** Uses `getUserMedia`; native iOS/Android live preview needs a Capacitor camera-preview plugin. The FAB action is now gated behind `!Capacitor.isNativePlatform()` so native builds don't expose a broken entry point.
- **Server cost is the real ceiling.** Each ~1–2s of viewfinder time is one ViT-H/14 inference. The single-in-flight + gap throttle bounds per-user load, but real traffic would want rate limiting and/or a "only infer when the frame is sharp/stable" gate.
- Secure-context requirement: camera works on `localhost`/HTTPS; a plain LAN IP would need HTTPS.

## Test plan

- [x] `npm run fmt:check` clean
- [x] `npm run lint` — 0 errors
- [x] `tsc --noEmit` — passes
- [x] `npm run check:stories` — passes (LiveIdView has a sibling story)
- [x] `npm run build-storybook` — builds
- [ ] Manual: sign in, FAB → Live ID, grant camera + location, confirm live guesses update and shutter opens the upload modal with the captured photo
