### PR TITLE
fix(dev): follow dev-server port for vite HMR client (#659)

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,6 +6,12 @@ import { VitePWA } from "vite-plugin-pwa";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
+// Single knob for the dev-server port (defaults to Vite's usual 5173). A
+// multi-worktree setup can relocate the whole dev server with one env var
+// (e.g. VITE_PORT=5273) and the HMR client follows along instead of flooding
+// the console reconnecting to a stale 5173. See issue #659.
+const devPort = Number(process.env.VITE_PORT) || 5173;
+
 export default defineConfig({
   plugins: [
     react(),
@@ -74,6 +80,11 @@ export default defineConfig({
     emptyOutDir: true,
   },
   server: {
+    port: devPort,
+    // Pin the port so the resolved dev-server port can't silently drift off
+    // `devPort` (Vite would otherwise auto-increment past a busy port and
+    // leave `hmr.clientPort` pointing at the wrong server).
+    strictPort: true,
     fs: {
       // `../node_modules` so the dev server can serve dependency assets that
       // live outside the `src` root — e.g. the self-hosted @fontsource woff2
@@ -85,10 +96,12 @@ export default defineConfig({
       ],
     },
     hmr: {
-      // When accessed via the Rust proxy on port 3000, HMR WebSocket must still
-      // connect directly to Vite so it isn't routed through the proxy
-      host: 'localhost',
-      clientPort: 5173,
+      // When accessed via the Rust proxy on port 3000, the HMR WebSocket must
+      // still connect directly to Vite so it isn't routed through the proxy.
+      // Follows `devPort` rather than a hardcoded 5173 so other-port worktrees
+      // don't flood the console reconnecting to the wrong server.
+      host: "localhost",
+      clientPort: devPort,
     },
     proxy: {
       "/api": "http://localhost:3000",


### PR DESCRIPTION
## Problem

`frontend/vite.config.ts` hardcoded the HMR client port to `5173`. When a git worktree runs its dev server on any other port, the HMR WebSocket client keeps trying `ws://localhost:5173`, fails, and floods the console with reconnect errors — severe enough to choke the Playwright/MCP browser bridge during verification.

## Fix

Drive both `server.port` and `hmr.clientPort` from a single `VITE_PORT` env var (default `5173`), with `strictPort: true` so the resolved dev-server port can't silently drift off the configured `clientPort`. A multi-worktree setup now relocates the whole dev server (and its HMR client) with one env var.

No impact on the normal single-worktree / :3000-proxy path — with `VITE_PORT` unset everything stays on 5173.

## Verification

`VITE_PORT=5298 vite` → server binds 5298 and the injected `@vite/client` reports `hmrPort = 5298` (no stale 5173).

Closes #659