### PR TITLE
feat(dev): randomize local dev ports so multiple checkouts can run in parallel

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,6 +38,20 @@ DB_PASSWORD=mysecretpassword
 # HTTP port. process-compose sets this to 3000 for appview.
 # PORT=3000
 
+# Local dev ports are randomizable so several checkouts can run at once.
+# `npm run dev:stack` (scripts/dev.sh) picks one random offset and derives
+# all of these; set them by hand only to pin specific ports. See
+# docs/development.md. Postgres (5432) is deliberately not offset.
+# DEV_PORT_OFFSET=        # pin the offset the wrapper applies (0 = stock ports)
+# APPVIEW_PORT=3000
+# SPECIES_ID_PORT=3005
+# VITE_PORT=5173
+# TAP_INGESTER_PORT=8080
+
+# Where the appview proxies frontend requests when no static bundle exists.
+# Defaults to the Vite dev server on 5173; the wrapper points it at VITE_PORT.
+# VITE_DEV_SERVER_URL=http://localhost:5173
+
 # Where the media proxy caches resized images. Created on first run.
 CACHE_DIR=./cache/media
 

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -246,15 +246,20 @@ async fn main() {
                 .layer(axum_middleware::from_fn(middleware::static_cache_control))
         }
         None => {
-            let vite_url = "http://localhost:5173";
+            // Where the Vite dev server is listening. Defaults to Vite's usual
+            // 5173, but a randomized-port dev stack (scripts/dev.sh) relocates
+            // it and sets VITE_DEV_SERVER_URL so this proxy still finds it.
+            let vite_url = std::env::var("VITE_DEV_SERVER_URL")
+                .unwrap_or_else(|_| "http://localhost:5173".to_string());
             info!(
-                vite_url,
+                vite_url = %vite_url,
                 "No pre-built frontend found, proxying to Vite dev server"
             );
             let client = reqwest::Client::new();
             app.fallback(move |req: axum::extract::Request| {
                 let client = client.clone();
-                async move { vite_proxy(req, vite_url, &client).await }
+                let vite_url = vite_url.clone();
+                async move { vite_proxy(req, &vite_url, &client).await }
             })
         }
     };

--- a/docs/development.md
+++ b/docs/development.md
@@ -234,6 +234,35 @@ process-compose down
 Process names: `migrate`, `species-id`, `appview`, `tap-ingester`,
 `frontend` (in startup order).
 
+#### Running several checkouts at once (randomized ports)
+
+The four services default to fixed ports (`appview` 3000, `species-id`
+3005, `frontend`/Vite 5173, `tap-ingester` 8080), so two checkouts that
+both run `process-compose up` collide. To run them in parallel, start the
+stack through the wrapper instead:
+
+```bash
+npm run dev:stack        # or: ./scripts/dev.sh
+```
+
+It picks one random offset, applies it uniformly to every service, exports
+the derived ports, and prints where each one landed (including the
+`http://127.0.0.1:<appview>` front door to open). Cross-service URLs — the
+Vite `/api` proxy, the appview→Vite dev proxy, `SPECIES_ID_SERVICE_URL` —
+all follow the offset automatically. Postgres is left on `5432`; it lives
+outside process-compose and is meant to be shared.
+
+Pin the offset when you want stable, reproducible ports for a checkout:
+
+```bash
+DEV_PORT_OFFSET=2000 npm run dev:stack   # appview 5000, vite 7173, ...
+DEV_PORT_OFFSET=0 npm run dev:stack      # stock ports, no randomization
+```
+
+Plain `process-compose up` still works and keeps the stock ports — the
+ports are all `${VAR:-default}` overrides, and the wrapper just sets those
+vars.
+
 ### Individual Services
 
 ```bash

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,6 +25,11 @@ const resolvedNodeModules = path.resolve(
 // the console reconnecting to a stale 5173. See issue #659.
 const devPort = Number(process.env.VITE_PORT) || 5173;
 
+// The Rust appview that the dev server proxies /api, /oauth and /media calls
+// to. Follows APPVIEW_PORT so a randomized-port stack (scripts/dev.sh) still
+// reaches it; defaults to process-compose's usual 3000.
+const appviewPort = Number(process.env.APPVIEW_PORT) || 3000;
+
 export default defineConfig({
   plugins: [
     react(),
@@ -114,9 +119,9 @@ export default defineConfig({
       clientPort: devPort,
     },
     proxy: {
-      "/api": "http://localhost:3000",
-      "/oauth": "http://localhost:3000",
-      "/media": "http://localhost:3000",
+      "/api": `http://localhost:${appviewPort}`,
+      "/oauth": `http://localhost:${appviewPort}`,
+      "/media": `http://localhost:${appviewPort}`,
     },
   },
 });

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "generate-rust-types": "./scripts/generate-rust-types.sh",
     "setup": "./scripts/setup.sh",
     "dev": "vite -c frontend/vite.config.ts",
