### PR TITLE
feat(task-runner): backfill event_date bounds from event_date_raw

### DIFF
--- a/.sqlx/query-0997507aabef9d86f861b24b19dacd60f768afcaa57992e5d7addc1c2c65a054.json
+++ b/.sqlx/query-0997507aabef9d86f861b24b19dacd60f768afcaa57992e5d7addc1c2c65a054.json
@@ -1,0 +1,42 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "\n        SELECT uri, event_date_raw as \"event_date_raw!\"\n        FROM occurrences\n        WHERE event_date_raw IS NOT NULL\n          AND ($1::bool OR event_date_start IS NULL)\n          AND ($2::text IS NULL OR did = $2)\n        ORDER BY created_at ASC\n        LIMIT COALESCE($3, 9223372036854775807)\n        ",
+  "describe": {
+    "columns": [
+      {
+        "ordinal": 0,
+        "name": "uri",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "uri"
+          }
+        }
+      },
+      {
+        "ordinal": 1,
+        "name": "event_date_raw!",
+        "type_info": "Text",
+        "origin": {
+          "Table": {
+            "table": "occurrences",
+            "name": "event_date_raw"
+          }
+        }
+      }
+    ],
+    "parameters": {
+      "Left": [
+        "Bool",
+        "Text",
+        "Int8"
+      ]
+    },
+    "nullable": [
+      false,
+      true
+    ]
+  },
+  "hash": "0997507aabef9d86f861b24b19dacd60f768afcaa57992e5d7addc1c2c65a054"
+}

--- a/.sqlx/query-ce2762f7b00c2433f9d631f7c1eee6501da0fbe236d9344dc31cbce88bc9bf9b.json
+++ b/.sqlx/query-ce2762f7b00c2433f9d631f7c1eee6501da0fbe236d9344dc31cbce88bc9bf9b.json
@@ -1,0 +1,16 @@
+{
+  "db_name": "PostgreSQL",
+  "query": "UPDATE occurrences SET event_date_start = $2, event_date_end = $3 WHERE uri = $1",
+  "describe": {
+    "columns": [],
+    "parameters": {
+      "Left": [
+        "Text",
+        "Timestamptz",
+        "Timestamptz"
+      ]
+    },
+    "nullable": []
+  },
+  "hash": "ce2762f7b00c2433f9d631f7c1eee6501da0fbe236d9344dc31cbce88bc9bf9b"
+}

