### PR TITLE
design-audit: add empty/truncated stories to TaxonReferencesSection

### DIFF
--- a/frontend/src/components/taxon/TaxonReferencesSection.stories.tsx
+++ b/frontend/src/components/taxon/TaxonReferencesSection.stories.tsx
@@ -30,3 +30,20 @@ export const Default: Story = {
     ],
   },
 };
+
+export const Empty: Story = {
+  args: {
+    references: [],
+  },
+};
+
+// The section only renders the first 5 references; the trailing count chip
+// still reflects the full list, so it reads higher than the visible rows.
+export const ManyReferences: Story = {
+  args: {
+    references: Array.from({ length: 8 }, (_, i) => ({
+      citation: `Author ${i + 1}, A. (20${10 + i}). Reference title ${i + 1}.`,
+      link: `https://example.org/ref/${i + 1}`,
+    })),
+  },
+};


### PR DESCRIPTION
## What

`TaxonReferencesSection.stories.tsx` only had one story (`Default`), rendering a mid-size list of 3 references. But the component has two other real behaviors that were never demonstrated in Storybook:

- An **empty** reference list (`references: []`) — the section still renders with a `0` count chip.
- **Truncation**: the component only renders the first 5 references (`references.slice(0, 5)`), while the trailing chip shows the full count. With only a 3-item fixture, this cap was never exercised.

## Change

Adds two stories:

- `Empty` — `references: []`
- `ManyReferences` — 8 references, demonstrating the 5-item render cap against the full-count chip

No production code changes — pure Storybook additions.

## Verification

- `tsc --noEmit` — no new errors (3 pre-existing, unrelated module-resolution errors in `mapStyle.ts`/`mapUtils.ts`/`photoPicker.ts` from an environment without network-restricted deps installed)
- `oxlint` — clean
- `oxfmt --check` — passes
- `npm run check:stories` — all 79 components still have stories

---
_Generated by [Claude Code](https://claude.ai/code/session_013vdQZRcA43qFgfXfCaayqS)_