### PR TITLE
ci: install jacquard-lexgen from upstream crates.io

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,8 +297,8 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: rustfmt
-      - name: Install jacquard-codegen from fork (deterministic field ordering fix)
-        run: RUSTFLAGS="" cargo install --git https://tangled.org/rwell.org/jacquard.git --branch fix-builder-determinism jacquard-lexgen
+      - name: Install jacquard-lexgen
+        run: RUSTFLAGS="" cargo install jacquard-lexgen --version 0.12.1 --locked
       - name: Check generated lexicon types are up to date
         run: |
           ./scripts/generate-rust-types.sh

--- a/crates/observing-lexicons/src/bio_lexicons.rs
+++ b/crates/observing-lexicons/src/bio_lexicons.rs
@@ -3,4 +3,5 @@
 // This file was automatically generated from Lexicon schemas.
 // Any manual changes will be overwritten on the next regeneration.
 
+//! Generated bindings for the `bio.lexicons` Lexicon namespace/module.
 pub mod temp;

--- a/crates/observing-lexicons/src/bio_lexicons/temp.rs
+++ b/crates/observing-lexicons/src/bio_lexicons/temp.rs
@@ -3,4 +3,5 @@
 // This file was automatically generated from Lexicon schemas.
 // Any manual changes will be overwritten on the next regeneration.
 
+//! Generated bindings for the `bio.lexicons.temp` Lexicon namespace/module.
 pub mod v0_1;

--- a/crates/observing-lexicons/src/bio_lexicons/temp/v0_1.rs
+++ b/crates/observing-lexicons/src/bio_lexicons/temp/v0_1.rs
@@ -3,6 +3,7 @@
 // This file was automatically generated from Lexicon schemas.
 // Any manual changes will be overwritten on the next regeneration.
 
+//! Generated bindings for the `bio.lexicons.temp.v0.1` Lexicon namespace/module.
 pub mod identification;
 pub mod media;
 pub mod occurrence;

--- a/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/identification.rs
+++ b/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/identification.rs
@@ -314,7 +314,7 @@ pub mod identification_state {
 }
 
 /// Builder for constructing an instance of this type.
