### PR TITLE
design-audit: move map marker color to theme palette token

### DIFF
--- a/frontend/src/components/map/LocationMap.tsx
+++ b/frontend/src/components/map/LocationMap.tsx
@@ -6,7 +6,6 @@ import {
   createCircleGeoJSON,
   createMap,
   getRadiusBounds,
-  MAP_MARKER_COLOR,
   addUncertaintyLayers,
   setBasemapStyle,
 } from "./mapUtils";
@@ -25,6 +24,7 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
   const map = useRef<maplibregl.Map | null>(null);
   const theme = useTheme();
   const mode = theme.palette.mode;
+  const markerColor = theme.palette.mapMarker;
   const [basemap] = useBasemap();
   // Read the latest mode/basemap inside the create effect without making them
   // dependencies (theme/basemap changes swap the style in a separate effect
@@ -58,7 +58,7 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
 
     mapInstance.on("load", () => {
       // Add marker
-      new maplibregl.Marker({ color: MAP_MARKER_COLOR })
+      new maplibregl.Marker({ color: markerColor })
         .setLngLat([longitude, latitude])
         .addTo(mapInstance);
 
@@ -69,7 +69,7 @@ export function LocationMap({ latitude, longitude, uncertaintyMeters }: Location
           data: createCircleGeoJSON(longitude, latitude, uncertaintyMeters),
         });
 
-        addUncertaintyLayers(mapInstance);
+        addUncertaintyLayers(mapInstance, markerColor);
 
         // Fit map to uncertainty circle bounds
         mapInstance.fitBounds(getRadiusBounds(latitude, longitude, uncertaintyMeters), {

--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -96,25 +96,28 @@ export function LocationPicker({
   const uncertaintyMetersRef = useRef(uncertaintyMeters);
   uncertaintyMetersRef.current = uncertaintyMeters;
 
-  const updateMarker = useCallback((lng: number, lat: number, radius?: number) => {
-    if (!map.current) return;
+  const updateMarker = useCallback(
+    (lng: number, lat: number, radius?: number) => {
+      if (!map.current) return;
 
-    if (marker.current) {
-      marker.current.setLngLat([lng, lat]);
-    } else {
-      marker.current = new maplibregl.Marker({ color: markerColor })
-        .setLngLat([lng, lat])
-        .addTo(map.current);
-    }
+      if (marker.current) {
+        marker.current.setLngLat([lng, lat]);
+      } else {
+        marker.current = new maplibregl.Marker({ color: markerColor })
+          .setLngLat([lng, lat])
+          .addTo(map.current);
+      }
 
-    // Update uncertainty circle
-    const effectiveRadius = radius ?? uncertaintyMetersRef.current;
-    // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- maplibre getSource has no generic overload
-    const source = map.current.getSource("uncertainty") as maplibregl.GeoJSONSource | undefined;
-    if (source) {
-      source.setData(createCircleGeoJSON(lng, lat, effectiveRadius));
-    }
-  }, [markerColor]);
+      // Update uncertainty circle
+      const effectiveRadius = radius ?? uncertaintyMetersRef.current;
+      // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- maplibre getSource has no generic overload
+      const source = map.current.getSource("uncertainty") as maplibregl.GeoJSONSource | undefined;
+      if (source) {
+        source.setData(createCircleGeoJSON(lng, lat, effectiveRadius));
+      }
+    },
+    [markerColor],
+  );
 
   const flyToLocation = useCallback(
     (lat: number, lng: number) => {

--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -18,7 +18,6 @@ import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { mapContainerSx, MAPTILER_ENABLED } from "./mapStyle";
 import {
-  MAP_MARKER_COLOR,
   addUncertaintyLayers,
   createCircleGeoJSON,
   createMap,
@@ -83,6 +82,7 @@ export function LocationPicker({
   const [showCoordinates, setShowCoordinates] = useState(false);
   const theme = useTheme();
   const mode = theme.palette.mode;
+  const markerColor = theme.palette.mapMarker;
   const [basemap] = useBasemap();
   // Latest mode/basemap for the init effect (which runs once); theme/basemap
   // changes are handled by swapping the style, not rebuilding the map.
@@ -102,7 +102,7 @@ export function LocationPicker({
     if (marker.current) {
       marker.current.setLngLat([lng, lat]);
     } else {
-      marker.current = new maplibregl.Marker({ color: MAP_MARKER_COLOR })
+      marker.current = new maplibregl.Marker({ color: markerColor })
         .setLngLat([lng, lat])
         .addTo(map.current);
     }
@@ -114,7 +114,7 @@ export function LocationPicker({
     if (source) {
       source.setData(createCircleGeoJSON(lng, lat, effectiveRadius));
     }
-  }, []);
+  }, [markerColor]);
 
   const flyToLocation = useCallback(
     (lat: number, lng: number) => {
@@ -203,7 +203,7 @@ export function LocationPicker({
             : { type: "FeatureCollection", features: [] },
       });
 
-      addUncertaintyLayers(mapInstance);
+      addUncertaintyLayers(mapInstance, markerColor);
 
       if (latitude && longitude) {
         updateMarker(longitude, latitude);

--- a/frontend/src/components/map/mapUtils.ts
+++ b/frontend/src/components/map/mapUtils.ts
@@ -93,9 +93,6 @@ export function setBasemapStyle(map: maplibregl.Map, basemap: BasemapId, mode: B
   });
 }
 
-/** Color used for uncertainty circles and map markers */
-export const MAP_MARKER_COLOR = "#22c55e";
-
 /** Calculate lat/lng bounding box for a given radius in meters */
 export function getRadiusBounds(
   lat: number,
@@ -111,13 +108,13 @@ export function getRadiusBounds(
 }
 
 /** Add uncertainty circle layers to a map instance */
-export function addUncertaintyLayers(mapInstance: maplibregl.Map): void {
+export function addUncertaintyLayers(mapInstance: maplibregl.Map, color: string): void {
   mapInstance.addLayer({
     id: "uncertainty-fill",
     type: "fill",
     source: "uncertainty",
     paint: {
-      "fill-color": MAP_MARKER_COLOR,
+      "fill-color": color,
       "fill-opacity": 0.15,
     },
   });
@@ -127,7 +124,7 @@ export function addUncertaintyLayers(mapInstance: maplibregl.Map): void {
     type: "line",
     source: "uncertainty",
     paint: {
-      "line-color": MAP_MARKER_COLOR,
+      "line-color": color,
       "line-width": 2,
       "line-opacity": 0.5,
     },

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -1,18 +1,23 @@
 import { createTheme, type Theme, type PaletteMode } from "@mui/material/styles";
 
-// Custom palette token for the warm neutral used by empty/loading placeholder
-// surfaces (the "No image" tile and the loading skeleton), so the color lives
-// in one place instead of being duplicated as raw hex in components.
+// Custom palette tokens so semantic colors live in one place instead of being
+// duplicated as raw hex values in components.
 declare module "@mui/material/styles" {
   interface Palette {
     placeholder: string;
     iucn: Record<string, string>;
+    mapMarker: string;
   }
   interface PaletteOptions {
     placeholder?: string;
     iucn?: Record<string, string>;
+    mapMarker?: string;
   }
 }
+
+// Map marker / uncertainty-circle color — same in both themes (it's a
+// functional indicator, not a brand color, so it doesn't invert with the mode).
+const mapMarkerColor = "#22c55e";
 
 // Official IUCN Red List category colors — standardized by the IUCN,
 // so they are mode-invariant and shared across light and dark themes.
@@ -81,6 +86,7 @@ const darkPalette = {
   divider: "#333",
   placeholder: "#211f1b",
   iucn: iucnColors,
+  mapMarker: mapMarkerColor,
 };
 
 const lightPalette = {
@@ -113,6 +119,7 @@ const lightPalette = {
   divider: "#e2dbca",
   placeholder: "#efe7d4",
   iucn: iucnColors,
+  mapMarker: mapMarkerColor,
 };
 
 const createAppTheme = (mode: PaletteMode): Theme => {


### PR DESCRIPTION
## Summary

- `MAP_MARKER_COLOR = "#22c55e"` was a raw hex constant in `mapUtils.ts` that bypassed the theme system entirely. It is now `palette.mapMarker`, declared alongside the existing `placeholder` and `iucn` tokens in `theme/index.ts`.
- The color is mode-invariant (same value in both light and dark palettes) since it's a functional indicator for map markers/uncertainty circles, not a brand color that should invert with the theme.
- `addUncertaintyLayers` now accepts the color as an explicit parameter rather than closing over the module-level constant. Both callers (`LocationMap`, `LocationPicker`) already imported `useTheme` and now read `theme.palette.mapMarker` to pass in.

## Files changed

| File | Change |
|---|---|
| `frontend/src/theme/index.ts` | Adds `mapMarker: string` to palette type augmentation; defines `mapMarkerColor` constant; registers it in both `darkPalette` and `lightPalette` |
| `frontend/src/components/map/mapUtils.ts` | Removes exported `MAP_MARKER_COLOR`; `addUncertaintyLayers` now takes `color: string` param |
| `frontend/src/components/map/LocationMap.tsx` | Reads `theme.palette.mapMarker`; passes it to `Marker` and `addUncertaintyLayers` |
| `frontend/src/components/map/LocationPicker.tsx` | Same; adds `markerColor` to `updateMarker` useCallback deps |

---
_Generated by [Claude Code](https://claude.ai/code/session_01JnaTwqea4u7XaS4HtP43oR)_