### PR TITLE
feat(species-id): route live camera ID to a faster ViT-L service

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -195,10 +195,21 @@ RUN apt-get update && apt-get install -y curl && \
     cp onnxruntime-linux-x64-1.24.4/lib/libonnxruntime*.so* /usr/lib/ && \
     rm -rf onnxruntime-* /tmp/ort.tgz
 
+# Model bundle to bake in. Defaults to the full-accuracy ViT-H build used by
+# the upload/capture path. The faster live-loop service (ViT-L) is the same
+# binary built with a different bundle + version, e.g.:
+#   docker build --build-arg SERVICE=observing-species-id \
+#     --build-arg SPECIES_MODEL_URL=<vit-l bundle .tar.gz> \
+#     --build-arg MODEL_VERSION=bioclip-2-vit-l-14 -t observing-species-id-live .
+# TODO: publish the ViT-L bundle in observ-ing/bioclip-models and set its URL
+# when standing up the live service.
+ARG SPECIES_MODEL_URL=https://github.com/observ-ing/bioclip-models/releases/download/v2.1.0/bioclip-2.5-models.tar.gz
+ARG MODEL_VERSION=bioclip-2.5-vit-h-14
+
 # Download model artifacts (separate layer for better caching)
 RUN mkdir -p /app/models/bioclip && \
     curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 -o /tmp/models.tar.gz \
-      https://github.com/observ-ing/bioclip-models/releases/download/v2.1.0/bioclip-2.5-models.tar.gz && \
+      "${SPECIES_MODEL_URL}" && \
     tar xzf /tmp/models.tar.gz -C /app/models/bioclip && \
     rm /tmp/models.tar.gz
 
@@ -211,6 +222,7 @@ COPY --from=builder /app/target/release/observing-species-id /app/observing-spec
 ENV RUST_LOG=observing_species_id=info
 ENV PORT=3005
 ENV MODEL_DIR=/app/models/bioclip
+ENV MODEL_VERSION=${MODEL_VERSION}
 ENV ORT_DYLIB_PATH=/usr/lib/libonnxruntime.so
 EXPOSE 3005
 CMD ["/app/observing-species-id"]

--- a/crates/observing-appview/src/config.rs
+++ b/crates/observing-appview/src/config.rs
@@ -8,6 +8,10 @@ pub struct Config {
     pub cors_origins: Vec<String>,
     /// URL for the species identification service (optional)
     pub species_id_service_url: Option<String>,
+    /// URL for the faster, lower-latency species-id service used by the live
+    /// camera loop (ViT-L). Optional — when unset, live requests fall back to
+    /// the full-accuracy `species_id_service_url`.
+    pub species_id_live_service_url: Option<String>,
     /// Base URL for the tap-ingester service (optional). When set, its
     /// runtime interface is exposed as `ingester/*` tables in the admin
     /// browser; when unset, those tables are simply not registered.
@@ -48,6 +52,9 @@ impl Config {
             });
 
         let species_id_service_url = env::var("SPECIES_ID_SERVICE_URL").ok();
+        let species_id_live_service_url = env::var("SPECIES_ID_LIVE_SERVICE_URL")
+            .ok()
+            .filter(|s| !s.trim().is_empty());
 
         let ingester_url = env::var("INGESTER_URL")
             .ok()