--- a/crates/observing-task-runner/src/backfill_event_date_bounds.rs
+++ b/crates/observing-task-runner/src/backfill_event_date_bounds.rs
@@ -1,0 +1,149 @@
+//! `backfill-event-date-bounds` task: recompute `event_date_start`/
+//! `event_date_end` from the stored `event_date_raw` string.
+//!
+//! Why this exists: the `[start, end)` bounds are derived from the verbatim
+//! Darwin Core `eventDate` by `processing::expand_event_date`. Rows ingested
+//! while that parser was the hand-rolled version got NULL bounds for any value
+//! it couldn't handle — EDTF reduced precision / unspecified digits /
+//! uncertainty (`196X`, `1984?`, `1931-XX`, …). The `edtf` crate (now backing
+//! `expand_event_date`) parses those, so re-running it over the raw string
+//! recovers the bounds. Unlike `backfill-occurrences`, this needs **no PDS
+//! round-trip**: the source value is already in the DB, in `event_date_raw`.
+//!
+//! Safe to re-run: derivation is deterministic, so a second pass writes the
+//! same bounds. By default only rows still missing `event_date_start` are
+//! touched; `--all` re-derives every row that has a raw value. Rows whose raw
+//! string isn't a recognized date even under full EDTF are left untouched (the
+//! raw value still displays; it just has no sortable bounds).
+
+use observing_bootstrap::job::{self, JobOpts, Outcome};
+use observing_db::processing;
+use sqlx::postgres::PgPool;
+use std::process::ExitCode;
+use tracing::{error, info, warn};
+
+#[derive(clap::Args, Debug)]
+pub struct Args {
+    #[command(flatten)]
+    job: JobOpts,
+
+    /// Only process occurrences authored by this DID. Useful for verifying
+    /// behavior on one repo before the full sweep.
+    #[arg(long)]
+    did: Option<String>,
+
+    /// Re-derive bounds for every row that has an `event_date_raw`, not just
+    /// rows still missing `event_date_start`. Idempotent; this just widens the
+    /// candidate set.
+    #[arg(long)]
+    all: bool,
+
+    /// Number of UPDATEs to run concurrently.
+    #[arg(long, default_value_t = 8)]
+    concurrency: usize,
+}
+
+struct Row {
+    uri: String,
+    event_date_raw: String,
+}
+
+pub async fn run(args: Args) -> ExitCode {
+    let pool = match job::connect_pool(args.concurrency).await {
+        Ok(p) => p,
+        Err(e) => {
+            error!("{e}");
+            return ExitCode::from(1);
+        }
+    };
+
+    let rows = match fetch_rows(&pool, &args).await {
+        Ok(r) => r,
+        Err(e) => {
+            error!(error = %e, "failed to list occurrences");
+            return ExitCode::from(1);
+        }
+    };
+    info!(
+        candidates = rows.len(),
+        "occurrences to re-derive bounds for"
+    );
+
+    let summary = job::drive(rows, args.concurrency, |row| {
+        backfill_one(&pool, row, args.job.dry_run)
+    })
+    .await;
+
+    info!(
+        scanned = summary.scanned(),
+        done = ?summary.done,
+        skipped = summary.skipped,
+        failed = summary.failed,
+        "done"
+    );
+    ExitCode::SUCCESS
+}
+
+async fn fetch_rows(pool: &PgPool, args: &Args) -> Result<Vec<Row>, sqlx::Error> {
+    sqlx::query_as!(
+        Row,
+        r#"
+        SELECT uri, event_date_raw as "event_date_raw!"
+        FROM occurrences
+        WHERE event_date_raw IS NOT NULL
+          AND ($1::bool OR event_date_start IS NULL)
+          AND ($2::text IS NULL OR did = $2)
+        ORDER BY created_at ASC
+        LIMIT COALESCE($3, 9223372036854775807)
+        "#,
+        args.all,
+        args.did.as_deref(),
+        args.job.limit,
+    )
+    .fetch_all(pool)
+    .await
+}
+
+async fn backfill_one(pool: &PgPool, row: Row, dry_run: bool) -> Outcome {
+    // The raw string is present but not a recognized date/interval even under
+    // full EDTF — leave the bounds NULL. `failed` is reserved for write errors,
+    // which point at a real bug rather than expected unparseable data.
+    let bounds = match processing::expand_event_date(&row.event_date_raw) {
+        Some(b) => b,
+        None => {
+            warn!(uri = %row.uri, raw = %row.event_date_raw, "skipped: unparseable eventDate");
+            return Outcome::Skipped;
+        }
+    };
+
+    if dry_run {
+        info!(
+            uri = %row.uri,
+            raw = %row.event_date_raw,
+            start = %bounds.start,
+            end = %bounds.end,
+            "would backfill bounds"
+        );
+        return Outcome::Done("filled");
+    }
+
+    // `event_date_range` is a generated column, so it updates automatically.
+    match sqlx::query!(
+        "UPDATE occurrences SET event_date_start = $2, event_date_end = $3 WHERE uri = $1",
+        row.uri,
+        bounds.start,
+        bounds.end,
+    )
+    .execute(pool)
+    .await
+    {
+        Ok(_) => {
+            info!(uri = %row.uri, start = %bounds.start, end = %bounds.end, "backfilled bounds");
+            Outcome::Done("filled")
+        }
+        Err(e) => {
+            warn!(uri = %row.uri, error = %e, "failed: update");
+            Outcome::Failed
+        }
+    }
+}

