### PR TITLE
feat(common): generic search-box styling; match taxa search to design

### DIFF
--- a/frontend/src/components/common/SearchField.stories.tsx
+++ b/frontend/src/components/common/SearchField.stories.tsx
@@ -1,0 +1,40 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { SearchField } from "./SearchField";
+
+const meta = {
+  title: "Common/SearchField",
+  component: SearchField,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  args: {
+    label: "Search",
+    placeholder: "Search taxa",
+  },
+  decorators: [
+    (Story) => (
+      <Box sx={{ maxWidth: 320 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof SearchField>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Controlled: Story = {
+  render: (args) => {
+    const [value, setValue] = useState("");
+    return <SearchField {...args} value={value} onChange={(e) => setValue(e.target.value)} />;
+  },
+};
+
+export const Small: Story = {
+  args: { size: "small" },
+};

--- a/frontend/src/components/common/SearchField.tsx
+++ b/frontend/src/components/common/SearchField.tsx
@@ -1,0 +1,61 @@
+import { InputAdornment, TextField } from "@mui/material";
+import type { TextFieldProps } from "@mui/material";
+import SearchIcon from "@mui/icons-material/Search";
+
+/**
+ * Shared "search box" styling: rounded corners, a paper fill, and a soft
+ * divider-colored border. Applied to standalone search inputs ({@link
+ * SearchField}) and to autocomplete-backed search inputs (see
+ * `renderAutocompleteInput`'s `search` option) so every search field across the
+ * app reads the same. Plain object so callers can also nest it in an `sx`
+ * array (e.g. `sx={[searchFieldSx, { mb: 1 }]}`).
+ */
+export const searchFieldSx = {
+  "& .MuiOutlinedInput-root": {
+    borderRadius: 1.5,
+    backgroundColor: "background.paper",
+  },
+  "& .MuiOutlinedInput-notchedOutline": {
+    borderColor: "divider",
+  },
+};
+
+/** Leading magnifier icon shown inside search inputs. */
+export function SearchAdornment() {
+  return (
+    <InputAdornment position="start">
+      <SearchIcon fontSize="small" sx={{ color: "text.disabled" }} />
+    </InputAdornment>
+  );
+}
+
+export type SearchFieldProps = Omit<TextFieldProps, "label"> & {
+  /** Accessible name for the input (rendered as `aria-label`, not a visible label). */
+  label: string;
+};
+
+/**
+ * A generic search text input: a label-less, rounded {@link TextField} with a
+ * leading search icon, driven by its placeholder. Use for any standalone
+ * search box (place search, list filters, …). For autocomplete-backed search,
+ * pass `search` to `renderAutocompleteInput` instead so the look stays in sync.
+ */
+export function SearchField({ label, sx, slotProps, ...props }: SearchFieldProps) {
+  // slotProps.input / .htmlInput can each be an object or a callback; only an
+  // object can be safely merged with our defaults (a callback is passed through
+  // as-is, replacing them).
+  const inputSlot = typeof slotProps?.input === "object" ? slotProps.input : undefined;
+  const htmlInputSlot = typeof slotProps?.htmlInput === "object" ? slotProps.htmlInput : undefined;
+  return (
+    <TextField
+      fullWidth
+      sx={[searchFieldSx, ...(Array.isArray(sx) ? sx : [sx])]}
+      slotProps={{
+        ...slotProps,
+        input: { startAdornment: <SearchAdornment />, ...inputSlot },
+        htmlInput: { "aria-label": label, ...htmlInputSlot },
+      }}
+      {...props}
+    />
+  );
+}

--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -40,6 +40,8 @@ interface TaxaAutocompleteViewProps {
   onClear: () => void;
   /** Force the popup open state. Uncontrolled when omitted. */
   open?: boolean;
+  /** Render the input as a rounded, icon-led search box (see SearchField). */
+  search?: boolean;
 }
 
 export function TaxaAutocompleteView({
@@ -56,6 +58,7 @@ export function TaxaAutocompleteView({
   onSearch,
   onClear,
   open,
+  search,
 }: TaxaAutocompleteViewProps) {
   return (
     <Box>
@@ -90,7 +93,14 @@ export function TaxaAutocompleteView({
         filterOptions={(x) => x}
         {...(size ? { size } : {})}
         renderInput={(params) =>
-          renderAutocompleteInput({ params, loading, label, placeholder, margin })
+          renderAutocompleteInput({
+            params,
+            loading,
+            label,
+            placeholder,
+            margin,
+            ...(search ? { search } : {}),
+          })
         }
         renderOption={(props, option) => {
           const { key, ...otherProps } = props;

--- a/frontend/src/components/common/autocompleteInput.tsx
+++ b/frontend/src/components/common/autocompleteInput.tsx
@@ -1,5 +1,6 @@
 import { CircularProgress, TextField } from "@mui/material";
 import type { AutocompleteRenderInputParams } from "@mui/material";
+import { SearchAdornment, searchFieldSx } from "./SearchField";
 
 interface RenderAutocompleteInputOptions {
   params: AutocompleteRenderInputParams;
@@ -7,11 +8,18 @@ interface RenderAutocompleteInputOptions {
   label: string;
   placeholder: string;
   margin?: "normal" | "dense" | "none";
+  /**
+   * Render as a search box — rounded, with a leading search icon and no visible
+   * label (the `label` becomes the input's `aria-label`) — to match the shared
+   * {@link SearchField} look. Defaults to the standard floating-label field.
+   */
+  search?: boolean;
 }
 
 /**
  * Shared `renderInput` for MUI Autocomplete components: threads through MUI's
- * slot props while adding a loading spinner as an endAdornment.
+ * slot props while adding a loading spinner as an endAdornment. Pass `search`
+ * for the rounded, icon-led search-box variant.
  */
 export function renderAutocompleteInput({
   params,
@@ -19,19 +27,31 @@ export function renderAutocompleteInput({
   label,
   placeholder,
   margin,
+  search,
 }: RenderAutocompleteInputOptions) {
   const { slotProps: paramsSlotProps, ...rest } = params;
   return (
     <TextField
       {...rest}
       fullWidth
-      label={label}
+      {...(search ? {} : { label })}
       placeholder={placeholder}
       {...(margin ? { margin } : {})}
+      {...(search ? { sx: searchFieldSx } : {})}
       slotProps={{
         ...paramsSlotProps,
         input: {
           ...paramsSlotProps.input,
+          ...(search
+            ? {
+                startAdornment: (
+                  <>
+                    <SearchAdornment />
+                    {paramsSlotProps.input?.startAdornment}
+                  </>
+                ),
+              }
+            : {}),
           endAdornment: (
             <>
               {loading && <CircularProgress color="inherit" size={20} />}
@@ -39,6 +59,7 @@ export function renderAutocompleteInput({
             </>
           ),
         },
+        ...(search ? { htmlInput: { ...paramsSlotProps.htmlInput, "aria-label": label } } : {}),
       }}
     />
   );

--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -5,13 +5,11 @@ import {
   TextField,
   Autocomplete,
   Stack,
-  InputAdornment,
   Slider,
   Button,
   Collapse,
   useTheme,
 } from "@mui/material";
-import SearchIcon from "@mui/icons-material/Search";
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import maplibregl from "maplibre-gl";
@@ -26,6 +24,7 @@ import {
 } from "./mapUtils";
 import { useBasemap } from "./useBasemap";
 import { BasemapSelector } from "./BasemapSelector";
+import { SearchAdornment, searchFieldSx } from "../common/SearchField";
 import { formatCoordinate } from "../../lib/utils";
 
 interface LocationPickerProps {
@@ -333,14 +332,10 @@ export function LocationPicker({
                 ...params.slotProps,
                 input: {
                   ...params.slotProps.input,
-                  startAdornment: (
-                    <InputAdornment position="start">
-                      <SearchIcon fontSize="small" sx={{ color: "text.disabled" }} />
-                    </InputAdornment>
-                  ),
+                  startAdornment: <SearchAdornment />,
                 },
               }}
-              sx={{ mb: 1 }}
+              sx={[searchFieldSx, { mb: 1 }]}
             />
           );
         }}

--- a/frontend/src/components/taxon/TaxonSearchBox.tsx
+++ b/frontend/src/components/taxon/TaxonSearchBox.tsx
@@ -40,9 +40,10 @@ export function TaxonSearchBox({ onNavigate }: TaxonSearchBoxProps) {
       onChange={setValue}
       onMatchChange={handleMatch}
       label="Search taxa"
-      placeholder="Search by common or scientific name..."
+      placeholder="Search taxa"
       size="small"
       margin="none"
+      search
       options={options}
       loading={loading}
       onSearch={handleSearch}


### PR DESCRIPTION
## Summary

The taxa-page design shows the classification-tree search as a **rounded box with a leading magnifier icon and a "Search taxa" placeholder** (no floating label). The live input was a default labeled MUI `TextField` with no icon. This brings it to the design — but implemented as a **shared, reusable primitive** rather than one-off inline styling.

## Changes
- **New `common/SearchField`** — a label-less, rounded `TextField` with a leading search icon, driven by its placeholder. Also exports `searchFieldSx` + `SearchAdornment` so the look is shared, not duplicated. (+ story)
- **`renderAutocompleteInput` gains a `search` option** (leading icon + rounded + `aria-label`, no visible label) so autocomplete-backed searches get the same look. Threaded through `TaxaAutocompleteView`; **`TaxonSearchBox`** opts in with placeholder `"Search taxa"`. The forms autocomplete (`TaxaAutocomplete`) is unchanged — `search` is opt-in.
- **`LocationPicker`** place search now reuses `SearchAdornment` + `searchFieldSx` instead of hand-rolling the same icon adornment.

## Before / after
- Taxa sidebar search: plain labeled field → rounded box, magnifier, "Search taxa" placeholder, divider border (matches the mockup).
- Forms "Species Name" autocomplete: **unchanged** (verified in Storybook).
- Map place search: same look, now sourced from the shared primitive.

## Verification
- `tsc --noEmit` ✓ · `oxlint` 0 errors (only pre-existing map/modal `exhaustive-deps` warnings) ✓ · `oxfmt` ✓
- `vitest` 161/161 ✓ · `check:stories` 79 components ✓ · `vite build` ✓
- Storybook visual check of `Taxon/TaxonTreePanel` (new look), `Common/TaxaAutocompleteView` (unchanged), and `Common/SearchField`.
