### PR TITLE
chore(fab): remove Quick Photo action and prune camera photo path

### DIFF
--- a/frontend/src/components/common/FAB.tsx
+++ b/frontend/src/components/common/FAB.tsx
@@ -2,13 +2,11 @@ import { useState } from "react";
 import { SpeedDial, SpeedDialAction, SpeedDialIcon } from "@mui/material";
 import AddIcon from "@mui/icons-material/Add";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
-import AddAPhotoIcon from "@mui/icons-material/AddAPhoto";
 import CenterFocusStrongIcon from "@mui/icons-material/CenterFocusStrong";
 import { useNavigate } from "react-router-dom";
 import { Capacitor } from "@capacitor/core";
 import { useAppDispatch, useAppSelector } from "../../store";
-import { openUploadModal, setPendingUploadFiles } from "../../store/uiSlice";
-import { pickPhotos } from "../../lib/photoPicker";
+import { openUploadModal } from "../../store/uiSlice";
 
 export function FAB() {
   const dispatch = useAppDispatch();
@@ -28,22 +26,12 @@ export function FAB() {
     dispatch(openUploadModal());
   };
 
-  const handleQuickPhoto = async () => {
-    setOpen(false);
-    const files = await pickPhotos({ source: "camera" });
-    if (files.length > 0) {
-      setPendingUploadFiles(files);
-      dispatch(openUploadModal());
-    }
-  };
-
   const handleLiveId = () => {
     navigate("/identify");
   };
 
   const actions = [
     { icon: <CameraAltIcon />, name: "New Observation", action: handleNewObservation },
-    { icon: <AddAPhotoIcon />, name: "Quick Photo", action: handleQuickPhoto },
     // Live ID relies on getUserMedia, which only works on web/PWA. Native
     // builds would open a broken viewfinder, so hide the entry point there
     // until a Capacitor camera-preview plugin is wired up.

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -322,7 +322,6 @@ export function UploadModal() {
       return;
     }
     const files = await pickPhotos({
-      source: "gallery",
       multiple: true,
       maxCount: remaining,
     });

--- a/frontend/src/lib/photoPicker.ts
+++ b/frontend/src/lib/photoPicker.ts
@@ -1,43 +1,26 @@
 import { Capacitor } from "@capacitor/core";
-import { Camera } from "@capacitor/camera";
 import { OriginalPhotoPicker } from "capacitor-original-photo-picker";
 
-export type PhotoSource = "camera" | "gallery";
-
 interface PickPhotosOptions {
-  source: PhotoSource;
   multiple?: boolean;
   maxCount?: number;
 }
 
-export async function pickPhotos(options: PickPhotosOptions): Promise<File[]> {
+export async function pickPhotos(options: PickPhotosOptions = {}): Promise<File[]> {
   if (Capacitor.isNativePlatform()) {
-    return pickNative(options);
+    return pickNative();
   }
   return pickWeb(options);
 }
 
-async function pickNative({ source }: PickPhotosOptions): Promise<File[]> {
-  if (source === "gallery") {
-    // Use our custom plugin instead of Camera.chooseFromGallery so that
-    // MediaStore.setRequireOriginal runs and EXIF GPS survives.
-    const result = await OriginalPhotoPicker.pickPhoto();
-    if (result.cancelled || !result.base64) return [];
-    const blob = base64ToBlob(result.base64, result.mimeType ?? "image/jpeg");
-    const filename = result.filename ?? `photo-${Date.now()}.jpg`;
-    return [new File([blob], filename, { type: blob.type })];
-  }
-
-  // Camera path stays on @capacitor/camera. EXIF preservation here is at the
-  // mercy of the user's camera app — there's no setRequireOriginal equivalent
-  // for ACTION_IMAGE_CAPTURE.
-  const result = await Camera.takePhoto({
-    quality: 100,
-    correctOrientation: false,
-    saveToGallery: false,
-  });
-  if (!result.webPath) return [];
-  return [await fetchAsFile(result.webPath, result.metadata?.format)];
+async function pickNative(): Promise<File[]> {
+  // Use our custom plugin instead of Camera.chooseFromGallery so that
+  // MediaStore.setRequireOriginal runs and EXIF GPS survives.
+  const result = await OriginalPhotoPicker.pickPhoto();
+  if (result.cancelled || !result.base64) return [];
+  const blob = base64ToBlob(result.base64, result.mimeType ?? "image/jpeg");
+  const filename = result.filename ?? `photo-${Date.now()}.jpg`;
+  return [new File([blob], filename, { type: blob.type })];
 }
 
 function base64ToBlob(base64: string, mimeType: string): Blob {
@@ -49,22 +32,11 @@ function base64ToBlob(base64: string, mimeType: string): Blob {
   return new Blob([bytes], { type: mimeType });
 }
 
-async function fetchAsFile(webPath: string, format?: string): Promise<File> {
-  const response = await fetch(webPath);
-  const blob = await response.blob();
-  const ext = (format ?? "jpg").replace("jpeg", "jpg");
-  const type = blob.type || `image/${ext === "jpg" ? "jpeg" : ext}`;
-  return new File([blob], `photo-${Date.now()}.${ext}`, { type });
-}
-
-function pickWeb({ source, multiple }: PickPhotosOptions): Promise<File[]> {
+function pickWeb({ multiple }: PickPhotosOptions): Promise<File[]> {
   return new Promise((resolve) => {
     const input = document.createElement("input");
     input.type = "file";
     input.accept = "image/jpeg,image/png,image/webp";
-    if (source === "camera") {
-      input.setAttribute("capture", "environment");
-    }
     if (multiple) {
       input.multiple = true;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "(MIT OR Apache-2.0)",
       "dependencies": {
         "@capacitor/android": "^8.3.4",
-        "@capacitor/camera": "^8.2.0",
         "@capacitor/core": "^8.3.4",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.1",
@@ -1873,15 +1872,6 @@
       "license": "MIT",
       "peerDependencies": {
         "@capacitor/core": "^8.4.0"
-      }
-    },
-    "node_modules/@capacitor/camera": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/@capacitor/camera/-/camera-8.2.0.tgz",
-      "integrity": "sha512-hYfrT6xpL936qoEkIpJzSnb0fQCaTkOux1cXzGBfH8QLOGqr6gSLiWZlZz/fqMPmMKJMNRBqlTQkj5fuMhVZog==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@capacitor/core": ">=8.0.0"
       }
     },
     "node_modules/@capacitor/cli": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   },
   "dependencies": {
     "@capacitor/android": "^8.3.4",
-    "@capacitor/camera": "^8.2.0",
     "@capacitor/core": "^8.3.4",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.1",


### PR DESCRIPTION
## What

- Remove the **Quick Photo** speed-dial action from the FAB. It duplicated **New Observation** — both ended up in the upload modal, the only difference being Quick Photo jumped straight to the camera.
- With its sole source:"camera" caller gone, prune the now-dead camera path from photoPicker.ts: drop the Camera.takePhoto native branch, the capture="environment" web branch, the unused fetchAsFile helper, and collapse the API to gallery-only.
- Remove the now-unused @capacitor/camera dependency (package.json + lockfile).

## Why

The camera shortcut had a single caller for its entire life (added in #403, 2026-05-03) and added a third, redundant item to the speed dial. Dropping it simplifies the FAB and removes a dependency. **New Observation** and **Live ID** remain.

## Verification

- tsc --noEmit clean
- oxfmt --check clean
- lint clean (only pre-existing, unrelated react-hooks/exhaustive-deps warnings)

## Notes

No android/ios projects exist in this worktree, so there was no native plugin registration to clean up. If those native projects live elsewhere, a `npx cap sync` on the next native build will fully drop the camera plugin.