### PR TITLE
refactor(bootstrap): extract per-workload PgPool construction into PoolConfig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2927,6 +2927,7 @@ dependencies = [
 name = "observing-migrate"
 version = "0.1.0"
 dependencies = [
+ "observing-bootstrap",
  "observing-db",
  "sqlx",
  "tokio",
@@ -2940,6 +2941,7 @@ name = "observing-resolve-taxa"
 version = "0.1.0"
 dependencies = [
  "clap",
+ "observing-bootstrap",
  "observing-db",
  "observing-taxonomy-gbif",
  "sqlx",

--- a/crates/observing-appview/Cargo.toml
+++ b/crates/observing-appview/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT OR Apache-2.0"
 
 [dependencies]
 # Internal crates
-observing-bootstrap = { path = "../observing-bootstrap" }
+observing-bootstrap = { path = "../observing-bootstrap", features = ["db"] }
 axum-admin = { path = "../axum-admin" }
 observing-db = { path = "../observing-db", features = ["processing"] }
 atproto-identity = { path = "../atproto-identity" }

--- a/crates/observing-appview/src/main.rs
+++ b/crates/observing-appview/src/main.rs
@@ -17,7 +17,6 @@ mod validation;
 
 use std::path::PathBuf;
 use std::sync::Arc;
-use std::time::Duration;
 
 use axum::extract::DefaultBodyLimit;
 use axum::http::{header, Method};
@@ -25,7 +24,7 @@ use axum::middleware as axum_middleware;
 use axum::response::IntoResponse;
 use axum::routing::{get, post};
 use axum::Router;
-use sqlx::postgres::PgPoolOptions;
+use observing_bootstrap::db::PoolConfig;
 use tower_http::compression::CompressionLayer;
 use tower_http::cors::{Any, CorsLayer};
 use tower_http::services::{ServeDir, ServeFile};
@@ -51,11 +50,7 @@ async fn main() {
     info!(port = config.port, "Starting observing-appview");
 
     // Connect to database
-    let pool = PgPoolOptions::new()
-        .max_connections(50)
-        .acquire_timeout(Duration::from_secs(5))
-        .idle_timeout(Some(Duration::from_secs(300)))
-        .max_lifetime(Some(Duration::from_secs(1800)))
+    let pool = PoolConfig::service()
         .connect(&config.database_url)
         .await
         .expect("Failed to connect to database");

--- a/crates/observing-bootstrap/Cargo.toml
+++ b/crates/observing-bootstrap/Cargo.toml
@@ -9,9 +9,12 @@ license = "MIT OR Apache-2.0"
 default = ["http"]
 # HTTP service scaffolding (`serve`). Pulls axum.
 http = ["dep:axum", "dep:tokio"]
+# Postgres pool construction (`db` module): per-workload `PoolConfig` presets.
+# Pulls sqlx + pg-url-env.
+db = ["dep:sqlx", "dep:pg-url-env"]
 # One-shot batch-job scaffolding (`job` module): shared CLI flags, a
-# bounded-concurrency drive loop, and pool setup. Pulls sqlx/clap/futures.
-job = ["dep:sqlx", "dep:clap", "dep:futures", "dep:pg-url-env"]
+# bounded-concurrency drive loop, and pool setup. Builds on `db`, adds clap/futures.
+job = ["db", "dep:clap", "dep:futures"]
 
 [dependencies]
 tracing = { workspace = true }

--- a/crates/observing-bootstrap/src/db.rs
+++ b/crates/observing-bootstrap/src/db.rs
@@ -1,0 +1,159 @@
+//! Postgres pool construction, sized per workload.
+//!
+//! Every binary that talks to the database was hand-rolling the same
+//! `PgPoolOptions::new().max_connections(..).acquire_timeout(..)...connect(url)`
+//! chain, differing only in the numbers. The numbers *should* differ — a
+//! 50-connection public API pool and a single-connection migration runner want
+//! very different sizing — so this module keeps the shape in one place and
+//! exposes the per-workload sizing as named [`PoolConfig`] presets.
+//!
+//! URL resolution stays separate: [`PoolConfig::connect`] takes an
+//! already-resolved connection string (for callers that read `DATABASE_URL`
+//! themselves, e.g. an admin migration role), and [`PoolConfig::connect_from_env`]
+//! layers `pg_url_env` resolution on top for the common Cloud Run / Cloud SQL
+//! case.
+
+use std::time::Duration;
+
+use sqlx::postgres::{PgPool, PgPoolOptions};
+
+/// Connection-pool sizing for one workload.
+///
+/// Construct with a preset ([`service`](Self::service), [`ingester`](Self::ingester),
+/// [`migration`](Self::migration), [`worker`](Self::worker), [`job`](Self::job)),
+/// then override individual fields with the builder setters if a specific
+/// deployment needs to. All presets use the same defaults for the pieces they
+/// don't care about (no idle recycling, no max lifetime).
+#[derive(Debug, Clone)]
+pub struct PoolConfig {
+    /// Upper bound on open connections.
+    pub max_connections: u32,
+    /// How long `acquire()` waits for a free connection before erroring.
+    pub acquire_timeout: Duration,
+    /// Close a connection after it sits idle this long. `None` keeps idle
+    /// connections open for the pool's lifetime.
+    pub idle_timeout: Option<Duration>,
+    /// Retire and reopen a connection after it has lived this long, regardless
+    /// of activity. `None` never retires on age.
+    pub max_lifetime: Option<Duration>,
+}
+
+impl PoolConfig {
+    /// Long-lived public API service. Wide pool (50), short acquire timeout so
+    /// a saturated pool fails fast, and both idle recycling and a max lifetime
+    /// so connections churn behind a connection-pooling proxy / Cloud SQL.
+    pub fn service() -> Self {
+        Self {
+            max_connections: 50,
+            acquire_timeout: Duration::from_secs(5),
+            idle_timeout: Some(Duration::from_secs(300)),
+            max_lifetime: Some(Duration::from_secs(1800)),
+        }
+    }
+
+    /// Firehose ingester. Moderate pool (10) for the concurrent write path,
+    /// fast acquire timeout, idle recycling but no forced max lifetime.
+    pub fn ingester() -> Self {
+        Self {
+            max_connections: 10,
+            acquire_timeout: Duration::from_secs(5),
+            idle_timeout: Some(Duration::from_secs(300)),
+            max_lifetime: None,
+        }
+    }
+
+    /// One-shot migration runner: a single admin connection, patient acquire
+    /// timeout (cold Cloud SQL instances can be slow to accept the first
+    /// connection).
+    pub fn migration() -> Self {
+        Self {
+            max_connections: 1,
+            acquire_timeout: Duration::from_secs(30),
+            idle_timeout: None,
+            max_lifetime: None,
+        }
+    }
+
+    /// Long-running background worker doing periodic sweeps. A couple of
+    /// connections, patient-ish acquire timeout.
+    pub fn worker() -> Self {
+        Self {
+            max_connections: 2,
+            acquire_timeout: Duration::from_secs(10),
+            idle_timeout: None,
+            max_lifetime: None,
+        }
+    }
+
+    /// One-shot batch job sized for `concurrency` in-flight queries, plus one
+    /// spare so the driving loop isn't starved by its own workers.
+    pub fn job(concurrency: usize) -> Self {
+        Self {
+            max_connections: concurrency.max(1) as u32 + 1,
+            acquire_timeout: Duration::from_secs(30),
+            idle_timeout: None,
+            max_lifetime: None,
+        }
+    }
+
+    /// Override the connection cap.
+    pub fn with_max_connections(mut self, max: u32) -> Self {
+        self.max_connections = max;
+        self
+    }
+
+    /// Override the acquire timeout.
+    pub fn with_acquire_timeout(mut self, timeout: Duration) -> Self {
+        self.acquire_timeout = timeout;
+        self
+    }
+
+    /// Override the idle timeout (`None` disables idle recycling).
+    pub fn with_idle_timeout(mut self, timeout: Option<Duration>) -> Self {
+        self.idle_timeout = timeout;
+        self
+    }
+
+    /// Override the max connection lifetime (`None` disables age-based retirement).
+    pub fn with_max_lifetime(mut self, lifetime: Option<Duration>) -> Self {
+        self.max_lifetime = lifetime;
+        self
+    }
+
+    /// Connect a pool against an already-resolved connection string.
+    ///
+    /// Use this when the caller owns URL resolution — e.g. a migration runner
+    /// that insists on a full admin `DATABASE_URL` rather than assembled
+    /// `DB_*` parts. For the common case, prefer [`connect_from_env`](Self::connect_from_env).
+    pub async fn connect(&self, url: &str) -> Result<PgPool, sqlx::Error> {
+        let mut opts = PgPoolOptions::new()
+            .max_connections(self.max_connections)
+            .acquire_timeout(self.acquire_timeout);
+        if let Some(idle) = self.idle_timeout {
+            opts = opts.idle_timeout(Some(idle));
+        }
+        if let Some(lifetime) = self.max_lifetime {
+            opts = opts.max_lifetime(Some(lifetime));
+        }
+        opts.connect(url).await
+    }
+
+    /// Resolve the connection string from the environment, then connect.
+    ///
+    /// The URL is resolved the way the services resolve theirs: `DATABASE_URL`
+    /// if set (local dev), otherwise assembled from the
+    /// `DB_HOST`/`DB_NAME`/`DB_USER`/`DB_PASSWORD` parts (Cloud Run + Cloud SQL,
+    /// where a role-scoped password comes from a secret). `default_db_name` is
+    /// the database name to fall back to when only `DB_HOST` is provided.
+    ///
+    /// Returns a human-readable error string suitable for logging immediately
+    /// before a non-zero exit.
+    pub async fn connect_from_env(&self, default_db_name: &str) -> Result<PgPool, String> {
+        let url = pg_url_env::database_url_from_env(default_db_name).ok_or_else(|| {
+            "set DATABASE_URL, or DB_HOST/DB_NAME/DB_USER/DB_PASSWORD".to_string()
+        })?;
+        self.connect(&url)
+            .await
+            .map_err(|e| format!("failed to connect: {e}"))
+    }
+}

--- a/crates/observing-bootstrap/src/job.rs
+++ b/crates/observing-bootstrap/src/job.rs
@@ -13,10 +13,11 @@
 
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::time::Duration;
 
 use futures::stream::{self, StreamExt};
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::PgPool;
+
+use crate::db::PoolConfig;
 
 /// CLI flags shared by every batch job. Flatten into a binary's own `Args`
 /// with `#[command(flatten)]`, then add job-specific flags alongside.
@@ -73,14 +74,9 @@ impl Summary {
 /// Returns a human-readable error string suitable for logging immediately
 /// before a non-zero exit.
 pub async fn connect_pool(concurrency: usize) -> Result<PgPool, String> {
-    let url = pg_url_env::database_url_from_env("observing")
-        .ok_or_else(|| "set DATABASE_URL, or DB_HOST/DB_NAME/DB_USER/DB_PASSWORD".to_string())?;
-    PgPoolOptions::new()
-        .max_connections(concurrency.max(1) as u32 + 1)
-        .acquire_timeout(Duration::from_secs(30))
-        .connect(&url)
+    PoolConfig::job(concurrency)
+        .connect_from_env("observing")
         .await
-        .map_err(|e| format!("failed to connect: {e}"))
 }
 
 /// Run `process` over `rows` with up to `concurrency` items in flight,

--- a/crates/observing-bootstrap/src/lib.rs
+++ b/crates/observing-bootstrap/src/lib.rs
@@ -1,7 +1,8 @@
 //! Shared bootstrap helpers for observ.ing binaries.
 //!
-//! Two independent, feature-gated halves:
+//! Independent, feature-gated pieces:
 //! - [`serve`] (feature `http`) — bind + serve an axum app, for HTTP services.
+//! - [`db`] (feature `db`) — Postgres pool construction sized per workload.
 //! - [`job`] (feature `job`) — scaffolding for one-shot batch jobs (data
 //!   backfills, replays).
 //!
@@ -13,6 +14,9 @@
 mod http;
 #[cfg(feature = "http")]
 pub use http::serve;
+
+#[cfg(feature = "db")]
+pub mod db;
 
 #[cfg(feature = "job")]
 pub mod job;

--- a/crates/observing-migrate/Cargo.toml
+++ b/crates/observing-migrate/Cargo.toml
@@ -6,6 +6,7 @@ description = "One-shot binary that runs Observ.ing database migrations and exit
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+observing-bootstrap = { path = "../observing-bootstrap", default-features = false, features = ["db"] }
 observing-db = { path = "../observing-db" }
 sqlx = { workspace = true }
 tokio = { workspace = true }

--- a/crates/observing-migrate/src/main.rs
+++ b/crates/observing-migrate/src/main.rs
@@ -5,9 +5,8 @@
 //! its own Cloud Run Job so that migrations happen as an explicit deploy step
 //! instead of a side effect of a service container's startup.
 
-use sqlx::postgres::PgPoolOptions;
+use observing_bootstrap::db::PoolConfig;
 use std::process::ExitCode;
-use std::time::Duration;
 use tracing::{error, info};
 use tracing_subscriber::{prelude::*, EnvFilter};
 
@@ -30,12 +29,7 @@ async fn main() -> ExitCode {
     };
 
     info!("Connecting with admin credentials to run migrations");
-    let pool = match PgPoolOptions::new()
-        .max_connections(1)
-        .acquire_timeout(Duration::from_secs(30))
-        .connect(&database_url)
-        .await
-    {
+    let pool = match PoolConfig::migration().connect(&database_url).await {
         Ok(p) => p,
         Err(e) => {
             error!(error = %e, "Failed to connect to database");

--- a/crates/observing-resolve-taxa/Cargo.toml
+++ b/crates/observing-resolve-taxa/Cargo.toml
@@ -6,6 +6,7 @@ description = "Background worker that fills accepted_taxon_key on identification
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+observing-bootstrap = { path = "../observing-bootstrap", default-features = false, features = ["db"] }
 observing-db = { path = "../observing-db", features = ["processing"] }
 observing-taxonomy-gbif = { path = "../observing-taxonomy-gbif" }
 wikidata-client = { path = "../wikidata-client" }

--- a/crates/observing-resolve-taxa/src/main.rs
+++ b/crates/observing-resolve-taxa/src/main.rs
@@ -30,9 +30,9 @@ mod taxon_uri;
 use std::time::Duration;
 
 use clap::Parser;
+use observing_bootstrap::db::PoolConfig;
 use observing_db::taxonomy_resolver::Resolver;
 use observing_taxonomy_gbif::GbifUpstream;
-use sqlx::postgres::PgPoolOptions;
 use sqlx::{PgPool, Row};
 use tracing::{error, info, warn};
 use tracing_subscriber::{prelude::*, EnvFilter};
@@ -84,12 +84,7 @@ async fn main() -> std::process::ExitCode {
         }
     };
 
-    let pool = match PgPoolOptions::new()
-        .max_connections(2)
-        .acquire_timeout(Duration::from_secs(10))
-        .connect(&database_url)
-        .await
-    {
+    let pool = match PoolConfig::worker().connect(&database_url).await {
         Ok(p) => p,
         Err(e) => {
             error!(error = %e, "Failed to connect to database");

--- a/crates/tap-ingester/Cargo.toml
+++ b/crates/tap-ingester/Cargo.toml
@@ -9,8 +9,9 @@ license = "MIT OR Apache-2.0"
 # Tap client wrapper — handles WebSocket + ack handshake + reconnection.
 tapped = { workspace = true }
 
-# Shared HTTP server bootstrap (bind + serve for the dashboard).
-observing-bootstrap = { path = "../observing-bootstrap" }
+# Shared HTTP server bootstrap (bind + serve for the dashboard) and Postgres
+# pool construction (`PoolConfig`).
+observing-bootstrap = { path = "../observing-bootstrap", features = ["db"] }
 
 # Database write path (shared processing module).
 observing-db = { path = "../observing-db", features = ["processing"] }

--- a/crates/tap-ingester/src/database.rs
+++ b/crates/tap-ingester/src/database.rs
@@ -8,10 +8,11 @@
 use crate::error::{IngesterError, Result};
 use crate::media_resolver::MediaResolver;
 use chrono::{DateTime, Utc};
+use observing_bootstrap::db::PoolConfig;
 use observing_db::identifications::CommunityIdsRefresher;
 use observing_db::processing;
 use serde_json::Value;
-use sqlx::postgres::{PgPool, PgPoolOptions};
+use sqlx::postgres::PgPool;
 use std::time::Duration;
 use tracing::{debug, info, warn};
 
@@ -79,12 +80,7 @@ pub struct Database {
 impl Database {
     pub async fn connect(database_url: &str) -> Result<Self> {
         info!("Connecting to database...");
-        let pool = PgPoolOptions::new()
-            .max_connections(10)
-            .acquire_timeout(std::time::Duration::from_secs(5))
-            .idle_timeout(Some(std::time::Duration::from_secs(300)))
-            .connect(database_url)
-            .await?;
+        let pool = PoolConfig::ingester().connect(database_url).await?;
         info!("Database connection established");
         let community_ids_refresher =
             CommunityIdsRefresher::spawn(pool.clone(), COMMUNITY_IDS_REFRESH_DEBOUNCE);


### PR DESCRIPTION
## What

Five binaries each hand-rolled the same `PgPoolOptions` chain to open a Postgres pool, differing only in the sizing numbers. This centralizes the *shape* while keeping the per-workload sizing explicit.

New `observing_bootstrap::db` module (feature `db`) with a `PoolConfig` struct and named presets:

| Preset | conns | acquire | idle | max lifetime | caller |
|--------|------:|--------:|-----:|-------------:|--------|
| `service()` | 50 | 5s | 300s | 1800s | observing-appview |
| `ingester()` | 10 | 5s | 300s | — | tap-ingester |
| `migration()` | 1 | 30s | — | — | observing-migrate |
| `worker()` | 2 | 10s | — | — | observing-resolve-taxa |
| `job(n)` | n+1 | 30s | — | — | `job::connect_pool` |

- `connect(url)` takes an already-resolved connection string (e.g. an admin migration `DATABASE_URL`).
- `connect_from_env(default_db)` layers `pg_url_env` resolution on top (the Cloud Run / Cloud SQL `DB_*` path).
- `with_max_connections` / `with_acquire_timeout` / … builder setters allow per-deployment overrides.

## Why

The pool chain was copy-pasted across `observing-appview`, `tap-ingester`, `observing-migrate`, `observing-resolve-taxa`, and `observing-bootstrap::job`. Centralizing it removes the boilerplate and gives one place to reason about pool sizing, while the named presets keep the intentional per-binary differences visible instead of buried in magic numbers.

## Notes

- **Sizing per binary is unchanged** — this is a pure refactor of the construction boilerplate.
- Tracing/log init stays deliberately per-binary (this PR does not touch it).
- `job::connect_pool` keeps its signature and now delegates to `PoolConfig::job(n).connect_from_env("observing")`.
- The `db` feature pulls only `sqlx` + `pg-url-env`; `job` now builds on `db`. Migrate/resolve-taxa depend on bootstrap with `default-features = false, features = ["db"]` so they don't pull axum.

## Testing

- `cargo build` for `observing-bootstrap --features job`, `observing-migrate`, `observing-resolve-taxa`, `tap-ingester`, `observing-appview` (SQLX_OFFLINE) — all green.
- `cargo clippy` on the touched crates — no new warnings.
- `cargo fmt` applied.

Part 1 of 2 from a pass over the Rust crates for extractable shared patterns.