### PR TITLE
design-audit: move raw rgba boxShadow literals to theme palette token

### DIFF
--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -319,7 +319,7 @@ export function ObservationDetail() {
                   maxHeight: 400,
                   objectFit: "contain",
                   display: "block",
-                  boxShadow: { xs: "none", sm: "0 4px 12px rgba(0, 0, 0, 0.15)" },
+                  boxShadow: (theme) => ({ xs: "none", sm: theme.palette.cardShadow["photo"] }),
                 }}
               />
             </ButtonBase>

--- a/frontend/src/components/taxon/TaxonHeroCard.tsx
+++ b/frontend/src/components/taxon/TaxonHeroCard.tsx
@@ -36,7 +36,7 @@ export function TaxonHeroCard({ taxon, heroUrl }: TaxonHeroCardProps) {
             overflow: "hidden",
             border: 1,
             borderColor: "divider",
-            boxShadow: "0 2px 10px rgba(60,50,30,0.08)",
+            boxShadow: (theme) => theme.palette.cardShadow["hero"],
             backgroundColor: "grey.900",
             display: "flex",
             alignItems: "center",

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -8,12 +8,14 @@ declare module "@mui/material/styles" {
     iucn: Record<string, string>;
     mapMarker: string;
     overlay: Record<string, string>;
+    cardShadow: Record<string, string>;
   }
   interface PaletteOptions {
     placeholder?: string;
     iucn?: Record<string, string>;
     mapMarker?: string;
     overlay?: Record<string, string>;
+    cardShadow?: Record<string, string>;
   }
 }
 
@@ -33,6 +35,13 @@ const overlayColors: Record<string, string> = {
   gradientTop: "linear-gradient(to bottom, rgba(0, 0, 0, 0.5), transparent)",
   gradientBottom: "linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent)",
   captureRing: "rgba(255, 255, 255, 0.5)",
+};
+
+// Elevated photo/image card shadows — mode-invariant like overlay/iucn/mapMarker
+// since these sit around photo content rather than app chrome.
+const cardShadowColors: Record<string, string> = {
+  hero: "0 2px 10px rgba(60, 50, 30, 0.08)",
+  photo: "0 4px 12px rgba(0, 0, 0, 0.15)",
 };
 
 // Official IUCN Red List category colors — standardized by the IUCN,
@@ -104,6 +113,7 @@ const darkPalette = {
   iucn: iucnColors,
   mapMarker: mapMarkerColor,
   overlay: overlayColors,
+  cardShadow: cardShadowColors,
 };
 
 const lightPalette = {
@@ -138,6 +148,7 @@ const lightPalette = {
   iucn: iucnColors,
   mapMarker: mapMarkerColor,
   overlay: overlayColors,
+  cardShadow: cardShadowColors,
 };
 
 const createAppTheme = (mode: PaletteMode): Theme => {


### PR DESCRIPTION
## Summary
- `TaxonHeroCard` and `ObservationDetail` each hardcoded a raw `rgba()` box-shadow string directly in their `sx` props, unlike every other photo-chrome color (overlay/iucn/mapMarker), which already live in the theme palette.
- Added a `cardShadow` palette token (`{ hero, photo }`) to `frontend/src/theme/index.ts`, following the existing mode-invariant token pattern used for `overlay`/`iucn`/`mapMarker`, and pointed both components at it. Visual output is unchanged — same values, just centralized.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint` on changed files — clean
- [x] `npx oxfmt --check` on changed files — clean
- [x] `npm run build` — succeeds
- [x] `npm run build-storybook` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011p3cL9FiUHHoUsEnAcL2vS

---
_Generated by [Claude Code](https://claude.ai/code/session_011p3cL9FiUHHoUsEnAcL2vS)_