### PR TITLE
fix(appview): pick preferred vernacular name on taxon detail page

### DIFF
--- a/crates/observing-appview/src/taxonomy/gbif.rs
+++ b/crates/observing-appview/src/taxonomy/gbif.rs
@@ -470,7 +470,7 @@ impl GbifClient {
         // Wikidata's primary image (P18) in parallel.
         let key_u64 = key as u64;
         let key_slice = [key_u64];
-        let (children, descriptions, references, media, wikidata_url, wikidata_images) = tokio::join!(
+        let (children, descriptions, references, media, vernacular_names, wikidata_url, wikidata_images) = tokio::join!(
             self.get_children(taxon_id, 20),
             async {
                 match self
@@ -496,6 +496,21 @@ impl GbifClient {
             },
             async {
                 match self.api.get_name_usage_media(key, Some(10), None).await {
+                    Ok(rv) => Ok(rv.into_inner().results),
+                    Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => Ok(vec![]),
+                    Err(e) => Err(GbifError::from(e)),
+                }
+            },
+            async {
+                // The v1 `/species/{key}` scalar `vernacularName` is unreliable
+                // (it can surface a non-preferred name, e.g. "Red Maple" for
+                // Acer saccharinum). Fetch the full vernacular list so we can
+                // apply the same preference logic as the search path.
+                match self
+                    .api
+                    .get_name_usage_vernacular_names(key, Some(100), None)
+                    .await
+                {
                     Ok(rv) => Ok(rv.into_inner().results),
                     Err(e) if e.status() == Some(reqwest::StatusCode::NOT_FOUND) => Ok(vec![]),
                     Err(e) => Err(GbifError::from(e)),
@@ -568,10 +583,15 @@ impl GbifClient {
             .cloned()
             .or_else(|| media.first().map(|m| m.url.clone()));
 
+        // Prefer the best entry from the full vernacular list; fall back to the
+        // v1 scalar when the list is empty or the request failed.
+        let common_name =
+            pick_vernacular(&vernacular_names.unwrap_or_default()).or(data.vernacular_name);
+
         let taxon_detail = TaxonDetail {
             id: build_taxon_path(resolved_name, &resolved_rank, data.kingdom.as_deref()),
             scientific_name: resolved_name.to_string(),
-            common_name: data.vernacular_name,
+            common_name,
             photo_url,
             rank: resolved_rank,
             kingdom: data.kingdom,
@@ -938,25 +958,43 @@ impl Default for GbifClient {
 
 /// Pick the best vernacular name for a search result.
 fn pick_vernacular_name(item: &NameUsageSearchResult) -> Option<String> {
+    pick_vernacular(&item.vernacular_names)
+}
+
+/// Pick the best vernacular name from a list of GBIF vernacular entries.
+///
+/// Preference order: English + `preferred`, then any English-tagged, then an
+/// untagged entry (GBIF often omits the language tag for English), then any
+/// `preferred` entry, then the first available. The English-and-preferred tier
+/// comes first because GBIF's lists routinely include several conflicting
+/// English names (e.g. *Acer saccharinum* lists "Red Maple" ahead of "Silver
+/// Maple"); only the authoritative `preferred` flag disambiguates them.
+fn pick_vernacular(names: &[gbif::checklistbank::types::VernacularName]) -> Option<String> {
     // The serialized form of `VernacularNameLanguage::Eng` is "eng"; we
     // compare via a serde round-trip so we don't depend on the enum's
     // identifier munging.
-    fn lang_str(v: &gbif::checklistbank::types::VernacularName) -> Option<String> {
-        v.language.as_ref().and_then(rank_to_string)
+    fn is_english(v: &gbif::checklistbank::types::VernacularName) -> bool {
+        v.language.as_ref().and_then(rank_to_string).as_deref() == Some("eng")
     }
 
-    // English-tagged.
-    if let Some(name) = item
-        .vernacular_names
+    // English + preferred.
+    if let Some(name) = names
         .iter()
-        .find(|v| lang_str(v).as_deref() == Some("eng"))
+        .find(|v| is_english(v) && v.preferred == Some(true))
+        .map(|v| v.vernacular_name.clone())
+    {
+        return Some(name);
+    }
+    // English-tagged.
+    if let Some(name) = names
+        .iter()
+        .find(|v| is_english(v))
         .map(|v| v.vernacular_name.clone())
     {
         return Some(name);
     }
     // Untagged (GBIF often omits the language tag for English).
-    if let Some(name) = item
-        .vernacular_names
+    if let Some(name) = names
         .iter()
         .find(|v| v.language.is_none())
         .map(|v| v.vernacular_name.clone())
@@ -964,8 +1002,7 @@ fn pick_vernacular_name(item: &NameUsageSearchResult) -> Option<String> {
         return Some(name);
     }
     // Preferred.
-    if let Some(name) = item
-        .vernacular_names
+    if let Some(name) = names
         .iter()
         .find(|v| v.preferred == Some(true))
         .map(|v| v.vernacular_name.clone())
@@ -973,9 +1010,7 @@ fn pick_vernacular_name(item: &NameUsageSearchResult) -> Option<String> {
         return Some(name);
     }
     // First available.
-    item.vernacular_names
-        .first()
-        .map(|v| v.vernacular_name.clone())
+    names.first().map(|v| v.vernacular_name.clone())
 }
 
 /// Cache hit/miss/entry-count snapshot.
@@ -1147,6 +1182,25 @@ mod tests {
         );
         let result = client.search_result_to_taxon(&item);
         assert_eq!(result.common_name.as_deref(), Some("Powdery Mildew Fungi"));
+    }
+
+    #[test]
+    fn test_vernacular_preferred_english_beats_earlier_english() {
+        // Reproduces the Acer saccharinum case: GBIF lists a non-preferred
+        // "Red Maple" ahead of the authoritative `preferred` "Silver Maple".
+        // The preferred English entry must win despite appearing later.
+        let client = GbifClient::new();
+        let item = make_search_result(
+            "Acer saccharinum",
+            "SPECIES",
+            None,
+            vec![
+                vn("Red Maple", Some("eng"), None),
+                vn("Silver Maple", Some("eng"), Some(true)),
+            ],
+        );
+        let result = client.search_result_to_taxon(&item);
+        assert_eq!(result.common_name.as_deref(), Some("Silver Maple"));
     }
 
     #[test]

--- a/crates/observing-appview/src/taxonomy/gbif.rs
+++ b/crates/observing-appview/src/taxonomy/gbif.rs
@@ -470,7 +470,15 @@ impl GbifClient {
         // Wikidata's primary image (P18) in parallel.
         let key_u64 = key as u64;
         let key_slice = [key_u64];
-        let (children, descriptions, references, media, vernacular_names, wikidata_url, wikidata_images) = tokio::join!(
+        let (
+            children,
+            descriptions,
+            references,
+            media,
+            vernacular_names,
+            wikidata_url,
+            wikidata_images,
+        ) = tokio::join!(
             self.get_children(taxon_id, 20),
             async {
                 match self


### PR DESCRIPTION
## Problem

The taxon detail page showed the wrong common name — e.g. [`/taxon/Plantae/Acer-saccharinum`](https://observ.ing/taxon/Plantae/Acer-saccharinum) (silver maple) displayed as **"Red Maple"** (which is *Acer rubrum*).

## Root cause

Common names on the detail page come live from GBIF, not a local table. The detail path (`get_by_id`) read GBIF's single scalar `vernacularName` from `/species/{key}`, which is unreliable. For *Acer saccharinum* that scalar is "Red Maple", even though GBIF's full vernacular list marks **"Silver Maple"** as `preferred: true` (UKSI, IUCN, VASCAN).

Verified against the live API:
- `Acer saccharinum` → key `3189837` (EXACT match — name resolution was never wrong)
- `GET /species/3189837` scalar → `"vernacularName": "Red Maple"` ❌
- `GET /species/3189837/vernacularNames` → "Silver Maple" `preferred: true` ✅, with "Red Maple" appearing earlier as a non-preferred entry

The search path already picked names smartly from the full list; only the detail path didn't.

## Fix

- `get_by_id` now fetches `/species/{key}/vernacularNames` (in parallel with the existing detail fetches) and picks the best entry, falling back to the v1 scalar only when the list is empty or the request fails.
- Refactored the search-path helper into a shared `pick_vernacular(&[VernacularName])` used by both paths.
- Added an **English + `preferred`** tier *above* plain English-tagged. This was necessary: GBIF lists the non-preferred "Red Maple" *before* the preferred "Silver Maple", so the old English-first order would still have picked the wrong name.

Preference order: English+preferred → English → untagged → preferred → first available.

## Tests

All 7 existing vernacular tests pass, plus a new `test_vernacular_preferred_english_beats_earlier_english` reproducing the maple case. `cargo clippy -p observing-appview` is clean.

## Note

This covers the GBIF-backed detail page (where the bug was reported). The search/autocomplete surfaces already shared the picking logic and now benefit from the new preferred-English tier too.