### PR TITLE
feat(observation): restructure create/edit modal as a vertical stepper

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -1,3 +1,8 @@
+// Create/edit observation modal, structured as an MUI vertical <Stepper>
+// (https://mui.com/material-ui/react-stepper/): Photos → Location → Identify →
+// Date & details. Location is the only required step and gates leaving it; the
+// rest are optional and skippable straight to Submit. Driven by the Redux
+// `uploadModalOpen` flag.
 import { lazy, Suspense, useState, useEffect, type FormEvent, type ChangeEvent } from "react";
 import {
   Avatar,
@@ -14,12 +19,12 @@ import {
   InputLabel,
   Select,
   MenuItem,
-  Accordion,
-  AccordionSummary,
-  AccordionDetails,
+  Stepper,
+  Step,
+  StepLabel,
+  StepContent,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
 import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
 import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
@@ -27,10 +32,10 @@ import ExifReader from "exifreader";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeUploadModal, consumePendingUploadFiles } from "../../store/uiSlice";
 import { trackSubmission } from "../../store/pendingSlice";
+import { makeTombstoneOccurrence, prependOccurrence } from "../../lib/query/occurrenceCache";
 import { useToast } from "../../hooks/useToast";
 import { useUserPreferences } from "../../lib/query/hooks";
 import { useSubmitObservation, useUpdateObservation } from "../../lib/query/mutations";
-import { makeTombstoneOccurrence, prependOccurrence } from "../../lib/query/occurrenceCache";
 import { validateTaxon } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
@@ -44,8 +49,6 @@ import { TAXON_RANKS } from "../../lib/taxonRanks";
 import { pickPhotos } from "../../lib/photoPicker";
 import { LICENSE_OPTIONS, DEFAULT_LICENSE } from "../../lib/licenses";
 
-// Lazy so maplibre-gl (heavy) is split into its own chunk, loaded only when the
-// upload modal actually opens (the MUI Dialog doesn't mount children until then).
 const LocationPicker = lazy(() =>
   import("../map/LocationPicker").then((m) => ({ default: m.LocationPicker })),
 );
@@ -67,8 +70,6 @@ interface ImageThumbnailProps {
   onRemove: () => void;
 }
 
-// An 80x80 photo tile with a zoom-on-click image and a corner remove button.
-// Shared by the existing-images and newly-added-images rows in the form.
 function ImageThumbnail({ src, alt, onEnlarge, onRemove }: ImageThumbnailProps) {
   return (
     <Box
@@ -85,12 +86,7 @@ function ImageThumbnail({ src, alt, onEnlarge, onRemove }: ImageThumbnailProps) 
       <ButtonBase
         onClick={onEnlarge}
         aria-label="Enlarge photo"
-        sx={{
-          display: "block",
-          width: "100%",
-          height: "100%",
-          cursor: "zoom-in",
-        }}
+        sx={{ display: "block", width: "100%", height: "100%", cursor: "zoom-in" }}
       >
         <Box
           component="img"
@@ -120,14 +116,19 @@ function ImageThumbnail({ src, alt, onEnlarge, onRemove }: ImageThumbnailProps) 
   );
 }
 
-// Darwin Core dwc:organismQuantityType values the backend lexicon recognizes.
-// "individuals" is the default for a plain count; the observation view renders
-// the chosen type next to the number (e.g. "12 (individuals)").
 const ORGANISM_QUANTITY_TYPES = [
   { value: "individuals", label: "Individuals" },
   { value: "percent-cover", label: "Percent cover" },
 ] as const;
 const DEFAULT_ORGANISM_QUANTITY_TYPE = "individuals";
+
+// Index of each step in the vertical stepper. Location is the only required
+// step; the rest are optional and can be skipped straight to submit.
+const STEP_PHOTOS = 0;
+const STEP_LOCATION = 1;
+const STEP_IDENTIFY = 2;
+const STEP_DETAILS = 3;
+const LAST_STEP = STEP_DETAILS;
 
 export function UploadModal() {
   const dispatch = useAppDispatch();
@@ -144,6 +145,7 @@ export function UploadModal() {
   const updateObs = useUpdateObservation();
   const isSubmitting = submitObs.isPending || updateObs.isPending;
 
+  const [activeStep, setActiveStep] = useState(STEP_PHOTOS);
   const [species, setSpecies] = useState("");
   const [matchedTaxon, setMatchedTaxon] = useState<TaxaResult | null>(null);
   const [kingdom, setKingdom] = useState("");
@@ -154,19 +156,12 @@ export function UploadModal() {
   const [images, setImages] = useState<ImagePreview[]>([]);
   const [existingImages, setExistingImages] = useState<string[]>([]);
   const [observationDate, setObservationDate] = useState(() => toDatetimeLocal(new Date()));
-  // Optional interval end (Darwin Core eventDate may be a range). Empty means a
-  // single date/time; when set, the observation spans `observationDate`'s day
-  // through this day inclusive, written as a `YYYY-MM-DD/YYYY-MM-DD` interval.
   const [observationEndDate, setObservationEndDate] = useState("");
   const [uncertaintyMeters, setUncertaintyMeters] = useState(50);
-  // Darwin Core organismQuantity (+ its type). Kept out of the default flow in a
-  // collapsed "More details" section — most users identifying a single organism
-  // never touch it.
   const [organismQuantity, setOrganismQuantity] = useState("");
   const [organismQuantityType, setOrganismQuantityType] = useState<string>(
     DEFAULT_ORGANISM_QUANTITY_TYPE,
   );
-  const [moreDetailsOpen, setMoreDetailsOpen] = useState(false);
   const [visualIdImageUrl, setVisualIdImageUrl] = useState<string | null>(null);
   const [isDirty, setIsDirty] = useState(false);
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
@@ -176,12 +171,14 @@ export function UploadModal() {
   const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
   const VALID_TYPES = ["image/jpeg", "image/png", "image/webp"];
 
+  const hasLocation = !!lat && !!lng;
+
   useEffect(() => {
     if (!isOpen) return undefined;
     setIsDirty(false);
+    setActiveStep(STEP_PHOTOS);
     setOrganismQuantity("");
     setOrganismQuantityType(DEFAULT_ORGANISM_QUANTITY_TYPE);
-    setMoreDetailsOpen(false);
     if (!editingObservation) {
       setLicense(defaultLicense ?? DEFAULT_LICENSE);
       if (currentLocation) {
@@ -206,8 +203,6 @@ export function UploadModal() {
       const start = parts[0] ?? editingObservation.eventDate;
       const end = parts[1];
       if (end) {
-        // Interval: ranges are recorded at day precision, so seed the start
-        // input at midnight of its day and populate the end-date field.
         setObservationDate(`${start.slice(0, 10)}T00:00`);
         setObservationEndDate(end.slice(0, 10));
       } else {
@@ -223,18 +218,13 @@ export function UploadModal() {
       }
     }
     setExistingImages((editingObservation.images || []).map((img) => img.url));
-    // Pre-fill quantity and expand the section so an existing value is visible
-    // (and not silently wiped) when editing.
     if (editingObservation.organismQuantity) {
       setOrganismQuantity(editingObservation.organismQuantity);
       setOrganismQuantityType(
         editingObservation.organismQuantityType || DEFAULT_ORGANISM_QUANTITY_TYPE,
       );
-      setMoreDetailsOpen(true);
     }
 
-    // Resolve the existing taxon name back to a TaxaResult so the form
-    // shows "Existing taxon" instead of incorrectly flagging it as new.
     if (!existingName) return undefined;
     const controller = new AbortController();
     validateTaxon(existingName, existingKingdom || undefined, controller.signal)
@@ -244,14 +234,12 @@ export function UploadModal() {
           setMatchedTaxon(result.taxon);
         }
       })
-      .catch(() => {
-        // Silent — fetch was aborted or failed; the unmatched-name UI is the
-        // safe default.
-      });
+      .catch(() => {});
     return () => controller.abort();
   }, [isOpen, currentLocation, editingObservation, defaultLicense]);
 
   const resetForm = () => {
+    setActiveStep(STEP_PHOTOS);
     setSpecies("");
     setMatchedTaxon(null);
     setKingdom("");
@@ -265,7 +253,6 @@ export function UploadModal() {
     setUncertaintyMeters(50);
     setOrganismQuantity("");
     setOrganismQuantityType(DEFAULT_ORGANISM_QUANTITY_TYPE);
-    setMoreDetailsOpen(false);
     setVisualIdImageUrl(null);
     setIsDirty(false);
   };
@@ -321,10 +308,7 @@ export function UploadModal() {
       toast.error(`Maximum ${MAX_IMAGES} images allowed.`);
       return;
     }
-    const files = await pickPhotos({
-      multiple: true,
-      maxCount: remaining,
-    });
+    const files = await pickPhotos({ multiple: true, maxCount: remaining });
     if (files.length > 0) addFiles(files);
   };
 
@@ -353,10 +337,6 @@ export function UploadModal() {
             ? gpsLng.description
             : parseFloat(String(gpsLng.description));
 
-        // Reject (0, 0). Android's photo picker (and some other privacy-
-        // scrubbed providers) returns the EXIF GPS *structure* with values
-        // zeroed instead of removing the tags. A real observation at the
-        // null island is so unlikely that treating zero as "missing" is safe.
         const isZeroIsland = latitude === 0 && longitude === 0;
         if (Number.isFinite(latitude) && Number.isFinite(longitude) && !isZeroIsland) {
           const latRefValue = Array.isArray(latRef?.value) ? latRef.value[0] : undefined;
@@ -372,7 +352,6 @@ export function UploadModal() {
 
       const dateOriginal = tags.DateTimeOriginal || tags.DateTime;
       if (dateOriginal?.description) {
-        // EXIF date format: "YYYY:MM:DD HH:MM:SS"
         const dateStr = dateOriginal.description;
         const parsed = dateStr.replace(/^(\d{4}):(\d{2}):(\d{2})/, "$1-$2-$3");
         const date = new Date(parsed);
@@ -409,11 +388,10 @@ export function UploadModal() {
 
     if (!lat || !lng) {
       toast.error("Please provide a location");
+      setActiveStep(STEP_LOCATION);
       return;
     }
 
-    // eventDate is a single date-time, or a `YYYY-MM-DD/YYYY-MM-DD` interval
-    // (day precision) when an end date is given.
     const startDay = observationDate.slice(0, 10);
     let eventDate: string;
     if (observationEndDate) {
@@ -429,6 +407,7 @@ export function UploadModal() {
     const trimmedSpecies = species.trim();
     if (trimmedSpecies && !matchedTaxon && !kingdom) {
       toast.error("Please select a kingdom for the taxon name you entered");
+      setActiveStep(STEP_IDENTIFY);
       return;
     }
 
@@ -479,9 +458,6 @@ export function UploadModal() {
       toast.error(`Failed to ${isEditMode ? "update" : "submit"}: ${getErrorMessage(error)}`);
     };
 
-    // Fields shared by create and update; the update path adds `uri` and
-    // `retainedBlobCids` on top. Conditional spreads omit empty/unset values
-    // so we never send blank taxonomy or quantity fields.
     const commonPayload = {
       ...(trimmedSpecies ? { scientificName: trimmedSpecies } : {}),
       ...(trimmedSpecies && kingdom ? { kingdom } : {}),
@@ -502,11 +478,7 @@ export function UploadModal() {
     };
 
     if (isEditMode && editingObservation) {
-      // Extract CIDs from retained existing image URLs (/media/blob/{did}/{cid})
-      const retainedBlobCids = existingImages.map((url) => {
-        return url.split("/").at(-1) ?? "";
-      });
-
+      const retainedBlobCids = existingImages.map((url) => url.split("/").at(-1) ?? "");
       updateObs.mutate(
         { uri: editingObservation.uri, ...commonPayload, retainedBlobCids },
         { onSuccess, onError },
@@ -522,6 +494,38 @@ export function UploadModal() {
     setIsDirty(true);
   };
 
+  // Short summary shown under each step's title once it's been filled in, so the
+  // collapsed steps still convey what was entered.
+  const photoCount = existingImages.length + images.length;
+  const stepSummaries: Record<number, string> = {
+    [STEP_PHOTOS]:
+      photoCount > 0 ? `${photoCount} photo${photoCount === 1 ? "" : "s"}` : "Optional",
+    [STEP_LOCATION]: hasLocation ? `${lat}, ${lng}` : "Required",
+    [STEP_IDENTIFY]: species.trim() || "Optional — leave blank if unknown",
+    [STEP_DETAILS]: observationEndDate
+      ? `${observationDate.slice(0, 10)} → ${observationEndDate}`
+      : observationDate.replace("T", " "),
+  };
+
+  // Back/Continue control row rendered at the bottom of each non-final step.
+  const StepNav = ({ step, continueDisabled }: { step: number; continueDisabled?: boolean }) => (
+    <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+      {step > STEP_PHOTOS && (
+        <Button onClick={() => setActiveStep((s) => s - 1)} color="inherit" size="small">
+          Back
+        </Button>
+      )}
+      <Button
+        variant="contained"
+        size="small"
+        disabled={continueDisabled}
+        onClick={() => setActiveStep((s) => s + 1)}
+      >
+        Continue
+      </Button>
+    </Stack>
+  );
+
   return (
     <>
       <ModalOverlay isOpen={isOpen} onClose={handleRequestClose}>
@@ -529,16 +533,6 @@ export function UploadModal() {
           {isEditMode ? "Edit Observation" : "New Observation"}
         </Typography>
         <form onSubmit={handleSubmit}>
-          <Typography
-            variant="body2"
-            sx={{
-              color: "text.secondary",
-              mb: 1,
-            }}
-          >
-            Photos (optional)
-          </Typography>
-
           <input
             type="file"
             accept="image/jpeg,image/png,image/webp"
@@ -547,347 +541,392 @@ export function UploadModal() {
             style={{ display: "none" }}
           />
 
-          {(existingImages.length > 0 || images.length > 0) && (
-            <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: "wrap", gap: 1 }}>
-              {existingImages.map((url, index) => (
-                <ImageThumbnail
-                  key={`existing-${index}`}
-                  src={url}
-                  alt={`Existing ${index + 1}`}
-                  onEnlarge={() => setLightbox({ src: url, alt: `Existing ${index + 1}` })}
-                  onRemove={() => handleRemoveExistingImage(index)}
-                />
-              ))}
-              {images.map((img, index) => (
-                <ImageThumbnail
-                  key={`new-${index}`}
-                  src={img.preview}
-                  alt={`Preview ${index + 1}`}
-                  onEnlarge={() => setLightbox({ src: img.preview, alt: `Preview ${index + 1}` })}
-                  onRemove={() => handleRemoveImage(index)}
-                />
-              ))}
-            </Stack>
-          )}
-
-          {existingImages.length + images.length < MAX_IMAGES && (
-            <Button
-              fullWidth
-              variant="outlined"
-              onClick={handleUploadClick}
-              startIcon={<AddPhotoAlternateIcon />}
-              sx={{
-                borderStyle: "dashed",
-                color: "text.disabled",
-                "&:hover": {
-                  borderColor: "primary.main",
-                  color: "primary.main",
-                },
-              }}
-            >
-              {images.length === 0 ? "Add photos" : "Add more photos"}
-            </Button>
-          )}
-
-          <Typography
-            variant="caption"
-            sx={{
-              color: "text.disabled",
-              display: "block",
-              mt: 0.5,
-            }}
-          >
-            JPG, PNG, or WebP - Max 10MB each - Up to {MAX_IMAGES} photos
-          </Typography>
-
-          <Suspense
-            fallback={
-              <Box
-                sx={{
-                  height: 260,
-                  display: "flex",
-                  alignItems: "center",
-                  justifyContent: "center",
-                }}
+          <Stepper activeStep={activeStep} orientation="vertical" nonLinear>
+            {/* Step 1 — Photos (optional) */}
+            <Step completed={photoCount > 0}>
+              <StepLabel
+                optional={<Typography variant="caption">{stepSummaries[STEP_PHOTOS]}</Typography>}
+                onClick={() => setActiveStep(STEP_PHOTOS)}
+                sx={{ cursor: "pointer" }}
               >
-                <CircularProgress size={24} />
-              </Box>
-            }
-          >
-            <LocationPicker
-              latitude={lat ? parseFloat(lat) : null}
-              longitude={lng ? parseFloat(lng) : null}
-              onChange={handleLocationChange}
-              uncertaintyMeters={uncertaintyMeters}
-              onUncertaintyChange={(m) => {
-                setUncertaintyMeters(m);
-                setIsDirty(true);
-              }}
-            />
-          </Suspense>
+                Photos
+              </StepLabel>
+              <StepContent>
+                {photoCount > 0 && (
+                  <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: "wrap", gap: 1 }}>
+                    {existingImages.map((url, index) => (
+                      <ImageThumbnail
+                        key={`existing-${index}`}
+                        src={url}
+                        alt={`Existing ${index + 1}`}
+                        onEnlarge={() => setLightbox({ src: url, alt: `Existing ${index + 1}` })}
+                        onRemove={() => handleRemoveExistingImage(index)}
+                      />
+                    ))}
+                    {images.map((img, index) => (
+                      <ImageThumbnail
+                        key={`new-${index}`}
+                        src={img.preview}
+                        alt={`Preview ${index + 1}`}
+                        onEnlarge={() =>
+                          setLightbox({ src: img.preview, alt: `Preview ${index + 1}` })
+                        }
+                        onRemove={() => handleRemoveImage(index)}
+                      />
+                    ))}
+                  </Stack>
+                )}
 
-          <TaxaAutocomplete
-            value={species}
-            onChange={(name) => {
-              setSpecies(name);
-              setIsDirty(true);
-              if (name === "") {
-                setMatchedTaxon(null);
-                setKingdom("");
-                setRank("");
-              }
-            }}
-            onMatchChange={(match) => {
-              setMatchedTaxon(match);
-              if (match?.kingdom) {
-                setKingdom(match.kingdom);
-              }
-              if (match) {
-                setRank("");
-              }
-            }}
-            label="Taxon (optional)"
-            placeholder="e.g. Eschscholzia californica - leave blank if unknown"
-            bottomContent={
-              species.trim() ? (
-                matchedTaxon ? (
-                  <Chip
-                    {...(matchedTaxon.photoUrl
-                      ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
-                      : { icon: <CheckCircleOutlinedIcon /> })}
-                    label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
-                      .filter((p): p is string => Boolean(p))
-                      .join(" · ")}
-                    color="success"
-                    size="small"
+                {photoCount < MAX_IMAGES && (
+                  <Button
+                    fullWidth
                     variant="outlined"
-                    sx={{ mt: 0.5 }}
+                    onClick={handleUploadClick}
+                    startIcon={<AddPhotoAlternateIcon />}
+                    sx={{
+                      borderStyle: "dashed",
+                      color: "text.disabled",
+                      "&:hover": { borderColor: "primary.main", color: "primary.main" },
+                    }}
+                  >
+                    {images.length === 0 ? "Add photos" : "Add more photos"}
+                  </Button>
+                )}
+
+                <Typography
+                  variant="caption"
+                  sx={{ color: "text.disabled", display: "block", mt: 0.5 }}
+                >
+                  JPG, PNG, or WebP - Max 10MB each - Up to {MAX_IMAGES} photos
+                </Typography>
+
+                <StepNav step={STEP_PHOTOS} />
+              </StepContent>
+            </Step>
+
+            {/* Step 2 — Location (required) */}
+            <Step completed={hasLocation}>
+              <StepLabel
+                error={activeStep > STEP_LOCATION && !hasLocation}
+                optional={<Typography variant="caption">{stepSummaries[STEP_LOCATION]}</Typography>}
+                onClick={() => setActiveStep(STEP_LOCATION)}
+                sx={{ cursor: "pointer" }}
+              >
+                Location
+              </StepLabel>
+              <StepContent>
+                <Suspense
+                  fallback={
+                    <Box
+                      sx={{
+                        height: 260,
+                        display: "flex",
+                        alignItems: "center",
+                        justifyContent: "center",
+                      }}
+                    >
+                      <CircularProgress size={24} />
+                    </Box>
+                  }
+                >
+                  <LocationPicker
+                    latitude={lat ? parseFloat(lat) : null}
+                    longitude={lng ? parseFloat(lng) : null}
+                    onChange={handleLocationChange}
+                    uncertaintyMeters={uncertaintyMeters}
+                    onUncertaintyChange={(m) => {
+                      setUncertaintyMeters(m);
+                      setIsDirty(true);
+                    }}
                   />
-                ) : (
-                  <Chip
-                    icon={<AddCircleOutlinedIcon />}
-                    label="New taxon"
-                    color="info"
-                    size="small"
-                    variant="outlined"
-                    sx={{ mt: 0.5 }}
-                  />
-                )
-              ) : visualIdImageUrl ? (
-                <VisualId
-                  imageUrl={visualIdImageUrl}
-                  latitude={lat ? parseFloat(lat) : undefined}
-                  longitude={lng ? parseFloat(lng) : undefined}
-                  onSelect={(s) => {
-                    setSpecies(s.scientificName);
+                </Suspense>
+                <StepNav step={STEP_LOCATION} continueDisabled={!hasLocation} />
+              </StepContent>
+            </Step>
+
+            {/* Step 3 — Identify (optional) */}
+            <Step completed={!!species.trim()}>
+              <StepLabel
+                optional={<Typography variant="caption">{stepSummaries[STEP_IDENTIFY]}</Typography>}
+                onClick={() => setActiveStep(STEP_IDENTIFY)}
+                sx={{ cursor: "pointer" }}
+              >
+                Identify
+              </StepLabel>
+              <StepContent>
+                <TaxaAutocomplete
+                  value={species}
+                  onChange={(name) => {
+                    setSpecies(name);
                     setIsDirty(true);
-                    if (s.taxonMatch) {
-                      setMatchedTaxon(s.taxonMatch);
-                      setKingdom(s.taxonMatch.kingdom ?? "");
+                    if (name === "") {
+                      setMatchedTaxon(null);
+                      setKingdom("");
                       setRank("");
-                    } else if (s.kingdom) {
-                      setKingdom(s.kingdom);
                     }
                   }}
-                  onSelectAncestor={(ancestor) => {
-                    setSpecies(ancestor.name);
-                    setMatchedTaxon(null);
-                    setIsDirty(true);
-                    if (ancestor.kingdom) setKingdom(ancestor.kingdom);
-                    setRank(ancestor.rank);
+                  onMatchChange={(match) => {
+                    setMatchedTaxon(match);
+                    if (match?.kingdom) {
+                      setKingdom(match.kingdom);
+                    }
+                    if (match) {
+                      setRank("");
+                    }
                   }}
-                  disabled={isSubmitting}
+                  label="Taxon (optional)"
+                  placeholder="e.g. Eschscholzia californica - leave blank if unknown"
+                  bottomContent={
+                    species.trim() ? (
+                      matchedTaxon ? (
+                        <Chip
+                          {...(matchedTaxon.photoUrl
+                            ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
+                            : { icon: <CheckCircleOutlinedIcon /> })}
+                          label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
+                            .filter((p): p is string => Boolean(p))
+                            .join(" · ")}
+                          color="success"
+                          size="small"
+                          variant="outlined"
+                          sx={{ mt: 0.5 }}
+                        />
+                      ) : (
+                        <Chip
+                          icon={<AddCircleOutlinedIcon />}
+                          label="New taxon"
+                          color="info"
+                          size="small"
+                          variant="outlined"
+                          sx={{ mt: 0.5 }}
+                        />
+                      )
+                    ) : visualIdImageUrl ? (
+                      <VisualId
+                        imageUrl={visualIdImageUrl}
+                        latitude={lat ? parseFloat(lat) : undefined}
+                        longitude={lng ? parseFloat(lng) : undefined}
+                        onSelect={(s) => {
+                          setSpecies(s.scientificName);
+                          setIsDirty(true);
+                          if (s.taxonMatch) {
+                            setMatchedTaxon(s.taxonMatch);
+                            setKingdom(s.taxonMatch.kingdom ?? "");
+                            setRank("");
+                          } else if (s.kingdom) {
+                            setKingdom(s.kingdom);
+                          }
+                        }}
+                        onSelectAncestor={(ancestor) => {
+                          setSpecies(ancestor.name);
+                          setMatchedTaxon(null);
+                          setIsDirty(true);
+                          if (ancestor.kingdom) setKingdom(ancestor.kingdom);
+                          setRank(ancestor.rank);
+                        }}
+                        disabled={isSubmitting}
+                      />
+                    ) : undefined
+                  }
                 />
-              ) : undefined
-            }
-          />
 
-          {!!species.trim() && !matchedTaxon && (
-            <FormControl fullWidth margin="normal" required>
-              <InputLabel id="kingdom-label">Kingdom</InputLabel>
-              <Select
-                labelId="kingdom-label"
-                value={kingdom}
-                label="Kingdom"
-                onChange={(e) => {
-                  setKingdom(e.target.value);
-                  setIsDirty(true);
-                }}
+                {!!species.trim() && !matchedTaxon && (
+                  <FormControl fullWidth margin="normal" required>
+                    <InputLabel id="kingdom-label">Kingdom</InputLabel>
+                    <Select
+                      labelId="kingdom-label"
+                      value={kingdom}
+                      label="Kingdom"
+                      onChange={(e) => {
+                        setKingdom(e.target.value);
+                        setIsDirty(true);
+                      }}
+                    >
+                      <MenuItem value="">
+                        <em>None</em>
+                      </MenuItem>
+                      {KINGDOMS.map((k) => (
+                        <MenuItem key={k.value} value={k.value}>
+                          {k.label}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+
+                {!!species.trim() && !matchedTaxon && (
+                  <FormControl fullWidth margin="normal">
+                    <InputLabel id="rank-label">Rank (optional)</InputLabel>
+                    <Select
+                      labelId="rank-label"
+                      value={rank}
+                      label="Rank (optional)"
+                      onChange={(e) => {
+                        setRank(e.target.value);
+                        setIsDirty(true);
+                      }}
+                    >
+                      <MenuItem value="">
+                        <em>None</em>
+                      </MenuItem>
+                      {TAXON_RANKS.map((r) => (
+                        <MenuItem key={r} value={r}>
+                          {r}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                )}
+
+                <StepNav step={STEP_IDENTIFY} />
+              </StepContent>
+            </Step>
+
+            {/* Step 4 — Details + submit */}
+            <Step completed={false}>
+              <StepLabel
+                optional={<Typography variant="caption">{stepSummaries[STEP_DETAILS]}</Typography>}
+                onClick={() => setActiveStep(STEP_DETAILS)}
+                sx={{ cursor: "pointer" }}
               >
-                <MenuItem value="">
-                  <em>None</em>
-                </MenuItem>
-                {KINGDOMS.map((k) => (
-                  <MenuItem key={k.value} value={k.value}>
-                    {k.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          )}
-
-          {!!species.trim() && !matchedTaxon && (
-            <FormControl fullWidth margin="normal">
-              <InputLabel id="rank-label">Rank (optional)</InputLabel>
-              <Select
-                labelId="rank-label"
-                value={rank}
-                label="Rank (optional)"
-                onChange={(e) => {
-                  setRank(e.target.value);
-                  setIsDirty(true);
-                }}
-              >
-                <MenuItem value="">
-                  <em>None</em>
-                </MenuItem>
-                {TAXON_RANKS.map((r) => (
-                  <MenuItem key={r} value={r}>
-                    {r}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          )}
-
-          <FormControl fullWidth margin="normal">
-            <InputLabel id="license-label">License</InputLabel>
-            <Select
-              labelId="license-label"
-              value={license}
-              label="License"
-              onChange={(e) => {
-                setLicense(e.target.value);
-                setIsDirty(true);
-              }}
-            >
-              {LICENSE_OPTIONS.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-
-          <TextField
-            fullWidth
-            label={observationEndDate ? "Start date" : "Observation date"}
-            type="datetime-local"
-            value={observationDate}
-            onChange={(e) => {
-              setObservationDate(e.target.value);
-              setIsDirty(true);
-            }}
-            margin="normal"
-            slotProps={{
-              inputLabel: { shrink: true },
-            }}
-          />
-
-          <TextField
-            fullWidth
-            label="End date (optional)"
-            type="date"
-            value={observationEndDate}
-            onChange={(e) => {
-              setObservationEndDate(e.target.value);
-              setIsDirty(true);
-            }}
-            margin="normal"
-            error={observationEndDate !== "" && observationEndDate < observationDate.slice(0, 10)}
-            helperText={
-              observationEndDate !== "" && observationEndDate < observationDate.slice(0, 10)
-                ? "End date can't be before the start date."
-                : "Set to record an observation spanning a date range."
-            }
-            slotProps={{
-              inputLabel: { shrink: true },
-              htmlInput: { min: observationDate.slice(0, 10) },
-            }}
-          />
-
-          <Accordion
-            expanded={moreDetailsOpen}
-            onChange={(_, expanded) => setMoreDetailsOpen(expanded)}
-            disableGutters
-            elevation={0}
-            square
-            sx={{
-              mt: 1,
-              bgcolor: "transparent",
-              "&:before": { display: "none" },
-            }}
-          >
-            <AccordionSummary expandIcon={<ExpandMoreIcon />} sx={{ px: 0, minHeight: "auto" }}>
-              <Typography variant="body2" color="text.secondary">
-                More details (optional)
-              </Typography>
-            </AccordionSummary>
-            <AccordionDetails sx={{ px: 0, pt: 0 }}>
-              <Stack direction="row" spacing={1}>
-                <TextField
-                  label="Quantity"
-                  value={organismQuantity}
-                  onChange={(e) => {
-                    setOrganismQuantity(e.target.value);
-                    setIsDirty(true);
-                  }}
-                  margin="normal"
-                  placeholder="e.g. 1, 12, or 10–100"
-                  sx={{ flex: 1 }}
-                />
-                <FormControl margin="normal" sx={{ minWidth: 150 }}>
-                  <InputLabel id="organism-quantity-type-label">Type</InputLabel>
+                Date &amp; details
+              </StepLabel>
+              <StepContent>
+                <FormControl fullWidth margin="normal">
+                  <InputLabel id="license-label">License</InputLabel>
                   <Select
-                    labelId="organism-quantity-type-label"
-                    value={organismQuantityType}
-                    label="Type"
+                    labelId="license-label"
+                    value={license}
+                    label="License"
                     onChange={(e) => {
-                      setOrganismQuantityType(e.target.value);
+                      setLicense(e.target.value);
                       setIsDirty(true);
                     }}
                   >
-                    {ORGANISM_QUANTITY_TYPES.map((opt) => (
+                    {LICENSE_OPTIONS.map((opt) => (
                       <MenuItem key={opt.value} value={opt.value}>
                         {opt.label}
                       </MenuItem>
                     ))}
                   </Select>
                 </FormControl>
-              </Stack>
-              <Typography variant="caption" color="text.secondary">
-                How many organisms you observed. Optional — leave blank if unsure.
-              </Typography>
-            </AccordionDetails>
-          </Accordion>
 
-          <Stack
-            direction="row"
-            spacing={1}
-            sx={{
-              justifyContent: "flex-end",
-              mt: 2,
-            }}
-          >
-            <Button onClick={handleRequestClose} color="inherit">
-              Cancel
-            </Button>
-            <Button
-              type="submit"
-              variant="contained"
-              color="primary"
-              disabled={isSubmitting}
-              startIcon={isSubmitting ? <CircularProgress size={16} color="inherit" /> : undefined}
+                <TextField
+                  fullWidth
+                  label={observationEndDate ? "Start date" : "Observation date"}
+                  type="datetime-local"
+                  value={observationDate}
+                  onChange={(e) => {
+                    setObservationDate(e.target.value);
+                    setIsDirty(true);
+                  }}
+                  margin="normal"
+                  slotProps={{ inputLabel: { shrink: true } }}
+                />
+
+                <TextField
+                  fullWidth
+                  label="End date (optional)"
+                  type="date"
+                  value={observationEndDate}
+                  onChange={(e) => {
+                    setObservationEndDate(e.target.value);
+                    setIsDirty(true);
+                  }}
+                  margin="normal"
+                  error={
+                    observationEndDate !== "" && observationEndDate < observationDate.slice(0, 10)
+                  }
+                  helperText={
+                    observationEndDate !== "" && observationEndDate < observationDate.slice(0, 10)
+                      ? "End date can't be before the start date."
+                      : "Set to record an observation spanning a date range."
+                  }
+                  slotProps={{
+                    inputLabel: { shrink: true },
+                    htmlInput: { min: observationDate.slice(0, 10) },
+                  }}
+                />
+
+                <Stack direction="row" spacing={1} sx={{ mt: 1 }}>
+                  <TextField
+                    label="Quantity (optional)"
+                    value={organismQuantity}
+                    onChange={(e) => {
+                      setOrganismQuantity(e.target.value);
+                      setIsDirty(true);
+                    }}
+                    margin="normal"
+                    placeholder="e.g. 1, 12, or 10–100"
+                    sx={{ flex: 1 }}
+                  />
+                  <FormControl margin="normal" sx={{ minWidth: 150 }}>
+                    <InputLabel id="organism-quantity-type-label">Type</InputLabel>
+                    <Select
+                      labelId="organism-quantity-type-label"
+                      value={organismQuantityType}
+                      label="Type"
+                      onChange={(e) => {
+                        setOrganismQuantityType(e.target.value);
+                        setIsDirty(true);
+                      }}
+                    >
+                      {ORGANISM_QUANTITY_TYPES.map((opt) => (
+                        <MenuItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </MenuItem>
+                      ))}
+                    </Select>
+                  </FormControl>
+                </Stack>
+
+                <Stack direction="row" spacing={1} sx={{ mt: 2 }}>
+                  <Button onClick={() => setActiveStep(STEP_IDENTIFY)} color="inherit" size="small">
+                    Back
+                  </Button>
+                  <Button
+                    type="submit"
+                    variant="contained"
+                    color="primary"
+                    disabled={isSubmitting}
+                    startIcon={
+                      isSubmitting ? <CircularProgress size={16} color="inherit" /> : undefined
+                    }
+                  >
+                    {isSubmitting
+                      ? isEditMode
+                        ? "Saving..."
+                        : "Submitting..."
+                      : isEditMode
+                        ? "Save Changes"
+                        : "Submit"}
+                  </Button>
+                </Stack>
+              </StepContent>
+            </Step>
+          </Stepper>
+
+          {/* Persistent footer so submit/cancel are reachable from any step. */}
+          {activeStep !== LAST_STEP && (
+            <Stack
+              direction="row"
+              spacing={1}
+              sx={{
+                justifyContent: "flex-end",
+                mt: 2,
+                pt: 2,
+                borderTop: 1,
+                borderColor: "divider",
+              }}
             >
-              {isSubmitting
-                ? isEditMode
-                  ? "Saving..."
-                  : "Submitting..."
-                : isEditMode
-                  ? "Save Changes"
-                  : "Submit"}
-            </Button>
-          </Stack>
+              <Button onClick={handleRequestClose} color="inherit">
+                Cancel
+              </Button>
+              <Button type="submit" variant="contained" color="primary" disabled={isSubmitting}>
+                {isEditMode ? "Save Changes" : "Submit"}
+              </Button>
+            </Stack>
+          )}
         </form>
       </ModalOverlay>
       <ConfirmDialog

--- a/frontend/tests/accessibility.spec.ts
+++ b/frontend/tests/accessibility.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { test as authTest, expect as authExpect } from "./fixtures/mock-auth";
-import { openUploadModal } from "./helpers/navigation";
+import { openUploadModal, gotoUploadStep } from "./helpers/navigation";
 import { mockOwnObservationFeed } from "./helpers/mock-observation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 
@@ -40,6 +40,7 @@ authTest.describe("Accessibility - Authenticated", () => {
   authTest("pressing Escape closes upload modal", async ({ authenticatedPage: page }) => {
     await page.goto("/");
     await openUploadModal(page);
+    await gotoUploadStep(page, "Identify");
     await authExpect(page.getByLabel(/Taxon/i)).toBeVisible();
     await page.keyboard.press("Escape");
     await authExpect(page.getByLabel(/Taxon/i)).not.toBeVisible();
@@ -50,6 +51,7 @@ authTest.describe("Accessibility - Authenticated", () => {
     await mockTaxaSearchRoute(page);
     await page.goto("/");
     await openUploadModal(page);
+    await gotoUploadStep(page, "Identify");
 
     const speciesInput = page.getByLabel(/Taxon/i);
     await speciesInput.click();

--- a/frontend/tests/auto-identification.spec.ts
+++ b/frontend/tests/auto-identification.spec.ts
@@ -1,5 +1,5 @@
 import { test as authTest, expect as authExpect } from "./fixtures/mock-auth";
-import { openUploadModal, revealCoordinateInputs } from "./helpers/navigation";
+import { openUploadModal, gotoUploadStep, revealCoordinateInputs } from "./helpers/navigation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 import {
   mockOwnObservationFeed,
@@ -61,6 +61,7 @@ authTest.describe("Auto-Identification on Upload", () => {
 
       await page.goto("/");
       await openUploadModal(page);
+      await gotoUploadStep(page, "Identify");
 
       const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.click();
@@ -84,7 +85,7 @@ authTest.describe("Auto-Identification on Upload", () => {
       // ingester poll runs in the background behind the TopBar indicator. Wait
       // for the modal to close, then go to the (mocked) detail page directly to
       // assert the auto-created identification rendered.
-      await authExpect(page.getByLabel(/Taxon/i)).not.toBeVisible({ timeout: 10_000 });
+      await authExpect(page.getByRole("dialog")).not.toBeVisible({ timeout: 10_000 });
       await page.goto(`/observation/${MOCK_OBS_DID}/${AUTO_ID_RKEY}`);
 
       await authExpect(page.getByText("Identification History")).toBeVisible({ timeout: 10000 });

--- a/frontend/tests/e2e.spec.ts
+++ b/frontend/tests/e2e.spec.ts
@@ -1,6 +1,6 @@
 import { expect, type Page } from "@playwright/test";
 import { test as authTest } from "./fixtures/auth";
-import { openUploadModal, revealCoordinateInputs } from "./helpers/navigation";
+import { openUploadModal, gotoUploadStep, revealCoordinateInputs } from "./helpers/navigation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 
 async function waitForOccurrenceIndexed(page: Page, uri: string, timeoutMs = 30_000) {
@@ -46,6 +46,7 @@ authTest.describe("E2E CRUD flow", () => {
     await authTest.step("create occurrence", async () => {
       await mockTaxaSearchRoute(page);
       await openUploadModal(page);
+      await gotoUploadStep(page, "Identify");
 
       const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.click();
@@ -79,7 +80,7 @@ authTest.describe("E2E CRUD flow", () => {
       occurrenceUri = (await resp.json()).uri as string;
 
       // Modal closes immediately and we stay put (no redirect to /observation).
-      await expect(page.getByLabel(/Taxon/i)).not.toBeVisible({ timeout: 10_000 });
+      await expect(page.getByRole("dialog")).not.toBeVisible({ timeout: 10_000 });
 
       const match = occurrenceUri.match(/^at:\/\/([^/]+)\/[^/]+\/([^/]+)$/);
       expect(match).toBeTruthy();
@@ -168,6 +169,7 @@ authTest.describe("E2E CRUD flow", () => {
 
       await mockTaxaSearchRoute(page);
       await openUploadModal(page);
+      await gotoUploadStep(page, "Identify");
 
       const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.click();
@@ -187,7 +189,9 @@ authTest.describe("E2E CRUD flow", () => {
 
       // Set a start date and an end date so the eventDate is written as a
       // `YYYY-MM-DD/YYYY-MM-DD` interval. The start field is labelled
-      // "Observation date" until an end date is present.
+      // "Observation date" until an end date is present. The date inputs live
+      // in the Date & details step.
+      await gotoUploadStep(page, "Date & details");
       await page.getByLabel("Observation date").fill("2024-05-21T08:00");
       await page.getByLabel("End date (optional)").fill("2024-05-23");
 

--- a/frontend/tests/helpers/navigation.ts
+++ b/frontend/tests/helpers/navigation.ts
@@ -2,9 +2,15 @@ import type { Page } from "@playwright/test";
 
 const FAB = 'button[aria-label="Create actions"]';
 
+/** Steps of the upload modal's vertical stepper, in order. */
+export type UploadStep = "Photos" | "Location" | "Identify" | "Date & details";
+
 /**
  * Opens the upload modal via the FAB menu and waits for it to be ready.
  * Replaces hard-coded `waitForTimeout()` calls with a real readiness check.
+ *
+ * The modal opens on the Photos step; Location/Identify/Date fields live in
+ * later steps and are collapsed until revealed via {@link gotoUploadStep}.
  */
 export async function openUploadModal(page: Page) {
   const fab = page.locator(FAB);
@@ -15,15 +21,32 @@ export async function openUploadModal(page: Page) {
   });
   await newObsAction.waitFor({ state: "visible", timeout: 5_000 });
   await newObsAction.click();
-  // Wait for the modal content to actually render instead of a fixed delay
-  await page.getByLabel(/Taxon/i).waitFor({ state: "visible", timeout: 10_000 });
+  // Wait for the modal to actually render instead of a fixed delay. The heading
+  // is always present regardless of which step is active.
+  await page
+    .getByRole("dialog")
+    .getByRole("heading", { name: "New Observation" })
+    .waitFor({ state: "visible", timeout: 10_000 });
+}
+
+/**
+ * Reveals a step's content in the upload modal's (non-linear) vertical stepper
+ * by clicking its step header. Required before interacting with fields that
+ * live in a collapsed step — e.g. Taxon (Identify) or the date inputs
+ * (Date & details). Step state is preserved across navigation, so callers may
+ * fill steps in any order.
+ */
+export async function gotoUploadStep(page: Page, step: UploadStep) {
+  await page.getByRole("dialog").locator(".MuiStepLabel-root", { hasText: step }).click();
 }
 
 /**
  * Expands the collapsed manual-coordinate inputs in LocationPicker so that
- * the Latitude/Longitude TextFields become accessible.
+ * the Latitude/Longitude TextFields become accessible. Navigates to the
+ * Location step first, since the picker lives in a collapsed step.
  */
 export async function revealCoordinateInputs(page: Page) {
+  await gotoUploadStep(page, "Location");
   const toggle = page.getByRole("button", { name: "Enter coordinates manually" });
   await toggle.scrollIntoViewIfNeeded();
   await toggle.click();

--- a/frontend/tests/observation-edit.spec.ts
+++ b/frontend/tests/observation-edit.spec.ts
@@ -5,6 +5,7 @@ import {
   mockOwnObservationFeed,
   mockObservationDetailRoute,
 } from "./helpers/mock-observation";
+import { gotoUploadStep } from "./helpers/navigation";
 
 test.describe("Observation Edit - Logged Out", () => {
   // TC-EDIT-002: Edit menu item hidden for others' observations
@@ -93,7 +94,8 @@ authTest.describe("Observation Edit - Logged In", () => {
     await page.getByRole("menuitem", { name: "Edit" }).click();
     await authExpect(page.getByText("Edit Observation")).toBeVisible({ timeout: 5000 });
 
-    // Species input should have value
+    // Species input lives in the (collapsed) Identify step; reveal it first.
+    await gotoUploadStep(page, "Identify");
     const speciesInput = page.getByLabel(/Taxon/i);
     await authExpect(speciesInput).toHaveValue("Quercus alba");
   });

--- a/frontend/tests/species-input.spec.ts
+++ b/frontend/tests/species-input.spec.ts
@@ -1,5 +1,5 @@
 import { test as authTest, expect as authExpect } from "./fixtures/mock-auth";
-import { openUploadModal } from "./helpers/navigation";
+import { openUploadModal, gotoUploadStep } from "./helpers/navigation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 import { mockOwnObservationFeed } from "./helpers/mock-observation";
 
@@ -31,6 +31,8 @@ authTest.describe("Species Input", () => {
     await mockTaxaSearchRoute(page);
     await page.goto("/");
     await openUploadModal(page);
+    // Taxon input lives in the Identify step; reveal it for every test here.
+    await gotoUploadStep(page, "Identify");
   });
 
   // TC-SPECIES-001: Common name autocomplete

--- a/frontend/tests/upload.spec.ts
+++ b/frontend/tests/upload.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 import { test as authTest, expect as authExpect, getTestUser } from "./fixtures/mock-auth";
-import { openUploadModal, revealCoordinateInputs } from "./helpers/navigation";
+import { openUploadModal, gotoUploadStep, revealCoordinateInputs } from "./helpers/navigation";
 import { mockOwnObservationFeed } from "./helpers/mock-observation";
 import { mockTaxaSearchRoute } from "./helpers/mock-taxa";
 
@@ -37,7 +37,7 @@ authTest.describe("Upload Modal - Logged In", () => {
     await page.goto("/");
     await openUploadModal(page);
     await page.getByRole("button", { name: "Cancel" }).click();
-    await authExpect(page.getByLabel(/Taxon/i)).not.toBeVisible();
+    await authExpect(page.getByRole("dialog")).not.toBeVisible();
   });
 
   // Regression: the create speed-dial must stay closed after an action opens
@@ -49,7 +49,7 @@ authTest.describe("Upload Modal - Logged In", () => {
       await page.goto("/");
       await openUploadModal(page); // opens the dial, picks New Observation, opens modal
       await page.getByRole("button", { name: "Cancel" }).click();
-      await authExpect(page.getByLabel(/Taxon/i)).not.toBeVisible();
+      await authExpect(page.getByRole("dialog")).not.toBeVisible();
 
       // Focus has returned to the FAB; the dial must not have re-opened.
       await authExpect(page.getByRole("menuitem", { name: "New Observation" })).not.toBeVisible();
@@ -68,6 +68,7 @@ authTest.describe("Upload Modal - Logged In", () => {
   authTest("quick species chips populate species input", async ({ authenticatedPage: page }) => {
     await page.goto("/");
     await openUploadModal(page);
+    await gotoUploadStep(page, "Identify");
     const poppyChip = page.getByRole("button", {
       name: /California Poppy/i,
     });
@@ -84,6 +85,7 @@ authTest.describe("Upload Modal - Logged In", () => {
     async ({ authenticatedPage: page }) => {
       await page.goto("/");
       await openUploadModal(page);
+      await gotoUploadStep(page, "Identify");
       const speciesInput = page.getByLabel(/Taxon/i);
       await speciesInput.click();
       await Promise.all([
@@ -100,6 +102,7 @@ authTest.describe("Upload Modal - Logged In", () => {
     async ({ authenticatedPage: page }) => {
       await page.goto("/");
       await openUploadModal(page);
+      await gotoUploadStep(page, "Date & details");
       const dateInput = page.getByLabel("Observation date");
       await authExpect(dateInput).toBeVisible();
       const value = await dateInput.inputValue();
@@ -137,6 +140,7 @@ authTest.describe("Upload Modal - Logged In", () => {
 
     await page.goto("/");
     await openUploadModal(page);
+    await gotoUploadStep(page, "Identify");
 
     const speciesInput = page.getByLabel(/Taxon/i);
     await speciesInput.fill("Quercus alba");


### PR DESCRIPTION
## What

Reorganizes the create/edit observation modal (`UploadModal`) from a single scrolling form into an MUI [vertical `<Stepper>`](https://mui.com/material-ui/react-stepper/):

1. **Photos** (optional) — upload tiles + EXIF extraction
2. **Location** (required) — the lazy `LocationPicker`
3. **Identify** (optional) — `TaxaAutocomplete` + visual-ID suggestions
4. **Date & details** — license, date/end-date, organism quantity (the old "More details" accordion folded inline), plus Submit

## Behavior

- **`nonLinear` + clickable step labels** — jump between steps freely (handy in edit mode, where everything's pre-filled).
- **Per-step summaries** under each collapsed label (photo count, the lat/lng, the chosen taxon, the date) so context survives collapsing.
- **Location gating** — the step's "Continue" is disabled until lat/lng exist, and the label shows an error state if bypassed. On submit, validation failures (missing location, missing kingdom) jump you to the offending step instead of only toasting.
- **Persistent Cancel/Submit footer** on non-final steps, so you're never forced to click through to step 4 to submit.

## Scope

This is a **render-only** restructure. All form state, EXIF parsing, edit-mode prefill, dirty-tracking, the optimistic tombstone insert on create, and submit/validation logic are unchanged from the previous `UploadModal`. Existing `UploadModal.stories.tsx` (Closed / NewObservation / EditExisting / WithGeolocation) and `App.tsx` need no changes since the component name and props are unchanged.

## Verification

- `tsc --noEmit` clean; `oxfmt` formatted; `oxlint` clean (only the pre-existing `exhaustive-deps` warning inherited from the original).
- Verified all stories render in Storybook, including edit-mode prefill (completed-step checkmarks, photo thumbnail, coordinates, taxon, date, "Save Changes" footer).

## Open questions / follow-ups

- The map now lives behind step 2. For a photo-first flow EXIF auto-fills it, but users who set location manually lose the at-a-glance map — worth deciding whether Location should be step 1.
- Edit mode is slightly heavier as a wizard since everything's pre-filled; `nonLinear` + clickable labels mostly mitigate this.