### PR TITLE
feat(taxon): show a loading state when switching taxa

### DIFF
--- a/frontend/src/components/taxon/TaxonDetailPanel.tsx
+++ b/frontend/src/components/taxon/TaxonDetailPanel.tsx
@@ -7,6 +7,7 @@ import {
   Stack,
   IconButton,
   Divider,
+  LinearProgress,
   Link as MuiLink,
   Accordion,
   AccordionSummary,
@@ -27,6 +28,8 @@ interface TaxonDetailPanelProps {
   observations: Occurrence[];
   hasMore: boolean;
   loadingMore: boolean;
+  /** A newly-selected taxon is loading; the still-visible content is stale. */
+  loading?: boolean;
   onLoadMore: () => void;
   onBack: () => void;
   onToggleTree?: () => void;
@@ -38,6 +41,7 @@ export function TaxonDetailPanel({
   observations,
   hasMore,
   loadingMore,
+  loading = false,
   onLoadMore,
   onBack,
   onToggleTree,
@@ -75,35 +79,29 @@ export function TaxonDetailPanel({
           </IconButton>
         )}
       </Box>
-      {/* Main Content */}
-      <Box sx={{ p: 3 }}>
-        <TaxonHeroCard taxon={taxon} heroUrl={heroUrl} />
+      {/* While a newly-selected taxon loads we keep the previous one visible
+          (no empty flash) but signal the swap: a progress bar pinned below the
+          header, plus a dimmed, inert content area — mirroring how the
+          classification tree is disabled during the same load. */}
+      {loading && <LinearProgress sx={{ position: "sticky", top: 0, zIndex: 2 }} />}
+      <Box
+        sx={{
+          opacity: loading ? 0.5 : 1,
+          pointerEvents: loading ? "none" : "auto",
+          transition: "opacity 0.2s",
+        }}
+      >
+        {/* Main Content */}
+        <Box sx={{ p: 3 }}>
+          <TaxonHeroCard taxon={taxon} heroUrl={heroUrl} />
 
-        {/* Media Gallery — lazy-loaded */}
-        <Accordion
-          sx={{ mt: 3 }}
-          onChange={(_e, expanded) => {
-            if (expanded) setGalleryMounted(true);
-          }}
-        >
-          <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-            <Typography
-              variant="subtitle2"
-              sx={{
-                color: "text.secondary",
-              }}
-            >
-              Media
-            </Typography>
-          </AccordionSummary>
-          <AccordionDetails>
-            {galleryMounted ? <WikiCommonsGallery taxonName={taxon.scientificName} /> : null}
-          </AccordionDetails>
-        </Accordion>
-
-        {/* Descriptions */}
-        {taxon.descriptions && taxon.descriptions.length > 0 && (
-          <Accordion defaultExpanded>
+          {/* Media Gallery — lazy-loaded */}
+          <Accordion
+            sx={{ mt: 3 }}
+            onChange={(_e, expanded) => {
+              if (expanded) setGalleryMounted(true);
+            }}
+          >
             <AccordionSummary expandIcon={<ExpandMoreIcon />}>
               <Typography
                 variant="subtitle2"
@@ -111,141 +109,160 @@ export function TaxonDetailPanel({
                   color: "text.secondary",
                 }}
               >
-                Description
+                Media
               </Typography>
             </AccordionSummary>
             <AccordionDetails>
-              {taxon.descriptions.slice(0, 2).map((d, idx) => (
-                <Box key={idx} sx={{ mb: idx < (taxon.descriptions?.length ?? 0) - 1 ? 2 : 0 }}>
-                  <Typography
-                    variant="body2"
-                    component="div"
-                    sx={{
-                      ...(!descExpanded && {
-                        display: "-webkit-box",
-                        WebkitLineClamp: 6,
-                        WebkitBoxOrient: "vertical",
-                        overflow: "hidden",
-                      }),
-                      "& p": { m: 0 },
-                      "& em, & i": { fontStyle: "italic" },
-                    }}
-                    // eslint-disable-next-line react/no-danger -- sanitized with DOMPurify
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(d.description, {
-                        ALLOWED_TAGS: ["p", "br", "em", "i", "strong", "b", "a"],
-                        ALLOWED_ATTR: ["href", "target", "rel"],
-                      }),
-                    }}
-                  />
-                  {d.source && (
+              {galleryMounted ? <WikiCommonsGallery taxonName={taxon.scientificName} /> : null}
+            </AccordionDetails>
+          </Accordion>
+
+          {/* Descriptions */}
+          {taxon.descriptions && taxon.descriptions.length > 0 && (
+            <Accordion defaultExpanded>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    color: "text.secondary",
+                  }}
+                >
+                  Description
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                {taxon.descriptions.slice(0, 2).map((d, idx) => (
+                  <Box key={idx} sx={{ mb: idx < (taxon.descriptions?.length ?? 0) - 1 ? 2 : 0 }}>
                     <Typography
+                      variant="body2"
+                      component="div"
+                      sx={{
+                        ...(!descExpanded && {
+                          display: "-webkit-box",
+                          WebkitLineClamp: 6,
+                          WebkitBoxOrient: "vertical",
+                          overflow: "hidden",
+                        }),
+                        "& p": { m: 0 },
+                        "& em, & i": { fontStyle: "italic" },
+                      }}
+                      // eslint-disable-next-line react/no-danger -- sanitized with DOMPurify
+                      dangerouslySetInnerHTML={{
+                        __html: DOMPurify.sanitize(d.description, {
+                          ALLOWED_TAGS: ["p", "br", "em", "i", "strong", "b", "a"],
+                          ALLOWED_ATTR: ["href", "target", "rel"],
+                        }),
+                      }}
+                    />
+                    {d.source && (
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: "text.secondary",
+                          mt: 0.5,
+                          display: "block",
+                        }}
+                      >
+                        Source: {d.source}
+                      </Typography>
+                    )}
+                  </Box>
+                ))}
+                <Button
+                  size="small"
+                  onClick={() => setDescExpanded((v) => !v)}
+                  sx={{ mt: 1, textTransform: "none" }}
+                >
+                  {descExpanded ? "Show less" : "Read more"}
+                </Button>
+              </AccordionDetails>
+            </Accordion>
+          )}
+
+          {/* References */}
+          {taxon.references && taxon.references.length > 0 && (
+            <Accordion>
+              <AccordionSummary expandIcon={<ExpandMoreIcon />}>
+                <Typography
+                  variant="subtitle2"
+                  sx={{
+                    color: "text.secondary",
+                  }}
+                >
+                  References ({taxon.references.length})
+                </Typography>
+              </AccordionSummary>
+              <AccordionDetails>
+                <Stack spacing={0.5}>
+                  {taxon.references.slice(0, 5).map((r, idx) => (
+                    <Typography
+                      key={idx}
                       variant="caption"
                       sx={{
                         color: "text.secondary",
-                        mt: 0.5,
-                        display: "block",
                       }}
                     >
-                      Source: {d.source}
+                      {r.link || r.doi ? (
+                        <MuiLink
+                          href={r.link || `https://doi.org/${r.doi}`}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          color="primary"
+                        >
+                          {r.citation}
+                        </MuiLink>
+                      ) : (
+                        r.citation
+                      )}
                     </Typography>
-                  )}
-                </Box>
-              ))}
-              <Button
-                size="small"
-                onClick={() => setDescExpanded((v) => !v)}
-                sx={{ mt: 1, textTransform: "none" }}
-              >
-                {descExpanded ? "Show less" : "Read more"}
-              </Button>
-            </AccordionDetails>
-          </Accordion>
-        )}
-
-        {/* References */}
-        {taxon.references && taxon.references.length > 0 && (
-          <Accordion>
-            <AccordionSummary expandIcon={<ExpandMoreIcon />}>
-              <Typography
-                variant="subtitle2"
-                sx={{
-                  color: "text.secondary",
-                }}
-              >
-                References ({taxon.references.length})
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails>
-              <Stack spacing={0.5}>
-                {taxon.references.slice(0, 5).map((r, idx) => (
-                  <Typography
-                    key={idx}
-                    variant="caption"
-                    sx={{
-                      color: "text.secondary",
-                    }}
-                  >
-                    {r.link || r.doi ? (
-                      <MuiLink
-                        href={r.link || `https://doi.org/${r.doi}`}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        color="primary"
-                      >
-                        {r.citation}
-                      </MuiLink>
-                    ) : (
-                      r.citation
-                    )}
-                  </Typography>
-                ))}
-              </Stack>
-            </AccordionDetails>
-          </Accordion>
-        )}
-      </Box>
-      {/* Observations Section */}
-      <Divider />
-      <Box sx={{ px: 3, py: 2 }}>
-        <Typography
-          variant="subtitle2"
-          sx={{
-            color: "text.secondary",
-          }}
-        >
-          Recent Observations
-        </Typography>
-      </Box>
-      {observations.length === 0 ? (
-        <Box sx={{ px: 3, py: 5, textAlign: "center" }}>
+                  ))}
+                </Stack>
+              </AccordionDetails>
+            </Accordion>
+          )}
+        </Box>
+        {/* Observations Section */}
+        <Divider />
+        <Box sx={{ px: 3, py: 2 }}>
           <Typography
