### PR TITLE
design-audit: dedupe left-accent list-item sx into layoutSx

### DIFF
--- a/frontend/src/components/comment/CommentSection.tsx
+++ b/frontend/src/components/comment/CommentSection.tsx
@@ -12,6 +12,7 @@ import {
 } from "@mui/material";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutlineOutlined";
 import { countChipSx } from "../common/chipSx";
+import { accentListItemSx } from "../common/layoutSx";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useAppSelector } from "../../store";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
@@ -114,12 +115,9 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
             <Box
               key={comment.uri}
               sx={{
-                pl: 2,
-                borderLeft: 3,
+                ...accentListItemSx,
                 borderColor: "divider",
                 transition: "all 0.2s ease",
-                borderRadius: "0 4px 4px 0",
-                py: 1,
                 "&:hover": {
                   bgcolor: "action.hover",
                   borderColor: "primary.main",

--- a/frontend/src/components/common/layoutSx.ts
+++ b/frontend/src/components/common/layoutSx.ts
@@ -27,3 +27,15 @@ export const stickyHeaderSx: SxProps<Theme> = {
   backgroundColor: (theme) => alpha(theme.palette.background.default, 0.86),
   backdropFilter: "blur(8px)",
 };
+
+/**
+ * Left-accent row shell shared by feed-style lists (identification history,
+ * comments): a colored border-left with rounded outer corners. Callers add
+ * their own `borderColor`, `transition`, and hover behavior on top.
+ */
+export const accentListItemSx = {
+  pl: 2,
+  borderLeft: 3,
+  borderRadius: "0 4px 4px 0",
+  py: 1,
+} as const;

--- a/frontend/src/components/identification/IdentificationHistory.tsx
+++ b/frontend/src/components/identification/IdentificationHistory.tsx
@@ -13,6 +13,7 @@ import {
 } from "@mui/material";
 import HistoryIcon from "@mui/icons-material/History";
 import { countChipSx } from "../common/chipSx";
+import { accentListItemSx } from "../common/layoutSx";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import type { Identification } from "../../services/types";
 import { TaxonLink } from "../common/TaxonLink";
@@ -107,12 +108,9 @@ export function IdentificationHistory({
               <Box
                 key={id.uri}
                 sx={{
-                  pl: 2,
-                  borderLeft: 3,
+                  ...accentListItemSx,
                   borderColor: isSuperseded ? "text.disabled" : "primary.main",
                   transition: "background-color 0.2s ease",
-                  borderRadius: "0 4px 4px 0",
-                  py: 1,
                   opacity: isSuperseded ? 0.5 : 1,
                   "&:hover": { bgcolor: "action.hover" },
                 }}


### PR DESCRIPTION
## What

`IdentificationHistory.tsx` and `CommentSection.tsx` each hand-wrote an identical border-left row shell for their feed-style list items:

```tsx
// IdentificationHistory.tsx
sx={{
  pl: 2,
  borderLeft: 3,
  borderColor: isSuperseded ? "text.disabled" : "primary.main",
  transition: "background-color 0.2s ease",
  borderRadius: "0 4px 4px 0",
  py: 1,
  opacity: isSuperseded ? 0.5 : 1,
  "&:hover": { bgcolor: "action.hover" },
}}

// CommentSection.tsx
sx={{
  pl: 2,
  borderLeft: 3,
  borderColor: "divider",
  transition: "all 0.2s ease",
  borderRadius: "0 4px 4px 0",
  py: 1,
  "&:hover": { bgcolor: "action.hover", borderColor: "primary.main" },
}}
```

The `pl`, `borderLeft`, `borderRadius`, `py` values are byte-for-byte identical between the two — only `borderColor`/`transition`/hover behavior genuinely differ per component. Both files already import a shared style constant (`countChipSx` from `common/chipSx.ts`), so this drift was inconsistent with an established convention for exactly this kind of thing.

## Change

Adds `accentListItemSx` to `common/layoutSx.ts` (alongside the existing `detailHeaderSx`/`stickyHeaderSx` shared layout constants) with just the truly-shared properties, and has both components spread it before their own `borderColor`/`transition`/hover overrides. No visual or behavioral change — pure extraction.

## Why now

Both call sites render on every observation-detail page view (identification history + discussion), a high-traffic surface, and this is the "duplicated `sx` blocks → shared object" category from prior design-audit passes.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint frontend/src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — passes on all touched files
- `vitest run` — 161 tests passed
- `npm run check:stories` — all 79 components still have stories


---
_Generated by [Claude Code](https://claude.ai/code/session_01TMnnGW1HuZQkxrL9biwHzf)_