### PR TITLE
design-audit: use common.white token instead of raw white literals

### DIFF
--- a/frontend/src/components/common/UserCard.tsx
+++ b/frontend/src/components/common/UserCard.tsx
@@ -101,7 +101,7 @@ export function UserCard({
         width: avatarSize,
         height: avatarSize,
         background: gradientFromString(did ?? actor.handle ?? displayName),
-        color: "#fff",
+        color: "common.white",
         fontWeight: 600,
         fontSize: avatarSize * 0.45,
       }}

--- a/frontend/src/components/feed/PendingBadge.tsx
+++ b/frontend/src/components/feed/PendingBadge.tsx
@@ -16,7 +16,7 @@ export function PendingBadge() {
         left: 8,
         zIndex: 1,
         bgcolor: "rgba(0, 0, 0, 0.65)",
-        color: "white",
+        color: "common.white",
       }}
     />
   );

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -104,7 +104,7 @@ function ImageThumbnail({ src, alt, onEnlarge, onRemove }: ImageThumbnailProps) 
           top: 2,
           right: 2,
           bgcolor: "rgba(0, 0, 0, 0.7)",
-          color: "white",
+          color: "common.white",
           width: 20,
           height: 20,
           "&:hover": { bgcolor: "error.main" },


### PR DESCRIPTION
## What

Replaces raw `"#fff"` / `"white"` color literals with the theme's `common.white` token in three components:

- `UserCard.tsx` — avatar-fallback text color
- `PendingBadge.tsx` — processing badge text color
- `UploadModal.tsx` — image thumbnail remove-button icon color

## Why

All three render white text/icons on top of a dark, semi-transparent scrim over a photo — the exact same idiom `PhotoLightbox.tsx` already implements, and it correctly uses `color: "common.white"` (MUI's semantic token) rather than a raw literal. The other three components had silently drifted to `"#fff"` or `"white"` instead of following that established convention.

This is a pure consistency fix — `common.white` resolves to the same value as `"#fff"`/`"white"` in both light and dark mode, so there's no visual change. It just means all four call sites now express "white" the same, theme-aware way.

`LiveIdView.tsx` was intentionally left untouched: it's a fixed-black, full-screen camera overlay (independent of app theme mode), and its white/black usage is already internally consistent rather than drifting from another component's pattern.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint frontend/src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — all files pass
- `vitest` — UserCard/PendingBadge/UploadModal-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TuWeqsYmHid3aqP3KBZwbr


---
_Generated by [Claude Code](https://claude.ai/code/session_01TuWeqsYmHid3aqP3KBZwbr)_