### PR TITLE
feat(upload): enter & display eventDate ranges

### DIFF
--- a/frontend/.storybook/fixtures.ts
+++ b/frontend/.storybook/fixtures.ts
@@ -80,7 +80,8 @@ export const FERN_OBSERVATION: Occurrence = {
     genus: "Polypodium",
   },
   identificationCount: 1,
-  eventDate: "2026-04-10T14:00:00Z",
+  // A date-range eventDate (Darwin Core interval) to exercise range rendering.
+  eventDate: "2026-04-08/2026-04-10",
   location: { latitude: 51.51, longitude: -0.13 },
   images: [PHOTO],
   createdAt: "2026-04-10T14:05:00Z",

--- a/frontend/src/components/feed/ExploreTable.tsx
+++ b/frontend/src/components/feed/ExploreTable.tsx
@@ -66,6 +66,24 @@ function formatDate(iso?: string): string {
   return d.toISOString().slice(0, 10);
 }
 
+// Compact one endpoint of a Darwin Core eventDate: trim a full date-time to its
+// date portion, but keep reduced precision ("1971", "1906-06") as-is.
+function compactEventDatePart(part: string): string {
+  const p = part.trim();
+  if (p.length > 10) {
+    const d = new Date(p);
+    if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+  }
+  return p;
+}
+
+// Render an eventDate compactly for the table, preserving intervals as
+// "<start> – <end>". Falls back to an em dash when absent.
+function formatEventDateCell(value?: string): string {
+  if (!value) return "—";
+  return value.split("/").map(compactEventDatePart).join(" – ");
+}
+
 function formatCoord(n?: number): string {
   return typeof n === "number" ? n.toFixed(5) : "—";
 }
