### PR TITLE
refactor(observation): refresh and unify the observation detail view

### DIFF
--- a/frontend/src/components/comment/CommentSection.tsx
+++ b/frontend/src/components/comment/CommentSection.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Typography,
   Stack,
-  Paper,
   TextField,
   Button,
   IconButton,
@@ -21,6 +20,7 @@ import type { Comment } from "../../services/types";
 import { getPdslsUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { UserCard } from "../common/UserCard";
+import { Section, SectionHeader } from "../common/Section";
 
 interface CommentSectionProps {
   observationUri: string;
@@ -76,47 +76,28 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
   };
 
   return (
-    <Paper
-      elevation={0}
-      sx={{
-        p: 2.5,
-        bgcolor: "background.paper",
-        borderRadius: 2,
-        border: 1,
-        borderColor: "divider",
-      }}
-    >
-      <Stack
-        direction="row"
-        spacing={1}
-        sx={{
-          alignItems: "center",
-          mb: 2,
-        }}
-      >
-        <ChatBubbleOutlineIcon fontSize="small" sx={{ color: "primary.main" }} />
-        <Typography
-          variant="subtitle2"
-          sx={{
-            fontWeight: 600,
-          }}
-        >
-          Discussion
-        </Typography>
-        {comments.length > 0 && (
-          <Chip label={comments.length} size="small" sx={{ height: 20, fontSize: "0.75rem" }} />
-        )}
-        {user && !showForm && (
-          <Button
-            size="small"
-            startIcon={<ChatBubbleOutlineIcon />}
-            onClick={() => setShowForm(true)}
-            sx={{ ml: "auto" }}
-          >
-            Add
-          </Button>
-        )}
-      </Stack>
+    <Section>
+      <SectionHeader
+        icon={<ChatBubbleOutlineIcon fontSize="small" sx={{ color: "primary.main" }} />}
+        title="Discussion"
+        sx={{ mb: 2 }}
+        trailing={
+          <>
+            {comments.length > 0 && (
+              <Chip label={comments.length} size="small" sx={{ height: 20, fontSize: "0.75rem" }} />
+            )}
+            {user && !showForm && (
+              <Button
+                size="small"
+                startIcon={<ChatBubbleOutlineIcon />}
+                onClick={() => setShowForm(true)}
+              >
+                Add
+              </Button>
+            )}
+          </>
+        }
+      />
       {comments.length === 0 && !showForm && (
         <Typography
           variant="body2"
@@ -256,6 +237,6 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
           Log in to add a comment
         </Typography>
       )}
-    </Paper>
+    </Section>
   );
 }

--- a/frontend/src/components/common/Section.stories.tsx
+++ b/frontend/src/components/common/Section.stories.tsx
@@ -1,0 +1,85 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Chip, Typography } from "@mui/material";
+import HistoryIcon from "@mui/icons-material/History";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import { Section, SectionHeader } from "./Section";
+
+const meta = {
+  title: "Common/Section",
+  component: Section,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component:
+          "Bordered card wrapper used by the observation detail sections so they read as peers. Pair it with `SectionHeader` for the icon + title (+ trailing slot) row.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  // Each story supplies its own composition via `render`; this satisfies the
+  // required `children` prop on the meta.
+  args: {
+    children: null,
+  },
+} satisfies Meta<typeof Section>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  render: () => (
+    <Section>
+      <SectionHeader
+        icon={<InfoOutlinedIcon fontSize="small" sx={{ color: "primary.main" }} />}
+        title="Details"
+        sx={{ mb: 1.5 }}
+      />
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        Section body content goes here.
+      </Typography>
+    </Section>
+  ),
+};
+
+export const WithTrailingCount: Story = {
+  render: () => (
+    <Section>
+      <SectionHeader
+        icon={<HistoryIcon fontSize="small" sx={{ color: "primary.main" }} />}
+        title="Identification History"
+        sx={{ mb: 1.5 }}
+        trailing={<Chip label={3} size="small" sx={{ height: 20, fontSize: "0.75rem" }} />}
+      />
+      <Typography variant="body2" sx={{ color: "text.secondary" }}>
+        The trailing slot is right-aligned — use it for a count chip, an action button, or a
+        collapse toggle.
+      </Typography>
+    </Section>
+  ),
+};
+
+export const Clickable: Story = {
+  render: () => (
+    <Section>
+      <SectionHeader
+        icon={<InfoOutlinedIcon fontSize="small" sx={{ color: "primary.main" }} />}
+        title="Data quality"
+        onClick={() => {}}
+        trailing={
+          <Typography variant="caption" sx={{ color: "text.secondary" }}>
+            All criteria met
+          </Typography>
+        }
+      />
+    </Section>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Passing `onClick` makes the whole header row a pointer target (used by collapsibles).",
+      },
+    },
+  },
+};

