### PR TITLE
design-audit: move IUCN conservation status colors to theme palette

### DIFF
--- a/frontend/src/components/common/ConservationStatus.tsx
+++ b/frontend/src/components/common/ConservationStatus.tsx
@@ -1,4 +1,5 @@
 import { Box, Chip, Tooltip, Typography } from "@mui/material";
+import { useTheme } from "@mui/material/styles";
 import type {
   IUCNCategory,
   ConservationStatus as ConservationStatusType,
@@ -12,16 +13,16 @@ interface ConservationStatusProps {
   size?: "sm" | "md";
 }
 
-const CATEGORY_INFO: Record<string, { label: string; color: string }> = {
-  EX: { label: "Extinct", color: "#000000" },
-  EW: { label: "Extinct in the Wild", color: "#542344" },
-  CR: { label: "Critically Endangered", color: "#d81e05" },
-  EN: { label: "Endangered", color: "#fc7f3f" },
-  VU: { label: "Vulnerable", color: "#f9e814" },
-  NT: { label: "Near Threatened", color: "#cce226" },
-  LC: { label: "Least Concern", color: "#60c659" },
-  DD: { label: "Data Deficient", color: "#d1d1c6" },
-  NE: { label: "Not Evaluated", color: "#ffffff" },
+const CATEGORY_INFO: Record<string, { label: string }> = {
+  EX: { label: "Extinct" },
+  EW: { label: "Extinct in the Wild" },
+  CR: { label: "Critically Endangered" },
+  EN: { label: "Endangered" },
+  VU: { label: "Vulnerable" },
+  NT: { label: "Near Threatened" },
+  LC: { label: "Least Concern" },
+  DD: { label: "Data Deficient" },
+  NE: { label: "Not Evaluated" },
 };
 
 const DARK_TEXT_CATEGORIES: ReadonlySet<string> = new Set(["VU", "NT", "LC", "DD", "NE"]);
@@ -41,9 +42,11 @@ export function ConservationStatus({
   showLabel = false,
   size = "md",
 }: ConservationStatusProps) {
+  const theme = useTheme();
   const info = CATEGORY_INFO[status.category];
   if (!info) return null;
 
+  const iucnColor = theme.palette.iucn[status.category];
   const needsDarkText = DARK_TEXT_CATEGORIES.has(status.category);
   const source = SOURCE_INFO[status.source];
 
@@ -69,9 +72,9 @@ export function ConservationStatus({
         label={showLabel ? info.label : status.category}
         size={size === "sm" ? "small" : "medium"}
         sx={{
-          backgroundColor: info.color,
+          backgroundColor: iucnColor,
           color: needsDarkText ? "common.black" : "common.white",
-          borderColor: status.category === "NE" ? CATEGORY_INFO["DD"]?.color : info.color,
+          borderColor: status.category === "NE" ? theme.palette.iucn["DD"] : iucnColor,
           fontWeight: 600,
           textTransform: "uppercase",
           letterSpacing: "0.025em",

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -6,11 +6,27 @@ import { createTheme, type Theme, type PaletteMode } from "@mui/material/styles"
 declare module "@mui/material/styles" {
   interface Palette {
     placeholder: string;
+    iucn: Record<string, string>;
   }
   interface PaletteOptions {
     placeholder?: string;
+    iucn?: Record<string, string>;
   }
 }
+
+// Official IUCN Red List category colors — standardized by the IUCN,
+// so they are mode-invariant and shared across light and dark themes.
+const iucnColors: Record<string, string> = {
+  EX: "#000000",
+  EW: "#542344",
+  CR: "#d81e05",
+  EN: "#fc7f3f",
+  VU: "#f9e814",
+  NT: "#cce226",
+  LC: "#60c659",
+  DD: "#d1d1c6",
+  NE: "#ffffff",
+};
 
 // Brand type stack: DM Sans for UI (geometric, friendly, reads well at every
 // size), JetBrains Mono for data/numerals. System fonts remain as fallbacks.
@@ -64,6 +80,7 @@ const darkPalette = {
   },
   divider: "#333",
   placeholder: "#211f1b",
+  iucn: iucnColors,
 };
 
 const lightPalette = {
@@ -95,6 +112,7 @@ const lightPalette = {
   },
   divider: "#e2dbca",
   placeholder: "#efe7d4",
+  iucn: iucnColors,
 };
 
 const createAppTheme = (mode: PaletteMode): Theme => {


### PR DESCRIPTION
## Summary

- Adds a `palette.iucn` token group (`Record<string, string>`) to the MUI theme, following the existing `placeholder` token pattern.
- Removes 9 hardcoded hex literals from `ConservationStatus.tsx` and replaces them with `theme.palette.iucn[category]` via `useTheme()`.
- The IUCN colors are official standards that don't change per mode, so a single `iucnColors` object is shared between `lightPalette` and `darkPalette`.

**Before:** 9 raw hex values scattered in a module-level constant inside the component file — no way for the rest of the app to reference them.

**After:** All 9 IUCN Red List category colors live in the theme and are accessible to any future consumer (map legend, chart axis, story decorators, etc.) via `theme.palette.iucn`.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint` — 0 new warnings (2 pre-existing unrelated warnings unchanged)
- `oxfmt --check` — all files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8FFqSvphj1LkKAvTAKEDM

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8FFqSvphj1LkKAvTAKEDM)_