### PR TITLE
design-audit: move LiveIdView camera overlay colors to theme palette

### DIFF
--- a/frontend/src/components/identification/LiveIdView.tsx
+++ b/frontend/src/components/identification/LiveIdView.tsx
@@ -1,6 +1,14 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
-import { Box, Button, CircularProgress, IconButton, Stack, Typography } from "@mui/material";
+import {
+  Box,
+  Button,
+  CircularProgress,
+  IconButton,
+  Stack,
+  Typography,
+  useTheme,
+} from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import PlaceIcon from "@mui/icons-material/Place";
@@ -17,6 +25,7 @@ import { openUploadModal, setPendingUploadFiles, addToast } from "../../store/ui
 export function LiveIdView() {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
+  const theme = useTheme();
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
 
@@ -148,8 +157,8 @@ export function LiveIdView() {
           position: "fixed",
           inset: 0,
           zIndex: 1300,
-          bgcolor: "black",
-          color: "white",
+          bgcolor: "common.black",
+          color: "common.white",
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
@@ -162,7 +171,7 @@ export function LiveIdView() {
         <IconButton
           onClick={handleClose}
           aria-label="Close"
-          sx={{ position: "absolute", top: 8, left: 8, color: "white" }}
+          sx={{ position: "absolute", top: 8, left: 8, color: "common.white" }}
         >
           <CloseIcon />
         </IconButton>
@@ -174,7 +183,7 @@ export function LiveIdView() {
               Live identification uses your location to narrow suggestions to species found near
               you. Allow location access to continue.
             </Typography>
-            <CircularProgress size={20} sx={{ color: "white", mt: 1 }} />
+            <CircularProgress size={20} sx={{ color: "common.white", mt: 1 }} />
           </>
         ) : (
           <>
@@ -193,7 +202,7 @@ export function LiveIdView() {
   }
 
   return (
-    <Box sx={{ position: "fixed", inset: 0, zIndex: 1300, bgcolor: "black" }}>
+    <Box sx={{ position: "fixed", inset: 0, zIndex: 1300, bgcolor: "common.black" }}>
       <Box
         component="video"
         ref={videoRef}
@@ -215,13 +224,13 @@ export function LiveIdView() {
           display: "flex",
           justifyContent: "space-between",
           alignItems: "center",
-          background: "linear-gradient(to bottom, rgba(0,0,0,0.5), transparent)",
+          background: theme.palette.overlay["gradientTop"],
         }}
       >
-        <IconButton onClick={handleClose} sx={{ color: "white" }} aria-label="Close">
+        <IconButton onClick={handleClose} sx={{ color: "common.white" }} aria-label="Close">
           <CloseIcon />
         </IconButton>
-        {isInferring && <CircularProgress size={18} sx={{ color: "white", mr: 1 }} />}
+        {isInferring && <CircularProgress size={18} sx={{ color: "common.white", mr: 1 }} />}
       </Box>
 
       {error && (
@@ -236,7 +245,7 @@ export function LiveIdView() {
             textAlign: "center",
           }}
         >
-          <Typography sx={{ color: "white" }}>{error}</Typography>
+          <Typography sx={{ color: "common.white" }}>{error}</Typography>
         </Box>
       )}
 
@@ -250,14 +259,14 @@ export function LiveIdView() {
           pt: 6,
           pb: 3,
           px: 2,
-          background: "linear-gradient(to top, rgba(0,0,0,0.7), transparent)",
+          background: theme.palette.overlay["gradientBottom"],
           display: "flex",
           flexDirection: "column",
           alignItems: "center",
           gap: 2,
         }}
       >
-        <Box sx={{ minHeight: 56, textAlign: "center", color: "white" }}>
+        <Box sx={{ minHeight: 56, textAlign: "center", color: "common.white" }}>
           {top ? (
             <>
               <Stack
@@ -299,10 +308,10 @@ export function LiveIdView() {
           sx={{
             width: 68,
             height: 68,
-            bgcolor: "white",
-            color: "black",
-            border: "4px solid rgba(255,255,255,0.5)",
-            "&:hover": { bgcolor: "white" },
+            bgcolor: "common.white",
+            color: "common.black",
+            border: `4px solid ${theme.palette.overlay["captureRing"]}`,
+            "&:hover": { bgcolor: "common.white" },
           }}
         >
           <CameraAltIcon />

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -21,8 +21,8 @@ declare module "@mui/material/styles" {
 // functional indicator, not a brand color, so it doesn't invert with the mode).
 const mapMarkerColor = "#22c55e";
 
-// Dark scrims/chips placed over photos (lightbox backdrop, icon-button chips,
-// status badges). Black-alpha rather than a mode-aware color since these sit
+// Overlay chrome placed over photo/camera content (scrims, gradients, chips,
+// badges). Black/white-alpha rather than a mode-aware color since these sit
 // on top of photo content, not app background — mode-invariant like iucn/mapMarker.
 const overlayColors: Record<string, string> = {
   scrim: "rgba(0, 0, 0, 0.9)",
@@ -30,6 +30,9 @@ const overlayColors: Record<string, string> = {
   chipHover: "rgba(0, 0, 0, 0.6)",
   badge: "rgba(0, 0, 0, 0.65)",
   modalChip: "rgba(0, 0, 0, 0.7)",
+  gradientTop: "linear-gradient(to bottom, rgba(0, 0, 0, 0.5), transparent)",
+  gradientBottom: "linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent)",
+  captureRing: "rgba(255, 255, 255, 0.5)",
 };
 
 // Official IUCN Red List category colors — standardized by the IUCN,


### PR DESCRIPTION
## What

`LiveIdView.tsx` — the full-screen live camera identifier — hand-wrote its own black/white color literals and `rgba()` gradients instead of using the theme's existing overlay-color system:

```tsx
// before
bgcolor: "black",
color: "white",
background: "linear-gradient(to bottom, rgba(0,0,0,0.5), transparent)",
border: "4px solid rgba(255,255,255,0.5)",
```

9 separate `"white"`/`"black"` literals plus 3 raw `rgba()` values (two gradients, one ring border) across the file.

## Why

`theme/index.ts` already has a `palette.overlay` token group (`scrim`, `chip`, `chipHover`, `badge`, `modalChip`) built for exactly this idiom — dark chrome placed over photo content — and it's already adopted by `PhotoLightbox.tsx`, `UploadModal.tsx`, and `PendingBadge.tsx` (`common.white` for foreground color, `theme.palette.overlay[...]` for background). `LiveIdView.tsx` is a highly-visible, camera-based screen that never adopted either convention.

## Change

- Extends `overlayColors` in `theme/index.ts` with three new entries needed by this file: `gradientTop`, `gradientBottom` (the two scrim gradients), and `captureRing` (the white-alpha shutter-button ring) — following the existing mode-invariant pattern (same rationale as `iucn`/`mapMarker`: this sits on top of camera/photo content, not app background).
- Repoints all `"white"`/`"black"` literals in `LiveIdView.tsx` to `common.white`/`common.black`.
- Repoints all three `rgba()` values to `theme.palette.overlay[...]`.

No values changed — pure extraction, no visual diff.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — passes on touched files
- `vitest run` — 161 tests passed
- `npm run check:stories` — all 79 components still have stories


---
_Generated by [Claude Code](https://claude.ai/code/session_01YRW56Az9CJaZM9qjtd1DCW)_