### PR TITLE
fix(frontend): serve @fontsource woff2 from the resolved node_modules

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,10 +1,23 @@
 import { defineConfig } from "vite";
 import { fileURLToPath } from "url";
+import { createRequire } from "module";
 import path from "path";
 import react from "@vitejs/plugin-react";
 import { VitePWA } from "vite-plugin-pwa";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const require = createRequire(import.meta.url);
+
+// Resolve where dependencies actually live. A hardcoded `../node_modules` is
+// wrong inside a git worktree without its own `node_modules`: deps resolve
+// (hoisted) to the main checkout's node_modules, so the self-hosted @fontsource
+// woff2 files end up outside `fs.allow` and 403 — brand fonts then fall back to
+// system sans. Anchoring on a real dependency follows the same upward lookup
+// Node/Vite use, so this points at the node_modules that is genuinely in play.
+const resolvedNodeModules = path.resolve(
+  path.dirname(require.resolve("@fontsource/dm-sans/package.json")),
+  "../..",
+);
 
 export default defineConfig({
   plugins: [
@@ -75,14 +88,11 @@ export default defineConfig({
   },
   server: {
     fs: {
-      // `../node_modules` so the dev server can serve dependency assets that
-      // live outside the `src` root — e.g. the self-hosted @fontsource woff2
-      // files (otherwise they 403 and the brand fonts fall back to system sans).
-      allow: [
-        path.resolve(__dirname, "../lexicons"),
-        path.resolve(__dirname, "../node_modules"),
-        ".",
-      ],
+      // Allow serving dependency assets that live outside the `src` root — e.g.
+      // the self-hosted @fontsource woff2 files (otherwise they 403 and the
+      // brand fonts fall back to system sans). `resolvedNodeModules` finds the
+      // node_modules actually in use (see its definition for the worktree case).
+      allow: [path.resolve(__dirname, "../lexicons"), resolvedNodeModules, "."],
     },
     hmr: {
       // When accessed via the Rust proxy on port 3000, HMR WebSocket must still


### PR DESCRIPTION
Closes #651

## Problem

The self-hosted brand fonts (DM Sans, JetBrains Mono) fail to load in **dev mode**, so the UI falls back to system sans. The woff2 requests return **403**:

```
/@fs/.../node_modules/@fontsource/dm-sans/files/dm-sans-latin-400-normal.woff2  →  403
```

`server.fs.allow` used `path.resolve(__dirname, "../node_modules")` — a worktree-relative path. When the dev server runs from a git worktree that has no `node_modules` of its own, dependencies resolve (hoisted) to the **main checkout's** `node_modules`. The woff2 files the browser actually fetches then live *outside* the allow-list → 403.

It was sneaky because the font **CSS** still returns 200 (Vite reads it off disk during transform, which isn't gated by `fs.allow`), so the `@font-face` declares but the woff2 never loads.

Production was **not** affected — the build emits all woff2 files and references them at `/assets/*.woff2`.

## Fix

Resolve the real `node_modules` by anchoring on an actual dependency, following the same upward module lookup Node/Vite use:

```ts
const resolvedNodeModules = path.resolve(
  path.dirname(require.resolve("@fontsource/dm-sans/package.json")),
  "../..",
);
```

Works identically in a normal checkout (→ `../node_modules`) and in a worktree (→ the main checkout's `node_modules`).

## Verification

- Patched dev server: the previously-403 woff2 now returns `200 content-type: font/woff2` (both DM Sans and JetBrains Mono).
- `vite build` succeeds; all 24 woff2 assets still emit.
- `oxlint` clean.