### PR TITLE
refactor(identity): replace PoC Did newtype with jacquard_common Did

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ dependencies = [
 name = "atproto-identity"
 version = "0.1.0"
 dependencies = [
+ "jacquard-common",
  "moka",
  "reqwest 0.13.4",
  "serde",

--- a/crates/atproto-blob-resolver/src/lib.rs
+++ b/crates/atproto-blob-resolver/src/lib.rs
@@ -7,7 +7,7 @@ pub mod error;
 pub mod resolver;
 pub mod types;
 
-pub use atproto_identity::{Did, DidParseError};
+pub use atproto_identity::Did;
 pub use error::{BlobResolverError, Result};
 pub use resolver::BlobResolver;
 pub use types::{PlcDirectoryResponse, PlcService};

--- a/crates/atproto-blob-resolver/src/resolver.rs
+++ b/crates/atproto-blob-resolver/src/resolver.rs
@@ -2,7 +2,7 @@
 
 use crate::error::{BlobResolverError, Result};
 use crate::types::PlcDirectoryResponse;
-use atproto_identity::{plc_directory_url, Did, DidMethod};
+use atproto_identity::{plc_directory_url, Did, DidExt, DidMethod};
 use jacquard_common::types::string::AtUri;
 use reqwest::Client;
 use std::str::FromStr;
@@ -33,8 +33,11 @@ impl BlobResolver {
     /// Resolve a DID to its PDS URL
     pub async fn resolve_pds_url(&self, did: &Did) -> Result<String> {
         match did.method() {
-            DidMethod::Plc(_) => self.resolve_plc_did(did).await,
-            DidMethod::Web(host) => self.resolve_web_did(did, host),
+            Some(DidMethod::Plc(_)) => self.resolve_plc_did(did).await,
+            Some(DidMethod::Web(host)) => self.resolve_web_did(did, host),
+            None => Err(BlobResolverError::DidResolution(format!(
+                "unsupported DID method: {did}"
+            ))),
         }
     }
 
@@ -180,7 +183,7 @@ impl BlobResolver {
             )));
         };
         let authority = parsed.authority();
