### PR TITLE
chore(upload): remove redundant EXIF date toast

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -378,7 +378,6 @@ export function UploadModal() {
         const date = new Date(parsed);
         if (!isNaN(date.getTime())) {
           setObservationDate(toDatetimeLocal(date));
-          toast.success("Date extracted from photo EXIF data");
         }
       }
     } catch (error) {


### PR DESCRIPTION
## Summary
Removes the "Date extracted from photo EXIF data" toast in the upload modal. The observation date is still extracted from EXIF and applied silently — we just don't surface a toast for it.

## Notes
The location EXIF toast is left intact.