+    "dev:stack": "./scripts/dev.sh",
     "fmt": "oxfmt frontend/src frontend/tests scripts",
     "fmt:check": "oxfmt --check frontend/src frontend/tests scripts",
     "lint": "oxlint frontend/src",

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -23,13 +23,13 @@ processes:
   species-id:
     command: cargo run -p observing-species-id
     environment:
-      - PORT=3005
+      - PORT=${SPECIES_ID_PORT:-3005}
       - MODEL_DIR=./models/bioclip
       - ORT_DYLIB_PATH=/opt/homebrew/lib/libonnxruntime.dylib
     readiness_probe:
       http_get:
         host: localhost
-        port: 3005
+        port: ${SPECIES_ID_PORT:-3005}
         path: /health
       initial_delay_seconds: 10
       period_seconds: 5
@@ -38,9 +38,10 @@ processes:
     command: cargo run -p observing-appview
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:${DB_PASSWORD:-mysecretpassword}@localhost:5432/observing}
-      - PORT=3000
+      - PORT=${APPVIEW_PORT:-3000}
       - CACHE_DIR=./cache/media
-      - SPECIES_ID_SERVICE_URL=http://localhost:3005
+      - SPECIES_ID_SERVICE_URL=http://localhost:${SPECIES_ID_PORT:-3005}
+      - VITE_DEV_SERVER_URL=http://localhost:${VITE_PORT:-5173}
       - PUBLIC_URL=${PUBLIC_URL:-}
     depends_on:
       migrate:
@@ -50,7 +51,7 @@ processes:
     readiness_probe:
       http_get:
         host: localhost
-        port: 3000
+        port: ${APPVIEW_PORT:-3000}
         path: /health
       initial_delay_seconds: 120
       period_seconds: 5
