### PR TITLE
chore(dev): headless stack option + decouple appview from species-id

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -76,6 +76,20 @@ docker run --name observing-postgres \
 docker start observing-postgres
 ```
 
+**Apple Silicon (arm64):** the official `postgis/postgis` image is amd64-only
+(no arm64 manifest), so it runs under slow QEMU emulation. Either pass
+`--platform linux/amd64` explicitly to silence the warning and force emulation,
+or use a native multi-arch image like `imresamu/postgis` (drop-in replacement,
+same env vars) for better performance:
+
+```bash
+docker run --name observing-postgres \
+  -e POSTGRES_PASSWORD=mysecretpassword \
+  -e POSTGRES_DB=observing \
+  -p 5432:5432 \
+  -d imresamu/postgis        # native arm64 + amd64; or add --platform linux/amd64 to postgis/postgis
+```
+
 Native installs (Postgres.app, Homebrew `postgresql@N` + `postgis`,
 etc.) work too — anything that exposes PostgreSQL with PostGIS on
 `localhost:5432` is fine.
@@ -257,6 +271,22 @@ Pin the offset when you want stable, reproducible ports for a checkout:
 ```bash
 DEV_PORT_OFFSET=2000 npm run dev:stack   # appview 5000, vite 7173, ...
 DEV_PORT_OFFSET=0 npm run dev:stack      # stock ports, no randomization
+```
+
+#### Headless / non-interactive (no TTY)
+
+`process-compose up` launches a TUI that needs a TTY and fails with
+`open /dev/tty: device not configured` in CI, SSH-without-pty, or other
+headless shells. Use the headless wrapper, which disables the TUI
+(`-t=false`) and runs the stack as a detached daemon (`-D`) while keeping the
+same port-offset logic:
+
+```bash
+npm run dev:stack:headless        # or: ./scripts/dev.sh --headless
+DEV_HEADLESS=1 npm run dev:stack  # equivalent, via env var
+
+process-compose process list      # check status
+process-compose down              # stop the stack
 ```
 
 Plain `process-compose up` still works and keeps the stock ports — the

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "setup": "./scripts/setup.sh",
     "dev": "vite -c frontend/vite.config.ts",
     "dev:stack": "./scripts/dev.sh",
+    "dev:stack:headless": "./scripts/dev.sh --headless",
     "fmt": "oxfmt frontend/src frontend/tests scripts",
     "fmt:check": "oxfmt --check frontend/src frontend/tests scripts",
     "lint": "oxlint frontend/src",

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -44,10 +44,17 @@ processes:
       - VITE_DEV_SERVER_URL=http://localhost:${VITE_PORT:-5173}
       - PUBLIC_URL=${PUBLIC_URL:-}
     depends_on:
+      # migrate must finish first so the schema exists before appview reads it.
       migrate:
         condition: process_completed_successfully
+      # appview only calls species-id lazily (the image-ID feature), so it does
+      # not need a *healthy* species-id at boot. species-id loads a ~2.4 GB
+      # BioCLIP ONNX model and is slow to become healthy; gating on
+      # process_started (not process_healthy) lets appview — and the frontend
+      # that depends on it — come up immediately instead of waiting on the
+      # heavy ML service.
       species-id:
-        condition: process_healthy
+        condition: process_started
     readiness_probe:
       http_get:
         host: localhost

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -11,13 +11,29 @@
 # Usage:
 #   ./scripts/dev.sh                 # random offset, then `process-compose up`
 #   ./scripts/dev.sh -D              # extra args are forwarded to process-compose
+#   ./scripts/dev.sh --headless      # TUI off + detached (no TTY needed; for CI / headless shells)
+#   DEV_HEADLESS=1 ./scripts/dev.sh  # same, via env var
 #   DEV_PORT_OFFSET=0 ./scripts/dev.sh   # pin the stock ports (no randomization)
 #   DEV_PORT_OFFSET=2000 ./scripts/dev.sh  # pin a specific offset
+#
+# Headless mode disables the process-compose TUI (which needs a TTY and fails
+# with "open /dev/tty: device not configured" in non-interactive contexts) and
+# runs the stack as a detached daemon. Check on it with
+# `process-compose process list` and stop it with `process-compose down`.
 #
 # The derived ports are exported, so `process-compose.yaml` (and Vite, via the
 # inherited environment) pick them up through their `${VAR:-default}` fallbacks.
 
 set -euo pipefail
+
+# Headless mode: TUI off (-t=false) + detached (-D) so the stack comes up in
+# non-interactive / headless shells that have no TTY. Triggered by DEV_HEADLESS=1
+# or a leading `--headless` arg (which is consumed here, not forwarded).
+HEADLESS="${DEV_HEADLESS:-}"
+if [[ "${1:-}" == "--headless" ]]; then
+  HEADLESS=1
+  shift
+fi
 
 # Base ports, matching the defaults baked into process-compose.yaml.
 BASE_APPVIEW_PORT=3000
@@ -51,5 +67,15 @@ Starting dev stack with port offset ${DEV_PORT_OFFSET}:
 
 Open the app at http://127.0.0.1:${APPVIEW_PORT}
 EOF
+
+if [[ -n "${HEADLESS}" ]]; then
+  cat <<'EOF'
+
+Headless mode: TUI disabled, running detached.
+  process-compose process list   # check status
+  process-compose down           # stop the stack
+EOF
+  exec process-compose up -t=false -D "$@"
+fi
 
 exec process-compose up "$@"


### PR DESCRIPTION
Local-dev ergonomics: makes the stack usable in headless shells and stops the heavy ML service from gating the rest of the stack at boot.

## Changes

### 1. Headless stack option
`process-compose up` launches a TUI that needs a TTY and fails with `open /dev/tty: device not configured` in CI / SSH-without-pty / headless shells. Added:
- `npm run dev:stack:headless` script.
- A `--headless` flag and `DEV_HEADLESS=1` env var on `scripts/dev.sh` that run `process-compose up -t=false -D` (TUI off, detached) while keeping the existing port-offset logic and forwarding any remaining args.
- The wrapper prints how to check status (`process-compose process list`) and stop the stack (`process-compose down`).
- Interactive `dev:stack` is unchanged.

### 2. Decouple `appview` from `species-id` health
`appview` only calls `species-id` lazily (the image-ID feature), but it depended on `species-id` being `process_healthy`. `species-id` loads a ~2.4 GB BioCLIP ONNX model and is slow to become healthy, which blocked `appview` (and the frontend that depends on it) from coming up. Changed the condition to `process_started` with an explanatory comment. `migrate` still gates `appview` via `process_completed_successfully` so the schema exists first.

### 3. Apple-Silicon Postgres docs
`docs/development.md` Database Setup now notes that `postgis/postgis` is amd64-only (runs under QEMU on arm64) and recommends the native multi-arch `imresamu/postgis` as a drop-in alternative, or `--platform linux/amd64` for the existing image.

## Validation
- `bash -n scripts/dev.sh` — OK
- `package.json` parses as valid JSON
- `process-compose up --dry-run -t=false` — "Validated 5 configured processes" (exit 0)
- No servers started; config/docs/scripts only.