### PR TITLE
design-audit: add aria-label to icon-only nav buttons in TopBar

### DIFF
--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -137,7 +137,7 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
           <Box sx={{ display: "flex", alignItems: "center", gap: { xs: 0.5, md: 1.5 } }}>
             {!isMobile && (
               <Tooltip title="Docs">
-                <IconButton component={Link} to="/docs" color="inherit">
+                <IconButton component={Link} to="/docs" color="inherit" aria-label="Docs">
                   <MenuBook />
                 </IconButton>
               </Tooltip>
@@ -145,14 +145,19 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
 
             {notificationItem && (
               <Tooltip title="Notifications">
-                <IconButton component={Link} to={notificationItem.path} color="inherit">
+                <IconButton
+                  component={Link}
+                  to={notificationItem.path}
+                  color="inherit"
+                  aria-label="Notifications"
+                >
                   {notificationItem.icon}
                 </IconButton>
               </Tooltip>
             )}
 
             <Tooltip title="Settings">
-              <IconButton component={Link} to="/settings" color="inherit">
+              <IconButton component={Link} to="/settings" color="inherit" aria-label="Settings">
                 <Settings />
               </IconButton>
             </Tooltip>


### PR DESCRIPTION
## What

The Docs, Notifications, and Settings `IconButton`s in `TopBar.tsx`'s primary navigation were icon-only and relied solely on a `Tooltip` for identification, but MUI's `Tooltip` only wires `aria-describedby` — it does not provide an accessible name. Screen readers announced these three buttons with no label.

The sibling mobile-menu button (`aria-label="menu"`) and Account-menu button (`aria-label="Account menu"`) in the same file already followed the correct pattern; these three had drifted from it.

## Change

```diff
- <IconButton component={Link} to="/docs" color="inherit">
+ <IconButton component={Link} to="/docs" color="inherit" aria-label="Docs">
- <IconButton component={Link} to={notificationItem.path} color="inherit">
+ <IconButton component={Link} to={notificationItem.path} color="inherit" aria-label="Notifications">
- <IconButton component={Link} to="/settings" color="inherit">
+ <IconButton component={Link} to="/settings" color="inherit" aria-label="Settings">
```

No visual change — `aria-label` only affects the accessibility tree.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — passes


---
_Generated by [Claude Code](https://claude.ai/code/session_01SvkLjQdcotWsGZPEu6ZL5Y)_