### PR TITLE
feat(identify): request a high-res live camera stream

### DIFF
--- a/frontend/src/components/identification/LiveIdView.tsx
+++ b/frontend/src/components/identification/LiveIdView.tsx
@@ -58,7 +58,20 @@ export function LiveIdView() {
     let cancelled = false;
 
     navigator.mediaDevices
-      .getUserMedia({ video: { facingMode: "environment" }, audio: false })
+      // Request a high-res stream so the full-screen preview stays sharp (a
+      // default ~640x480 stream upscaled to fill a phone screen looks blurry,
+      // which is easily mistaken for the camera failing to focus). `ideal` so
+      // it degrades gracefully on devices that can't deliver 1080p. Note this
+      // only affects the preview and the shutter-captured photo — each live
+      // inference frame is downscaled to 384px before upload regardless.
+      .getUserMedia({
+        video: {
+          facingMode: "environment",
+          width: { ideal: 1920 },
+          height: { ideal: 1080 },
+        },
+        audio: false,
+      })
       .then((s) => {
         if (cancelled) {
           s.getTracks().forEach((t) => t.stop());
@@ -66,6 +79,10 @@ export function LiveIdView() {
         }
         stream = s;
         streamRef.current = s;
+        // Surface the resolution we actually negotiated — handy for diagnosing
+        // a soft preview (the browser may hand back less than requested).
+        const settings = s.getVideoTracks()[0]?.getSettings();
+        console.info(`[LiveId] camera resolution: ${settings?.width}x${settings?.height}`);
         const video = videoRef.current;
         if (video) {
           video.srcObject = s;


### PR DESCRIPTION
## Problem
The live camera preview looked soft/blurry — easy to read as the camera failing to focus. The actual cause: `LiveIdView` requested `getUserMedia` with **no resolution**, so the browser returned its default (often ~640×480). The preview `<video>` fills the screen with `object-fit: cover`, so that low-res stream is upscaled ~3× on a phone display → visibly soft. (Web `getUserMedia` also has no tap-to-focus on iOS, so there's no focus-API fix — but this isn't a focus problem.)

## Change
- Request `width/height: { ideal: 1920×1080 }` (`ideal`, so it degrades gracefully on devices that can't deliver 1080p).
- Log the **negotiated** resolution (`track.getSettings()`) so a still-soft preview is easy to diagnose on-device.

## Scope / expectations
- ✅ Sharper preview, and a better shutter-captured photo (`handleCapture` grabs at native `videoWidth/videoHeight`).
- ➖ **No effect on live-ID accuracy** — each inference frame is downscaled to 384px (`useLiveId`) and the server resizes to 224×224 regardless. This is purely a preview/capture-quality fix.
- Negligible extra decode/battery for the higher-res preview.

Verified: oxfmt, oxlint (0 errors), `tsc` typecheck all clean.