### PR TITLE
cost(species-id-live): scale to zero (min-instances 1→0)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,10 +554,13 @@ jobs:
             --startup-probe=tcpSocket.port=8080,periodSeconds=10,failureThreshold=30,timeoutSeconds=5 \
             --set-env-vars=RUST_LOG=observing_species_id=info,LOG_FORMAT=json
 
-      # Faster ViT-L service for the live camera loop. Same flags as
-      # observing-species-id but only 4 GiB — the ViT-L bundle's resident
-      # footprint is ~3 GB (vs ViT-H's ~4.4 GB), so half the memory of the full
-      # service is enough. MODEL_VERSION is already baked into the image.
+      # Faster ViT-L service for the live camera loop. Like observing-species-id
+      # but only 4 GiB — the ViT-L bundle's resident footprint is ~3 GB (vs
+      # ViT-H's ~4.4 GB), so half the memory of the full service is enough.
+      # MODEL_VERSION is already baked into the image.
+      # min-instances=0: the live feature is experimental and sees ~no traffic,
+      # so scale to zero rather than pay to keep a 4 GiB instance warm 24/7.
+      # Flip back to 1 if/when it launches and cold starts hurt UX.
       - name: Deploy species-id-live
         run: |
           gcloud run deploy observing-species-id-live \
@@ -567,7 +570,7 @@ jobs:
             --cpu=2 \
             --memory=4Gi \
             --cpu-boost \
-            --min-instances=1 \
+            --min-instances=0 \
             --startup-probe=tcpSocket.port=8080,periodSeconds=10,failureThreshold=30,timeoutSeconds=5 \
             --set-env-vars=RUST_LOG=observing_species_id=info,LOG_FORMAT=json
 


### PR DESCRIPTION
The live-camera species-id service (`observing-species-id-live`) keeps a **4 GiB instance warm 24/7** but has seen **0 requests over the last 7 days** — so we pay Cloud Run min-instance charges (~**\$27/mo**) for no benefit.

## Change
`--min-instances=1` → `--min-instances=0` in the `species-id-live` deploy step. It now scales to zero when idle. The only cost is a cold start on the first request, which is fine while the live feature is experimental.

Flip back to `1` when the feature launches if cold-start latency hurts UX.

## Context
Found while auditing GCP spend via the billing export. Cloud Run min-instance warm capacity was ~\$74/mo of a ~\$310/mo bill; this recovers the `species-id-live` share. Sibling `observing-species-id` (8 GiB, min=1) is left as-is since it serves real traffic; `tap-ingester` is untouched (needs CPU-always-on for the firehose).

Other savings identified but not in this PR: Artifact Registry cleanup policy (222 GB repo, no policy) and Cloud SQL right-sizing/CUD.