### PR TITLE
fix(pwa): reload only once the new service worker controls the page

### DIFF
--- a/frontend/src/components/common/UpdatePrompt.tsx
+++ b/frontend/src/components/common/UpdatePrompt.tsx
@@ -1,15 +1,19 @@
-import { Snackbar, Button } from "@mui/material";
+import { Snackbar, Button, CircularProgress } from "@mui/material";
+import { useRef, useState } from "react";
 import { useRegisterSW } from "virtual:pwa-register/react";
 
 const HOUR_MS = 60 * 60 * 1000;
 
 export function UpdatePrompt() {
+  const registrationRef = useRef<ServiceWorkerRegistration | null>(null);
+
   const {
     needRefresh: [needRefresh, setNeedRefresh],
     updateServiceWorker,
   } = useRegisterSW({
     onRegisteredSW(_swUrl, registration) {
       if (!registration) return;
+      registrationRef.current = registration;
       // Check immediately so a freshly opened PWA picks up a deploy without
       // waiting for the hourly tick (mobile suspends backgrounded tabs, so
       // a setInterval timer rarely actually fires).
@@ -29,14 +33,35 @@ export function UpdatePrompt() {
     },
   });
 
+  const [reloading, setReloading] = useState(false);
+
   const close = () => setNeedRefresh(false);
 
-  const reload = async () => {
-    // updateServiceWorker(true) only reloads via the SW's "controlling" event,
-    // which never fires if there's no waiting worker (already activated in
-    // another tab, reclaimed by the browser) or no prior controller (first
-    // uncontrolled load). Force a reload afterward so the button always works.
-    await updateServiceWorker(true);
+  const reload = () => {
+    setReloading(true);
+    const registration = registrationRef.current;
+    // When a worker is waiting AND this page is already controlled by a SW,
+    // activating it fires "controllerchange", and updateServiceWorker(true)
+    // reloads only *then* — once the NEW worker controls the page and serves
+    // the fresh index.html with current chunk hashes.
+    //
+    // Don't reload eagerly here: that races the activating worker. The old
+    // index.html would be served while cleanupOutdatedCaches has already purged
+    // its chunks, so a lazy route's import() 404s -> the "Update available"
+    // chunk-load error screen, which a full browser reload was needed to escape.
+    if (registration?.waiting && navigator.serviceWorker.controller) {
+      void updateServiceWorker(true);
+      // Safety net: if controllerchange somehow never fires (e.g. the new
+      // worker fails to activate), still recover instead of leaving the button
+      // dead. The normal controllerchange reload tears down this page first, so
+      // this only fires when the update is genuinely stuck.
+      window.setTimeout(() => window.location.reload(), 5000);
+      return;
+    }
+    // No waiting worker (already activated in another tab / reclaimed) or no
+    // prior controller (first, uncontrolled load): controllerchange never
+    // fires, so updateServiceWorker can't reload us. A plain reload is correct
+    // here — there's no concurrently-activating worker to race.
     window.location.reload();
   };
 
@@ -48,10 +73,16 @@ export function UpdatePrompt() {
       anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
       action={
         <>
-          <Button color="inherit" size="small" onClick={reload}>
-            Reload
+          <Button
+            color="inherit"
+            size="small"
+            onClick={reload}
+            disabled={reloading}
+            startIcon={reloading ? <CircularProgress size={14} color="inherit" /> : undefined}
+          >
+            {reloading ? "Reloading…" : "Reload"}
           </Button>
-          <Button color="inherit" size="small" onClick={close}>
+          <Button color="inherit" size="small" onClick={close} disabled={reloading}>
             Dismiss
           </Button>
         </>


### PR DESCRIPTION
## Problem

Clicking **Reload** on the "A new version is available." update toast frequently dropped users onto the `ErrorBoundary` "Update available / This page couldn't load…" chunk-load screen, which only a full browser reload could escape.

### Root cause

`UpdatePrompt`'s handler did:

```tsx
await updateServiceWorker(true);
window.location.reload();
```

`updateServiceWorker(true)` resolves almost immediately (after posting `SKIP_WAITING`), so the explicit `window.location.reload()` fires while the **old** worker still controls the page. The reload is served the old `index.html`, but the new worker is concurrently activating and `cleanupOutdatedCaches: true` has already purged the old chunks — so a lazy route's `import()` 404s → chunk-load error screen.

## Fix

- Reload eagerly **only** when `controllerchange` will never fire (no waiting worker, or an uncontrolled first load — the cases the eager reload was originally added for).
- When a worker is waiting and the page is controlled, let `updateServiceWorker(true)` reload via `controllerchange` — i.e. only after the **new** worker controls the page and serves fresh chunk hashes. A 5s safety-net reload covers a stuck activation.
- Add a loading state to the Reload button: spinner + "Reloading…", both buttons disabled, so the toast reads as working until the page swaps.

## Testing

`tsc --noEmit` and `oxfmt --check` pass. Service-worker handoff timing is best validated against a real deploy rather than local `:3000` (where the PWA SW serves a stale precached bundle).