### PR TITLE
fix(e2e): seed the renamed eventDate columns

### DIFF
--- a/frontend/tests/seed.sql
+++ b/frontend/tests/seed.sql
@@ -1,12 +1,18 @@
 -- Seed data for e2e tests in CI.
 -- Uses the test account DID so the identity resolver can find the handle.
+--
+-- eventDate is stored across three columns (see the eventDate-range work):
+-- `event_date_start`/`event_date_end` are the sortable/filterable bounds and
+-- `event_date_raw` is the verbatim string the appview displays.
 
-INSERT INTO occurrences (uri, cid, did, scientific_name, kingdom, family, genus, taxon_rank, event_date, location, created_at, associated_media)
+INSERT INTO occurrences (uri, cid, did, scientific_name, kingdom, family, genus, taxon_rank, event_date_start, event_date_end, event_date_raw, location, created_at, associated_media)
 VALUES
   ('at://did:plc:jh6n3ntljfhhtr4jbvrm3k5b/bio.lexicons.temp.occurrence/seed001',
    'bafyseed001', 'did:plc:jh6n3ntljfhhtr4jbvrm3k5b',
    'Eschscholzia californica', 'Plantae', 'Papaveraceae', 'Eschscholzia', 'species',
    NOW() - INTERVAL '1 hour',
+   NOW() - INTERVAL '1 hour' + INTERVAL '1 second',
+   to_char((NOW() - INTERVAL '1 hour') AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
    ST_SetSRID(ST_MakePoint(-122.4194, 37.7749), 4326),
    NOW() - INTERVAL '1 hour',
    '[]'::jsonb),
@@ -15,6 +21,8 @@ VALUES
    'bafyseed002', 'did:plc:jh6n3ntljfhhtr4jbvrm3k5b',
    'Quercus agrifolia', 'Plantae', 'Fagaceae', 'Quercus', 'species',
    NOW() - INTERVAL '2 hours',
+   NOW() - INTERVAL '2 hours' + INTERVAL '1 second',
+   to_char((NOW() - INTERVAL '2 hours') AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
    ST_SetSRID(ST_MakePoint(-118.2437, 34.0522), 4326),
    NOW() - INTERVAL '2 hours',
    '[]'::jsonb),
@@ -23,6 +31,8 @@ VALUES
    'bafyseed003', 'did:plc:jh6n3ntljfhhtr4jbvrm3k5b',
    'Calypte anna', 'Animalia', 'Trochilidae', 'Calypte', 'species',
    NOW() - INTERVAL '3 hours',
+   NOW() - INTERVAL '3 hours' + INTERVAL '1 second',
+   to_char((NOW() - INTERVAL '3 hours') AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS"Z"'),
    ST_SetSRID(ST_MakePoint(-121.8863, 36.6002), 4326),
    NOW() - INTERVAL '3 hours',
    '[]'::jsonb);


### PR DESCRIPTION
## Problem
The e2e job is **failing on `main`**:
```
psql:frontend/tests/seed.sql:28: ERROR: column "event_date" of relation "occurrences" does not exist
```
PR #665 renamed `occurrences.event_date` → `event_date_start` (and added `event_date_end` / `event_date_raw`), but `frontend/tests/seed.sql` still inserted into the old `event_date` column. Because the seed SQL isn't `sqlx`-checked, the only thing that exercised it was the live e2e run — so it slipped through #665's green checks and went red post-merge.

## Fix
Seed the new columns instead: `event_date_start`/`event_date_end` (sortable/filterable bounds) and `event_date_raw` (the verbatim string the appview displays, so seeded rows still show a date). The generated `event_date_range` populates automatically.

## Verified
- `sqlx migrate info` confirms both eventDate migrations are applied and the columns exist; the `to_char(... AT TIME ZONE 'UTC', ...)` pattern is the same one used in the PR #1 backfill migration.
- The authoritative check is this PR's **e2e job**, which runs `seed.sql` against a fresh Postgres.