--- a/frontend/src/components/common/Section.tsx
+++ b/frontend/src/components/common/Section.tsx
@@ -1,0 +1,71 @@
+import type { ReactNode } from "react";
+import { Box, Paper, Stack, Typography } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material";
+
+export interface SectionProps {
+  children: ReactNode;
+  /** Extra `sx` merged onto the card wrapper. */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Bordered card wrapper shared by the observation detail sections (Details,
+ * Data quality, Identification history, Discussion) so they read as peers
+ * instead of each defining its own Paper styling.
+ */
+export function Section({ children, sx }: SectionProps) {
+  return (
+    <Paper
+      elevation={0}
+      sx={{
+        p: 2.5,
+        bgcolor: "background.paper",
+        borderRadius: 2,
+        border: 1,
+        borderColor: "divider",
+        ...sx,
+      }}
+    >
+      {children}
+    </Paper>
+  );
+}
+
+export interface SectionHeaderProps {
+  /** Leading icon (caller sets its own color, typically `primary.main`). */
+  icon: ReactNode;
+  title: ReactNode;
+  /** Trailing content (count chip, add button, expand toggle), right-aligned. */
+  trailing?: ReactNode;
+  /** When set the whole header row becomes clickable (used by collapsibles). */
+  onClick?: () => void;
+  /** Extra `sx` merged onto the header row (e.g. bottom spacing). */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Icon + title (+ optional right-aligned trailing slot) row used as the header
+ * of each {@link Section}.
+ */
+export function SectionHeader({ icon, title, trailing, onClick, sx }: SectionHeaderProps) {
+  return (
+    <Stack
+      direction="row"
+      spacing={1}
+      {...(onClick ? { onClick } : {})}
+      sx={{
+        alignItems: "center",
+        ...(onClick ? { cursor: "pointer", userSelect: "none" } : {}),
+        ...sx,
+      }}
+    >
+      {icon}
+      <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+        {title}
+      </Typography>
+      {trailing != null && (
+        <Box sx={{ ml: "auto", display: "flex", alignItems: "center", gap: 1 }}>{trailing}</Box>
+      )}
+    </Stack>
+  );
+}

--- a/frontend/src/components/identification/IdentificationHistory.tsx
+++ b/frontend/src/components/identification/IdentificationHistory.tsx
@@ -5,7 +5,6 @@ import {
   Typography,
   Avatar,
   Stack,
-  Paper,
   Chip,
   IconButton,
   Link as MuiLink,
@@ -18,6 +17,7 @@ import type { Identification } from "../../services/types";
 import { TaxonLink } from "../common/TaxonLink";
 import { getPdslsUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
+import { Section, SectionHeader } from "../common/Section";
 
 export interface IdentificationHistoryProps {
   identifications: Identification[];
@@ -77,18 +77,25 @@ export function IdentificationHistory({
     ? sortedIds.find((id) => id.did === observerDid)?.uri
     : undefined;
 
-  if (sortedIds.length === 0) {
-    return (
-      <Paper
-        elevation={0}
-        sx={{
-          p: 2.5,
-          bgcolor: "background.paper",
-          borderRadius: 2,
-          border: 1,
-          borderColor: "divider",
-        }}
-      >
+  return (
+    <Section>
+      <SectionHeader
+        icon={<HistoryIcon fontSize="small" sx={{ color: "primary.main" }} />}
+        title="Identification History"
+        sx={{ mb: 2 }}
+        {...(sortedIds.length > 0
+          ? {
+              trailing: (
+                <Chip
+                  label={sortedIds.length}
+                  size="small"
+                  sx={{ height: 20, fontSize: "0.75rem" }}
+                />
+              ),
+            }
+          : {})}
+      />
+      {sortedIds.length === 0 ? (
         <Typography
           variant="body2"
           sx={{
@@ -97,173 +104,136 @@ export function IdentificationHistory({
         >
           No identifications yet. Be the first to suggest an ID!
         </Typography>
-        {footer}
-      </Paper>
-    );
-  }
-
-  return (
-    <Paper
-      elevation={0}
-      sx={{
-        p: 2.5,
-        bgcolor: "background.paper",
-        borderRadius: 2,
-        border: 1,
-        borderColor: "divider",
-      }}
-    >
-      <Stack
-        direction="row"
-        spacing={1}
-        sx={{
-          alignItems: "center",
-          mb: 2,
-        }}
-      >
-        <HistoryIcon fontSize="small" sx={{ color: "primary.main" }} />
-        <Typography
-          variant="subtitle2"
-          sx={{
-            fontWeight: 600,
-          }}
-        >
-          Identification History
-        </Typography>
-        <Chip
-          label={sortedIds.length}
-          size="small"
-          sx={{ ml: "auto", height: 20, fontSize: "0.75rem" }}
-        />
-      </Stack>
-      <Stack spacing={2}>
-        {sortedIds.map((id) => {
-          const isSuperseded = supersededUris.has(id.uri);
-          return (
-            <Box
-              key={id.uri}
-              sx={{
-                pl: 2,
-                borderLeft: 3,
-                borderColor: isSuperseded ? "text.disabled" : "primary.main",
-                transition: "background-color 0.2s ease",
-                borderRadius: "0 4px 4px 0",
-                py: 1,
-                opacity: isSuperseded ? 0.5 : 1,
-                "&:hover": { bgcolor: "action.hover" },
-              }}
-            >
-              <Stack
-                direction="row"
-                spacing={1.5}
+      ) : (
+        <Stack spacing={2}>
+          {sortedIds.map((id) => {
+            const isSuperseded = supersededUris.has(id.uri);
+            return (
+              <Box
+                key={id.uri}
                 sx={{
-                  alignItems: "flex-start",
+                  pl: 2,
+                  borderLeft: 3,
+                  borderColor: isSuperseded ? "text.disabled" : "primary.main",
+                  transition: "background-color 0.2s ease",
+                  borderRadius: "0 4px 4px 0",
+                  py: 1,
+                  opacity: isSuperseded ? 0.5 : 1,
+                  "&:hover": { bgcolor: "action.hover" },
                 }}
               >
-                <RouterLink to={`/profile/${encodeURIComponent(id.identifier?.did || id.did)}`}>
-                  <Avatar
-                    {...(id.identifier?.avatar ? { src: id.identifier.avatar } : {})}
-                    sx={{ width: 32, height: 32 }}
-                  >
-                    {(id.identifier?.displayName || id.identifier?.handle || "?")[0]}
-                  </Avatar>
-                </RouterLink>
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Stack
-                    direction="row"
-                    spacing={1}
-                    sx={{
-                      alignItems: "center",
-                      flexWrap: "wrap",
-                    }}
-                  >
-                    <MuiLink
-                      component={RouterLink}
-                      to={`/profile/${encodeURIComponent(id.identifier?.did || id.did)}`}
-                      underline="none"
-                      color="inherit"
+                <Stack
+                  direction="row"
+                  spacing={1.5}
+                  sx={{
+                    alignItems: "flex-start",
+                  }}
+                >
+                  <RouterLink to={`/profile/${encodeURIComponent(id.identifier?.did || id.did)}`}>
+                    <Avatar
+                      {...(id.identifier?.avatar ? { src: id.identifier.avatar } : {})}
+                      sx={{ width: 32, height: 32 }}
                     >
-                      <Typography
-                        variant="body2"
-                        sx={{
-                          fontWeight: "medium",
-                          color: "text.primary",
-                        }}
-                      >
-                        {id.identifier?.displayName || id.identifier?.handle || "Unknown"}
-                      </Typography>
-                    </MuiLink>
-                    <Typography
-                      variant="caption"
+                      {(id.identifier?.displayName || id.identifier?.handle || "?")[0]}
+                    </Avatar>
+                  </RouterLink>
+                  <Box sx={{ flex: 1, minWidth: 0 }}>
+                    <Stack
+                      direction="row"
+                      spacing={1}
                       sx={{
-                        color: "text.secondary",
+                        alignItems: "center",
+                        flexWrap: "wrap",
                       }}
                     >
-                      <RelativeTime date={new Date(id.date_identified)} withAgo />
-                    </Typography>
-                    {id.uri === observerFirstIdUri && (
-                      <Chip label="Observer's ID" size="small" color="info" variant="outlined" />
-                    )}
-                    {isSuperseded && <Chip label="Superseded" size="small" variant="outlined" />}
-                  </Stack>
-                  <Box sx={{ mt: 0.5, textDecoration: isSuperseded ? "line-through" : "none" }}>
-                    <TaxonLink
-                      name={id.scientific_name}
-                      kingdom={id.kingdom || kingdom}
-                      rank={id.taxon_rank}
-                    />
-                  </Box>
-                </Box>
-                <Box sx={{ alignSelf: "flex-start", mt: 0.5 }}>
-                  <IconButton
-                    size="small"
-                    onClick={(e) => handleMenuOpen(id.uri, e)}
-                    aria-label="More options"
-                    sx={{ color: "text.disabled", p: 0.5 }}
-                  >
-                    <MoreVertIcon fontSize="small" />
-                  </IconButton>
-                  <Menu
-                    anchorEl={menuAnchorEl[id.uri]}
-                    open={Boolean(menuAnchorEl[id.uri])}
-                    onClose={() => handleMenuClose(id.uri)}
-                    anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                    transformOrigin={{ vertical: "top", horizontal: "right" }}
-                  >
-                    <MenuItem
-                      component="a"
-                      href={getPdslsUrl(id.uri)}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      onClick={() => handleMenuClose(id.uri)}
-                    >
-                      View on AT Protocol
-                    </MenuItem>
-                    {currentUserDid && id.did === currentUserDid && onDeleteIdentification && (
-                      <MenuItem
-                        onClick={async () => {
-                          handleMenuClose(id.uri);
-                          setDeletingUri(id.uri);
-                          try {
-                            await onDeleteIdentification(id.uri);
-                          } finally {
-                            setDeletingUri(null);
-                          }
-                        }}
-                        disabled={deletingUri === id.uri}
-                        sx={{ color: "error.main" }}
+                      <MuiLink
+                        component={RouterLink}
+                        to={`/profile/${encodeURIComponent(id.identifier?.did || id.did)}`}
+                        underline="none"
+                        color="inherit"
                       >
-                        Delete
+                        <Typography
+                          variant="body2"
+                          sx={{
+                            fontWeight: "medium",
+                            color: "text.primary",
+                          }}
+                        >
+                          {id.identifier?.displayName || id.identifier?.handle || "Unknown"}
+                        </Typography>
+                      </MuiLink>
+                      <Typography
+                        variant="caption"
+                        sx={{
+                          color: "text.secondary",
+                        }}
+                      >
+                        <RelativeTime date={new Date(id.date_identified)} withAgo />
+                      </Typography>
+                      {id.uri === observerFirstIdUri && (
+                        <Chip label="Observer's ID" size="small" color="info" variant="outlined" />
+                      )}
+                      {isSuperseded && <Chip label="Superseded" size="small" variant="outlined" />}
+                    </Stack>
+                    <Box sx={{ mt: 0.5, textDecoration: isSuperseded ? "line-through" : "none" }}>
+                      <TaxonLink
+                        name={id.scientific_name}
+                        kingdom={id.kingdom || kingdom}
+                        rank={id.taxon_rank}
+                      />
+                    </Box>
+                  </Box>
+                  <Box sx={{ alignSelf: "flex-start", mt: 0.5 }}>
+                    <IconButton
+                      size="small"
+                      onClick={(e) => handleMenuOpen(id.uri, e)}
+                      aria-label="More options"
+                      sx={{ color: "text.disabled", p: 0.5 }}
+                    >
+                      <MoreVertIcon fontSize="small" />
+                    </IconButton>
+                    <Menu
+                      anchorEl={menuAnchorEl[id.uri]}
+                      open={Boolean(menuAnchorEl[id.uri])}
+                      onClose={() => handleMenuClose(id.uri)}
+                      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+                      transformOrigin={{ vertical: "top", horizontal: "right" }}
+                    >
+                      <MenuItem
+                        component="a"
+                        href={getPdslsUrl(id.uri)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={() => handleMenuClose(id.uri)}
+                      >
+                        View on AT Protocol
                       </MenuItem>
-                    )}
-                  </Menu>
-                </Box>
-              </Stack>
-            </Box>
-          );
-        })}
-      </Stack>
+                      {currentUserDid && id.did === currentUserDid && onDeleteIdentification && (
+                        <MenuItem
+                          onClick={async () => {
+                            handleMenuClose(id.uri);
+                            setDeletingUri(id.uri);
+                            try {
+                              await onDeleteIdentification(id.uri);
+                            } finally {
+                              setDeletingUri(null);
+                            }
+                          }}
+                          disabled={deletingUri === id.uri}
+                          sx={{ color: "error.main" }}
+                        >
+                          Delete
+                        </MenuItem>
+                      )}
+                    </Menu>
+                  </Box>
+                </Stack>
+              </Box>
+            );
+          })}
+        </Stack>
+      )}
       {footer}
-    </Paper>
+    </Section>
   );
 }

--- a/frontend/src/components/observation/DataQualitySection.tsx
+++ b/frontend/src/components/observation/DataQualitySection.tsx
@@ -1,7 +1,5 @@
 import { useState } from "react";
 import {
-  Box,
-  Stack,
   Typography,
   List,
   ListItem,
@@ -15,6 +13,7 @@ import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CancelIcon from "@mui/icons-material/Cancel";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import type { QualityIssue } from "../../bindings/QualityIssue";
+import { Section, SectionHeader } from "../common/Section";
 
 interface DataQualitySectionProps {
   issues: QualityIssue[];
@@ -81,37 +80,31 @@ export function DataQualitySection({ issues }: DataQualitySectionProps) {
   const [expanded, setExpanded] = useState(!allMet);
 
   return (
-    <Box>
-      <Stack
-        direction="row"
-        spacing={1}
+    <Section>
+      <SectionHeader
         onClick={() => setExpanded((prev) => !prev)}
-        sx={{
-          alignItems: "center",
-          mb: expanded ? 1 : 0,
-          cursor: "pointer",
-          userSelect: "none",
-        }}
-      >
-        <VerifiedOutlinedIcon fontSize="small" sx={{ color: "primary.main" }} />
-        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-          Data quality
-        </Typography>
-        <Typography variant="caption" sx={{ color: "text.secondary", ml: "auto" }}>
-          {allMet ? "All criteria met" : `${metCount}/${CRITERIA.length}`}
-        </Typography>
-        <IconButton
-          size="small"
-          aria-label={expanded ? "Collapse data quality" : "Expand data quality"}
-          sx={{
-            p: 0.25,
-            transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
-            transition: (theme) => theme.transitions.create("transform"),
-          }}
-        >
-          <ExpandMoreIcon fontSize="small" />
-        </IconButton>
-      </Stack>
+        icon={<VerifiedOutlinedIcon fontSize="small" sx={{ color: "primary.main" }} />}
+        title="Data quality"
+        sx={{ mb: expanded ? 1.5 : 0 }}
+        trailing={
+          <>
+            <Typography variant="caption" sx={{ color: "text.secondary" }}>
+              {allMet ? "All criteria met" : `${metCount}/${CRITERIA.length}`}
+            </Typography>
+            <IconButton
+              size="small"
+              aria-label={expanded ? "Collapse data quality" : "Expand data quality"}
+              sx={{
+                p: 0.25,
+                transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+                transition: (theme) => theme.transitions.create("transform"),
+              }}
+            >
+              <ExpandMoreIcon fontSize="small" />
+            </IconButton>
+          </>
+        }
+      />
       <Collapse in={expanded} unmountOnExit>
         <List disablePadding>
           {CRITERIA.map((criterion) => {
@@ -141,6 +134,6 @@ export function DataQualitySection({ issues }: DataQualitySectionProps) {
           })}
         </List>
       </Collapse>
-    </Box>
+    </Section>
   );
 }

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -1,8 +1,9 @@
 import { lazy, Suspense, useState } from "react";
-import { useParams, useNavigate, Link } from "react-router-dom";
+import { useParams, useNavigate } from "react-router-dom";
 import {
   Box,
   Container,
+  Divider,
   Typography,
   Button,
   Stack,
@@ -20,7 +21,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
-import CalendarTodayIcon from "@mui/icons-material/CalendarToday";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
 import NumbersIcon from "@mui/icons-material/Numbers";
 import { getImageUrl } from "../../services/api";
@@ -39,6 +40,7 @@ import { ObservationDetailSkeleton } from "./ObservationDetailSkeleton";
 import { PhotoLightbox } from "./PhotoLightbox";
 import { DataQualitySection } from "./DataQualitySection";
 import { UserCard } from "../common/UserCard";
+import { Section, SectionHeader } from "../common/Section";
 import {
   formatEventDate,
   getPdslsUrl,
@@ -227,8 +229,10 @@ export function ObservationDetail() {
           </Box>
         </Box>
 
-        {/* Species Header */}
-        <Box sx={{ px: 3, pt: 2, pb: 1 }}>
+        {/* Identity header: species, then observer + date with the like
+            control — so what / who / when read as a single block. A divider
+            keeps the taxa title visually distinct from the attribution row. */}
+        <Box sx={{ px: 3, pt: 2, pb: 1.5 }}>
           {species ? (
             <TaxonLink name={species} kingdom={taxonomy?.kingdom} rank={taxonomy?.rank} />
           ) : (
@@ -251,48 +255,52 @@ export function ObservationDetail() {
           )}
         </Box>
 
-        {/* Like button */}
-        <Stack
-          direction="row"
-          sx={{
-            alignItems: "center",
-            px: 3,
-            pb: 1,
-          }}
-        >
+        <Divider sx={{ mx: 3 }} />
+
+        <Stack direction="row" spacing={1} sx={{ alignItems: "center", px: 3, pt: 1.5, pb: 1.5 }}>
+          <UserCard
+            actor={observation.observer}
+            avatarSize={44}
+            spacing={1.5}
+            link
+            showHandle
+            sx={{ flex: 1, minWidth: 0 }}
+            belowName={
+              <Typography variant="caption" sx={{ color: "text.secondary" }}>
+                {observation.eventDate
+                  ? `Observed ${formatEventDate(observation.eventDate)}`
+                  : "Date not recorded"}
+              </Typography>
+            }
+          />
           <Tooltip title={!user ? "Log in to like" : ""}>
             <span>
-              <IconButton
-                size="small"
-                onClick={() =>
-                  like.mutate({ uri: observation.uri, cid: observation.cid, liked: !liked })
-                }
-                disabled={!user}
-                aria-label={liked ? "Unlike" : "Like"}
-                sx={{
-                  color: liked ? "error.main" : "text.disabled",
-                  ml: -0.5,
-                }}
-              >
-                {liked ? (
-                  <FavoriteIcon fontSize="small" />
-                ) : (
-                  <FavoriteBorderIcon fontSize="small" />
+              <Stack direction="row" sx={{ alignItems: "center" }}>
+                <IconButton
+                  size="small"
+                  onClick={() =>
+                    like.mutate({ uri: observation.uri, cid: observation.cid, liked: !liked })
+                  }
+                  disabled={!user}
+                  aria-label={liked ? "Unlike" : "Like"}
+                  sx={{
+                    color: liked ? "error.main" : "text.disabled",
+                  }}
+                >
+                  {liked ? (
+                    <FavoriteIcon fontSize="small" />
+                  ) : (
+                    <FavoriteBorderIcon fontSize="small" />
+                  )}
+                </IconButton>
+                {likeCount > 0 && (
+                  <Typography variant="body2" sx={{ color: "text.secondary", ml: -0.25 }}>
+                    {likeCount}
+                  </Typography>
                 )}
-              </IconButton>
+              </Stack>
             </span>
           </Tooltip>
-          {likeCount > 0 && (
-            <Typography
-              variant="body2"
-              sx={{
-                color: "text.secondary",
-                ml: -0.25,
-              }}
-            >
-              {likeCount}
-            </Typography>
-          )}
         </Stack>
 
         {/* Images */}
@@ -364,195 +372,167 @@ export function ObservationDetail() {
           </Box>
         )}
 
-        {/* Content */}
-        <Box sx={{ p: 3 }}>
-          {/* Observer */}
-          <ListItem
-            component={Link}
-            to={`/profile/${encodeURIComponent(observation.observer.did)}`}
-            sx={{
-              textDecoration: "none",
-              color: "inherit",
-              "&:hover": { bgcolor: "action.hover" },
-              mx: -2,
-              borderRadius: 1,
-            }}
-          >
-            <UserCard actor={observation.observer} avatarSize={40} spacing={2} showHandle />
-          </ListItem>
-
-          {/* Observation Details */}
-          <List disablePadding sx={{ mt: 1 }}>
-            <ListItem disableGutters alignItems="flex-start">
-              <ListItemIcon sx={{ minWidth: 36, mt: 0.5 }}>
-                <CalendarTodayIcon sx={{ fontSize: 18, color: "text.secondary" }} />
-              </ListItemIcon>
-              <ListItemText
-                primary="Observed"
-                secondary={observation.eventDate ? formatEventDate(observation.eventDate) : "—"}
-                slotProps={{
-                  primary: { variant: "caption", color: "text.secondary" },
-                  secondary: { variant: "body1", color: "text.primary" },
-                }}
+        {/* Content: a uniform vertical stack of peer sections. */}
+        <Box sx={{ p: { xs: 2, sm: 3 } }}>
+          <Stack spacing={2.5}>
+            {/* Details */}
+            <Section>
+              <SectionHeader
+                icon={<InfoOutlinedIcon fontSize="small" sx={{ color: "primary.main" }} />}
+                title="Details"
+                sx={{ mb: 1.5 }}
               />
-            </ListItem>
-
-            {observation.organismQuantity && (
-              <ListItem disableGutters alignItems="flex-start">
-                <ListItemIcon sx={{ minWidth: 36, mt: 0.5 }}>
-                  <NumbersIcon sx={{ fontSize: 18, color: "text.secondary" }} />
-                </ListItemIcon>
-                <ListItemText
-                  primary="Quantity"
-                  secondary={
-                    <>
-                      {observation.organismQuantity}
-                      {observation.organismQuantityType && (
-                        <Typography
-                          component="span"
-                          variant="body2"
-                          sx={{ color: "text.disabled" }}
-                        >
-                          {" "}
-                          ({observation.organismQuantityType.replace(/-/g, " ")})
-                        </Typography>
-                      )}
-                    </>
-                  }
-                  slotProps={{
-                    primary: { variant: "caption", color: "text.secondary" },
-                    secondary: {
-                      variant: "body1",
-                      color: "text.primary",
-                      component: "div",
-                    },
-                  }}
-                />
-              </ListItem>
-            )}
-
-            <ListItem disableGutters alignItems="flex-start">
-              <ListItemIcon sx={{ minWidth: 36, mt: 0.5 }}>
-                <MyLocationIcon sx={{ fontSize: 18, color: "text.secondary" }} />
-              </ListItemIcon>
-              <ListItemText
-                primary="Coordinates"
-                secondary={
-                  observation.location ? (
-                    <>
-                      {observation.location.latitude.toFixed(5)},{" "}
-                      {observation.location.longitude.toFixed(5)}
-                      {observation.location.uncertaintyMeters && (
-                        <Typography
-                          component="span"
-                          variant="body2"
-                          sx={{
-                            color: "text.disabled",
-                          }}
-                        >
-                          {" "}
-                          (±{observation.location.uncertaintyMeters}m)
-                        </Typography>
-                      )}
-                    </>
-                  ) : (
-                    "—"
-                  )
-                }
-                slotProps={{
-                  primary: { variant: "caption", color: "text.secondary" },
-                  secondary: {
-                    variant: "body1",
-                    color: "text.primary",
-                    component: "div",
-                  },
-                }}
-              />
-            </ListItem>
-            {observation.location && (
-              <Box sx={{ ml: 4.5, mb: 1 }}>
-                <Suspense fallback={<Box sx={{ height: 180 }} />}>
-                  <LocationMap
-                    latitude={observation.location.latitude}
-                    longitude={observation.location.longitude}
-                    uncertaintyMeters={observation.location.uncertaintyMeters}
-                  />
-                </Suspense>
-              </Box>
-            )}
-          </List>
-
-          {/* Data Quality */}
-          <Box sx={{ mt: 3 }}>
-            <DataQualitySection issues={observation.qualityIssues} />
-          </Box>
-
-          <Box sx={{ mt: 3 }}>
-            {/* Identification History */}
-            <Box sx={{ mt: 2 }}>
-              <IdentificationHistory
-                identifications={identifications}
-                kingdom={taxonomy?.kingdom}
-                currentUserDid={user?.did}
-                onDeleteIdentification={async (uri) => {
-                  if (!atUri) return;
-                  try {
-                    await deleteId.mutateAsync({ uri, occurrenceUri: atUri });
-                    toast.success("Identification deleted");
-                  } catch (error) {
-                    const message = getErrorMessage(error, "Failed to delete identification");
-                    toast.error(message);
-                    if (message.includes("Session expired")) {
-                      dispatch(checkAuth());
-                    }
-                    throw error;
-                  }
-                }}
-                observerDid={observation.observer.did}
-                footer={
-                  user ? (
-                    <IdentificationPanel
-                      observation={{
-                        uri: observation.uri,
-                        cid: observation.cid,
-                        scientificName: taxonomy?.scientificName,
-                        communityId: observation.communityId,
-                        kingdom: taxonomy?.kingdom,
-                        rank: taxonomy?.rank,
-                      }}
-                      imageUrl={
-                        observation.images[0] != null
-                          ? getImageUrl(observation.images[0].url)
-                          : undefined
+              <List disablePadding>
+                {observation.organismQuantity && (
+                  <ListItem disableGutters alignItems="flex-start">
+                    <ListItemIcon sx={{ minWidth: 36, mt: 0.5 }}>
+                      <NumbersIcon sx={{ fontSize: 18, color: "text.secondary" }} />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary="Quantity"
+                      secondary={
+                        <>
+                          {observation.organismQuantity}
+                          {observation.organismQuantityType && (
+                            <Typography
+                              component="span"
+                              variant="body2"
+                              sx={{ color: "text.disabled" }}
+                            >
+                              {" "}
+                              ({observation.organismQuantityType.replace(/-/g, " ")})
+                            </Typography>
+                          )}
+                        </>
                       }
-                      latitude={observation.location?.latitude}
-                      longitude={observation.location?.longitude}
-                    />
-                  ) : (
-                    <Typography
-                      variant="body2"
-                      sx={{
-                        color: "text.secondary",
-                        mt: 2,
-                        textAlign: "center",
+                      slotProps={{
+                        primary: { variant: "caption", color: "text.secondary" },
+                        secondary: {
+                          variant: "body1",
+                          color: "text.primary",
+                          component: "div",
+                        },
                       }}
-                    >
-                      Log in to add an identification
-                    </Typography>
-                  )
-                }
-              />
-            </Box>
-          </Box>
+                    />
+                  </ListItem>
+                )}
 
-          {/* Discussion / Comments */}
-          <Box sx={{ mt: 3 }}>
+                <ListItem disableGutters alignItems="flex-start">
+                  <ListItemIcon sx={{ minWidth: 36, mt: 0.5 }}>
+                    <MyLocationIcon sx={{ fontSize: 18, color: "text.secondary" }} />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Coordinates"
+                    secondary={
+                      observation.location ? (
+                        <>
+                          {observation.location.latitude.toFixed(5)},{" "}
+                          {observation.location.longitude.toFixed(5)}
+                          {observation.location.uncertaintyMeters && (
+                            <Typography
+                              component="span"
+                              variant="body2"
+                              sx={{
+                                color: "text.disabled",
+                              }}
+                            >
+                              {" "}
+                              (±{observation.location.uncertaintyMeters}m)
+                            </Typography>
+                          )}
+                        </>
+                      ) : (
+                        "—"
+                      )
+                    }
+                    slotProps={{
+                      primary: { variant: "caption", color: "text.secondary" },
+                      secondary: {
+                        variant: "body1",
+                        color: "text.primary",
+                        component: "div",
+                      },
+                    }}
+                  />
+                </ListItem>
+                {observation.location && (
+                  <Box sx={{ mt: 1 }}>
+                    <Suspense fallback={<Box sx={{ height: 180 }} />}>
+                      <LocationMap
+                        latitude={observation.location.latitude}
+                        longitude={observation.location.longitude}
+                        uncertaintyMeters={observation.location.uncertaintyMeters}
+                      />
+                    </Suspense>
+                  </Box>
+                )}
+              </List>
+            </Section>
+
+            {/* Data Quality */}
+            <DataQualitySection issues={observation.qualityIssues} />
+
+            {/* Identification History */}
+            <IdentificationHistory
+              identifications={identifications}
+              kingdom={taxonomy?.kingdom}
+              currentUserDid={user?.did}
+              onDeleteIdentification={async (uri) => {
+                if (!atUri) return;
+                try {
+                  await deleteId.mutateAsync({ uri, occurrenceUri: atUri });
+                  toast.success("Identification deleted");
+                } catch (error) {
+                  const message = getErrorMessage(error, "Failed to delete identification");
+                  toast.error(message);
+                  if (message.includes("Session expired")) {
+                    dispatch(checkAuth());
+                  }
+                  throw error;
+                }
+              }}
+              observerDid={observation.observer.did}
+              footer={
+                user ? (
+                  <IdentificationPanel
+                    observation={{
+                      uri: observation.uri,
+                      cid: observation.cid,
+                      scientificName: taxonomy?.scientificName,
+                      communityId: observation.communityId,
+                      kingdom: taxonomy?.kingdom,
+                      rank: taxonomy?.rank,
+                    }}
+                    imageUrl={
+                      observation.images[0] != null
+                        ? getImageUrl(observation.images[0].url)
+                        : undefined
+                    }
+                    latitude={observation.location?.latitude}
+                    longitude={observation.location?.longitude}
+                  />
+                ) : (
+                  <Typography
+                    variant="body2"
+                    sx={{
+                      color: "text.secondary",
+                      mt: 2,
+                      textAlign: "center",
+                    }}
+                  >
+                    Log in to add an identification
+                  </Typography>
+                )
+              }
+            />
+
+            {/* Discussion / Comments */}
             <CommentSection
               observationUri={observation.uri}
               observationCid={observation.cid}
               comments={comments}
             />
-          </Box>
+          </Stack>
         </Box>
       </Container>
 

--- a/frontend/src/components/observation/ObservationDetailSkeleton.tsx
+++ b/frontend/src/components/observation/ObservationDetailSkeleton.tsx
@@ -1,4 +1,4 @@
-import { Box, Skeleton } from "@mui/material";
+import { Box, Divider, Skeleton } from "@mui/material";
 
 /**
  * Skeleton loader matching observation detail page layout
@@ -21,50 +21,31 @@ export function ObservationDetailSkeleton() {
       </Box>
 
       {/* Species header */}
-      <Box sx={{ px: 3, pt: 2, pb: 1 }}>
+      <Box sx={{ px: 3, pt: 2, pb: 1.5 }}>
         <Skeleton variant="text" width="40%" height={32} />
         <Skeleton variant="text" width="25%" height={20} />
       </Box>
 
-      {/* Like button */}
-      <Box sx={{ px: 3, pb: 1 }}>
+      <Divider sx={{ mx: 3 }} />
+
+      {/* Observer + date with like control */}
+      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, px: 3, pt: 1.5, pb: 1.5 }}>
+        <Skeleton variant="circular" width={44} height={44} />
+        <Box sx={{ flex: 1 }}>
+          <Skeleton variant="text" width={120} height={20} />
+          <Skeleton variant="text" width={140} height={16} />
+        </Box>
         <Skeleton variant="circular" width={28} height={28} />
       </Box>
 
       {/* Image */}
       <Skeleton variant="rectangular" height={400} sx={{ width: "100%", bgcolor: "grey.800" }} />
 
-      {/* Content */}
-      <Box sx={{ p: 3 }}>
-        {/* Observer */}
-        <Box sx={{ display: "flex", alignItems: "center", gap: 2, mx: -2, px: 2, py: 1 }}>
-          <Skeleton variant="circular" width={40} height={40} />
-          <Box>
-            <Skeleton variant="text" width={120} height={20} />
-            <Skeleton variant="text" width={80} height={16} />
-          </Box>
-        </Box>
-
-        {/* Details as list items */}
-        <Box sx={{ mt: 1 }}>
-          {[1, 2, 3].map((i) => (
-            <Box key={i} sx={{ display: "flex", alignItems: "flex-start", py: 0.75 }}>
-              <Box sx={{ minWidth: 36, mt: 0.5 }}>
-                <Skeleton variant="circular" width={18} height={18} />
-              </Box>
-              <Box>
-                <Skeleton variant="text" width={60} height={14} />
-                <Skeleton variant="text" width={i === 2 ? 180 : 140} height={20} />
-              </Box>
-            </Box>
-          ))}
-        </Box>
-
-        {/* Map */}
-        <Skeleton variant="rectangular" height={200} sx={{ borderRadius: 2, ml: 4.5, mb: 1 }} />
-
-        {/* Identification section */}
-        <Skeleton variant="rectangular" height={100} sx={{ borderRadius: 2, mt: 3 }} />
+      {/* Content: uniform section cards */}
+      <Box sx={{ p: { xs: 2, sm: 3 }, display: "flex", flexDirection: "column", gap: 2.5 }}>
+        <Skeleton variant="rectangular" height={220} sx={{ borderRadius: 2 }} />
+        <Skeleton variant="rectangular" height={56} sx={{ borderRadius: 2 }} />
+        <Skeleton variant="rectangular" height={120} sx={{ borderRadius: 2 }} />
       </Box>
     </Box>
   );

--- a/frontend/tests/observation-detail.spec.ts
+++ b/frontend/tests/observation-detail.spec.ts
@@ -40,10 +40,8 @@ test.describe("Observation Detail - Display", () => {
   // TC-DETAIL-004: Identification history section
   test("shows identification history section", async ({ page }) => {
     await navigateToDetail(page);
-    // Shows either the heading (when IDs exist) or the empty-state prompt
-    const heading = page.getByText("Identification History");
-    const emptyState = page.getByText("No identifications yet");
-    await expect(heading.or(emptyState)).toBeVisible();
+    // The section header renders regardless of whether any IDs exist.
+    await expect(page.getByRole("heading", { name: "Identification History" })).toBeVisible();
   });
 
   // TC-DETAIL-005: Discussion section


### PR DESCRIPTION
## What

Refreshes the single-observation detail view. The information above and below
the media was disorganized — attribution was split around the photo and the
below-media sections each had their own visual language.

### Changes
- **Identity header above the media:** species title → observer + observed
  date (moved up) → like control anchored on the attribution row. A hairline
  divider separates the taxa title from the author row so they read as
  distinct sections while staying grouped as one "what / who / when" block.
- **Unified sections:** new shared `Section` / `SectionHeader`
  (`components/common/Section.tsx`) defines the bordered-card + icon-header
  styling once. **Details** is now a `Section`; **Data quality**,
  **Identification history**, and **Discussion** were migrated onto it,
  removing three separately-styled `Paper` blocks. They now render as a
  uniform vertical stack of peer cards.
- **Skeleton** updated to match (observer above the image, uniform section
  cards, matching divider).

## Test plan
- `oxfmt`, `oxlint`, `tsc --noEmit`, and `check-stories` all pass.
- Manually verified in the running app against a populated observation
  (species, multi-photo media, two identifications, a comment, mixed
  data-quality) — header grouping, divider, and the unified section cards all
  render as intended.
