### PR TITLE
design-audit: extract shared ObservationGridCard from ExploreGridCard/ProfileView

### DIFF
--- a/frontend/src/components/common/ObservationGridCard.stories.tsx
+++ b/frontend/src/components/common/ObservationGridCard.stories.tsx
@@ -1,0 +1,69 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { ObservationGridCard } from "./ObservationGridCard";
+import { PendingBadge } from "../feed/PendingBadge";
+import { OAK_OBSERVATION, FERN_OBSERVATION } from "../../../.storybook/fixtures";
+
+const meta = {
+  title: "Common/ObservationGridCard",
+  component: ObservationGridCard,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: 280 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+} satisfies Meta<typeof ObservationGridCard>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Oak: Story = {
+  args: {
+    observation: OAK_OBSERVATION,
+  },
+};
+
+export const Fern: Story = {
+  args: {
+    observation: FERN_OBSERVATION,
+  },
+};
+
+export const Pending: Story = {
+  args: {
+    observation: OAK_OBSERVATION,
+    isPending: true,
+    badge: <PendingBadge />,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "An optimistic submission awaiting ingestion: dimmed, navigation-blocked, and badged (used by the feed's ExploreGridCard).",
+      },
+    },
+  },
+};
+
+const { effectiveTaxonomy: _drop, ...noTaxonomyObservation } = OAK_OBSERVATION;
+void _drop;
+
+export const NoTaxonomy: Story = {
+  args: {
+    observation: noTaxonomyObservation,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "When an observation hasn't been identified yet, the card falls back to a placeholder caption.",
+      },
+    },
+  },
+};

--- a/frontend/src/components/common/ObservationGridCard.tsx
+++ b/frontend/src/components/common/ObservationGridCard.tsx
@@ -1,0 +1,77 @@
+import { memo } from "react";
+import type { ReactNode } from "react";
+import { Link } from "react-router-dom";
+import { Typography, Card, CardActionArea, CardContent } from "@mui/material";
+import type { Occurrence } from "../../services/types";
+import { getImageUrl } from "../../services/api";
+import { getObservationUrl } from "../../lib/utils";
+import { RelativeTime } from "./RelativeTime";
+import { shouldItalicizeTaxonName } from "./TaxonLink";
+import { ImageWithSkeleton } from "./ImageWithSkeleton";
+
+interface ObservationGridCardProps {
+  observation: Occurrence;
+  isPending?: boolean;
+  // Overlay rendered inside the Card, above the CardActionArea (e.g. a
+  // PendingBadge) — needs the Card's `position: relative` to anchor to.
+  badge?: ReactNode;
+}
+
+export const ObservationGridCard = memo(function ObservationGridCard({
+  observation,
+  isPending = false,
+  badge,
+}: ObservationGridCardProps) {
+  const species = observation.communityId || observation.effectiveTaxonomy?.scientificName;
+
+  return (
+    <Card sx={{ display: "flex", flexDirection: "column", position: "relative" }}>
+      {badge}
+      <CardActionArea
+        component={Link}
+        to={getObservationUrl(observation.uri)}
+        onClick={isPending ? (e) => e.preventDefault() : undefined}
+        sx={{
+          flex: 1,
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "stretch",
+          ...(isPending && { opacity: 0.7, pointerEvents: "none" }),
+        }}
+      >
+        <ImageWithSkeleton
+          src={observation.images[0] ? getImageUrl(observation.images[0].url) : undefined}
+          alt={species || "Observation"}
+          sx={{ aspectRatio: "1" }}
+        />
+        <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
+          <Typography
+            variant="body2"
+            sx={{
+              fontStyle:
+                species && shouldItalicizeTaxonName(species, observation.effectiveTaxonomy?.rank)
+                  ? "italic"
+                  : "normal",
+              color: "primary.main",
+              fontWeight: 500,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+              whiteSpace: "nowrap",
+            }}
+          >
+            {species || "Unknown species"}
+          </Typography>
+          <Typography
+            variant="caption"
+            noWrap
+            sx={{
+              color: "text.disabled",
+            }}
+          >
+            <RelativeTime date={new Date(observation.createdAt)} />
+          </Typography>
+        </CardContent>
+      </CardActionArea>
+    </Card>
+  );
+});

--- a/frontend/src/components/feed/ExploreGridCard.tsx
+++ b/frontend/src/components/feed/ExploreGridCard.tsx
@@ -1,13 +1,7 @@
 import { memo } from "react";
-import { Link } from "react-router-dom";
-import { Typography, Card, CardActionArea, CardContent } from "@mui/material";
 import type { Occurrence } from "../../services/types";
 import { useIsPending } from "../../store/pendingSlice";
