### PR TITLE
design-audit: add aria-label to expand/collapse toggle buttons

### DIFF
--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -121,7 +121,9 @@ export function ExploreFilterPanel() {
             <Chip size="small" label={activeFilterCount} color="primary" sx={countChipSx} />
           )}
         </Stack>
-        <IconButton size="small">{isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}</IconButton>
+        <IconButton size="small" aria-label={isExpanded ? "Collapse section" : "Expand section"}>
+          {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
       </Box>
       {/* Collapsible filter content */}
       <Collapse in={isExpanded}>

--- a/frontend/src/components/lexicon/LexiconView.tsx
+++ b/frontend/src/components/lexicon/LexiconView.tsx
@@ -239,7 +239,9 @@ function DefSection({ name, def }: { name: string; def: LexiconDef }) {
         sx={{ display: "flex", alignItems: "center", cursor: "pointer" }}
         onClick={() => setOpen(!open)}
       >
-        <IconButton size="small">{open ? <ExpandLess /> : <ExpandMore />}</IconButton>
+        <IconButton size="small" aria-label={open ? "Collapse section" : "Expand section"}>
+          {open ? <ExpandLess /> : <ExpandMore />}
+        </IconButton>
         <Typography variant="subtitle2" component="code" sx={{ fontFamily: monoStack }}>
           #{name}
         </Typography>


### PR DESCRIPTION
## What

Two icon-only expand/collapse `IconButton`s had no accessible name:

- `LexiconView.tsx:242` — the `DefSection` toggle chevron (glossary property tables)
- `ExploreFilterPanel.tsx:124` — the filter-panel header toggle chevron (feed filters)

```tsx
// before
<IconButton size="small">{open ? <ExpandLess /> : <ExpandMore />}</IconButton>

// after
<IconButton size="small" aria-label={open ? "Collapse section" : "Expand section"}>
  {open ? <ExpandLess /> : <ExpandMore />}
</IconButton>
```

## Why

The codebase already has a house pattern for exactly this: the shared `common/CollapsibleSection.tsx` primitive sets `aria-label={expanded ? "Collapse section" : "Expand section"}` on its chevron `IconButton` (`CollapsibleSection.tsx:61`). These two call sites — which don't use that shared primitive — had drifted from it, leaving screen readers with no accessible name for the toggle. This is the same category of gap prior design-audit passes fixed for other icon-only buttons (TopBar nav icons in #715).

No visual change — `aria-label` only affects the accessibility tree.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint frontend/src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — passes on touched files
- `vitest run` — 161 tests passed
- `npm run check:stories` — all 79 components still have stories


---
_Generated by [Claude Code](https://claude.ai/code/session_01SzHyKKfheUNF4sNYd51vos)_