### PR TITLE
fix(feed): align kebab menu to right of feed card

### DIFF
--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -113,7 +113,7 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
               </Typography>
             }
           />
-          <Box>
+          <Box sx={{ ml: "auto" }}>
             <IconButton
               size="small"
               onClick={handleMenuOpen}


### PR DESCRIPTION
Moves the three-dot "more options" (kebab) menu on the main feed card to the right edge of the card header.

Previously the kebab `Box` sat directly next to the `UserCard` (with only `gap: 1` spacing). Adding `ml: "auto"` pushes it to the right side of the flex header row.

```
frontend/src/components/feed/FeedItem.tsx
```