### PR TITLE
feat(taxon): improve classification tree & search readability

### DIFF
--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -4,6 +4,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import type { TaxaResult } from "../../services/types";
 import { ConservationStatus } from "./ConservationStatus";
 import { renderAutocompleteInput } from "./autocompleteInput";
+import { shouldItalicizeTaxonName } from "./TaxonLink";
 import { nameToSlug } from "../../lib/taxonSlug";
 
 export function taxonUrlFor(option: TaxaResult): string | null {
@@ -133,6 +134,9 @@ export function TaxaAutocompleteView({
                   <Typography
                     sx={{
                       fontWeight: 600,
+                      fontStyle: shouldItalicizeTaxonName(option.scientificName, option.rank)
+                        ? "italic"
+                        : "normal",
                     }}
                   >
                     {option.scientificName}

--- a/frontend/src/components/taxon/TaxonTreePanel.tsx
+++ b/frontend/src/components/taxon/TaxonTreePanel.tsx
@@ -38,17 +38,19 @@ function renderTreeItems(
         slotProps={{ iconContainer: { onClick: (event) => event.stopPropagation() } }}
         label={
           <Box sx={{ display: "flex", alignItems: "center", gap: 0.75, py: 0.5 }}>
-            <Box
-              sx={{
-                width: 20,
-                height: 20,
-                flexShrink: 0,
-                borderRadius: 0.5,
-                overflow: "hidden",
-                bgcolor: "action.hover",
-              }}
-            >
-              {thumb && (
+            {/* Only reserve the thumbnail slot when there's actually an image —
+                most taxa have none, and a column of empty placeholders is just
+                noise that steals width the name needs at depth. */}
+            {thumb && (
+              <Box
+                sx={{
+                  width: 20,
+                  height: 20,
+                  flexShrink: 0,
+                  borderRadius: 0.5,
+                  overflow: "hidden",
+                }}
+              >
                 <Box
                   component="img"
                   src={thumb}
@@ -56,13 +58,14 @@ function renderTreeItems(
                   loading="lazy"
                   sx={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
                 />
-              )}
-            </Box>
+              </Box>
+            )}
             <Box sx={{ display: "flex", flexDirection: "column", minWidth: 0, flexGrow: 1 }}>
               <Typography
                 variant="body2"
                 component="span"
                 noWrap
+                title={String(item.label)}
                 sx={{
                   fontStyle: shouldItalicizeTaxonName(String(item.label), item.rank)
                     ? "italic"
@@ -77,6 +80,7 @@ function renderTreeItems(
                   variant="caption"
                   component="span"
                   noWrap
+                  title={item.commonName}
                   sx={{
                     color: "text.secondary",
                     lineHeight: 1.2,
@@ -86,12 +90,18 @@ function renderTreeItems(
                 </Typography>
               )}
             </Box>
+            {/* Rank yields to the name: with a large flex-shrink it collapses
+                before the (more important) name truncates, so short names show
+                the rank and long names reclaim the full row. */}
             <Typography
               variant="caption"
               component="span"
               sx={{
-                ml: 1,
-                flexShrink: 0,
+                ml: 0.75,
+                flexShrink: 100,
+                minWidth: 0,
+                overflow: "hidden",
+                whiteSpace: "nowrap",
                 color: "text.disabled",
                 fontSize: "0.65rem",
                 letterSpacing: "0.04em",


### PR DESCRIPTION
## Summary

The classification tree spent its scarce horizontal width on things other than the taxon name, so at depth nearly every name truncated to an indistinguishable stub (e.g. `Quercus a…`) — even the **currently-selected** taxon showed its own name cut off — with **no tooltip** to recover the full text. This PR rebalances that, plus a small search-result consistency fix.

## Tree (`TaxonTreePanel.tsx`)

- **Tooltips** — add a `title` to every scientific and common name, so truncated text is recoverable on hover and exposed to assistive tech (there were previously zero tooltips in the tree).
- **No empty thumbnail placeholders** — render the 20px image slot only when an image actually exists. Most taxa have none, so the old always-on box was a noisy column of empty grey squares that also stole ~26px from the name on every image-less row. Bonus: the rows that *do* have images (the ancestor spine) now stand out.
- **Rank yields to the name** — a large `flex-shrink` collapses the rank label *before* the more-important name truncates. Short names still show their rank (`Cerris dulcis  SPECIES`); long names reclaim the full row (`Cyclobalanopsis bapou…`).

**Net effect:** name area at species depth grows ~70% (≈85px → ≈144px), the selected taxon's name no longer truncates, and sibling species become distinguishable — most visibly in the 300px mobile drawer (`Cyclobal…` → `Cyclobalanopsis bap…`).

## Search (`TaxaAutocompleteView.tsx`)

- Italicize scientific names via the shared `shouldItalicizeTaxonName` helper, matching the tree and taxonomic convention: genus/species italic, family-and-above upright. Verified: *Quercus* / *Parascirtothrips fagaceae* italic, `Fagaceae` upright. (Shared component, so this also applies to the upload/visual-ID autocomplete.)

## Verification

- Reviewed live in Playwright at desktop (1440) and mobile (390) widths; measured the layout deltas above.
- Collapse-via-arrow still doesn't select/navigate (unaffected).
- `oxfmt --check`, `oxlint`, and `tsc --noEmit` all pass.

## Not included (noted during review, separate follow-ups)
- Common-name casing is inconsistent in the data (`California live oak` vs `Beef Wood` vs `Carrots, Ivies, And Allies`).
- The **Quercus agrifolia** detail page renders a description about **Quercus ellipsoidalis** — a wrong-species data mismatch.