@@ -72,6 +79,7 @@ impl Config {
             database_url,
             cors_origins,
             species_id_service_url,
+            species_id_live_service_url,
             ingester_url,
             public_url,
             hidden_dids,

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -69,6 +69,11 @@ async fn main() {
         .as_deref()
         .map(|url| Arc::new(SpeciesIdClient::new(url)));
 
+    let species_id_live = config
+        .species_id_live_service_url
+        .as_deref()
+        .map(|url| Arc::new(SpeciesIdClient::new(url)));
+
     let media = media::MediaCache::from_env().await;
 
     let state = AppState {
@@ -76,6 +81,7 @@ async fn main() {
         resolver: Arc::new(atproto_identity::IdentityResolver::from_env()),
         taxonomy: Arc::new(TaxonomyClient::new()),
         species_id,
+        species_id_live,
         oauth_client: Arc::new(oauth_client),
         media,
         public_url: config.public_url.clone(),

--- a/crates/observing-appview/src/routes/species_id.rs
+++ b/crates/observing-appview/src/routes/species_id.rs
@@ -18,6 +18,12 @@ pub struct IdentifyRequest {
     longitude: Option<f64>,
     #[serde(default)]
     limit: Option<usize>,
+    /// Route to the faster live-loop model (ViT-L). The continuous camera
+    /// preview sets this; the upload/capture re-ID leaves it false so it gets
+    /// the full-accuracy model. Falls back to the full model when no live
+    /// service is configured.
+    #[serde(default)]
+    live: bool,
 }
 
 #[derive(Serialize)]
@@ -62,9 +68,13 @@ pub async fn identify(
     _user: AuthUser,
     Json(body): Json<IdentifyRequest>,
 ) -> impl IntoResponse {
-    let client = match &state.species_id {
-        Some(c) => c,
-        None => {
+    // Live requests prefer the faster ViT-L service, falling back to the full
+    // model when no live service is configured (e.g. local dev). Non-live
+    // requests (upload/capture re-ID) always use the full-accuracy model.
+    let client = match (body.live, &state.species_id_live, &state.species_id) {
+        (true, Some(live), _) => live,
+        (_, _, Some(full)) => full,
+        (_, _, None) => {
             return (
                 StatusCode::SERVICE_UNAVAILABLE,
                 Json(ErrorResponse {

--- a/crates/observing-appview/src/state.rs
+++ b/crates/observing-appview/src/state.rs
@@ -95,6 +95,9 @@ pub struct AppState {
     pub resolver: Arc<IdentityResolver>,
     pub taxonomy: Arc<TaxonomyClient>,
     pub species_id: Option<Arc<SpeciesIdClient>>,
+    /// Faster ViT-L service for the live camera loop. `None` falls back to
+    /// `species_id` so single-service deployments (e.g. local dev) still work.
+    pub species_id_live: Option<Arc<SpeciesIdClient>>,
     pub oauth_client: Arc<OAuthClientType>,
     /// In-process AT Protocol blob cache + PDS fetcher (formerly the
     /// `observing-media-proxy` service).

--- a/crates/observing-species-id/src/model.rs
+++ b/crates/observing-species-id/src/model.rs
@@ -85,12 +85,18 @@ impl BioclipModel {
             info!(geo_boost, "Geo-prior reranking enabled");
         }
 
+        // Reported in the `/identify` response and `/health`. Defaults to the
+        // full ViT-H build; the live ViT-L deployment overrides it via
+        // `MODEL_VERSION` so clients and logs can tell the two services apart.
+        let version =
+            std::env::var("MODEL_VERSION").unwrap_or_else(|_| "bioclip-2.5-vit-h-14".to_string());
+
         Ok(Self {
             session: Mutex::new(session),
             species,
             geo_index,
             geo_boost,
-            version: "bioclip-2.5-vit-h-14".to_string(),
+            version,
         })
     }
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,8 @@ Deployed via GitHub Actions (`.github/workflows/ci.yml`) on push to `main` after
 |---------|-----------|--------|-----------|---------|-------|
 | observing-appview | `SERVICE=observing-appview` | Yes | Yes | `appview_runtime` | REST API + OAuth + media cache + GBIF taxonomy + serves frontend |
 | tap-ingester | `SERVICE=tap-ingester` | Yes | Yes | `ingester_runtime` | Sole firehose-driven ingester. Bundles the upstream `tap` Go binary (built from a pinned indigo commit) and spawns it as a child process. Tap state is persisted in the Cloud SQL `tap` schema (`search_path=tap`), so tracked-DID lists and cursors survive deploys and instance recycles. min-instances=1 / max-instances=1. Runs with `--no-cpu-throttling` (always-allocated CPU) + 2 vCPU because the firehose consumer is a background loop, not request-driven — under Cloud Run's default request-scoped CPU it gets starved and falls behind the relay's ~72h retention window. |
-| observing-species-id | `SERVICE=observing-species-id` | Yes | No | — | BioCLIP species identification (2 CPU, 8 GiB, cpu-boost, min-instances=1) |
+| observing-species-id | `SERVICE=observing-species-id` | Yes | No | — | BioCLIP species identification, full-accuracy ViT-H/14 used by the upload/capture path (2 CPU, 8 GiB, cpu-boost, min-instances=1) |
+| observing-species-id-live | `SERVICE=observing-species-id` + `SPECIES_MODEL_URL=<ViT-L bundle>` + `MODEL_VERSION=bioclip-2-vit-l-14` | Yes | No | — | Same binary as `observing-species-id`, built with the smaller/faster ViT-L model bundle. Serves the live camera loop (frontend sends `live: true`; appview routes here via `SPECIES_ID_LIVE_SERVICE_URL`). Same sizing as above. **Blocked on publishing the ViT-L bundle in `observ-ing/bioclip-models`.** |
 
 ### Jobs
 
@@ -54,6 +55,9 @@ Database passwords and secrets come from Google Secret Manager; non-secret confi
 PORT=3000
 PUBLIC_URL=https://your-domain.run.app
 SPECIES_ID_SERVICE_URL=https://observing-species-id-xxx.run.app
+# Optional: faster ViT-L service for the live camera loop. When unset, live
+# requests fall back to SPECIES_ID_SERVICE_URL (the full ViT-H model).
+SPECIES_ID_LIVE_SERVICE_URL=https://observing-species-id-live-xxx.run.app
 
 # Cloud SQL (Unix socket in prod)
 DB_HOST=/cloudsql/<project>:<region>:observing-db
@@ -111,9 +115,12 @@ lands after backfill completes.
 PORT=3005
 MODEL_DIR=/app/models/bioclip
 ORT_DYLIB_PATH=/usr/lib/libonnxruntime.so
+# Reported in /identify + /health responses. Defaults to the ViT-H build's
+# string; the live ViT-L image bakes this in via the MODEL_VERSION build-arg.
+MODEL_VERSION=bioclip-2.5-vit-h-14
 ```
 
-No database access.
+No database access. Both `observing-species-id` and `observing-species-id-live` use this same config; they differ only in the baked model bundle and `MODEL_VERSION`.
 
 ### Migrate Job (`postgres`)
 

--- a/frontend/src/hooks/useLiveId.ts
+++ b/frontend/src/hooks/useLiveId.ts
@@ -135,6 +135,9 @@ export function useLiveId({ videoRef, active, latitude, longitude }: UseLiveIdOp
             const params: Parameters<typeof identifySpecies>[0] = {
               image: base64,
               limit: LIVE_LIMIT,
+              // Use the faster ViT-L service for the continuous loop; the
+              // upload/capture re-ID (useVisualId) keeps the full-accuracy model.
+              live: true,
             };
             if (latitude != null && Number.isFinite(latitude)) params.latitude = latitude;
             if (longitude != null && Number.isFinite(longitude)) params.longitude = longitude;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -477,6 +477,12 @@ export async function identifySpecies(data: {
   latitude?: number;
   longitude?: number;
   limit?: number;
+  /**
+   * Route to the faster live-loop model (ViT-L). The continuous camera preview
+   * sets this; the upload/capture re-ID leaves it unset so it gets the
+   * full-accuracy model.
+   */
+  live?: boolean;
 }): Promise<IdentifyResponse> {
   return fetchApi(`${API_BASE}/api/species-id`, "Species identification failed", {
     method: "POST",


### PR DESCRIPTION
Routes the live camera ID loop to a separate, faster **ViT-L** service while the upload/capture path keeps the full-accuracy **ViT-H** model. ~2× faster per-frame inference for the live preview at a ~5.7% zero-shot accuracy give-back; the heavy model still has the final say on capture (`useVisualId`).

## How
Two Cloud Run services built from the **same binary** (different baked model bundle). The frontend live loop sends `live: true`; the appview routes those to `SPECIES_ID_LIVE_SERVICE_URL`, **falling back to the full model** when no live service is configured (e.g. local dev), so nothing breaks before the live service exists.

## Changes
- **appview**: `SPECIES_ID_LIVE_SERVICE_URL` config + `species_id_live` client; `live` flag on `/api/species-id` with full-model fallback.
- **species-id**: `MODEL_VERSION` env so the ViT-L service self-identifies in `/identify` + `/health`.
- **frontend**: `identifySpecies({ live })`, set by `useLiveId`.
- **Dockerfile**: `SPECIES_MODEL_URL` / `MODEL_VERSION` build-args (same image, different model).
- **docs/deployment.md**: new `observing-species-id-live` service row.

## Status
**Draft.** Verified: `cargo check`, `cargo fmt --check`, 82 unit tests, frontend oxfmt/oxlint. **Not yet verified end-to-end** — standing up the live service needs the ViT-L bundle from observ-ing/bioclip-models#7. Until that's published and `SPECIES_ID_LIVE_SERVICE_URL` is set, the fallback (live → full model) is what runs.

Depends on observ-ing/bioclip-models#7.