### PR TITLE
fix(taxon): match hero image bg to occurrence photo dark grey

### DIFF
--- a/frontend/src/components/taxon/TaxonHeroCard.tsx
+++ b/frontend/src/components/taxon/TaxonHeroCard.tsx
@@ -37,7 +37,7 @@ export function TaxonHeroCard({ taxon, heroUrl }: TaxonHeroCardProps) {
             border: 1,
             borderColor: "divider",
             boxShadow: "0 2px 10px rgba(60,50,30,0.08)",
-            backgroundColor: "action.hover",
+            backgroundColor: "grey.900",
             display: "flex",
             alignItems: "center",
             justifyContent: "center",


### PR DESCRIPTION
The taxon hero image card sat on a light `action.hover` background, which clashed with the dark grey backdrop behind occurrence photos. This switches it to `grey.900` so both image areas share the same dark backing.

Closes #708