@@ -63,20 +64,26 @@ processes:
     environment:
       - DATABASE_URL=${DATABASE_URL:-postgresql://postgres:${DB_PASSWORD:-mysecretpassword}@localhost:5432/observing}
       - TAP_DATABASE_URL=${TAP_DATABASE_URL:-sqlite:./.tap-ingester/tap.db}
-      - PORT=8080
+      - PORT=${TAP_INGESTER_PORT:-8080}
     depends_on:
       migrate:
         condition: process_completed_successfully
     readiness_probe:
       http_get:
         host: localhost
-        port: 8080
+        port: ${TAP_INGESTER_PORT:-8080}
         path: /health
       initial_delay_seconds: 30
       period_seconds: 5
 
   frontend:
     command: npm run dev
+    environment:
+      # Vite reads VITE_PORT for its own listen port and APPVIEW_PORT for the
+      # /api proxy target (see frontend/vite.config.ts). Kept in sync with the
+      # appview service above so a randomized-port stack stays coherent.
+      - VITE_PORT=${VITE_PORT:-5173}
+      - APPVIEW_PORT=${APPVIEW_PORT:-3000}
     depends_on:
       appview:
         condition: process_healthy

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Bring up the full local dev stack with a randomized port offset so several
+# checkouts / git worktrees can run side by side without colliding on the
+# usual 3000 / 3005 / 5173 / 8080 ports.
+#
+# A single random base offset is picked once and applied uniformly to every
+# service, so their relative gaps (and therefore every cross-service URL the
+# stack builds from them) stay intact. Postgres is intentionally left on its
+# fixed port — it lives outside process-compose and is meant to be shared.
+#
+# Usage:
+#   ./scripts/dev.sh                 # random offset, then `process-compose up`
+#   ./scripts/dev.sh -D              # extra args are forwarded to process-compose
+#   DEV_PORT_OFFSET=0 ./scripts/dev.sh   # pin the stock ports (no randomization)
+#   DEV_PORT_OFFSET=2000 ./scripts/dev.sh  # pin a specific offset
+#
+# The derived ports are exported, so `process-compose.yaml` (and Vite, via the
+# inherited environment) pick them up through their `${VAR:-default}` fallbacks.
+
+set -euo pipefail
+
+# Base ports, matching the defaults baked into process-compose.yaml.
+BASE_APPVIEW_PORT=3000
+BASE_SPECIES_ID_PORT=3005
+BASE_VITE_PORT=5173
+BASE_TAP_INGESTER_PORT=8080
+
+# One random offset for the whole stack. Stepped by 10 and capped at 5000 so
+# every derived port stays in a sane, unprivileged, in-range band and the
+# services never overlap each other. Override DEV_PORT_OFFSET to pin it (0
+# reproduces the stock ports).
+if [[ -z "${DEV_PORT_OFFSET:-}" ]]; then
+  DEV_PORT_OFFSET=$(( (RANDOM % 501) * 10 ))
+fi
+
+export APPVIEW_PORT=$(( BASE_APPVIEW_PORT + DEV_PORT_OFFSET ))
+export SPECIES_ID_PORT=$(( BASE_SPECIES_ID_PORT + DEV_PORT_OFFSET ))
+export VITE_PORT=$(( BASE_VITE_PORT + DEV_PORT_OFFSET ))
+export TAP_INGESTER_PORT=$(( BASE_TAP_INGESTER_PORT + DEV_PORT_OFFSET ))
+
+# Let the appview proxy and any direct `cargo run` find the relocated Vite.
+export VITE_DEV_SERVER_URL="http://localhost:${VITE_PORT}"
+
+cat <<EOF
+Starting dev stack with port offset ${DEV_PORT_OFFSET}:
+  appview        http://localhost:${APPVIEW_PORT}   (front door)
+  species-id     http://localhost:${SPECIES_ID_PORT}
+  tap-ingester   http://localhost:${TAP_INGESTER_PORT}
+  vite           http://localhost:${VITE_PORT}
+  postgres       localhost:5432   (fixed, shared)
+
+Open the app at http://127.0.0.1:${APPVIEW_PORT}
+EOF
+
+exec process-compose up "$@"


### PR DESCRIPTION
## What

Two checkouts (or git worktrees) that both run `process-compose up` collide on the fixed dev ports — `appview` 3000, `species-id` 3005, Vite 5173, `tap-ingester` 8080. This adds a wrapper that relocates the whole stack to a randomized port band so several can run side by side.

## How

- **`scripts/dev.sh` / `npm run dev:stack`** — picks **one** random base offset and applies it uniformly to every service, so their relative gaps (and therefore every cross-service URL built from them) stay intact. Prints where each service landed, then runs `process-compose up`.
- The derived ports (`APPVIEW_PORT`, `SPECIES_ID_PORT`, `VITE_PORT`, `TAP_INGESTER_PORT`) are exported and threaded through `process-compose.yaml` via `${VAR:-default}` fallbacks, so a **plain `process-compose up` still uses the stock ports** — nothing breaks for existing workflows.
- `DEV_PORT_OFFSET` pins the offset for reproducible ports (`0` = stock ports).

To keep cross-service references coherent under an offset:
- appview proxies to the Vite dev server via a new `VITE_DEV_SERVER_URL` env (was a hardcoded `:5173`)
- the Vite `/api`, `/oauth`, `/media` proxy follows `APPVIEW_PORT`
- `SPECIES_ID_SERVICE_URL` and all readiness probes follow their service ports

Postgres (`5432`) is deliberately left fixed — it lives outside process-compose and is meant to be shared.

## Notes

- This builds on the existing single-knob `VITE_PORT` work from #659, generalizing it to the whole stack.
- Docs updated in `docs/development.md`; new env knobs documented in `.env.example`.

## Verification

- `cargo check -p observing-appview` passes.
- `process-compose.yaml` parses; `scripts/dev.sh` passes `bash -n` and produces the expected derived ports (e.g. `DEV_PORT_OFFSET=2000` → appview 5000, species-id 5005, vite 7173, tap 10080).
- ⚠️ Not yet run end-to-end (`npm run dev:stack`) against a live Postgres — left as draft for that reason. The one behavior worth confirming on real hardware is that process-compose expands `${VAR:-default}` inside the `readiness_probe.port` integer fields (it already does so for `environment`/`command` in this file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012LD2bnvLgd2f7o7PoEvW3m)_