### PR TITLE
design-audit: move dark photo-overlay colors to theme palette token

### DIFF
--- a/frontend/src/components/feed/PendingBadge.tsx
+++ b/frontend/src/components/feed/PendingBadge.tsx
@@ -1,10 +1,11 @@
-import { Chip, CircularProgress } from "@mui/material";
+import { Chip, CircularProgress, useTheme } from "@mui/material";
 
 // Overlay chip marking a feed row as a not-yet-ingested optimistic submission.
 // Pair it with a dimmed, interaction-disabled card; it clears once the ingester
 // catches up and the pending slice drops the row's uri (see pendingSlice +
 // occurrenceCache `reconcileOccurrence`).
 export function PendingBadge() {
+  const theme = useTheme();
   return (
     <Chip
       size="small"
@@ -15,7 +16,7 @@ export function PendingBadge() {
         top: 8,
         left: 8,
         zIndex: 1,
-        bgcolor: "rgba(0, 0, 0, 0.65)",
+        bgcolor: theme.palette.overlay["badge"],
         color: "common.white",
       }}
     />

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -23,6 +23,7 @@ import {
   Step,
   StepLabel,
   StepContent,
+  useTheme,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
@@ -71,6 +72,7 @@ interface ImageThumbnailProps {
 }
 
 function ImageThumbnail({ src, alt, onEnlarge, onRemove }: ImageThumbnailProps) {
+  const theme = useTheme();
   return (
     <Box
       sx={{
@@ -103,7 +105,7 @@ function ImageThumbnail({ src, alt, onEnlarge, onRemove }: ImageThumbnailProps) 
           position: "absolute",
           top: 2,
           right: 2,
-          bgcolor: "rgba(0, 0, 0, 0.7)",
+          bgcolor: theme.palette.overlay["modalChip"],
           color: "common.white",
           width: 20,
           height: 20,

--- a/frontend/src/components/observation/PhotoLightbox.tsx
+++ b/frontend/src/components/observation/PhotoLightbox.tsx
@@ -1,4 +1,4 @@
-import { Box, IconButton, Modal, Fade, Typography } from "@mui/material";
+import { Box, IconButton, Modal, Fade, Typography, useTheme } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import { getLicenseLabel } from "../../lib/licenses";
 
@@ -11,6 +11,7 @@ interface PhotoLightboxProps {
 }
 
 export function PhotoLightbox({ open, onClose, src, alt, license }: PhotoLightboxProps) {
+  const theme = useTheme();
   return (
     <Modal
       open={open}
@@ -20,7 +21,7 @@ export function PhotoLightbox({ open, onClose, src, alt, license }: PhotoLightbo
         display: "flex",
         alignItems: "center",
         justifyContent: "center",
-        bgcolor: "rgba(0, 0, 0, 0.9)",
+        bgcolor: theme.palette.overlay["scrim"],
       }}
     >
       <Fade in={open}>
@@ -49,8 +50,8 @@ export function PhotoLightbox({ open, onClose, src, alt, license }: PhotoLightbo
               top: 16,
               right: 16,
               color: "common.white",
-              bgcolor: "rgba(0, 0, 0, 0.4)",
-              "&:hover": { bgcolor: "rgba(0, 0, 0, 0.6)" },
+              bgcolor: theme.palette.overlay["chip"],
+              "&:hover": { bgcolor: theme.palette.overlay["chipHover"] },
             }}
           >
             <CloseIcon />

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -7,17 +7,30 @@ declare module "@mui/material/styles" {
     placeholder: string;
     iucn: Record<string, string>;
     mapMarker: string;
+    overlay: Record<string, string>;
   }
   interface PaletteOptions {
     placeholder?: string;
     iucn?: Record<string, string>;
     mapMarker?: string;
+    overlay?: Record<string, string>;
   }
 }
 
 // Map marker / uncertainty-circle color — same in both themes (it's a
 // functional indicator, not a brand color, so it doesn't invert with the mode).
 const mapMarkerColor = "#22c55e";
+
+// Dark scrims/chips placed over photos (lightbox backdrop, icon-button chips,
+// status badges). Black-alpha rather than a mode-aware color since these sit
+// on top of photo content, not app background — mode-invariant like iucn/mapMarker.
+const overlayColors: Record<string, string> = {
+  scrim: "rgba(0, 0, 0, 0.9)",
+  chip: "rgba(0, 0, 0, 0.4)",
+  chipHover: "rgba(0, 0, 0, 0.6)",
+  badge: "rgba(0, 0, 0, 0.65)",
+  modalChip: "rgba(0, 0, 0, 0.7)",
+};
 
 // Official IUCN Red List category colors — standardized by the IUCN,
 // so they are mode-invariant and shared across light and dark themes.
@@ -87,6 +100,7 @@ const darkPalette = {
   placeholder: "#211f1b",
   iucn: iucnColors,
   mapMarker: mapMarkerColor,
+  overlay: overlayColors,
 };
 
 const lightPalette = {
@@ -120,6 +134,7 @@ const lightPalette = {
   placeholder: "#efe7d4",
   iucn: iucnColors,
   mapMarker: mapMarkerColor,
+  overlay: overlayColors,
 };
 
 const createAppTheme = (mode: PaletteMode): Theme => {


### PR DESCRIPTION
## What

`PhotoLightbox.tsx`, `PendingBadge.tsx`, and `UploadModal.tsx` each hand-wrote their own `rgba(0, 0, 0, ...)` black-alpha literal for the translucent dark scrim/chip they place over photo content:

- `PhotoLightbox.tsx` — `rgba(0, 0, 0, 0.9)` full-screen backdrop, `rgba(0, 0, 0, 0.4)` close-button chip, `rgba(0, 0, 0, 0.6)` hover
- `PendingBadge.tsx` — `rgba(0, 0, 0, 0.65)` status-badge background
- `UploadModal.tsx` — `rgba(0, 0, 0, 0.7)` remove-button chip on the upload thumbnail

These are the same three components a prior design-audit pass (#714) unified on `common.white` for their *foreground* icon/text color, but the *background* scrim color was left as raw per-file literals — bypassing the theme the same way the earlier `iucn`/`mapMarker` passes fixed.

## Change

Adds a `palette.overlay` token group to `theme/index.ts` (`Record<string, string>`, following the existing `iucn` pattern) with the five distinct values already in use:

```ts
const overlayColors: Record<string, string> = {
  scrim: "rgba(0, 0, 0, 0.9)",
  chip: "rgba(0, 0, 0, 0.4)",
  chipHover: "rgba(0, 0, 0, 0.6)",
  badge: "rgba(0, 0, 0, 0.65)",
  modalChip: "rgba(0, 0, 0, 0.7)",
};
```

Mode-invariant (same in light/dark) since these sit on top of photo content rather than app background, mirroring `iucn`/`mapMarker`. Repoints all three components to `theme.palette.overlay[...]` via `useTheme()`. No values changed — this is a pure extraction, so there's no visual diff.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint frontend/src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — passes on all touched files
- `vitest` — PendingBadge/PhotoLightbox/UploadModal-related tests pass
- `npm run check:stories` — all 79 components still have stories

---
_Generated by [Claude Code](https://claude.ai/code/session_01Sq5HDpSDUV92WVxHFV5f17)_