### PR TITLE
design-audit: add aria-label to icon-only buttons in TaxonDetailHeader

### DIFF
--- a/frontend/src/components/taxon/TaxonDetailHeader.tsx
+++ b/frontend/src/components/taxon/TaxonDetailHeader.tsx
@@ -19,7 +19,7 @@ interface TaxonDetailHeaderProps {
 export function TaxonDetailHeader({ rank, onBack, onToggleTree }: TaxonDetailHeaderProps) {
   return (
     <Box sx={stickyHeaderSx}>
-      <IconButton onClick={onBack} sx={{ mr: 1 }}>
+      <IconButton onClick={onBack} sx={{ mr: 1 }} aria-label="Back">
         <ArrowBackIcon />
       </IconButton>
       <Typography
@@ -33,7 +33,11 @@ export function TaxonDetailHeader({ rank, onBack, onToggleTree }: TaxonDetailHea
         {rank.charAt(0).toUpperCase() + rank.slice(1)}
       </Typography>
       {onToggleTree && (
-        <IconButton onClick={onToggleTree} sx={{ display: { xs: "inline-flex", md: "none" } }}>
+        <IconButton
+          onClick={onToggleTree}
+          sx={{ display: { xs: "inline-flex", md: "none" } }}
+          aria-label="Classification tree"
+        >
           <AccountTreeIcon />
         </IconButton>
       )}


### PR DESCRIPTION
## What

`TaxonDetailHeader.tsx`'s two icon-only buttons — the back button and the mobile-only classification-tree toggle — had no accessible name:

```diff
- <IconButton onClick={onBack} sx={{ mr: 1 }}>
+ <IconButton onClick={onBack} sx={{ mr: 1 }} aria-label="Back">
    <ArrowBackIcon />
  </IconButton>
  ...
- <IconButton onClick={onToggleTree} sx={{ display: { xs: "inline-flex", md: "none" } }}>
+ <IconButton
+   onClick={onToggleTree}
+   sx={{ display: { xs: "inline-flex", md: "none" } }}
+   aria-label="Classification tree"
+ >
    <AccountTreeIcon />
  </IconButton>
```

Every other icon-only `IconButton` in the codebase (`TopBar`, `FeedItem`, `CommentSection`) already sets `aria-label`; this pair drifted from that established pattern — the same category a prior pass (#715) fixed in `TopBar`. This header renders on every taxon detail page view, so it's a high-traffic gap.

No visual change — `aria-label` only affects the accessibility tree.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint frontend/src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — passes
- `vitest run` — 161 tests passed
- `npm run check:stories` — all 79 components still have stories


---
_Generated by [Claude Code](https://claude.ai/code/session_012mBYaDNxG2LjY4US5WkGD4)_