-import { getImageUrl } from "../../services/api";
-import { getObservationUrl } from "../../lib/utils";
-import { RelativeTime } from "../common/RelativeTime";
-import { shouldItalicizeTaxonName } from "../common/TaxonLink";
-import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
+import { ObservationGridCard } from "../common/ObservationGridCard";
 import { PendingBadge } from "./PendingBadge";
 
 interface ExploreGridCardProps {
@@ -17,59 +11,15 @@ interface ExploreGridCardProps {
 export const ExploreGridCard = memo(function ExploreGridCard({
   observation,
 }: ExploreGridCardProps) {
-  const species = observation.communityId || observation.effectiveTaxonomy?.scientificName;
   // Optimistic tombstone awaiting ingestion: dim it and block navigation to a
   // detail page that would 404 until the record lands.
   const isPending = useIsPending(observation.uri);
 
   return (
-    <Card sx={{ display: "flex", flexDirection: "column", position: "relative" }}>
-      {isPending && <PendingBadge />}
-      <CardActionArea
-        component={Link}
-        to={getObservationUrl(observation.uri)}
-        onClick={isPending ? (e) => e.preventDefault() : undefined}
-        sx={{
-          flex: 1,
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "stretch",
-          ...(isPending && { opacity: 0.7, pointerEvents: "none" }),
-        }}
-      >
-        <ImageWithSkeleton
-          src={observation.images[0] ? getImageUrl(observation.images[0].url) : undefined}
-          alt={species || "Observation"}
-          sx={{ aspectRatio: "1" }}
-        />
-        <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
-          <Typography
-            variant="body2"
-            sx={{
-              fontStyle:
-                species && shouldItalicizeTaxonName(species, observation.effectiveTaxonomy?.rank)
-                  ? "italic"
-                  : "normal",
-              color: "primary.main",
-              fontWeight: 500,
-              overflow: "hidden",
-              textOverflow: "ellipsis",
-              whiteSpace: "nowrap",
-            }}
-          >
-            {species || "Unknown species"}
-          </Typography>
-          <Typography
-            variant="caption"
-            noWrap
-            sx={{
-              color: "text.disabled",
-            }}
-          >
-            <RelativeTime date={new Date(observation.createdAt)} />
-          </Typography>
-        </CardContent>
-      </CardActionArea>
-    </Card>
+    <ObservationGridCard
+      observation={observation}
+      isPending={isPending}
+      badge={isPending ? <PendingBadge /> : undefined}
+    />
   );
 });

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -16,13 +16,12 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import GrassIcon from "@mui/icons-material/Grass";
-import { getImageUrl } from "../../services/api";
 import { useProfileFeed } from "../../lib/query/hooks";
 import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { UserCard } from "../common/UserCard";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
-import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
+import { ObservationGridCard } from "../common/ObservationGridCard";
 import { CenteredSpinner } from "../common/CenteredSpinner";
 import { EmptyState } from "../common/EmptyState";
 import { ProfileHeaderSkeleton } from "./ProfileHeaderSkeleton";
@@ -231,48 +230,7 @@ export function ProfileView() {
       {activeTab === "observations" && (
         <Box sx={observationGridSx()}>
           {occurrences.map((occ) => (
-            <Card key={occ.uri} sx={{ display: "flex", flexDirection: "column" }}>
-              <CardActionArea
-                component={Link}
-                to={getObservationUrl(occ.uri)}
-                sx={{ flex: 1, display: "flex", flexDirection: "column", alignItems: "stretch" }}
-              >
-                <ImageWithSkeleton
-                  src={occ.images[0] ? getImageUrl(occ.images[0].url) : undefined}
-                  alt={occ.communityId || occ.effectiveTaxonomy?.scientificName || "Observation"}
-                  sx={{ aspectRatio: "1" }}
-                />
-                <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
-                  <Typography
-                    variant="body2"
-                    sx={{
-                      fontStyle: shouldItalicizeTaxonName(
-                        occ.communityId || occ.effectiveTaxonomy?.scientificName || "",
-                        occ.effectiveTaxonomy?.rank,
-                      )
-                        ? "italic"
-                        : "normal",
-                      color: "primary.main",
-                      fontWeight: 500,
-                      overflow: "hidden",
-                      textOverflow: "ellipsis",
-                      whiteSpace: "nowrap",
-                    }}
-                  >
-                    {occ.communityId || occ.effectiveTaxonomy?.scientificName || "Unknown species"}
-                  </Typography>
-                  <Typography
-                    variant="caption"
-                    noWrap
-                    sx={{
-                      color: "text.disabled",
-                    }}
-                  >
-                    <RelativeTime date={new Date(occ.createdAt)} />
-                  </Typography>
-                </CardContent>
-              </CardActionArea>
-            </Card>
+            <ObservationGridCard key={occ.uri} observation={occ} />
           ))}
 
           {isLoading && occurrences.length === 0 && (


### PR DESCRIPTION
## Summary
- `ExploreGridCard` (feed) and `ProfileView`'s observations tab both rendered the same `Card > CardActionArea > ImageWithSkeleton > CardContent` markup, down to an identical truncated-species-name `sx` block (~90 duplicated lines across 2 files).
- Extracted the shared markup into `frontend/src/components/common/ObservationGridCard.tsx`, used by both call sites.
- `ExploreGridCard` keeps its feed-specific optimistic-pending behavior (dimming, blocked navigation, `PendingBadge`) via an optional `isPending` prop and `badge` slot on the new primitive, so the shared component stays generic.
- The `ProfileView` identifications tab was left untouched — its markup (fingerprint icon thumbnail, no image) is genuinely different, not duplicated.
- Added `ObservationGridCard.stories.tsx` (Oak/Fern/Pending/NoTaxonomy variants) alongside the new component.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings
- [x] `npm run fmt:check` — passes
- [x] `npm run check:stories` — all 80 components have stories
- [x] `npm run build-storybook` — builds successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_016eKXCfRhac78g3cBw4YH61)_