@@ -128,7 +146,7 @@ const ExploreTableRow = memo(function ExploreTableRow({
         {text(tax?.genus)}
       </TableCell>
       <TableCell>{getDisplayName(obs.observer)}</TableCell>
-      <TableCell>{formatDate(obs.eventDate)}</TableCell>
+      <TableCell>{formatEventDateCell(obs.eventDate)}</TableCell>
       <TableCell sx={numericSx}>{formatCoord(obs.location?.latitude)}</TableCell>
       <TableCell sx={numericSx}>{formatCoord(obs.location?.longitude)}</TableCell>
       <TableCell sx={numericSx}>

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -152,6 +152,10 @@ export function UploadModal() {
   const [images, setImages] = useState<ImagePreview[]>([]);
   const [existingImages, setExistingImages] = useState<string[]>([]);
   const [observationDate, setObservationDate] = useState(() => toDatetimeLocal(new Date()));
+  // Optional interval end (Darwin Core eventDate may be a range). Empty means a
+  // single date/time; when set, the observation spans `observationDate`'s day
+  // through this day inclusive, written as a `YYYY-MM-DD/YYYY-MM-DD` interval.
+  const [observationEndDate, setObservationEndDate] = useState("");
   const [uncertaintyMeters, setUncertaintyMeters] = useState(50);
   // Darwin Core organismQuantity (+ its type). Kept out of the default flow in a
   // collapsed "More details" section — most users identifying a single organism
@@ -196,7 +200,18 @@ export function UploadModal() {
     setMatchedTaxon(null);
     setRank("");
     if (editingObservation.eventDate) {
-      setObservationDate(toDatetimeLocal(new Date(editingObservation.eventDate)));
+      const parts = editingObservation.eventDate.split("/");
+      const start = parts[0] ?? editingObservation.eventDate;
+      const end = parts[1];
+      if (end) {
+        // Interval: ranges are recorded at day precision, so seed the start
+        // input at midnight of its day and populate the end-date field.
+        setObservationDate(`${start.slice(0, 10)}T00:00`);
+        setObservationEndDate(end.slice(0, 10));
+      } else {
+        setObservationDate(toDatetimeLocal(new Date(start)));
+        setObservationEndDate("");
+      }
     }
     if (editingObservation.location) {
       setLat(formatCoordinate(editingObservation.location.latitude));
@@ -244,6 +259,7 @@ export function UploadModal() {
     setImages([]);
     setExistingImages([]);
     setObservationDate(toDatetimeLocal(new Date()));
+    setObservationEndDate("");
     setUncertaintyMeters(50);
     setOrganismQuantity("");
     setOrganismQuantityType(DEFAULT_ORGANISM_QUANTITY_TYPE);
@@ -395,6 +411,20 @@ export function UploadModal() {
       return;
     }
 
+    // eventDate is a single date-time, or a `YYYY-MM-DD/YYYY-MM-DD` interval
+    // (day precision) when an end date is given.
+    const startDay = observationDate.slice(0, 10);
+    let eventDate: string;
+    if (observationEndDate) {
+      if (observationEndDate < startDay) {
+        toast.error("End date can't be before the start date");
+        return;
+      }
+      eventDate = `${startDay}/${observationEndDate}`;
+    } else {
+      eventDate = new Date(observationDate).toISOString();
+    }
+
     const trimmedSpecies = species.trim();
     if (trimmedSpecies && !matchedTaxon && !kingdom) {
       toast.error("Please select a kingdom for the taxon name you entered");
@@ -442,7 +472,7 @@ export function UploadModal() {
           }
         : {}),
       license,
-      eventDate: new Date(observationDate).toISOString(),
+      eventDate,
       ...(imageData.length > 0 ? { images: imageData } : {}),
     };
 
@@ -716,7 +746,7 @@ export function UploadModal() {
 
           <TextField
             fullWidth
-            label="Observation date"
+            label={observationEndDate ? "Start date" : "Observation date"}
             type="datetime-local"
             value={observationDate}
             onChange={(e) => {
@@ -726,6 +756,28 @@ export function UploadModal() {
             margin="normal"
             slotProps={{
               inputLabel: { shrink: true },
+            }}
+          />
+
+          <TextField
+            fullWidth
+            label="End date (optional)"
+            type="date"
+            value={observationEndDate}
+            onChange={(e) => {
+              setObservationEndDate(e.target.value);
+              setIsDirty(true);
+            }}
+            margin="normal"
+            error={observationEndDate !== "" && observationEndDate < observationDate.slice(0, 10)}
+            helperText={
+              observationEndDate !== "" && observationEndDate < observationDate.slice(0, 10)
+                ? "End date can't be before the start date."
+                : "Set to record an observation spanning a date range."
+            }
+            slotProps={{
+              inputLabel: { shrink: true },
+              htmlInput: { min: observationDate.slice(0, 10) },
             }}
           />
 

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -39,7 +39,12 @@ import { ObservationDetailSkeleton } from "./ObservationDetailSkeleton";
 import { PhotoLightbox } from "./PhotoLightbox";
 import { DataQualitySection } from "./DataQualitySection";
 import { UserCard } from "../common/UserCard";
-import { formatDate, getPdslsUrl, buildOccurrenceAtUri, getErrorMessage } from "../../lib/utils";
+import {
+  formatEventDate,
+  getPdslsUrl,
+  buildOccurrenceAtUri,
+  getErrorMessage,
+} from "../../lib/utils";
 import { getLicenseLabel } from "../../lib/licenses";
 
 // Lazy so maplibre-gl is split into its own chunk, loaded only when an
@@ -384,7 +389,7 @@ export function ObservationDetail() {
               </ListItemIcon>
               <ListItemText
                 primary="Observed"
-                secondary={observation.eventDate ? formatDate(observation.eventDate) : "—"}
+                secondary={observation.eventDate ? formatEventDate(observation.eventDate) : "—"}
                 slotProps={{
                   primary: { variant: "caption", color: "text.secondary" },
                   secondary: { variant: "body1", color: "text.primary" },

--- a/frontend/src/lib/utils.test.ts
+++ b/frontend/src/lib/utils.test.ts
@@ -3,6 +3,7 @@ import {
   formatTimeAgo,
   formatRelativeTime,
   formatDate,
+  formatEventDate,
   getPdslsUrl,
   parseAtUri,
   getObservationUrl,
@@ -95,6 +96,35 @@ describe("formatDate", () => {
     // Locale varies by host, but the year should always appear.
     expect(out).toContain("2024");
     expect(out.length).toBeGreaterThan("2024".length);
+  });
+});
+
+describe("formatEventDate", () => {
+  it("shows reduced precision verbatim", () => {
+    expect(formatEventDate("1971")).toBe("1971");
+  });
+
+  it("formats year-month without a day", () => {
+    const out = formatEventDate("1906-06");
+    expect(out).toContain("1906");
+    expect(out).not.toContain("31");
+  });
+
+  it("formats a date-only value in UTC (no day shift)", () => {
+    // Regardless of host timezone, the 8th must not slip to the 7th.
+    expect(formatEventDate("1963-03-08")).toContain("8");
+    expect(formatEventDate("1963-03-08")).toContain("1963");
+  });
+
+  it("renders an interval as start – end", () => {
+    const out = formatEventDate("1995-05-21/1995-05-23");
+    expect(out).toContain(" – ");
+    expect(out).toContain("21");
+    expect(out).toContain("23");
+  });
+
+  it("returns unparseable input verbatim", () => {
+    expect(formatEventDate("not a date")).toBe("not a date");
   });
 });
 

--- a/frontend/src/lib/utils.ts
+++ b/frontend/src/lib/utils.ts
@@ -59,6 +59,59 @@ export function formatDate(dateString: string): string {
   });
 }
 
+const YEAR_RE = /^\d{4}$/;
+const YEAR_MONTH_RE = /^\d{4}-\d{2}$/;
+const DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Format one endpoint of a Darwin Core eventDate at its own precision. Reduced
+ * precision is shown as-is ("1971", "June 1906"); date-only values are
+ * formatted in UTC so they don't shift a day across timezones. Unparseable
+ * input is returned verbatim.
+ */
+function formatEventDatePart(part: string): string {
+  const p = part.trim();
+  if (YEAR_RE.test(p)) return p;
+  if (YEAR_MONTH_RE.test(p)) {
+    const [y = "", m = ""] = p.split("-");
+    return new Date(Date.UTC(Number(y), Number(m) - 1, 1)).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "long",
+      timeZone: "UTC",
+    });
+  }
+  if (DATE_ONLY_RE.test(p)) {
+    const [y = "", m = "", d = ""] = p.split("-");
+    return new Date(Date.UTC(Number(y), Number(m) - 1, Number(d))).toLocaleDateString(undefined, {
+      year: "numeric",
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC",
+    });
+  }
+  const date = new Date(p);
+  if (Number.isNaN(date.getTime())) return p;
+  return date.toLocaleDateString(undefined, {
+    year: "numeric",
+    month: "long",
+    day: "numeric",
+  });
+}
+
+/**
+ * Format a Darwin Core eventDate, which may be a single date, a date-time, a
+ * reduced-precision value ("1971", "1906-06"), or an interval whose endpoints
+ * are separated by a solidus ("1995-05-21/1995-05-23"). Intervals render as
+ * "<start> – <end>".
+ */
+export function formatEventDate(value: string): string {
+  const slash = value.indexOf("/");
+  if (slash === -1) return formatEventDatePart(value);
+  return `${formatEventDatePart(value.slice(0, slash))} – ${formatEventDatePart(
+    value.slice(slash + 1),
+  )}`;
+}
+
 /**
  * Generate a PDSLS URL for viewing an AT Protocol record
  */


### PR DESCRIPTION
Stacked PR **3 of 3** for date ranges in `eventDate`. **Base: #665** (this diff is against the PR 2 branch; merge 1 → 2 → 3 in order).

## What
The frontend half: observers can now **enter** a date range, and ranges / reduced precision **display** correctly throughout.

## Changes
- **`formatEventDate`** (`lib/utils.ts`) — range-aware long-form formatter: intervals render as `start – end`, reduced precision shows at its own granularity (`1971`, `June 1906`), and date-only values format in **UTC** so they don't shift a day across timezones. Used in `ObservationDetail`; `ExploreTable` gets a compact `YYYY-MM-DD – YYYY-MM-DD` variant for its CSV-friendly column.
- **`UploadModal`** — adds an optional **End date** field. When set, `eventDate` is written as a `YYYY-MM-DD/YYYY-MM-DD` interval (day precision) with the end validated on/after the start; the existing single date-time path is otherwise unchanged. Edit mode round-trips an existing range into the two inputs.
- Storybook fixture uses a range; unit tests cover formatting (interval, reduced precision, UTC day, unparseable).

## Test
- `npx tsc --project tsconfig.json` ✓ · `oxlint` 0 errors ✓ · `vitest run` (161) ✓
- e2e for creating a ranged observation against the live stack is a manual/follow-up verification item.

## Notes
- Ranges are entered at day precision (a multi-day observation has no single honest time); single observations keep full date-time precision.