-        let did = Did::parse(authority.as_str()).map_err(|e| {
+        let did = Did::new_owned(authority.as_str()).map_err(|e| {
             BlobResolverError::DidResolution(format!("unparseable DID in {at_uri}: {e}"))
         })?;
         let pds_url = self.resolve_pds_url(&did).await?;
@@ -205,14 +208,14 @@ mod tests {
     use super::*;
 
     fn web_did(s: &str) -> Did {
-        Did::parse(s).expect("test fixture must parse")
+        Did::new_owned(s).expect("test fixture must parse")
     }
 
     #[test]
     fn test_resolve_web_did_simple_domain() {
         let resolver = BlobResolver::new();
         let did = web_did("did:web:example.com");
-        let DidMethod::Web(host) = did.method() else {
+        let Some(DidMethod::Web(host)) = did.method() else {
             panic!("expected web method")
         };
 
@@ -224,7 +227,7 @@ mod tests {
     fn test_resolve_web_did_url_encoded_port() {
         let resolver = BlobResolver::new();
         let did = web_did("did:web:example.com%3A8080");
-        let DidMethod::Web(host) = did.method() else {
+        let Some(DidMethod::Web(host)) = did.method() else {
             panic!("expected web method")
         };
 
@@ -232,7 +235,13 @@ mod tests {
         assert_eq!(result, "https://example.com:8080");
     }
 
-    // Unsupported-method coverage now lives at the type boundary: Did::parse
-    // refuses anything other than did:plc:/did:web:, so resolve_pds_url cannot
-    // be reached with an unsupported method in the first place.
+    #[tokio::test]
+    async fn unsupported_method_is_rejected() {
+        // jacquard's Did accepts any syntactically valid method, so the
+        // unsupported-method guard now lives in resolve_pds_url itself.
+        let resolver = BlobResolver::new();
+        let did = Did::new_owned("did:key:z6MkExample").expect("valid did syntax");
+        let err = resolver.resolve_pds_url(&did).await.unwrap_err();
+        assert!(matches!(err, BlobResolverError::DidResolution(_)));
+    }
 }

--- a/crates/atproto-identity/Cargo.toml
+++ b/crates/atproto-identity/Cargo.toml
@@ -6,6 +6,9 @@ description = "AT Protocol identity resolution and profile caching"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+# AT Protocol types (validated DID)
+jacquard-common = "0.12"
+
 # HTTP client
 reqwest = { workspace = true }
 

--- a/crates/atproto-identity/src/did.rs
+++ b/crates/atproto-identity/src/did.rs
@@ -1,203 +1,41 @@
-//! Validated DID (Decentralized Identifier) newtype.
+//! DID method discrimination layered on jacquard's validated `Did`.
 //!
-//! This is a **proof-of-concept** step toward addressing stringly-typed DIDs
-//! across the codebase. Today, DIDs flow through the system as plain `String`s,
-//! which means every site that consumes one has to re-validate or trust the
-//! caller. A newtype makes the invariants ("starts with `did:plc:` or
-//! `did:web:`, matches the AT Protocol DID syntax") a property of the type
-//! system instead of a runtime assumption.
-//!
-//! Only this module uses `Did` so far — migrating call sites is intentionally
-//! left to follow-up PRs, so reviewers can evaluate the type's shape in
-//! isolation before committing to a sweep.
-//!
-//! Validation follows the [AT Protocol DID spec][spec]:
-//!
-//! * Overall length ≤ 2048 bytes.
-//! * Only the ASCII character set `A-Z a-z 0-9 . - _ : %` (percent-encoding is
-//!   allowed but not decoded — `did:web:localhost%3A3000` round-trips
-//!   verbatim).
-//! * Must not end with `:` or `-`.
-//! * `did:plc:<id>` — `<id>` is exactly 24 characters of lowercase base32
-//!   (`a-z`, `2-7`).
-//! * `did:web:<host>` — `<host>` is non-empty. Full hostname validation is
-//!   left to the resolver so percent-encoded ports continue to pass through.
-//!
-//! [spec]: https://atproto.com/specs/did
+//! The DID newtype itself now comes from [`jacquard_common`], which validates
+//! the full AT Protocol DID syntax (see <https://atproto.com/specs/did>). This
+//! module keeps only the observ.ing-specific piece jacquard does not provide:
+//! classifying a DID by method (`did:plc:` vs `did:web:`) so the resolver knows
+//! how to fetch its document.
 
-use std::fmt;
-use std::str::FromStr;
-
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-
-/// Maximum length of a DID string, per the AT Protocol DID spec.
-const MAX_DID_LEN: usize = 2048;
-
-/// Length of the method-specific identifier for `did:plc:`.
-const PLC_ID_LEN: usize = 24;
-
-/// A parsed AT Protocol DID.
-///
-/// Construct with [`Did::parse`] (or `"…".parse::<Did>()`). The stored string
-/// is guaranteed to:
-///
-/// * start with a supported method prefix (`did:plc:` or `did:web:`),
-/// * have a non-empty, well-formed method-specific identifier, and
-/// * satisfy the AT Protocol DID syntax rules (length, character set, no
-///   trailing separator).
-#[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub struct Did(String);
+use jacquard_common::types::string::Did;
 
 /// DID method discriminant, with a borrowed view of the method-specific part.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DidMethod<'a> {
     /// `did:plc:<id>` — placeholder method, resolved via plc.directory.
-    /// `<id>` is always 24 characters of lowercase base32.
     Plc(&'a str),
     /// `did:web:<host>` — resolved via HTTPS at `<host>/.well-known/did.json`.
     /// `%3A` port-separator escaping is preserved as stored.
     Web(&'a str),
 }
 
-/// Errors produced by [`Did::parse`].
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DidParseError {
-    /// The string did not begin with a supported `did:<method>:` prefix.
-    UnsupportedMethod,
-    /// The method-specific identifier (after the second colon) was empty.
-    EmptyIdentifier,
-    /// The DID exceeded the 2048-byte maximum length.
-    TooLong,
-    /// The DID contained a character outside the AT Protocol DID syntax set.
-    InvalidCharacter,
-    /// The DID ended with `:` or `-`, which the spec forbids.
-    InvalidTrailingCharacter,
-    /// A `did:plc:` identifier was not exactly 24 chars of lowercase base32.
-    InvalidPlcIdentifier,
+/// Classify a [`Did`] by its method.
+pub trait DidExt {
+    /// Return the [`DidMethod`] for this DID, or `None` for methods other than
+    /// `did:plc:` / `did:web:` (which observ.ing treats as unsupported).
+    ///
+    /// jacquard guarantees the value is a syntactically valid `did:<method>:<id>`,
+    /// so the only `None` case is an unsupported method.
+    fn method(&self) -> Option<DidMethod<'_>>;
 }
 
-impl fmt::Display for DidParseError {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::UnsupportedMethod => {
-                f.write_str("unsupported DID method (expected did:plc: or did:web:)")
-            }
-            Self::EmptyIdentifier => f.write_str("DID method-specific identifier is empty"),
-            Self::TooLong => f.write_str("DID exceeds maximum length of 2048 bytes"),
-            Self::InvalidCharacter => f.write_str(
-                "DID contains a character outside the allowed set (A-Z a-z 0-9 . - _ : %)",
-            ),
-            Self::InvalidTrailingCharacter => f.write_str("DID must not end with ':' or '-'"),
-            Self::InvalidPlcIdentifier => {
-                f.write_str("did:plc: identifier must be 24 chars of lowercase base32 (a-z, 2-7)")
-            }
-        }
-    }
-}
-
-impl std::error::Error for DidParseError {}
-
-impl Did {
-    /// Parse a string into a validated DID.
-    pub fn parse(s: &str) -> Result<Self, DidParseError> {
-        if s.len() > MAX_DID_LEN {
-            return Err(DidParseError::TooLong);
-        }
-
-        // Method detection runs first so "did:plc:" reports EmptyIdentifier
-        // rather than being caught by the trailing-`:` rule below.
+impl DidExt for Did {
+    fn method(&self) -> Option<DidMethod<'_>> {
+        let s = self.as_str();
         if let Some(rest) = s.strip_prefix("did:plc:") {
-            if rest.is_empty() {
-                return Err(DidParseError::EmptyIdentifier);
-            }
-            validate_did_syntax(s)?;
-            if !is_valid_plc_id(rest) {
-                return Err(DidParseError::InvalidPlcIdentifier);
-            }
-        } else if let Some(rest) = s.strip_prefix("did:web:") {
-            if rest.is_empty() {
-                return Err(DidParseError::EmptyIdentifier);
-            }
-            validate_did_syntax(s)?;
+            Some(DidMethod::Plc(rest))
         } else {
-            return Err(DidParseError::UnsupportedMethod);
+            s.strip_prefix("did:web:").map(DidMethod::Web)
         }
-
-        Ok(Did(s.to_owned()))
-    }
-
-    /// Borrow the full DID string (`did:plc:...` or `did:web:...`).
-    pub fn as_str(&self) -> &str {
-        &self.0
-    }
-
-    /// Classify the DID by method, exposing the method-specific suffix.
-    pub fn method(&self) -> DidMethod<'_> {
-        if let Some(rest) = self.0.strip_prefix("did:plc:") {
-            DidMethod::Plc(rest)
-        } else if let Some(rest) = self.0.strip_prefix("did:web:") {
-            DidMethod::Web(rest)
-        } else {
-            // Unreachable: `parse` is the only constructor and it rejects
-            // anything that does not start with a supported prefix.
-            unreachable!("Did constructed without a supported method prefix")
-        }
-    }
-}
-
-/// Apply the method-agnostic AT Protocol DID syntax rules: allowed character
-/// set and no trailing `:` / `-`.
-fn validate_did_syntax(s: &str) -> Result<(), DidParseError> {
-    if !s.bytes().all(is_valid_did_byte) {
-        return Err(DidParseError::InvalidCharacter);
-    }
-    match s.as_bytes().last() {
-        Some(b':' | b'-') => Err(DidParseError::InvalidTrailingCharacter),
-        _ => Ok(()),
-    }
-}
-
-/// ATProto DID grammar: `ALPHA / DIGIT / "." / "-" / "_" / ":" / "%"`.
-fn is_valid_did_byte(b: u8) -> bool {
-    b.is_ascii_alphanumeric() || matches!(b, b'.' | b'-' | b'_' | b':' | b'%')
-}
-
-/// `did:plc:` identifiers are exactly 24 chars of lowercase base32 (RFC 4648,
-/// alphabet `a-z2-7`).
-fn is_valid_plc_id(id: &str) -> bool {
-    id.len() == PLC_ID_LEN && id.bytes().all(|b| matches!(b, b'a'..=b'z' | b'2'..=b'7'))
-}
-
-impl fmt::Display for Did {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(&self.0)
-    }
-}
-
-impl AsRef<str> for Did {
-    fn as_ref(&self) -> &str {
-        &self.0
-    }
-}
-
-impl FromStr for Did {
-    type Err = DidParseError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::parse(s)
-    }
-}
-
-impl Serialize for Did {
-    fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        serializer.serialize_str(&self.0)
-    }
-}
-
-impl<'de> Deserialize<'de> for Did {
-    fn deserialize<D: Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
-        let s = String::deserialize(deserializer)?;
-        Did::parse(&s).map_err(serde::de::Error::custom)
     }
 }
 
@@ -205,127 +43,25 @@ impl<'de> Deserialize<'de> for Did {
 mod tests {
     use super::*;
 
-    const VALID_PLC: &str = "did:plc:abcdefghijklmnopqrstuvwx"; // 24 chars a-z
-    const VALID_PLC_ID: &str = "abcdefghijklmnopqrstuvwx";
-
     #[test]
-    fn parses_did_plc() {
-        let did = Did::parse(VALID_PLC).unwrap();
-        assert_eq!(did.as_str(), VALID_PLC);
-        assert_eq!(did.method(), DidMethod::Plc(VALID_PLC_ID));
-    }
-
-    #[test]
-    fn parses_did_web() {
-        let did = Did::parse("did:web:example.com").unwrap();
-        assert_eq!(did.as_str(), "did:web:example.com");
-        assert_eq!(did.method(), DidMethod::Web("example.com"));
-    }
-
-    #[test]
-    fn preserves_percent_encoded_port_in_did_web() {
-        let did = Did::parse("did:web:localhost%3A3000").unwrap();
-        assert_eq!(did.method(), DidMethod::Web("localhost%3A3000"));
-    }
-
-    #[test]
-    fn rejects_unknown_method() {
+    fn plc_method() {
+        let did = Did::new_owned("did:plc:abcdefghijklmnopqrstuvwx").unwrap();
         assert_eq!(
-            Did::parse("did:key:z6Mk"),
-            Err(DidParseError::UnsupportedMethod)
-        );
-        assert_eq!(
-            Did::parse("https://example.com"),
-            Err(DidParseError::UnsupportedMethod)
+            did.method(),
+            Some(DidMethod::Plc("abcdefghijklmnopqrstuvwx"))
         );
     }
 
     #[test]
-    fn rejects_empty_identifier() {
-        assert_eq!(Did::parse("did:plc:"), Err(DidParseError::EmptyIdentifier));
-        assert_eq!(Did::parse("did:web:"), Err(DidParseError::EmptyIdentifier));
+    fn web_method_preserves_port_escaping() {
+        let did = Did::new_owned("did:web:localhost%3A3000").unwrap();
+        assert_eq!(did.method(), Some(DidMethod::Web("localhost%3A3000")));
     }
 
     #[test]
-    fn rejects_too_long() {
-        let long = format!("did:web:{}", "a".repeat(MAX_DID_LEN));
-        assert_eq!(Did::parse(&long), Err(DidParseError::TooLong));
-    }
-
-    #[test]
-    fn rejects_invalid_character() {
-        // `/` is outside the ATProto DID char set.
-        assert_eq!(
-            Did::parse("did:web:example.com/path"),
-            Err(DidParseError::InvalidCharacter)
-        );
-        // Whitespace is rejected.
-        assert_eq!(
-            Did::parse("did:web:example .com"),
-            Err(DidParseError::InvalidCharacter)
-        );
-    }
-
-    #[test]
-    fn rejects_trailing_separator() {
-        assert_eq!(
-            Did::parse("did:web:example.com-"),
-            Err(DidParseError::InvalidTrailingCharacter)
-        );
-        // Trailing `:` is caught before empty-identifier because the suffix
-        // is non-empty here ("example.com:").
-        assert_eq!(
-            Did::parse("did:web:example.com:"),
-            Err(DidParseError::InvalidTrailingCharacter)
-        );
-    }
-
-    #[test]
-    fn rejects_invalid_plc_identifier() {
-        // Wrong length.
-        assert_eq!(
-            Did::parse("did:plc:abc"),
-            Err(DidParseError::InvalidPlcIdentifier)
-        );
-        // Uppercase base32 is not allowed — ATProto requires lowercase.
-        assert_eq!(
-            Did::parse("did:plc:ABCDEFGHIJKLMNOPQRSTUVWX"),
-            Err(DidParseError::InvalidPlcIdentifier)
-        );
-        // `0` and `1` are outside the RFC 4648 base32 alphabet.
-        assert_eq!(
-            Did::parse("did:plc:0bcdefghijklmnopqrstuvwx"),
-            Err(DidParseError::InvalidPlcIdentifier)
-        );
-    }
-
-    #[test]
-    fn display_round_trips() {
-        let did = Did::parse(VALID_PLC).unwrap();
-        assert_eq!(did.to_string(), VALID_PLC);
-    }
-
-    #[test]
-    fn parses_via_from_str() {
-        let did: Did = VALID_PLC.parse().unwrap();
-        assert_eq!(did.as_str(), VALID_PLC);
-
-        let err: Result<Did, _> = "not-a-did".parse();
-        assert_eq!(err, Err(DidParseError::UnsupportedMethod));
-    }
-
-    #[test]
-    fn serde_round_trips() {
-        let did = Did::parse(VALID_PLC).unwrap();
-        let json = serde_json::to_string(&did).unwrap();
-        assert_eq!(json, format!("\"{VALID_PLC}\""));
-        let back: Did = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, did);
-    }
-
-    #[test]
-    fn serde_rejects_invalid() {
-        let err = serde_json::from_str::<Did>("\"did:key:nope\"").unwrap_err();
-        assert!(err.to_string().contains("unsupported DID method"));
+    fn unsupported_method_is_none() {
+        // Syntactically valid per jacquard, but not a method the resolver handles.
+        let did = Did::new_owned("did:key:z6Mk").unwrap();
+        assert_eq!(did.method(), None);
     }
 }

--- a/crates/atproto-identity/src/lib.rs
+++ b/crates/atproto-identity/src/lib.rs
@@ -8,9 +8,14 @@ mod did;
 mod resolver;
 mod types;
 
-pub use did::{Did, DidMethod, DidParseError};
+pub use did::{DidExt, DidMethod};
 pub use resolver::IdentityResolver;
 pub use types::{Profile, ResolveResult};
+
+/// Validated AT Protocol DID, backed by jacquard's `Did` (default `SmolStr`
+/// backing). jacquard owns the syntax validation; [`DidExt`] adds method
+/// classification on top.
+pub type Did = jacquard_common::types::string::Did;
 
 /// Base URL of the PLC directory used to resolve `did:plc:` documents.
 ///

--- a/crates/atproto-identity/src/resolver.rs
+++ b/crates/atproto-identity/src/resolver.rs
@@ -6,7 +6,9 @@ use moka::future::Cache;
 use reqwest::Client;
 use tracing::{debug, error, warn};
 
-use crate::did::{Did, DidMethod};
+use jacquard_common::types::string::Did;
+
+use crate::did::{DidExt, DidMethod};
 use crate::types::{
     DidDocument, Profile, ProfileResponse, ProfilesResponse, ResolveHandleResponse, ResolveResult,
 };
@@ -88,7 +90,7 @@ impl IdentityResolver {
             Ok(response) if response.status().is_success() => {
                 match response.json::<ResolveHandleResponse>().await {
                     Ok(data) => {
-                        let did = match Did::parse(&data.did) {
+                        let did = match Did::new_owned(&data.did) {
                             Ok(d) => d,
                             Err(e) => {
                                 warn!(
@@ -186,10 +188,14 @@ impl IdentityResolver {
     /// Get the DID document for a DID
     async fn get_did_document(&self, did: &Did) -> Option<DidDocument> {
         let url = match did.method() {
-            DidMethod::Plc(_) => format!("{}/{}", self.plc_directory_url, did.as_str()),
-            DidMethod::Web(host) => {
+            Some(DidMethod::Plc(_)) => format!("{}/{}", self.plc_directory_url, did.as_str()),
+            Some(DidMethod::Web(host)) => {
                 let domain = host.replace("%3A", ":");
                 format!("https://{domain}/.well-known/did.json")
+            }
+            None => {
+                warn!(did = %did, "unsupported DID method; cannot resolve document");
+                return None;
             }
         };
 

--- a/crates/atproto-identity/src/types.rs
+++ b/crates/atproto-identity/src/types.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-use crate::did::Did;
+use jacquard_common::types::string::Did;
 
 /// AT Protocol profile
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/observing-appview/src/routes/media.rs
+++ b/crates/observing-appview/src/routes/media.rs
@@ -64,7 +64,7 @@ pub async fn get_thumb(
 }
 
 async fn serve_blob(media: &MediaCache, did_str: &str, cid: &str) -> Response {
-    let did = match Did::parse(did_str) {
+    let did = match Did::new_owned(did_str) {
         Ok(d) => d,
         Err(e) => {
             warn!(did = %did_str, error = %e, "Rejecting blob request with invalid DID");

--- a/crates/observing-appview/src/routes/oauth.rs
+++ b/crates/observing-appview/src/routes/oauth.rs
@@ -217,7 +217,7 @@ pub async fn me(
             // The session_did cookie has already been validated as a Did above
             // (atrium's validator), so re-parsing through our newtype should
             // succeed; if it doesn't, just fall back to the raw string.
-            let handle = match atproto_identity::Did::parse(&did) {
+            let handle = match atproto_identity::Did::new_owned(&did) {
                 Ok(parsed) => state
                     .resolver
                     .resolve_did(&parsed)


### PR DESCRIPTION
Re-lands the content of #674 against `main`.

**Context:** #674 was accidentally merged into the `refactor/at-uri-jacquard-rebased` feature branch instead of `main`. `main` already has the AtUri change (via #673), so this PR carries only the **Did delta** and applies cleanly on top of `main`.

## What

Retires the hand-rolled, self-described "proof-of-concept" `Did` newtype in `atproto-identity` in favor of `jacquard_common::types::string::Did`, which the workspace already depends on for lexicon types and which validates the full AT Protocol DID syntax.

- `atproto-identity` exposes `pub type Did = jacquard_common::…::Did` (SmolStr backing) and keeps only what jacquard doesn't provide: the `DidMethod` enum + a `DidExt::method()` helper classifying `did:plc:` / `did:web:`. `plc_directory_url()` unchanged.
- Deleted the ~300-line newtype (validation, `DidParseError`, parse/serde).
- `Did::parse` → `Did::new_owned` (`Result<_, AtStrError>`); method classification is now `Option`, so `resolve_pds_url` / `get_did_document` handle an unsupported method explicitly.

## Behavioral note

jacquard validates the generic DID grammar but does not enforce the `did:plc` 24-char base32 rule the PoC did — a malformed plc id now fails at resolution rather than at parse (matches the official TS impl).

## Testing

`cargo build` / `cargo clippy` clean for `atproto-identity`, `atproto-blob-resolver`, `observing-appview`; `cargo test -p atproto-identity -p atproto-blob-resolver` passes.