--- a/crates/observing-task-runner/src/main.rs
+++ b/crates/observing-task-runner/src/main.rs
@@ -10,6 +10,7 @@
 //!
 //! ```text
 //! observing-task-runner backfill-occurrences --dry-run --all
+//! observing-task-runner backfill-event-date-bounds --dry-run
 //! observing-task-runner replay-failed-records --collection bio.lexicons.temp.v0-1.occurrence
 //! ```
 //!
@@ -20,6 +21,7 @@ use clap::{Parser, Subcommand};
 use std::process::ExitCode;
 use tracing_subscriber::{prelude::*, EnvFilter};
 
+mod backfill_event_date_bounds;
 mod backfill_occurrences;
 mod replay_failed_records;
 
@@ -35,6 +37,9 @@ enum Task {
     /// Re-fetch occurrences from their authoring PDS and re-run the upsert, to
     /// backfill newly-extracted columns (organismQuantity/organismQuantityType).
     BackfillOccurrences(backfill_occurrences::Args),
+    /// Recompute event_date_start/end from event_date_raw, recovering bounds
+    /// for EDTF values the old parser couldn't handle. No PDS round-trip.
+    BackfillEventDateBounds(backfill_event_date_bounds::Args),
     /// Replay rows from `ingester.failed_records` back through the upsert path.
     ReplayFailedRecords(replay_failed_records::Args),
 }
@@ -52,6 +57,7 @@ async fn main() -> ExitCode {
 
     match Cli::parse().task {
         Task::BackfillOccurrences(args) => backfill_occurrences::run(args).await,
+        Task::BackfillEventDateBounds(args) => backfill_event_date_bounds::run(args).await,
         Task::ReplayFailedRecords(args) => replay_failed_records::run(args).await,
     }
 }


### PR DESCRIPTION
Follow-up #2 — the data backfill, built with the `edtf`-backed parser (per your call to build it rather than wait on the prod counts).

## What
Adds a `backfill-event-date-bounds` subcommand to `observing-task-runner` that recomputes `event_date_start`/`event_date_end` by re-running `processing::expand_event_date` over the stored `event_date_raw`.

```
observing-task-runner backfill-event-date-bounds --dry-run        # preview
observing-task-runner backfill-event-date-bounds                  # fill NULL-bound rows
observing-task-runner backfill-event-date-bounds --all            # re-derive every row with a raw
```

## Why this is the cheap tier (no PDS round-trip)
The `[start, end)` bounds are *derived* from the raw eventDate string, which is already in the DB. Rows ingested while the parser was hand-rolled got **NULL bounds** for any value it rejected — EDTF reduced precision / unspecified digits / uncertainty (`196X`, `1984?`, `1931-XX`). Since the `edtf` swap (#667) those parse, so re-deriving recovers the bounds **without** re-fetching from the PDS (unlike `backfill-occurrences`).

This targets exactly the `null_start_has_raw` bucket from the prod-count decision tree. If that count is 0, the task is a harmless no-op (0 candidates).

## Notes
- Reuses the `observing_bootstrap::job` harness: `--dry-run`, `--limit`, `--did`, `--concurrency`. Same shape as the existing `backfill-occurrences`.
- Deterministic / idempotent; the generated `event_date_range` column updates automatically. Unparseable raws are **skipped**, not failed (they keep displaying the raw string, just without sortable bounds).
- Default set is rows missing `event_date_start`; `--all` widens to every row with a raw.

## Verification
- `cargo check` / `cargo clippy -p observing-task-runner --all-targets -- -D warnings` ✓
- `cargo sqlx prepare` validated both new queries against the live schema (cache committed).
- Bounds correctness (incl. `196X` → `[1960,1970)`, `1984?` → `[1984,1985)`) is covered by `expand_event_date`'s unit tests in `observing-db`.
- A live local run wasn't possible (the local dev Postgres container was recreated mid-session with unknown creds); the task is `--dry-run`-first by design, so the operator previews against prod before writing.