### PR TITLE
fix(Breadcrumbs): drop redundant MemoryRouter decorator from story

### DIFF
--- a/frontend/src/components/common/Breadcrumbs.stories.tsx
+++ b/frontend/src/components/common/Breadcrumbs.stories.tsx
@@ -1,7 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { MemoryRouter } from "react-router-dom";
 import { Breadcrumbs } from "./Breadcrumbs";
 
+// The global preview decorator (.storybook/preview.tsx) already wraps every
+// story in a MemoryRouter, so this story must NOT add its own — nested routers
+// throw "You cannot render a <Router> inside another <Router>".
 const meta = {
   title: "Common/Breadcrumbs",
   component: Breadcrumbs,
@@ -9,13 +11,6 @@ const meta = {
     layout: "padded",
   },
   tags: ["autodocs"],
-  decorators: [
-    (Story) => (
-      <MemoryRouter>
-        <Story />
-      </MemoryRouter>
-    ),
-  ],
   args: {
     items: [
       { label: "Animalia", href: "/taxon/Animalia" },


### PR DESCRIPTION
## Problem
`Common/Breadcrumbs` story (`?path=/story/common-breadcrumbs--default`) crashes with:

> Error: You cannot render a `<Router>` inside another `<Router>`. You should never have more than one in your app.

## Cause
The global Storybook preview decorator (`.storybook/preview.tsx`) already wraps every story in a `MemoryRouter`. `Breadcrumbs.stories.tsx` (added in #703) declared its **own** `MemoryRouter` decorator, nesting two routers — which React Router rejects. Other router-dependent stories (e.g. `TaxaAutocompleteView`) correctly rely on the global one.

## Fix
Remove the story's redundant `MemoryRouter` decorator + import, and add a comment noting the global one. Verified the story now renders (0 console errors). `tsc`, lint, `check:stories` all pass.