### PR TITLE
design-audit: move photo-backdrop grey.900/grey.400 colors to theme palette

### DIFF
--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -298,7 +298,7 @@ export function ObservationDetail() {
 
         {/* Images */}
         {activeImage && (
-          <Box sx={{ bgcolor: "grey.900", p: { xs: 0, sm: 2 } }}>
+          <Box sx={{ bgcolor: (theme) => theme.palette.overlay["backdrop"], p: { xs: 0, sm: 2 } }}>
             <ButtonBase
               onClick={() => setLightboxOpen(true)}
               aria-label="Enlarge photo"
@@ -329,7 +329,7 @@ export function ObservationDetail() {
                 sx={{
                   display: "block",
                   textAlign: "center",
-                  color: "grey.400",
+                  color: (theme) => theme.palette.overlay["caption"],
                   px: 1,
                   pt: { xs: 1, sm: 0.5 },
                 }}

--- a/frontend/src/components/observation/PhotoLightbox.tsx
+++ b/frontend/src/components/observation/PhotoLightbox.tsx
@@ -74,7 +74,7 @@ export function PhotoLightbox({ open, onClose, src, alt, license }: PhotoLightbo
               onClick={(e) => e.stopPropagation()}
               sx={{
                 mt: 1,
-                color: "grey.400",
+                color: theme.palette.overlay["caption"],
                 textAlign: "center",
                 cursor: "default",
               }}

--- a/frontend/src/components/taxon/TaxonHeroCard.tsx
+++ b/frontend/src/components/taxon/TaxonHeroCard.tsx
@@ -37,7 +37,7 @@ export function TaxonHeroCard({ taxon, heroUrl }: TaxonHeroCardProps) {
             border: 1,
             borderColor: "divider",
             boxShadow: (theme) => theme.palette.cardShadow["hero"],
-            backgroundColor: "grey.900",
+            backgroundColor: (theme) => theme.palette.overlay["backdrop"],
             display: "flex",
             alignItems: "center",
             justifyContent: "center",

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -35,6 +35,8 @@ const overlayColors: Record<string, string> = {
   gradientTop: "linear-gradient(to bottom, rgba(0, 0, 0, 0.5), transparent)",
   gradientBottom: "linear-gradient(to top, rgba(0, 0, 0, 0.7), transparent)",
   captureRing: "rgba(255, 255, 255, 0.5)",
+  backdrop: "#212121",
+  caption: "#bdbdbd",
 };
 
 // Elevated photo/image card shadows — mode-invariant like overlay/iucn/mapMarker


### PR DESCRIPTION
## What

`TaxonHeroCard.tsx`, `ObservationDetail.tsx`, and `PhotoLightbox.tsx` each hand-wrote MUI's default `grey.900`/`grey.400` palette shades for the same two purposes — a dark photo-letterbox background and a muted caption-text color sitting on that backdrop — instead of using the theme's `overlay` token group:

```tsx
// before
backgroundColor: "grey.900",   // TaxonHeroCard, ObservationDetail
color: "grey.400",             // ObservationDetail, PhotoLightbox (license caption)
```

## Why

`theme/index.ts` already has a `palette.overlay` token group (`scrim`, `chip`, `chipHover`, `badge`, `modalChip`, `gradientTop`, `gradientBottom`, `captureRing`) built for exactly this idiom — chrome placed over photo content — extended across prior design-audit passes (#719 dark scrims/chips, #724 LiveIdView camera overlay, #725 `cardShadow`). These three components sit right next to already-tokenized `overlay`/`cardShadow` usages in the same `sx` blocks (e.g. `TaxonHeroCard.tsx` sets `boxShadow: theme.palette.cardShadow["hero"]` one line above the raw `backgroundColor: "grey.900"`) but never folded their own grey literals into that system.

## Change

- Adds `backdrop` (`#212121`, matching MUI's default `grey[900]`) and `caption` (`#bdbdbd`, matching `grey[400]`) to `overlayColors` in `theme/index.ts`, mode-invariant like the rest of the group since these sit around/over photo content rather than app chrome.
- Repoints all four call sites to `theme.palette.overlay["backdrop"]` / `theme.palette.overlay["caption"]`.

No values changed — pure extraction, no visual diff. High-traffic surfaces: observation detail page and taxon hero card are among the most-viewed views in the app.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint frontend/src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — passes
- `vitest run` — 161 tests passed
- `npm run check:stories` — all 79 components still have stories
- `npm run build-storybook` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015bGHij6ajE19pGQcTS1c8r)_