### PR TITLE
design-audit: remove grey.800 override from image Skeleton in ObservationDetail

### DIFF
--- a/frontend/src/components/observation/ObservationDetailSkeleton.tsx
+++ b/frontend/src/components/observation/ObservationDetailSkeleton.tsx
@@ -32,7 +32,7 @@ export function ObservationDetailSkeleton() {
       </Box>
 
       {/* Image */}
-      <Skeleton variant="rectangular" height={400} sx={{ width: "100%", bgcolor: "grey.800" }} />
+      <Skeleton variant="rectangular" height={400} sx={{ width: "100%" }} />
 
       {/* Content: uniform section cards */}
       <Box sx={{ p: { xs: 2, sm: 3 }, display: "flex", flexDirection: "column", gap: 2.5 }}>


### PR DESCRIPTION
## What

Removes `bgcolor: "grey.800"` from the image `<Skeleton>` in `ObservationDetailSkeleton`.

## Why

The theme already has a `MuiSkeleton` style override that sets `backgroundColor: theme.palette.placeholder` for every skeleton in the app. The explicit `bgcolor: "grey.800"` on this one skeleton fought that override — producing a cool-toned dark grey (`#424242`) instead of the warm `placeholder` token.

In **light mode** the result was a jarring dark slab (`#424242`) against the warm bone background (`#faf6ec`), rather than the warm placeholder (`#efe7d4`) that every other skeleton correctly shows.

Removing the property lets the theme-level override take effect, which is what all other `<Skeleton>` components in the codebase already rely on.

## Change

```diff
- <Skeleton variant="rectangular" height={400} sx={{ width: "100%", bgcolor: "grey.800" }} />
+ <Skeleton variant="rectangular" height={400} sx={{ width: "100%" }} />
```

One line removed, no new abstractions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CbFPdGxbMHW1D3Q1cZdnQ3

---
_Generated by [Claude Code](https://claude.ai/code/session_01CbFPdGxbMHW1D3Q1cZdnQ3)_