### PR TITLE
design-audit: add aria-label to back button in ObservationDetail

### DIFF
--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -177,7 +177,7 @@ export function ObservationDetail() {
       >
         {/* Header */}
         <Box sx={detailHeaderSx}>
-          <IconButton onClick={handleBack} sx={{ mr: 1 }}>
+          <IconButton onClick={handleBack} aria-label="Back" sx={{ mr: 1 }}>
             <ArrowBackIcon />
           </IconButton>
           <Typography


### PR DESCRIPTION
## What

`ObservationDetail.tsx`'s header back button was an icon-only `IconButton` with no accessible name:

```tsx
// before
<IconButton onClick={handleBack} sx={{ mr: 1 }}>
  <ArrowBackIcon />
</IconButton>
```

## Why

`TaxonDetailHeader.tsx` has the visually and functionally identical back button, already fixed to carry `aria-label="Back"` in a prior design-audit pass (#720, "add aria-label to icon-only buttons in TaxonDetailHeader"). `ObservationDetail`'s header is the sibling detail-page pattern (same `detailHeaderSx`, same back-arrow-then-title layout) but was missed in that pass — every other icon-only button in the file (`More options`, `Unlike`/`Like`) already has an `aria-label`.

## Change

- Adds `aria-label="Back"` to the back button in `ObservationDetail.tsx`, matching `TaxonDetailHeader.tsx`'s convention exactly.

No visual change — purely an accessible-name addition for screen readers.

## Verification

- `tsc --noEmit` — 0 errors
- `oxlint frontend/src` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings unchanged)
- `oxfmt --check` — passes
- `npm run check:stories` — all 79 components still have stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01PiwCmbe7Z1qbTgwbGStxAS)_