### PR TITLE
design-audit: use monoStack token for code labels in LexiconView

### DIFF
--- a/frontend/src/components/lexicon/LexiconView.tsx
+++ b/frontend/src/components/lexicon/LexiconView.tsx
@@ -18,6 +18,7 @@ import {
 } from "@mui/material";
 import { ExpandMore, ExpandLess } from "@mui/icons-material";
 import { labelChipSx } from "../common/chipSx";
+import { monoStack } from "../../theme";
 
 // Eagerly import all lexicons at build time via the @lexicons alias.
 // This avoids duplicating the schema files — the source of truth remains in /lexicons/.
@@ -129,7 +130,7 @@ function PropertyTable({
                     variant="body2"
                     component="code"
                     sx={{
-                      fontFamily: "monospace",
+                      fontFamily: monoStack,
                       fontSize: "0.8rem",
                       color: prop.description?.includes("[DEPRECATED")
                         ? "text.disabled"
@@ -153,7 +154,7 @@ function PropertyTable({
                 <Typography
                   variant="body2"
                   component="code"
-                  sx={{ fontFamily: "monospace", fontSize: "0.8rem" }}
+                  sx={{ fontFamily: monoStack, fontSize: "0.8rem" }}
                 >
                   {formatType(prop)}
                 </Typography>
@@ -239,7 +240,7 @@ function DefSection({ name, def }: { name: string; def: LexiconDef }) {
         onClick={() => setOpen(!open)}
       >
         <IconButton size="small">{open ? <ExpandLess /> : <ExpandMore />}</IconButton>
-        <Typography variant="subtitle2" component="code" sx={{ fontFamily: "monospace" }}>
+        <Typography variant="subtitle2" component="code" sx={{ fontFamily: monoStack }}>
           #{name}
         </Typography>
         {def.type && <Chip label={def.type} size="small" sx={{ ml: 1, ...labelChipSx }} />}
@@ -280,7 +281,7 @@ function LexiconCard({ schema }: { schema: LexiconSchema }) {
   return (
     <Card variant="outlined" sx={{ mb: 3, overflow: "hidden" }}>
       <CardContent>
-        <Typography variant="h6" component="code" sx={{ fontFamily: "monospace", fontWeight: 700 }}>
+        <Typography variant="h6" component="code" sx={{ fontFamily: monoStack, fontWeight: 700 }}>
           {schema.id}
         </Typography>
 


### PR DESCRIPTION
## What

`LexiconView.tsx` was using the bare `fontFamily: "monospace"` string in four `sx` blocks — once on the property-name column, once on the type column, once on definition section headings, and once on lexicon card titles.

`"monospace"` is the CSS generic family (system fallback), not the brand mono stack. The theme's `MuiCssBaseline` override already applies the full `monoStack` (`"JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace`) to all `code` elements, but an explicit `sx` prop has higher CSS specificity than the baseline rule — so these four overrides were silently reverting back to the system monospace, bypassing JetBrains Mono.

## Change

- Import the already-exported `monoStack` constant from `../../theme`
- Replace all four `fontFamily: "monospace"` values with `fontFamily: monoStack`

No logic changes. All four affected elements render as `component="code"`, so this brings their font rendering into line with the rest of the app's code/data typography.

## Why now

Prior design-audit passes handled palette tokens (map marker #700, IUCN #699). This pass addresses the "magic font string bypassing theme" category — the `monoStack` export exists precisely so components can reference it without duplicating the font stack string.


---
_Generated by [Claude Code](https://claude.ai/code/session_012wKgnfh2VSXLsDxYt1u9uu)_