+            variant="subtitle2"
             sx={{
               color: "text.secondary",
-              mb: 0.5,
             }}
           >
-            No observations yet
-          </Typography>
-          <Typography
-            variant="body2"
-            sx={{
-              color: "text.disabled",
-            }}
-          >
-            Be the first to observe <em>{taxon.commonName || taxon.scientificName}</em> on
-            Observ.ing!
+            Recent Observations
           </Typography>
         </Box>
-      ) : (
-        <Box>
-          {observations.map((obs) => (
-            <FeedItem key={obs.uri} observation={obs} />
-          ))}
+        {observations.length === 0 ? (
+          <Box sx={{ px: 3, py: 5, textAlign: "center" }}>
+            <Typography
+              sx={{
+                color: "text.secondary",
+                mb: 0.5,
+              }}
+            >
+              No observations yet
+            </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: "text.disabled",
+              }}
+            >
+              Be the first to observe <em>{taxon.commonName || taxon.scientificName}</em> on
+              Observ.ing!
+            </Typography>
+          </Box>
+        ) : (
+          <Box>
+            {observations.map((obs) => (
+              <FeedItem key={obs.uri} observation={obs} />
+            ))}
 
-          {hasMore && <LoadMoreButton loading={loadingMore} onClick={onLoadMore} />}
-        </Box>
-      )}
+            {hasMore && <LoadMoreButton loading={loadingMore} onClick={onLoadMore} />}
+          </Box>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -464,6 +464,7 @@ export function TaxonExplorer() {
         observations={observations}
         hasMore={hasMore}
         loadingMore={loadingMore}
+        loading={loading}
         onLoadMore={loadMoreObservations}
         onBack={handleBack}
         onToggleTree={() => setMobileTreeOpen(true)}


### PR DESCRIPTION
## Summary

Selecting a new taxon in the classification tree kept the **previous** taxon's
detail fully rendered until the new data arrived, with no signal that anything
was happening — only the tree itself dimmed. The right-hand content area now
reflects the load too.

While a newly-selected taxon is loading, `TaxonDetailPanel`:
- shows a `LinearProgress` bar pinned just below the header, and
- dims the (stale) content to 50% and makes it `pointer-events: none`,

mirroring how the classification tree is already disabled during the same load.
The header (back button / tree toggle) stays crisp and usable.

The previous content is still **held** rather than swapped for a skeleton, so
there's no empty flash — consistent with the existing "keep current taxon
visible until the new one is ready" behavior. Fast loads barely register
(the 0.2s opacity fade and the bar appear only briefly); slower loads read
clearly as loading.

## Implementation
- `TaxonDetailPanel` takes a new optional `loading` prop; wraps the content
  (below the header) in a dimmed/inert container and conditionally renders the
  progress bar.
- `TaxonExplorer` passes its existing `loading` flag (the same
  `taxonQuery.isFetching` value that already drives the tree's disabled state)
  to the panel.

> Note: the `TaxonDetailPanel.tsx` diff looks large but is almost entirely
> re-indentation from wrapping the content in one container — review with
> whitespace hidden. The real change is the new prop, the wrapper's sx, and the
> progress bar.

## Verification
- Driven in Playwright with CDP latency to hold the fetch open: confirmed the
  progress bar appears, the wrapper settles to `opacity: 0.54` and
  `pointer-events: none`, and the **previous** taxon's name stays visible while
  the new one loads. After load: bar gone, `opacity: 1`, `pointer-events: auto`.
- `oxfmt --check`, `oxlint`, and `tsc --noEmit` all pass.

## Relation to #656
Independent of #656 (classification tree & search readability), which is in the
merge queue — that PR touches `TaxonTreePanel.tsx` / `TaxaAutocompleteView.tsx`;
this one touches `TaxonDetailPanel.tsx` / `TaxonExplorer.tsx`. No overlap.