### PR TITLE
feat(feed): optimistic tombstone row for new observations

### DIFF
--- a/frontend/src/components/feed/ExploreGridCard.tsx
+++ b/frontend/src/components/feed/ExploreGridCard.tsx
@@ -1,12 +1,14 @@
 import { memo } from "react";
 import { Link } from "react-router-dom";
-import { Box, Typography, Card, CardActionArea, CardContent } from "@mui/material";
+import { Typography, Card, CardActionArea, CardContent } from "@mui/material";
 import type { Occurrence } from "../../services/types";
+import { useAppSelector } from "../../store";
 import { getImageUrl } from "../../services/api";
 import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
+import { PendingBadge } from "./PendingBadge";
 
 interface ExploreGridCardProps {
   observation: Occurrence;
@@ -16,17 +18,25 @@ export const ExploreGridCard = memo(function ExploreGridCard({
   observation,
 }: ExploreGridCardProps) {
   const species = observation.communityId || observation.effectiveTaxonomy?.scientificName;
+  // Optimistic tombstone awaiting ingestion: dim it and block navigation to a
+  // detail page that would 404 until the record lands.
+  const isPending = useAppSelector((state) =>
+    state.pending.submissions.some((s) => s.uri === observation.uri),
+  );
 
   return (
-    <Card sx={{ display: "flex", flexDirection: "column" }}>
+    <Card sx={{ display: "flex", flexDirection: "column", position: "relative" }}>
+      {isPending && <PendingBadge />}
       <CardActionArea
         component={Link}
         to={getObservationUrl(observation.uri)}
+        onClick={isPending ? (e) => e.preventDefault() : undefined}
         sx={{
           flex: 1,
           display: "flex",
           flexDirection: "column",
           alignItems: "stretch",
+          ...(isPending && { opacity: 0.7, pointerEvents: "none" }),
         }}
       >
         <ImageWithSkeleton

--- a/frontend/src/components/feed/ExploreGridCard.tsx
+++ b/frontend/src/components/feed/ExploreGridCard.tsx
@@ -2,7 +2,7 @@ import { memo } from "react";
 import { Link } from "react-router-dom";
 import { Typography, Card, CardActionArea, CardContent } from "@mui/material";
 import type { Occurrence } from "../../services/types";
-import { useAppSelector } from "../../store";
+import { useIsPending } from "../../store/pendingSlice";
 import { getImageUrl } from "../../services/api";
 import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
@@ -20,9 +20,7 @@ export const ExploreGridCard = memo(function ExploreGridCard({
   const species = observation.communityId || observation.effectiveTaxonomy?.scientificName;
   // Optimistic tombstone awaiting ingestion: dim it and block navigation to a
   // detail page that would 404 until the record lands.
-  const isPending = useAppSelector((state) =>
-    state.pending.submissions.some((s) => s.uri === observation.uri),
-  );
+  const isPending = useIsPending(observation.uri);
 
   return (
     <Card sx={{ display: "flex", flexDirection: "column", position: "relative" }}>

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -23,6 +23,7 @@ import { UserCard } from "../common/UserCard";
 import { getPdslsUrl, getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
+import { PendingBadge } from "./PendingBadge";
 import { FEED_CARD_SX, FEED_IMAGE_MAX_HEIGHT } from "./feedLayout";
 
 interface FeedItemProps {
@@ -42,6 +43,11 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
   const navigate = useNavigate();
   const currentUser = useAppSelector((state) => state.auth.user);
   const isOwnPost = currentUser?.did === observation.observer.did;
+  // True while this is an optimistic tombstone the ingester hasn't confirmed
+  // yet. Selecting a primitive keeps the subscription cheap and churn-free.
+  const isPending = useAppSelector((state) =>
+    state.pending.submissions.some((s) => s.uri === observation.uri),
+  );
 
   const owner = observation.observer;
   const handle = owner.handle ? `@${owner.handle}` : "";
@@ -90,8 +96,16 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
   };
 
   return (
-    <Card sx={FEED_CARD_SX}>
-      <CardActionArea onClick={handleCardClick} component="div">
+    <Card sx={{ ...FEED_CARD_SX, position: "relative", ...(isPending && { opacity: 0.7 }) }}>
+      {isPending && <PendingBadge />}
+      {/* While pending the row isn't ingested: navigation 404s and the menu's
+          edit/delete act on a record that doesn't exist yet, so we freeze all
+          interaction inside the action area until reconciliation. */}
+      <CardActionArea
+        onClick={isPending ? undefined : handleCardClick}
+        component="div"
+        sx={isPending ? { pointerEvents: "none" } : undefined}
+      >
         <Box sx={{ display: "flex", gap: 1, p: 2, alignItems: "flex-start" }}>
           <UserCard
             actor={owner}
@@ -187,7 +201,7 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
                   onClick={() =>
                     like.mutate({ uri: observation.uri, cid: observation.cid, liked: !liked })
                   }
-                  disabled={!currentUser}
+                  disabled={!currentUser || isPending}
                   aria-label={liked ? "Unlike" : "Like"}
                   sx={{
                     color: liked ? "error.main" : "text.disabled",

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -16,6 +16,7 @@ import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import type { Occurrence } from "../../services/types";
 import { useAppSelector } from "../../store";
+import { useIsPending } from "../../store/pendingSlice";
 import { getImageUrl } from "../../services/api";
 import { useLike } from "../../lib/query/mutations";
 import { TaxonLink } from "../common/TaxonLink";
@@ -43,11 +44,8 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
   const navigate = useNavigate();
   const currentUser = useAppSelector((state) => state.auth.user);
   const isOwnPost = currentUser?.did === observation.observer.did;
-  // True while this is an optimistic tombstone the ingester hasn't confirmed
-  // yet. Selecting a primitive keeps the subscription cheap and churn-free.
-  const isPending = useAppSelector((state) =>
-    state.pending.submissions.some((s) => s.uri === observation.uri),
-  );
+  // True while this is an optimistic tombstone the ingester hasn't confirmed yet.
+  const isPending = useIsPending(observation.uri);
 
   const owner = observation.observer;
   const handle = owner.handle ? `@${owner.handle}` : "";

--- a/frontend/src/components/feed/PendingBadge.stories.tsx
+++ b/frontend/src/components/feed/PendingBadge.stories.tsx
@@ -1,0 +1,34 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { PendingBadge } from "./PendingBadge";
+
+const meta = {
+  title: "Feed/PendingBadge",
+  component: PendingBadge,
+  parameters: {
+    layout: "padded",
+  },
+  // The badge is absolutely positioned, so anchor it to a relative box sized
+  // like the corner of a feed card it overlays.
+  decorators: [
+    (Story) => (
+      <Box
+        sx={{
+          position: "relative",
+          width: 280,
+          height: 120,
+          bgcolor: "placeholder",
+          borderRadius: 1,
+        }}
+      >
+        <Story />
+      </Box>
+    ),
+  ],
+  tags: ["autodocs"],
+} satisfies Meta<typeof PendingBadge>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/src/components/feed/PendingBadge.tsx
+++ b/frontend/src/components/feed/PendingBadge.tsx
@@ -1,0 +1,23 @@
+import { Chip, CircularProgress } from "@mui/material";
+
+// Overlay chip marking a feed row as a not-yet-ingested optimistic submission.
+// Pair it with a dimmed, interaction-disabled card; it clears once the ingester
+// catches up and the pending slice drops the row's uri (see pendingSlice +
+// occurrenceCache `reconcileOccurrence`).
+export function PendingBadge() {
+  return (
+    <Chip
+      size="small"
+      icon={<CircularProgress size={12} thickness={6} sx={{ color: "inherit !important" }} />}
+      label="Processing…"
+      sx={{
+        position: "absolute",
+        top: 8,
+        left: 8,
+        zIndex: 1,
+        bgcolor: "rgba(0, 0, 0, 0.65)",
+        color: "white",
+      }}
+    />
+  );
+}

--- a/frontend/src/components/layout/PendingIndicator.tsx
+++ b/frontend/src/components/layout/PendingIndicator.tsx
@@ -1,12 +1,13 @@
 import { Box, CircularProgress, Tooltip } from "@mui/material";
 import { useAppSelector } from "../../store";
+import { selectPendingCount } from "../../store/pendingSlice";
 
 // Small TopBar spinner that surfaces background observation submissions. The
 // upload modal closes immediately on a successful PDS write and hands the
 // ingester poll off to the `pending` slice; this is the only visible trace of
 // that in-flight work until the completion toast fires.
 export function PendingIndicator() {
-  const count = useAppSelector((state) => state.pending.submissions.length);
+  const count = useAppSelector(selectPendingCount);
 
   if (count === 0) return null;
 

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -30,6 +30,7 @@ import { trackSubmission } from "../../store/pendingSlice";
 import { useToast } from "../../hooks/useToast";
 import { useUserPreferences } from "../../lib/query/hooks";
 import { useSubmitObservation, useUpdateObservation } from "../../lib/query/mutations";
+import { makeTombstoneOccurrence, prependOccurrence } from "../../lib/query/occurrenceCache";
 import { validateTaxon } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
@@ -135,6 +136,7 @@ export function UploadModal() {
   const editingObservation = useAppSelector((state) => state.ui.editingObservation);
   const defaultLicense = useUserPreferences().data?.defaultLicense ?? null;
   const currentLocation = useAppSelector((state) => state.ui.currentLocation);
+  const currentUser = useAppSelector((state) => state.auth.user);
 
   const isEditMode = !!editingObservation;
 
@@ -442,11 +444,35 @@ export function UploadModal() {
 
     // The PDS write succeeded. Close the modal immediately so the submission
     // feels instant — the ingester poll, completion toast, and cache
-    // invalidation run in the background (surfaced by the TopBar pending
-    // indicator). The user stays on the current page; the new/updated row
-    // appears in place once the ingester catches up.
+    // reconciliation run in the background (surfaced by the TopBar pending
+    // indicator). For a create we also splice an optimistic "tombstone" row
+    // into the feeds so the new observation shows up right away (dimmed) instead
+    // of after the ingester catches up; trackSubmission swaps it for the real
+    // record once ingested.
     const onSuccess = (result: { uri: string; cid: string }) => {
       dispatch(closeUploadModal());
+      if (kind === "create" && currentUser) {
+        prependOccurrence(
+          makeTombstoneOccurrence({
+            uri: result.uri,
+            cid: result.cid,
+            observer: currentUser,
+            latitude: parseFloat(lat),
+            longitude: parseFloat(lng),
+            uncertaintyMeters: uncertaintyMeters,
+            eventDate,
+            scientificName: trimmedSpecies || undefined,
+            kingdom: kingdom || undefined,
+            rank: matchedTaxon?.rank ?? rank ?? undefined,
+            imageUrls: imageData.map((img) => `data:${img.mimeType};base64,${img.data}`),
+            license,
+            organismQuantity: organismQuantity.trim() || undefined,
+            organismQuantityType: organismQuantityType || undefined,
+            createdAt: new Date().toISOString(),
+          }),
+          currentUser.did,
+        );
+      }
       resetForm();
       void dispatch(trackSubmission({ uri: result.uri, cid: result.cid, kind }));
     };

--- a/frontend/src/lib/query/occurrenceCache.ts
+++ b/frontend/src/lib/query/occurrenceCache.ts
@@ -7,7 +7,12 @@
 import type { InfiniteData } from "@tanstack/react-query";
 import { queryClient } from "./queryClient";
 import { OCCURRENCE_LIST_TAGS } from "./keys";
-import type { Occurrence, OccurrenceDetailResponse } from "../../services/types";
+import type {
+  EffectiveTaxonomy,
+  Occurrence,
+  OccurrenceDetailResponse,
+  Profile,
+} from "../../services/types";
 
 // Any infinite-query page that carries occurrences (feed / profile / taxon).
 type OccurrencePage = { occurrences: Occurrence[]; cursor?: string };
@@ -69,4 +74,133 @@ export function invalidateObservation(uri: string): Promise<void> {
 /** Drop one observation's detail cache (after a delete). */
 export function removeObservation(uri: string): void {
   queryClient.removeQueries({ queryKey: ["observation", uri] });
+}
+
+// ── Optimistic "tombstone" rows ──────────────────────────────────────────────
+// A freshly-submitted observation only lands in the app DB after the async
+// tap-ingester replays the PDS commit (seconds later). To make the submission
+// feel instant we splice a client-built placeholder — a "tombstone" — into the
+// feeds right away, then swap it for the canonical record once the ingester has
+// it (`reconcileOccurrence`). Until then the row renders dimmed (the pending
+// slice tracks its uri) with the uploader's own inline image preview.
+
+// Optional fields accept an explicit `undefined` (not just absence) so the call
+// site can pass `value || undefined` directly under exactOptionalPropertyTypes.
+/** Fields the client can fill in for a just-submitted, not-yet-ingested row. */
+export interface TombstoneInput {
+  uri: string;
+  cid: string;
+  observer: Profile;
+  latitude: number;
+  longitude: number;
+  uncertaintyMeters?: number | undefined;
+  eventDate?: string | undefined;
+  scientificName?: string | undefined;
+  kingdom?: string | undefined;
+  rank?: string | undefined;
+  /** `data:`/`blob:` preview URLs for the uploader's just-picked photos. */
+  imageUrls: string[];
+  license?: string | undefined;
+  organismQuantity?: string | undefined;
+  organismQuantityType?: string | undefined;
+  createdAt: string;
+}
+
+/**
+ * Build a best-effort Occurrence from the submit form's own state. The
+ * server-resolved bits we can't know yet (full taxonomy hierarchy, community
+ * id, real blob URLs, quality issues) are left empty/optimistic and arrive when
+ * `reconcileOccurrence` replaces this row.
+ */
+export function makeTombstoneOccurrence(input: TombstoneInput): Occurrence {
+  const effectiveTaxonomy: EffectiveTaxonomy | undefined = input.scientificName
+    ? {
+        scientificName: input.scientificName,
+        ...(input.rank ? { rank: input.rank } : {}),
+        ...(input.kingdom ? { kingdom: input.kingdom } : {}),
+      }
+    : undefined;
+
+  return {
+    uri: input.uri,
+    cid: input.cid,
+    observer: input.observer,
+    ...(effectiveTaxonomy ? { effectiveTaxonomy } : {}),
+    identificationCount: 0,
+    ...(input.eventDate ? { eventDate: input.eventDate } : {}),
+    location: {
+      latitude: input.latitude,
+      longitude: input.longitude,
+      ...(input.uncertaintyMeters != null ? { uncertaintyMeters: input.uncertaintyMeters } : {}),
+    },
+    ...(input.organismQuantity ? { organismQuantity: input.organismQuantity } : {}),
+    ...(input.organismQuantityType ? { organismQuantityType: input.organismQuantityType } : {}),
+    images: input.imageUrls.map((url) => ({
+      url,
+      ...(input.license ? { license: input.license } : {}),
+    })),
+    createdAt: input.createdAt,
+    likeCount: 0,
+    viewerHasLiked: false,
+    qualityIssues: [],
+  };
+}
+
+/**
+ * Insert a tombstone at the top of the caches the author is most likely looking
+ * at right after submitting: the home/explore feed and their own profile feed.
+ * We deliberately skip taxonOccurrences — we can't reliably tell which taxon
+ * page a row belongs to client-side, and those reconcile on their next refresh.
+ * `setQueriesData` only touches caches that already exist, so an unmounted feed
+ * is simply left alone (it fetches fresh when next opened).
+ */
+export function prependOccurrence(occ: Occurrence, authorDid: string): void {
+  queryClient.setQueriesData<InfiniteData<OccurrencePage>>(
+    {
+      predicate: (query) => {
+        const [tag, did, type] = query.queryKey;
+        if (tag === "feed") return true;
+        if (tag === "profileFeed") return did === authorDid && type === "observations";
+        return false;
+      },
+    },
+    (data) => {
+      if (!data?.pages.length) return data;
+      const [first, ...rest] = data.pages;
+      if (!first) return data;
+      // Guard against a double insert (e.g. React strict-mode re-invocation).
+      if (data.pages.some((p) => p.occurrences.some((o) => o.uri === occ.uri))) return data;
+      return {
+        ...data,
+        pages: [{ ...first, occurrences: [occ, ...first.occurrences] }, ...rest],
+      };
+    },
+  );
+}
+
+/**
+ * Replace a tombstone with the canonical record once the ingester has it,
+ * patching every list cache by uri and seeding the detail cache. This swaps the
+ * optimistic fields (unresolved taxonomy, inline preview image) for real server
+ * data without a full feed refetch — preserving the feed's no-reorder behavior.
+ */
+export function reconcileOccurrence(detail: OccurrenceDetailResponse): void {
+  const { occurrence } = detail;
+  queryClient.setQueriesData<InfiniteData<OccurrencePage>>(
+    {
+      predicate: (query) => OCCURRENCE_LIST_TAGS.some((tag) => tag === query.queryKey[0]),
+    },
+    (data) => {
+      if (!data?.pages) return data;
+      return {
+        ...data,
+        pages: data.pages.map((page) => ({
+          ...page,
+          occurrences: page.occurrences.map((o) => (o.uri === occurrence.uri ? occurrence : o)),
+        })),
+      };
+    },
+  );
+
+  queryClient.setQueryData<OccurrenceDetailResponse>(["observation", occurrence.uri], detail);
 }

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -286,6 +286,10 @@ export async function deleteIdentification(uri: string): Promise<{ success: bool
 }
 
 export function getImageUrl(path: string): string {
+  // Already-complete URLs pass through untouched — notably the inline `data:`
+  // preview an optimistic tombstone row carries before the ingester returns the
+  // real `/media/blob/...` path. Only API-relative paths get the base prepended.
+  if (/^(?:data:|blob:|https?:)/.test(path)) return path;
   return `${API_BASE}${path}`;
 }
 

--- a/frontend/src/store/pendingSlice.ts
+++ b/frontend/src/store/pendingSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import type { RootState, AppDispatch } from "./index";
-import { pollObservation } from "../services/api";
+import { fetchObservation, pollObservation } from "../services/api";
+import { reconcileOccurrence } from "../lib/query/occurrenceCache";
 import { addToast } from "./uiSlice";
 
 const STORAGE_KEY = "observing-pending-submissions";
@@ -58,14 +59,13 @@ function persist(submissions: PendingSubmission[]) {
 
 // Poll the ingester for a freshly written observation in the background, then
 // notify on completion. The upload modal closes as soon as the PDS write
-// returns, so this work is invisible to the user except for the TopBar pending
-// indicator (driven by this slice) and this final toast.
+// returns; a client-built tombstone row (added by the modal on success) stands
+// in for the record in the feeds until this poll confirms ingestion.
 //
-// We deliberately do NOT refetch the feeds or observation detail here: the
-// record is now ingested and click-safe, and the lists pick it up on their
-// next natural refresh (navigation, window refocus, manual reload). The toast
-// is the only signal — see the discussion around optimistic prepend / in-place
-// refetch that we intentionally skipped.
+// Once the ingester has the canonical record we fetch it and `reconcileOccurrence`
+// swaps it in for the tombstone in-place — no full feed refetch, so the feed's
+// no-reorder behavior is preserved. On ingester timeout we leave the optimistic
+// row as-is; it reconciles on the next natural refresh.
 //
 // pollObservation never throws (network errors resolve to a missed predicate),
 // so this thunk fulfils even on ingester timeout — `processed` just reports
@@ -77,6 +77,14 @@ export const trackSubmission = createAsyncThunk<
   { state: RootState; dispatch: AppDispatch }
 >("pending/trackSubmission", async ({ uri, cid, kind }, { dispatch }) => {
   const processed = await pollObservation(uri, (r) => r?.occurrence?.cid === cid);
+
+  // Replace the tombstone (or a pre-edit row) with the canonical record now that
+  // the ingester has the matching cid. Both create and update benefit: the
+  // freshly-resolved taxonomy and real blob URLs land without a feed refetch.
+  if (processed) {
+    const detail = await fetchObservation(uri);
+    if (detail) reconcileOccurrence(detail);
+  }
 
   if (kind === "update") {
     dispatch(addToast({ message: "Observation updated successfully!", type: "success" }));

--- a/frontend/src/store/pendingSlice.ts
+++ b/frontend/src/store/pendingSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { useSelector } from "react-redux";
 import type { RootState, AppDispatch } from "./index";
 import { fetchObservation, pollObservation } from "../services/api";
 import { reconcileOccurrence } from "../lib/query/occurrenceCache";
@@ -142,3 +143,25 @@ const pendingSlice = createSlice({
 });
 
 export default pendingSlice.reducer;
+
+// Read patterns for the in-flight set live with the slice so the navbar
+// indicator and the per-row tombstone styling share one definition of
+// "pending" — keyed by the same stable atproto `uri`.
+
+/** Number of submissions still being ingested (drives the TopBar indicator). */
+export const selectPendingCount = (state: RootState): number => state.pending.submissions.length;
+
+/** Selector: is the observation at `uri` a still-processing submission? */
+export const selectIsPending =
+  (uri: string) =>
+  (state: RootState): boolean =>
+    state.pending.submissions.some((s) => s.uri === uri);
+
+/**
+ * Whether `uri` is a freshly-submitted observation the ingester hasn't
+ * confirmed yet — the tombstone rows render dimmed while this is true.
+ * Returns a primitive, so the subscription stays cheap and churn-free.
+ */
+export function useIsPending(uri: string): boolean {
+  return useSelector(selectIsPending(uri));
+}


### PR DESCRIPTION
## What

When you submit a new observation, it now appears **instantly** in the feed as a dimmed "Processing…" placeholder showing your own photo, then silently reconciles into the real record once the tap-ingester catches up.

Closes #424.

## Why

A freshly-submitted observation only lands in the app DB after the async tap-ingester replays the PDS commit (seconds later). PR #580 added a TopBar spinner + completion toast but **deliberately left the feed untouched**, so the new observation didn't show up until the next natural refresh (navigation/refocus/reload). This implements the issue's "placeholder/tombstone row… populated once it's done" idea.

## How

- **`occurrenceCache.ts`** — `makeTombstoneOccurrence` (scaffold an `Occurrence` from form state + current user), `prependOccurrence` (insert at the top of the home/explore feed + the author's own profile feed; dedupes), `reconcileOccurrence` (replace by `uri` across all list caches + seed the detail cache — no full feed refetch, so the feed's no-reorder behavior is preserved).
- **`pendingSlice.ts`** — once the ingester poll confirms the matching `cid`, fetch the record and reconcile in place (benefits edits too).
- **`UploadModal.tsx`** — on a successful create, build + prepend the tombstone.
- **`services/api.ts`** — `getImageUrl` passes `data:`/`blob:`/`http(s)` URLs through untouched so the inline base64 preview renders before the real blob URL exists.
- **`FeedItem.tsx` / `ExploreGridCard.tsx` / new `PendingBadge.tsx`** — pending rows render dimmed with a "Processing…" chip and disable navigation, like, and the menu (the record isn't ingested yet).

## Scope (v1 decisions)

- **Create-only** optimistic prepend; edits still reconcile in place but don't get a tombstone.
- **Conservative cache targeting** — feed + own profile feed only; taxon pages reconcile on natural refresh.
- **Reload during pending**: the tombstone is cache-only and lost on reload (the record reappears once ingested) — acceptable for v1.

## Verification

Drove the real UI in Chromium against this branch's dev server with the API mocked (no real PDS writes):

- ✅ Tombstone appears immediately above the existing feed, dimmed, with a "Processing…" badge + inline `data:` photo, like/menu/navigation disabled.
- ✅ On ingest it swaps to the canonical record in place (no duplicate row) and the completion toast fires.
- 🔍 Clicking a pending row does **not** navigate (detail would 404 until ingested).

`tsc`, `oxlint`, `oxfmt`, and the 161 unit tests are clean.

## Follow-ups (not in this PR)

- Add a permanent integration test for the optimistic flow.
- Minor: the ingester-timeout toast copy ("…may take a moment to appear") slightly undersells the now-visible optimistic row.