-pub struct IdentificationBuilder<S: BosStr, St: identification_state::State> {
+pub struct IdentificationBuilder<St: identification_state::State, S: BosStr = DefaultStr> {
     _state: PhantomData<fn() -> St>,
     _fields: (
         Option<S>,
@@ -327,15 +327,22 @@ pub struct IdentificationBuilder<S: BosStr, St: identification_state::State> {
     _type: PhantomData<fn() -> S>,
 }
 
-impl<S: BosStr> Identification<S> {
-    /// Create a new builder for this type.
-    pub fn new() -> IdentificationBuilder<S, identification_state::Empty> {
+impl Identification<DefaultStr> {
+    /// Create a new builder for this type, using the default string type (DefaultStr = SmolStr) if needed
+    pub fn new() -> IdentificationBuilder<identification_state::Empty, DefaultStr> {
         IdentificationBuilder::new()
     }
 }
 
-impl<S: BosStr> IdentificationBuilder<S, identification_state::Empty> {
-    /// Create a new builder with all fields unset.
+impl<S: BosStr> Identification<S> {
+    /// Create a new builder for this type
+    pub fn builder() -> IdentificationBuilder<identification_state::Empty, S> {
+        IdentificationBuilder::builder()
+    }
+}
+
+impl IdentificationBuilder<identification_state::Empty, DefaultStr> {
+    /// Create a new builder with all fields unset, using the default string type, if needed
     pub fn new() -> Self {
         IdentificationBuilder {
             _state: PhantomData,
@@ -345,7 +352,18 @@ impl<S: BosStr> IdentificationBuilder<S, identification_state::Empty> {
     }
 }
 
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
+impl<S: BosStr> IdentificationBuilder<identification_state::Empty, S> {
+    /// Create a new builder with all fields unset
+    pub fn builder() -> Self {
+        IdentificationBuilder {
+            _state: PhantomData,
+            _fields: (None, None, None, None, None, None),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<St: identification_state::State, S: BosStr> IdentificationBuilder<St, S> {
     /// Set the `identificationRemarks` field (optional)
     pub fn identification_remarks(mut self, value: impl Into<Option<S>>) -> Self {
         self._fields.0 = value.into();
@@ -358,7 +376,7 @@ impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
+impl<St: identification_state::State, S: BosStr> IdentificationBuilder<St, S> {
     /// Set the `kingdom` field (optional)
     pub fn kingdom(mut self, value: impl Into<Option<S>>) -> Self {
         self._fields.1 = value.into();
@@ -371,7 +389,7 @@ impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St> IdentificationBuilder<S, St>
+impl<St, S: BosStr> IdentificationBuilder<St, S>
 where
     St: identification_state::State,
     St::Occurrence: identification_state::IsUnset,
@@ -380,7 +398,7 @@ where
     pub fn occurrence(
         mut self,
         value: impl Into<StrongRef<S>>,
-    ) -> IdentificationBuilder<S, identification_state::SetOccurrence<St>> {
+    ) -> IdentificationBuilder<identification_state::SetOccurrence<St>, S> {
         self._fields.2 = Option::Some(value.into());
         IdentificationBuilder {
             _state: PhantomData,
@@ -390,7 +408,7 @@ where
     }
 }
 
-impl<S: BosStr, St> IdentificationBuilder<S, St>
+impl<St, S: BosStr> IdentificationBuilder<St, S>
 where
     St: identification_state::State,
     St::ScientificName: identification_state::IsUnset,
@@ -399,7 +417,7 @@ where
     pub fn scientific_name(
         mut self,
         value: impl Into<S>,
-    ) -> IdentificationBuilder<S, identification_state::SetScientificName<St>> {
+    ) -> IdentificationBuilder<identification_state::SetScientificName<St>, S> {
         self._fields.3 = Option::Some(value.into());
         IdentificationBuilder {
             _state: PhantomData,
@@ -409,7 +427,7 @@ where
     }
 }
 
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
+impl<St: identification_state::State, S: BosStr> IdentificationBuilder<St, S> {
     /// Set the `taxonID` field (optional)
     pub fn taxon_id(mut self, value: impl Into<Option<UriValue<S>>>) -> Self {
         self._fields.4 = value.into();
@@ -422,7 +440,7 @@ impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
+impl<St: identification_state::State, S: BosStr> IdentificationBuilder<St, S> {
     /// Set the `taxonRank` field (optional)
     pub fn taxon_rank(mut self, value: impl Into<Option<IdentificationTaxonRank<S>>>) -> Self {
         self._fields.5 = value.into();
@@ -435,7 +453,7 @@ impl<S: BosStr, St: identification_state::State> IdentificationBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St> IdentificationBuilder<S, St>
+impl<St, S: BosStr> IdentificationBuilder<St, S>
 where
     St: identification_state::State,
     St::Occurrence: identification_state::IsSet,

--- a/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/media.rs
+++ b/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/media.rs
@@ -358,21 +358,28 @@ pub mod aspect_ratio_state {
 }
 
 /// Builder for constructing an instance of this type.
-pub struct AspectRatioBuilder<S: BosStr, St: aspect_ratio_state::State> {
+pub struct AspectRatioBuilder<St: aspect_ratio_state::State, S: BosStr = DefaultStr> {
     _state: PhantomData<fn() -> St>,
     _fields: (Option<i64>, Option<i64>),
     _type: PhantomData<fn() -> S>,
 }
 
-impl<S: BosStr> AspectRatio<S> {
-    /// Create a new builder for this type.
-    pub fn new() -> AspectRatioBuilder<S, aspect_ratio_state::Empty> {
+impl AspectRatio<DefaultStr> {
+    /// Create a new builder for this type, using the default string type (DefaultStr = SmolStr) if needed
+    pub fn new() -> AspectRatioBuilder<aspect_ratio_state::Empty, DefaultStr> {
         AspectRatioBuilder::new()
     }
 }
 
-impl<S: BosStr> AspectRatioBuilder<S, aspect_ratio_state::Empty> {
-    /// Create a new builder with all fields unset.
+impl<S: BosStr> AspectRatio<S> {
+    /// Create a new builder for this type
+    pub fn builder() -> AspectRatioBuilder<aspect_ratio_state::Empty, S> {
+        AspectRatioBuilder::builder()
+    }
+}
+
+impl AspectRatioBuilder<aspect_ratio_state::Empty, DefaultStr> {
+    /// Create a new builder with all fields unset, using the default string type, if needed
     pub fn new() -> Self {
         AspectRatioBuilder {
             _state: PhantomData,
@@ -382,7 +389,18 @@ impl<S: BosStr> AspectRatioBuilder<S, aspect_ratio_state::Empty> {
     }
 }
 
-impl<S: BosStr, St> AspectRatioBuilder<S, St>
+impl<S: BosStr> AspectRatioBuilder<aspect_ratio_state::Empty, S> {
+    /// Create a new builder with all fields unset
+    pub fn builder() -> Self {
+        AspectRatioBuilder {
+            _state: PhantomData,
+            _fields: (None, None),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<St, S: BosStr> AspectRatioBuilder<St, S>
 where
     St: aspect_ratio_state::State,
     St::Height: aspect_ratio_state::IsUnset,
@@ -391,7 +409,7 @@ where
     pub fn height(
         mut self,
         value: impl Into<i64>,
-    ) -> AspectRatioBuilder<S, aspect_ratio_state::SetHeight<St>> {
+    ) -> AspectRatioBuilder<aspect_ratio_state::SetHeight<St>, S> {
         self._fields.0 = Option::Some(value.into());
         AspectRatioBuilder {
             _state: PhantomData,
@@ -401,7 +419,7 @@ where
     }
 }
 
-impl<S: BosStr, St> AspectRatioBuilder<S, St>
+impl<St, S: BosStr> AspectRatioBuilder<St, S>
 where
     St: aspect_ratio_state::State,
     St::Width: aspect_ratio_state::IsUnset,
@@ -410,7 +428,7 @@ where
     pub fn width(
         mut self,
         value: impl Into<i64>,
-    ) -> AspectRatioBuilder<S, aspect_ratio_state::SetWidth<St>> {
+    ) -> AspectRatioBuilder<aspect_ratio_state::SetWidth<St>, S> {
         self._fields.1 = Option::Some(value.into());
         AspectRatioBuilder {
             _state: PhantomData,
@@ -420,7 +438,7 @@ where
     }
 }
 
-impl<S: BosStr, St> AspectRatioBuilder<S, St>
+impl<St, S: BosStr> AspectRatioBuilder<St, S>
 where
     St: aspect_ratio_state::State,
     St::Height: aspect_ratio_state::IsSet,
@@ -581,7 +599,7 @@ pub mod media_state {
 }
 
 /// Builder for constructing an instance of this type.
-pub struct MediaBuilder<S: BosStr, St: media_state::State> {
+pub struct MediaBuilder<St: media_state::State, S: BosStr = DefaultStr> {
     _state: PhantomData<fn() -> St>,
     _fields: (
         Option<S>,
@@ -592,15 +610,22 @@ pub struct MediaBuilder<S: BosStr, St: media_state::State> {
     _type: PhantomData<fn() -> S>,
 }
 
-impl<S: BosStr> Media<S> {
-    /// Create a new builder for this type.
-    pub fn new() -> MediaBuilder<S, media_state::Empty> {
+impl Media<DefaultStr> {
+    /// Create a new builder for this type, using the default string type (DefaultStr = SmolStr) if needed
+    pub fn new() -> MediaBuilder<media_state::Empty, DefaultStr> {
         MediaBuilder::new()
     }
 }
 
-impl<S: BosStr> MediaBuilder<S, media_state::Empty> {
-    /// Create a new builder with all fields unset.
+impl<S: BosStr> Media<S> {
+    /// Create a new builder for this type
+    pub fn builder() -> MediaBuilder<media_state::Empty, S> {
+        MediaBuilder::builder()
+    }
+}
+
+impl MediaBuilder<media_state::Empty, DefaultStr> {
+    /// Create a new builder with all fields unset, using the default string type, if needed
     pub fn new() -> Self {
         MediaBuilder {
             _state: PhantomData,
@@ -610,7 +635,18 @@ impl<S: BosStr> MediaBuilder<S, media_state::Empty> {
     }
 }
 
-impl<S: BosStr, St: media_state::State> MediaBuilder<S, St> {
+impl<S: BosStr> MediaBuilder<media_state::Empty, S> {
+    /// Create a new builder with all fields unset
+    pub fn builder() -> Self {
+        MediaBuilder {
+            _state: PhantomData,
+            _fields: (None, None, None, None),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<St: media_state::State, S: BosStr> MediaBuilder<St, S> {
     /// Set the `alt` field (optional)
     pub fn alt(mut self, value: impl Into<Option<S>>) -> Self {
         self._fields.0 = value.into();
@@ -623,7 +659,7 @@ impl<S: BosStr, St: media_state::State> MediaBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: media_state::State> MediaBuilder<S, St> {
+impl<St: media_state::State, S: BosStr> MediaBuilder<St, S> {
     /// Set the `aspectRatio` field (optional)
     pub fn aspect_ratio(mut self, value: impl Into<Option<media::AspectRatio<S>>>) -> Self {
         self._fields.1 = value.into();
@@ -636,7 +672,7 @@ impl<S: BosStr, St: media_state::State> MediaBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St> MediaBuilder<S, St>
+impl<St, S: BosStr> MediaBuilder<St, S>
 where
     St: media_state::State,
     St::Image: media_state::IsUnset,
@@ -645,7 +681,7 @@ where
     pub fn image(
         mut self,
         value: impl Into<BlobRef<S>>,
-    ) -> MediaBuilder<S, media_state::SetImage<St>> {
+    ) -> MediaBuilder<media_state::SetImage<St>, S> {
         self._fields.2 = Option::Some(value.into());
         MediaBuilder {
             _state: PhantomData,
@@ -655,7 +691,7 @@ where
     }
 }
 
-impl<S: BosStr, St: media_state::State> MediaBuilder<S, St> {
+impl<St: media_state::State, S: BosStr> MediaBuilder<St, S> {
     /// Set the `license` field (optional)
     pub fn license(mut self, value: impl Into<Option<MediaLicense<S>>>) -> Self {
         self._fields.3 = value.into();
@@ -668,7 +704,7 @@ impl<S: BosStr, St: media_state::State> MediaBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St> MediaBuilder<S, St>
+impl<St, S: BosStr> MediaBuilder<St, S>
 where
     St: media_state::State,
     St::Image: media_state::IsSet,

--- a/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/occurrence.rs
+++ b/crates/observing-lexicons/src/bio_lexicons/temp/v0_1/occurrence.rs
@@ -252,7 +252,7 @@ pub mod occurrence_state {
 }
 
 /// Builder for constructing an instance of this type.
-pub struct OccurrenceBuilder<S: BosStr, St: occurrence_state::State> {
+pub struct OccurrenceBuilder<St: occurrence_state::State, S: BosStr = DefaultStr> {
     _state: PhantomData<fn() -> St>,
     _fields: (
         Option<StrongRef<S>>,
@@ -268,15 +268,22 @@ pub struct OccurrenceBuilder<S: BosStr, St: occurrence_state::State> {
     _type: PhantomData<fn() -> S>,
 }
 
-impl<S: BosStr> Occurrence<S> {
-    /// Create a new builder for this type.
-    pub fn new() -> OccurrenceBuilder<S, occurrence_state::Empty> {
+impl Occurrence<DefaultStr> {
+    /// Create a new builder for this type, using the default string type (DefaultStr = SmolStr) if needed
+    pub fn new() -> OccurrenceBuilder<occurrence_state::Empty, DefaultStr> {
         OccurrenceBuilder::new()
     }
 }
 
-impl<S: BosStr> OccurrenceBuilder<S, occurrence_state::Empty> {
-    /// Create a new builder with all fields unset.
+impl<S: BosStr> Occurrence<S> {
+    /// Create a new builder for this type
+    pub fn builder() -> OccurrenceBuilder<occurrence_state::Empty, S> {
+        OccurrenceBuilder::builder()
+    }
+}
+
+impl OccurrenceBuilder<occurrence_state::Empty, DefaultStr> {
+    /// Create a new builder with all fields unset, using the default string type, if needed
     pub fn new() -> Self {
         OccurrenceBuilder {
             _state: PhantomData,
@@ -286,7 +293,18 @@ impl<S: BosStr> OccurrenceBuilder<S, occurrence_state::Empty> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<S: BosStr> OccurrenceBuilder<occurrence_state::Empty, S> {
+    /// Create a new builder with all fields unset
+    pub fn builder() -> Self {
+        OccurrenceBuilder {
+            _state: PhantomData,
+            _fields: (None, None, None, None, None, None, None, None, None),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `acceptedIdentificationID` field (optional)
     pub fn accepted_identification_id(mut self, value: impl Into<Option<StrongRef<S>>>) -> Self {
         self._fields.0 = value.into();
@@ -299,7 +317,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `coordinateUncertaintyInMeters` field (optional)
     pub fn coordinate_uncertainty_in_meters(mut self, value: impl Into<Option<i64>>) -> Self {
         self._fields.1 = value.into();
@@ -312,7 +330,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `decimalLatitude` field (optional)
     pub fn decimal_latitude(mut self, value: impl Into<Option<S>>) -> Self {
         self._fields.2 = value.into();
@@ -325,7 +343,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `decimalLongitude` field (optional)
     pub fn decimal_longitude(mut self, value: impl Into<Option<S>>) -> Self {
         self._fields.3 = value.into();
@@ -338,7 +356,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `eventDate` field (optional)
     pub fn event_date(mut self, value: impl Into<Option<S>>) -> Self {
         self._fields.4 = value.into();
@@ -351,7 +369,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `media` field (optional)
     pub fn media(mut self, value: impl Into<Option<Vec<StrongRef<S>>>>) -> Self {
         self._fields.5 = value.into();
@@ -364,7 +382,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `organismQuantity` field (optional)
     pub fn organism_quantity(mut self, value: impl Into<Option<S>>) -> Self {
         self._fields.6 = value.into();
@@ -377,7 +395,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `organismQuantityType` field (optional)
     pub fn organism_quantity_type(
         mut self,
@@ -396,7 +414,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
+impl<St: occurrence_state::State, S: BosStr> OccurrenceBuilder<St, S> {
     /// Set the `taxonID` field (optional)
     pub fn taxon_id(mut self, value: impl Into<Option<UriValue<S>>>) -> Self {
         self._fields.8 = value.into();
@@ -409,7 +427,7 @@ impl<S: BosStr, St: occurrence_state::State> OccurrenceBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St> OccurrenceBuilder<S, St>
+impl<St, S: BosStr> OccurrenceBuilder<St, S>
 where
     St: occurrence_state::State,
 {

--- a/crates/observing-lexicons/src/com_atproto.rs
+++ b/crates/observing-lexicons/src/com_atproto.rs
@@ -3,4 +3,5 @@
 // This file was automatically generated from Lexicon schemas.
 // Any manual changes will be overwritten on the next regeneration.
 
+//! Generated bindings for the `com.atproto` Lexicon namespace/module.
 pub mod repo;

--- a/crates/observing-lexicons/src/com_atproto/repo.rs
+++ b/crates/observing-lexicons/src/com_atproto/repo.rs
@@ -3,4 +3,5 @@
 // This file was automatically generated from Lexicon schemas.
 // Any manual changes will be overwritten on the next regeneration.
 
+//! Generated bindings for the `com.atproto.repo` Lexicon namespace/module.
 pub mod strong_ref;

--- a/crates/observing-lexicons/src/com_atproto/repo/strong_ref.rs
+++ b/crates/observing-lexicons/src/com_atproto/repo/strong_ref.rs
@@ -97,21 +97,28 @@ pub mod strong_ref_state {
 }
 
 /// Builder for constructing an instance of this type.
-pub struct StrongRefBuilder<S: BosStr, St: strong_ref_state::State> {
+pub struct StrongRefBuilder<St: strong_ref_state::State, S: BosStr = DefaultStr> {
     _state: PhantomData<fn() -> St>,
     _fields: (Option<Cid<S>>, Option<AtUri<S>>),
     _type: PhantomData<fn() -> S>,
 }
 
-impl<S: BosStr> StrongRef<S> {
-    /// Create a new builder for this type.
-    pub fn new() -> StrongRefBuilder<S, strong_ref_state::Empty> {
+impl StrongRef<DefaultStr> {
+    /// Create a new builder for this type, using the default string type (DefaultStr = SmolStr) if needed
+    pub fn new() -> StrongRefBuilder<strong_ref_state::Empty, DefaultStr> {
         StrongRefBuilder::new()
     }
 }
 
-impl<S: BosStr> StrongRefBuilder<S, strong_ref_state::Empty> {
-    /// Create a new builder with all fields unset.
+impl<S: BosStr> StrongRef<S> {
+    /// Create a new builder for this type
+    pub fn builder() -> StrongRefBuilder<strong_ref_state::Empty, S> {
+        StrongRefBuilder::builder()
+    }
+}
+
+impl StrongRefBuilder<strong_ref_state::Empty, DefaultStr> {
+    /// Create a new builder with all fields unset, using the default string type, if needed
     pub fn new() -> Self {
         StrongRefBuilder {
             _state: PhantomData,
@@ -121,7 +128,18 @@ impl<S: BosStr> StrongRefBuilder<S, strong_ref_state::Empty> {
     }
 }
 
-impl<S: BosStr, St> StrongRefBuilder<S, St>
+impl<S: BosStr> StrongRefBuilder<strong_ref_state::Empty, S> {
+    /// Create a new builder with all fields unset
+    pub fn builder() -> Self {
+        StrongRefBuilder {
+            _state: PhantomData,
+            _fields: (None, None),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<St, S: BosStr> StrongRefBuilder<St, S>
 where
     St: strong_ref_state::State,
     St::Cid: strong_ref_state::IsUnset,
@@ -130,7 +148,7 @@ where
     pub fn cid(
         mut self,
         value: impl Into<Cid<S>>,
-    ) -> StrongRefBuilder<S, strong_ref_state::SetCid<St>> {
+    ) -> StrongRefBuilder<strong_ref_state::SetCid<St>, S> {
         self._fields.0 = Option::Some(value.into());
         StrongRefBuilder {
             _state: PhantomData,
@@ -140,7 +158,7 @@ where
     }
 }
 
-impl<S: BosStr, St> StrongRefBuilder<S, St>
+impl<St, S: BosStr> StrongRefBuilder<St, S>
 where
     St: strong_ref_state::State,
     St::Uri: strong_ref_state::IsUnset,
@@ -149,7 +167,7 @@ where
     pub fn uri(
         mut self,
         value: impl Into<AtUri<S>>,
-    ) -> StrongRefBuilder<S, strong_ref_state::SetUri<St>> {
+    ) -> StrongRefBuilder<strong_ref_state::SetUri<St>, S> {
         self._fields.1 = Option::Some(value.into());
         StrongRefBuilder {
             _state: PhantomData,
@@ -159,7 +177,7 @@ where
     }
 }
 
-impl<S: BosStr, St> StrongRefBuilder<S, St>
+impl<St, S: BosStr> StrongRefBuilder<St, S>
 where
     St: strong_ref_state::State,
     St::Cid: strong_ref_state::IsSet,

--- a/crates/observing-lexicons/src/ing_observ.rs
+++ b/crates/observing-lexicons/src/ing_observ.rs
@@ -3,4 +3,5 @@
 // This file was automatically generated from Lexicon schemas.
 // Any manual changes will be overwritten on the next regeneration.
 
+//! Generated bindings for the `ing.observ` Lexicon namespace/module.
 pub mod temp;

--- a/crates/observing-lexicons/src/ing_observ/temp.rs
+++ b/crates/observing-lexicons/src/ing_observ/temp.rs
@@ -3,6 +3,7 @@
 // This file was automatically generated from Lexicon schemas.
 // Any manual changes will be overwritten on the next regeneration.
 
+//! Generated bindings for the `ing.observ.temp` Lexicon namespace/module.
 pub mod comment;
 pub mod interaction;
 pub mod like;

--- a/crates/observing-lexicons/src/ing_observ/temp/comment.rs
+++ b/crates/observing-lexicons/src/ing_observ/temp/comment.rs
@@ -180,7 +180,7 @@ pub mod comment_state {
 }
 
 /// Builder for constructing an instance of this type.
-pub struct CommentBuilder<S: BosStr, St: comment_state::State> {
+pub struct CommentBuilder<St: comment_state::State, S: BosStr = DefaultStr> {
     _state: PhantomData<fn() -> St>,
     _fields: (
         Option<S>,
@@ -191,15 +191,22 @@ pub struct CommentBuilder<S: BosStr, St: comment_state::State> {
     _type: PhantomData<fn() -> S>,
 }
 
-impl<S: BosStr> Comment<S> {
-    /// Create a new builder for this type.
-    pub fn new() -> CommentBuilder<S, comment_state::Empty> {
+impl Comment<DefaultStr> {
+    /// Create a new builder for this type, using the default string type (DefaultStr = SmolStr) if needed
+    pub fn new() -> CommentBuilder<comment_state::Empty, DefaultStr> {
         CommentBuilder::new()
     }
 }
 
-impl<S: BosStr> CommentBuilder<S, comment_state::Empty> {
-    /// Create a new builder with all fields unset.
+impl<S: BosStr> Comment<S> {
+    /// Create a new builder for this type
+    pub fn builder() -> CommentBuilder<comment_state::Empty, S> {
+        CommentBuilder::builder()
+    }
+}
+
+impl CommentBuilder<comment_state::Empty, DefaultStr> {
+    /// Create a new builder with all fields unset, using the default string type, if needed
     pub fn new() -> Self {
         CommentBuilder {
             _state: PhantomData,
@@ -209,13 +216,24 @@ impl<S: BosStr> CommentBuilder<S, comment_state::Empty> {
     }
 }
 
-impl<S: BosStr, St> CommentBuilder<S, St>
+impl<S: BosStr> CommentBuilder<comment_state::Empty, S> {
+    /// Create a new builder with all fields unset
+    pub fn builder() -> Self {
+        CommentBuilder {
+            _state: PhantomData,
+            _fields: (None, None, None, None),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<St, S: BosStr> CommentBuilder<St, S>
 where
     St: comment_state::State,
     St::Body: comment_state::IsUnset,
 {
     /// Set the `body` field (required)
-    pub fn body(mut self, value: impl Into<S>) -> CommentBuilder<S, comment_state::SetBody<St>> {
+    pub fn body(mut self, value: impl Into<S>) -> CommentBuilder<comment_state::SetBody<St>, S> {
         self._fields.0 = Option::Some(value.into());
         CommentBuilder {
             _state: PhantomData,
@@ -225,7 +243,7 @@ where
     }
 }
 
-impl<S: BosStr, St> CommentBuilder<S, St>
+impl<St, S: BosStr> CommentBuilder<St, S>
 where
     St: comment_state::State,
     St::CreatedAt: comment_state::IsUnset,
@@ -234,7 +252,7 @@ where
     pub fn created_at(
         mut self,
         value: impl Into<Datetime>,
-    ) -> CommentBuilder<S, comment_state::SetCreatedAt<St>> {
+    ) -> CommentBuilder<comment_state::SetCreatedAt<St>, S> {
         self._fields.1 = Option::Some(value.into());
         CommentBuilder {
             _state: PhantomData,
@@ -244,7 +262,7 @@ where
     }
 }
 
-impl<S: BosStr, St: comment_state::State> CommentBuilder<S, St> {
+impl<St: comment_state::State, S: BosStr> CommentBuilder<St, S> {
     /// Set the `replyTo` field (optional)
     pub fn reply_to(mut self, value: impl Into<Option<StrongRef<S>>>) -> Self {
         self._fields.2 = value.into();
@@ -257,7 +275,7 @@ impl<S: BosStr, St: comment_state::State> CommentBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St> CommentBuilder<S, St>
+impl<St, S: BosStr> CommentBuilder<St, S>
 where
     St: comment_state::State,
     St::Subject: comment_state::IsUnset,
@@ -266,7 +284,7 @@ where
     pub fn subject(
         mut self,
         value: impl Into<StrongRef<S>>,
-    ) -> CommentBuilder<S, comment_state::SetSubject<St>> {
+    ) -> CommentBuilder<comment_state::SetSubject<St>, S> {
         self._fields.3 = Option::Some(value.into());
         CommentBuilder {
             _state: PhantomData,
@@ -276,7 +294,7 @@ where
     }
 }
 
-impl<S: BosStr, St> CommentBuilder<S, St>
+impl<St, S: BosStr> CommentBuilder<St, S>
 where
     St: comment_state::State,
     St::Body: comment_state::IsSet,

--- a/crates/observing-lexicons/src/ing_observ/temp/interaction.rs
+++ b/crates/observing-lexicons/src/ing_observ/temp/interaction.rs
@@ -752,7 +752,7 @@ pub mod interaction_state {
 }
 
 /// Builder for constructing an instance of this type.
-pub struct InteractionBuilder<S: BosStr, St: interaction_state::State> {
+pub struct InteractionBuilder<St: interaction_state::State, S: BosStr = DefaultStr> {
     _state: PhantomData<fn() -> St>,
     _fields: (
         Option<S>,
@@ -765,15 +765,22 @@ pub struct InteractionBuilder<S: BosStr, St: interaction_state::State> {
     _type: PhantomData<fn() -> S>,
 }
 
-impl<S: BosStr> Interaction<S> {
-    /// Create a new builder for this type.
-    pub fn new() -> InteractionBuilder<S, interaction_state::Empty> {
+impl Interaction<DefaultStr> {
+    /// Create a new builder for this type, using the default string type (DefaultStr = SmolStr) if needed
+    pub fn new() -> InteractionBuilder<interaction_state::Empty, DefaultStr> {
         InteractionBuilder::new()
     }
 }
 
-impl<S: BosStr> InteractionBuilder<S, interaction_state::Empty> {
-    /// Create a new builder with all fields unset.
+impl<S: BosStr> Interaction<S> {
+    /// Create a new builder for this type
+    pub fn builder() -> InteractionBuilder<interaction_state::Empty, S> {
+        InteractionBuilder::builder()
+    }
+}
+
+impl InteractionBuilder<interaction_state::Empty, DefaultStr> {
+    /// Create a new builder with all fields unset, using the default string type, if needed
     pub fn new() -> Self {
         InteractionBuilder {
             _state: PhantomData,
@@ -783,7 +790,18 @@ impl<S: BosStr> InteractionBuilder<S, interaction_state::Empty> {
     }
 }
 
-impl<S: BosStr, St: interaction_state::State> InteractionBuilder<S, St> {
+impl<S: BosStr> InteractionBuilder<interaction_state::Empty, S> {
+    /// Create a new builder with all fields unset
+    pub fn builder() -> Self {
+        InteractionBuilder {
+            _state: PhantomData,
+            _fields: (None, None, None, None, None, None),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<St: interaction_state::State, S: BosStr> InteractionBuilder<St, S> {
     /// Set the `comment` field (optional)
     pub fn comment(mut self, value: impl Into<Option<S>>) -> Self {
         self._fields.0 = value.into();
@@ -796,7 +814,7 @@ impl<S: BosStr, St: interaction_state::State> InteractionBuilder<S, St> {
     }
 }
 
-impl<S: BosStr, St> InteractionBuilder<S, St>
+impl<St, S: BosStr> InteractionBuilder<St, S>
 where
     St: interaction_state::State,
     St::CreatedAt: interaction_state::IsUnset,
@@ -805,7 +823,7 @@ where
     pub fn created_at(
         mut self,
         value: impl Into<Datetime>,
-    ) -> InteractionBuilder<S, interaction_state::SetCreatedAt<St>> {
+    ) -> InteractionBuilder<interaction_state::SetCreatedAt<St>, S> {
         self._fields.1 = Option::Some(value.into());
         InteractionBuilder {
             _state: PhantomData,
@@ -815,7 +833,7 @@ where
     }
 }
 
-impl<S: BosStr, St> InteractionBuilder<S, St>
+impl<St, S: BosStr> InteractionBuilder<St, S>
 where
     St: interaction_state::State,
     St::Direction: interaction_state::IsUnset,
@@ -824,7 +842,7 @@ where
     pub fn direction(
         mut self,
         value: impl Into<S>,
-    ) -> InteractionBuilder<S, interaction_state::SetDirection<St>> {
+    ) -> InteractionBuilder<interaction_state::SetDirection<St>, S> {
         self._fields.2 = Option::Some(value.into());
         InteractionBuilder {
             _state: PhantomData,
@@ -834,7 +852,7 @@ where
     }
 }
 
-impl<S: BosStr, St> InteractionBuilder<S, St>
+impl<St, S: BosStr> InteractionBuilder<St, S>
 where
     St: interaction_state::State,
     St::InteractionType: interaction_state::IsUnset,
@@ -843,7 +861,7 @@ where
     pub fn interaction_type(
         mut self,
         value: impl Into<InteractionInteractionType<S>>,
-    ) -> InteractionBuilder<S, interaction_state::SetInteractionType<St>> {
+    ) -> InteractionBuilder<interaction_state::SetInteractionType<St>, S> {
         self._fields.3 = Option::Some(value.into());
         InteractionBuilder {
             _state: PhantomData,
@@ -853,7 +871,7 @@ where
     }
 }
 
-impl<S: BosStr, St> InteractionBuilder<S, St>
+impl<St, S: BosStr> InteractionBuilder<St, S>
 where
     St: interaction_state::State,
     St::SubjectA: interaction_state::IsUnset,
@@ -862,7 +880,7 @@ where
     pub fn subject_a(
         mut self,
         value: impl Into<interaction::InteractionSubject<S>>,
-    ) -> InteractionBuilder<S, interaction_state::SetSubjectA<St>> {
+    ) -> InteractionBuilder<interaction_state::SetSubjectA<St>, S> {
         self._fields.4 = Option::Some(value.into());
         InteractionBuilder {
             _state: PhantomData,
@@ -872,7 +890,7 @@ where
     }
 }
 
-impl<S: BosStr, St> InteractionBuilder<S, St>
+impl<St, S: BosStr> InteractionBuilder<St, S>
 where
     St: interaction_state::State,
     St::SubjectB: interaction_state::IsUnset,
@@ -881,7 +899,7 @@ where
     pub fn subject_b(
         mut self,
         value: impl Into<interaction::InteractionSubject<S>>,
-    ) -> InteractionBuilder<S, interaction_state::SetSubjectB<St>> {
+    ) -> InteractionBuilder<interaction_state::SetSubjectB<St>, S> {
         self._fields.5 = Option::Some(value.into());
         InteractionBuilder {
             _state: PhantomData,
@@ -891,7 +909,7 @@ where
     }
 }
 
-impl<S: BosStr, St> InteractionBuilder<S, St>
+impl<St, S: BosStr> InteractionBuilder<St, S>
 where
     St: interaction_state::State,
     St::CreatedAt: interaction_state::IsSet,

--- a/crates/observing-lexicons/src/ing_observ/temp/like.rs
+++ b/crates/observing-lexicons/src/ing_observ/temp/like.rs
@@ -150,21 +150,28 @@ pub mod like_state {
 }
 
 /// Builder for constructing an instance of this type.
-pub struct LikeBuilder<S: BosStr, St: like_state::State> {
+pub struct LikeBuilder<St: like_state::State, S: BosStr = DefaultStr> {
     _state: PhantomData<fn() -> St>,
     _fields: (Option<Datetime>, Option<StrongRef<S>>),
     _type: PhantomData<fn() -> S>,
 }
 
-impl<S: BosStr> Like<S> {
-    /// Create a new builder for this type.
-    pub fn new() -> LikeBuilder<S, like_state::Empty> {
+impl Like<DefaultStr> {
+    /// Create a new builder for this type, using the default string type (DefaultStr = SmolStr) if needed
+    pub fn new() -> LikeBuilder<like_state::Empty, DefaultStr> {
         LikeBuilder::new()
     }
 }
 
-impl<S: BosStr> LikeBuilder<S, like_state::Empty> {
-    /// Create a new builder with all fields unset.
+impl<S: BosStr> Like<S> {
+    /// Create a new builder for this type
+    pub fn builder() -> LikeBuilder<like_state::Empty, S> {
+        LikeBuilder::builder()
+    }
+}
+
+impl LikeBuilder<like_state::Empty, DefaultStr> {
+    /// Create a new builder with all fields unset, using the default string type, if needed
     pub fn new() -> Self {
         LikeBuilder {
             _state: PhantomData,
@@ -174,7 +181,18 @@ impl<S: BosStr> LikeBuilder<S, like_state::Empty> {
     }
 }
 
-impl<S: BosStr, St> LikeBuilder<S, St>
+impl<S: BosStr> LikeBuilder<like_state::Empty, S> {
+    /// Create a new builder with all fields unset
+    pub fn builder() -> Self {
+        LikeBuilder {
+            _state: PhantomData,
+            _fields: (None, None),
+            _type: PhantomData,
+        }
+    }
+}
+
+impl<St, S: BosStr> LikeBuilder<St, S>
 where
     St: like_state::State,
     St::CreatedAt: like_state::IsUnset,
@@ -183,7 +201,7 @@ where
     pub fn created_at(
         mut self,
         value: impl Into<Datetime>,
-    ) -> LikeBuilder<S, like_state::SetCreatedAt<St>> {
+    ) -> LikeBuilder<like_state::SetCreatedAt<St>, S> {
         self._fields.0 = Option::Some(value.into());
         LikeBuilder {
             _state: PhantomData,
@@ -193,7 +211,7 @@ where
     }
 }
 
-impl<S: BosStr, St> LikeBuilder<S, St>
+impl<St, S: BosStr> LikeBuilder<St, S>
 where
     St: like_state::State,
     St::Subject: like_state::IsUnset,
@@ -202,7 +220,7 @@ where
     pub fn subject(
         mut self,
         value: impl Into<StrongRef<S>>,
-    ) -> LikeBuilder<S, like_state::SetSubject<St>> {
+    ) -> LikeBuilder<like_state::SetSubject<St>, S> {
         self._fields.1 = Option::Some(value.into());
         LikeBuilder {
             _state: PhantomData,
@@ -212,7 +230,7 @@ where
     }
 }
 
-impl<S: BosStr, St> LikeBuilder<S, St>
+impl<St, S: BosStr> LikeBuilder<St, S>
 where
     St: like_state::State,
     St::CreatedAt: like_state::IsSet,

--- a/crates/observing-lexicons/src/lib.rs
+++ b/crates/observing-lexicons/src/lib.rs
@@ -3,6 +3,43 @@
 // This file was automatically generated from Lexicon schemas.
 // Any manual changes will be overwritten on the next regeneration.
 
+//! Generated AT Protocol Lexicon bindings.
+//!
+//! This crate contains Rust bindings generated from Lexicon schemas. Most
+//! application code uses these types through the `jacquard::api` re-export,
+//! alongside `jacquard::Client` or one of the higher-level session helpers.
+//!
+//! ## Finding things
+//!
+//! Lexicon NSIDs map to Rust modules by replacing dots with module separators
+//! and using snake_case for Rust identifiers. For example,
+//! `app.bsky.feed.getTimeline` is generated under
+//! `app_bsky::feed::get_timeline`.
+//!
+//! Top-level namespace modules are feature-gated. Enable the feature matching
+//! the top-level namespace module, such as `app_bsky` or `com_atproto`, to use
+//! those bindings.
+//!
+//! ## String backing
+//!
+//! Many generated data types are generic over a string backing type,
+//! usually written as `S: BosStr = DefaultStr`. The generic is part of the
+//! public API: use the default owned backing when you do not need to choose,
+//! or select another backing such as `String`, `&str`, or `CowStr<'_>` when
+//! that is useful for your code.
+//!
+//! Common examples omit the generic because the default is inferred in the
+//! usual request/response paths.
+//!
+//! ## XRPC endpoints
+//!
+//! Endpoint modules contain request parameter/input structs, output structs,
+//! error enums, and marker types implementing
+//! `jacquard_common::xrpc::{XrpcRequest, XrpcResp, XrpcEndpoint}`. High-level
+//! client code normally constructs the request struct or marker type and sends
+//! it with `jacquard::Client`, then uses response helpers such as
+//! `into_output()` for default-backed output.
+//!
 extern crate alloc;
 
 #[cfg(feature = "bio_lexicons")]

--- a/scripts/generate-rust-types.sh
+++ b/scripts/generate-rust-types.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 # Usage:
 #   ./scripts/generate-rust-types.sh
 
-JACQUARD_LEXGEN_VERSION="0.12.0-beta.2"
+JACQUARD_LEXGEN_VERSION="0.12.1"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"


### PR DESCRIPTION
## Summary

The `rwell.org` fork of jacquard has been deleted, so CI can no longer install `jacquard-lexgen` from it.

Replaces the fork git dependency:

```yaml
cargo install --git https://tangled.org/rwell.org/jacquard.git --branch fix-builder-determinism jacquard-lexgen
```

with the published upstream release from crates.io, pinned and `--locked`:

```yaml
cargo install jacquard-lexgen --version 0.12.1 --locked
```

`jacquard-lexgen 0.12.1` was published upstream on 2026-06-26 and matches the `jacquard-* = "0.12"` library pins in the workspace.

## Note

If the `rust-lexicons-check` job's `git diff --exit-code` fails, it means the deterministic-field-ordering fix isn't in 0.12.1 and we'd need to point at the upstream git branch instead.