### PR TITLE
refactor(wikidata-client): use published sparqling crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,12 +4375,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "sparql-client"
+name = "sparqling"
 version = "0.1.0"
-source = "git+https://github.com/observ-ing/sparql-client?rev=2d2e9818e7ac84b886aac0464f92cd9e968d9fa0#2d2e9818e7ac84b886aac0464f92cd9e968d9fa0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2c634fbb030e7e5ede42e3332cb06b47f064f1baff51c8d7968a2a7476adcb"
 dependencies = [
  "reqwest 0.13.4",
  "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -5531,7 +5534,7 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 name = "wikidata-client"
 version = "0.1.0"
 dependencies = [
- "sparql-client",
+ "sparqling",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5534,6 +5534,7 @@ checksum = "72069c3113ab32ab29e5584db3c6ec55d416895e60715417b5b883a357c3e471"
 name = "wikidata-client"
 version = "0.1.0"
 dependencies = [
+ "serde",
  "sparqling",
  "tracing",
 ]

--- a/crates/wikidata-client/Cargo.toml
+++ b/crates/wikidata-client/Cargo.toml
@@ -6,8 +6,8 @@ description = "Rust client for the Wikidata SPARQL API"
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-# Generic SPARQL-over-HTTP client
-sparql-client = { git = "https://github.com/observ-ing/sparql-client", rev = "2d2e9818e7ac84b886aac0464f92cd9e968d9fa0" }
+# Generic SPARQL-over-HTTP client (published crate; imported as `sparql_client`)
+sparqling = "0.1"
 
 # Logging
 tracing = { workspace = true }

--- a/crates/wikidata-client/Cargo.toml
+++ b/crates/wikidata-client/Cargo.toml
@@ -9,5 +9,8 @@ license = "MIT OR Apache-2.0"
 # Generic SPARQL-over-HTTP client (published crate; imported as `sparql_client`)
 sparqling = "0.1"
 
+# Deserializing SPARQL result rows into typed structs
+serde = { workspace = true }
+
 # Logging
 tracing = { workspace = true }

--- a/crates/wikidata-client/src/lib.rs
+++ b/crates/wikidata-client/src/lib.rs
@@ -18,6 +18,7 @@
 //! # }
 //! ```
 
+use serde::Deserialize;
 use sparql_client::{escape_literal, SparqlClient};
 use std::collections::HashMap;
 use tracing::warn;
@@ -88,26 +89,30 @@ impl WikidataClient {
 }}",
         );
 
-        let bindings = match self.client.sparql_query(&query).await {
-            Ok(b) => b,
+        /// One `(external_id, item)` row; both are always bound by the query.
+        #[derive(Deserialize)]
+        struct Row {
+            external_id: String,
+            item: String,
+        }
+
+        let rows: Vec<Row> = match self.client.query_into(&query).await {
+            Ok(r) => r,
             Err(e) => {
                 warn!(error = ?e, "Wikidata entity lookup failed");
                 return HashMap::new();
             }
         };
 
-        let mut result = HashMap::new();
-        for binding in bindings {
-            if let (Some(id), Some(item)) = (binding.get("external_id"), binding.get("item")) {
-                let url = item.value.replace(
+        rows.into_iter()
+            .map(|row| {
+                let url = row.item.replace(
                     "http://www.wikidata.org/entity/",
                     "https://www.wikidata.org/wiki/",
                 );
-                result.insert(id.value.clone(), url);
-            }
-        }
-
-        result
+                (row.external_id, url)
+            })
+            .collect()
     }
 
     /// Cross-walk an external taxon identifier to a GBIF backbone usage key.
@@ -162,7 +167,7 @@ impl WikidataClient {
         bindings
             .first()
             .and_then(|b| b.get("gbif"))
-            .and_then(|v| v.value.parse::<i64>().ok())
+            .and_then(|v| v.as_i64())
     }
 
     /// Fetch images (Wikidata property P18) for items matching external IDs.
@@ -203,23 +208,28 @@ impl WikidataClient {
 }} GROUP BY ?external_id",
         );
 
-        let bindings = match self.client.sparql_query(&query).await {
-            Ok(b) => b,
+        /// One result row. `image` is `OPTIONAL` in the query, so it may be
+        /// unbound — `Option` maps an absent variable to `None`.
+        #[derive(Deserialize)]
+        struct Row {
+            external_id: String,
+            image: Option<String>,
+        }
+
+        let rows: Vec<Row> = match self.client.query_into(&query).await {
+            Ok(r) => r,
             Err(e) => {
                 warn!(error = ?e, "Wikidata image lookup failed");
                 return HashMap::new();
             }
         };
 
-        let mut result = HashMap::new();
-        for binding in bindings {
-            if let (Some(id), Some(image)) = (binding.get("external_id"), binding.get("image")) {
-                let thumb_url = to_thumbnail_url(&image.value, thumbnail_width);
-                result.insert(id.value.clone(), thumb_url);
-            }
-        }
-
-        result
+        rows.into_iter()
+            .filter_map(|row| {
+                let image = row.image?;
+                Some((row.external_id, to_thumbnail_url(&image, thumbnail_width)))
+            })
+            .collect()
     }
 }
 


### PR DESCRIPTION
## Summary

Adopt the newly-published [`sparqling` v0.1.0](https://crates.io/crates/sparqling) crate in `wikidata-client`, in two steps:

**1. Switch to the registry crate.** Replace the pinned git dependency with `sparqling = "0.1"`. `Cargo.lock` now resolves it from crates.io (with checksum); the git source is dropped. No code change for this step — the crate's `[lib] name` is `sparql_client`, so `use sparql_client::…` is unchanged.

**2. Use the strong-typing features.** The three lookup methods hand-pulled `.value` strings out of `binding.get("…")`. Now:
- `get_entities_by_property` / `get_images_by_property` use `query_into::<T>()` to deserialize each row into a local struct. The image column is `OPTIONAL`, so it deserializes to `Option<String>` (absent variable → `None`).
- `first_gbif_key` uses the `SparqlValue::as_i64()` accessor instead of `v.value.parse::<i64>()`.

Adds a `serde` dependency for the row structs.

## Verification

`cargo check --workspace`, `cargo test -p wikidata-client`, `cargo clippy -p wikidata-client --all-targets`, and `cargo fmt --check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)