### PR TITLE
design-audit: extract shared RecordOverflowMenu common component

### DIFF
--- a/frontend/src/components/comment/CommentSection.tsx
+++ b/frontend/src/components/comment/CommentSection.tsx
@@ -1,28 +1,17 @@
 import { useState, useCallback, type FormEvent } from "react";
-import {
-  Box,
-  Typography,
-  Stack,
-  TextField,
-  Button,
-  IconButton,
-  Menu,
-  MenuItem,
-  Chip,
-} from "@mui/material";
+import { Box, Typography, Stack, TextField, Button, Chip } from "@mui/material";
 import ChatBubbleOutlineIcon from "@mui/icons-material/ChatBubbleOutlineOutlined";
 import { countChipSx } from "../common/chipSx";
 import { accentListItemSx } from "../common/layoutSx";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { useAppSelector } from "../../store";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
 import { useToast } from "../../hooks/useToast";
 import { useSubmitComment } from "../../lib/query/mutations";
 import type { Comment } from "../../services/types";
-import { getPdslsUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { UserCard } from "../common/UserCard";
 import { Section, SectionHeader } from "../common/Section";
+import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
 
 interface CommentSectionProps {
   observationUri: string;
@@ -35,7 +24,6 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
   const user = useAppSelector((state) => state.auth.user);
   const [showForm, setShowForm] = useState(false);
   const [body, setBody] = useState("");
-  const [menuAnchorEl, setMenuAnchorEl] = useState<{ [key: string]: HTMLElement | null }>({});
 
   // The mutation invalidates the parent observation on success, so the new
   // comment shows up without the caller wiring a refetch callback.
@@ -57,14 +45,6 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
       setShowForm(false);
     },
   });
-
-  const handleMenuOpen = (commentUri: string, event: React.MouseEvent<HTMLElement>) => {
-    setMenuAnchorEl((prev) => ({ ...prev, [commentUri]: event.currentTarget }));
-  };
-
-  const handleMenuClose = (commentUri: string) => {
-    setMenuAnchorEl((prev) => ({ ...prev, [commentUri]: null }));
-  };
 
   const handleSubmit = (e: FormEvent) => {
     e.preventDefault();
@@ -143,31 +123,7 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
                       <RelativeTime date={new Date(comment.created_at)} withAgo />
                     </Typography>
                     <Box sx={{ ml: "auto" }}>
-                      <IconButton
-                        size="small"
-                        onClick={(e) => handleMenuOpen(comment.uri, e)}
-                        aria-label="More options"
-                        sx={{ color: "text.disabled", p: 0.5 }}
-                      >
-                        <MoreVertIcon fontSize="small" />
-                      </IconButton>
-                      <Menu
-                        anchorEl={menuAnchorEl[comment.uri]}
-                        open={Boolean(menuAnchorEl[comment.uri])}
-                        onClose={() => handleMenuClose(comment.uri)}
-                        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                        transformOrigin={{ vertical: "top", horizontal: "right" }}
-                      >
-                        <MenuItem
-                          component="a"
-                          href={getPdslsUrl(comment.uri)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          onClick={() => handleMenuClose(comment.uri)}
-                        >
-                          View on AT Protocol
-                        </MenuItem>
-                      </Menu>
+                      <RecordOverflowMenu atUri={comment.uri} sx={{ p: 0.5 }} />
                     </Box>
                   </>
                 }

--- a/frontend/src/components/common/RecordOverflowMenu.stories.tsx
+++ b/frontend/src/components/common/RecordOverflowMenu.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { RecordOverflowMenu } from "./RecordOverflowMenu";
+
+const meta = {
+  title: "Common/RecordOverflowMenu",
+  component: RecordOverflowMenu,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    atUri: "at://did:plc:example/ing.observ.occurrence/abc123",
+  },
+} satisfies Meta<typeof RecordOverflowMenu>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ViewOnly: Story = {};
+
+export const WithEdit: Story = {
+  args: { onEdit: () => {} },
+};
+
+export const WithEditAndDelete: Story = {
+  args: { onEdit: () => {}, onDelete: () => {} },
+};

--- a/frontend/src/components/common/RecordOverflowMenu.tsx
+++ b/frontend/src/components/common/RecordOverflowMenu.tsx
@@ -1,0 +1,102 @@
+import { useState, type MouseEvent } from "react";
+import { IconButton, Menu, MenuItem, type SxProps, type Theme } from "@mui/material";
+import MoreVertIcon from "@mui/icons-material/MoreVert";
+import { getPdslsUrl } from "../../lib/utils";
+
+export interface RecordOverflowMenuProps {
+  /** AT URI of the record; builds the "View on AT Protocol" link. */
+  atUri: string;
+  /** Shows an "Edit" item when provided. */
+  onEdit?: (() => void) | undefined;
+  /**
+   * Shows a "Delete" item when provided. May return a promise; the item
+   * disables itself for the duration so a slow delete can't be double-fired.
+   */
+  onDelete?: (() => void | Promise<void>) | undefined;
+  /**
+   * Set when this button sits inside another clickable element (e.g. a card
+   * that navigates on click) so opening the menu or clicking an item doesn't
+   * also trigger the ancestor's handler.
+   */
+  stopPropagation?: boolean;
+  sx?: SxProps<Theme>;
+}
+
+export function RecordOverflowMenu({
+  atUri,
+  onEdit,
+  onDelete,
+  stopPropagation,
+  sx,
+}: RecordOverflowMenuProps) {
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
+  const open = Boolean(anchorEl);
+
+  const handleOpen = (event: MouseEvent<HTMLElement>) => {
+    if (stopPropagation) {
+      event.preventDefault();
+      event.stopPropagation();
+    }
+    setAnchorEl(event.currentTarget);
+  };
+
+  const handleClose = () => setAnchorEl(null);
+
+  const handleDelete = async () => {
+    handleClose();
+    if (!onDelete) return;
+    setIsDeleting(true);
+    try {
+      await onDelete();
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
+  return (
+    <>
+      <IconButton
+        size="small"
+        onClick={handleOpen}
+        aria-label="More options"
+        sx={{ color: "text.disabled", ...sx }}
+      >
+        <MoreVertIcon fontSize="small" />
+      </IconButton>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleClose}
+        onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
+        anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+        transformOrigin={{ vertical: "top", horizontal: "right" }}
+      >
+        {onEdit && (
+          <MenuItem
+            onClick={() => {
+              handleClose();
+              onEdit();
+            }}
+          >
+            Edit
+          </MenuItem>
+        )}
+        {onDelete && (
+          <MenuItem onClick={handleDelete} disabled={isDeleting} sx={{ color: "error.main" }}>
+            Delete
+          </MenuItem>
+        )}
+        <MenuItem
+          component="a"
+          href={getPdslsUrl(atUri)}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={handleClose}
+        >
+          View on AT Protocol
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -1,17 +1,14 @@
-import { memo, useState } from "react";
+import { memo } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Box,
   Typography,
   IconButton,
-  Menu,
-  MenuItem,
   Card,
   CardContent,
   CardActionArea,
   Tooltip,
 } from "@mui/material";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import type { Occurrence } from "../../services/types";
@@ -21,7 +18,8 @@ import { getImageUrl } from "../../services/api";
 import { useLike } from "../../lib/query/mutations";
 import { TaxonLink } from "../common/TaxonLink";
 import { UserCard } from "../common/UserCard";
-import { getPdslsUrl, getObservationUrl } from "../../lib/utils";
+import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
+import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
 import { PendingBadge } from "./PendingBadge";
@@ -34,13 +32,11 @@ interface FeedItemProps {
 }
 
 export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }: FeedItemProps) {
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
   // Like state lives in the query cache: the optimistic mutation patches the
   // occurrence in every cache that holds it, so reading the prop is reactive.
   const liked = observation.viewerHasLiked ?? false;
   const likeCount = observation.likeCount ?? 0;
   const like = useLike();
-  const menuOpen = Boolean(anchorEl);
   const navigate = useNavigate();
   const currentUser = useAppSelector((state) => state.auth.user);
   const isOwnPost = currentUser?.did === observation.observer.did;
@@ -57,31 +53,6 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
   const imageUrl = observation.images[0] ? getImageUrl(observation.images[0].url) : "";
 
   const observationUrl = getObservationUrl(observation.uri);
-  const pdslsUrl = getPdslsUrl(observation.uri);
-
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-  };
-
-  const handleEditClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    handleMenuClose();
-    onEdit?.(observation);
-  };
-
-  const handleDeleteClick = (e: React.MouseEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    handleMenuClose();
-    onDelete?.(observation);
-  };
 
   const handleCardClick = (e: React.MouseEvent) => {
     // Don't navigate if clicking on interactive elements (links, buttons)
@@ -126,38 +97,12 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
             }
           />
           <Box sx={{ ml: "auto" }}>
-            <IconButton
-              size="small"
-              onClick={handleMenuOpen}
-              aria-label="More options"
-              sx={{ color: "text.disabled" }}
-            >
-              <MoreVertIcon fontSize="small" />
-            </IconButton>
-            <Menu
-              anchorEl={anchorEl}
-              open={menuOpen}
-              onClose={handleMenuClose}
-              onClick={(e) => e.stopPropagation()}
-              anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-              transformOrigin={{ vertical: "top", horizontal: "right" }}
-            >
-              {isOwnPost && onEdit && <MenuItem onClick={handleEditClick}>Edit</MenuItem>}
-              {isOwnPost && onDelete && (
-                <MenuItem onClick={handleDeleteClick} sx={{ color: "error.main" }}>
-                  Delete
-                </MenuItem>
-              )}
-              <MenuItem
-                component="a"
-                href={pdslsUrl}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={(e) => e.stopPropagation()}
-              >
-                View on AT Protocol
-              </MenuItem>
-            </Menu>
+            <RecordOverflowMenu
+              atUri={observation.uri}
+              stopPropagation
+              {...(isOwnPost && onEdit ? { onEdit: () => onEdit(observation) } : {})}
+              {...(isOwnPost && onDelete ? { onDelete: () => onDelete(observation) } : {})}
+            />
           </Box>
         </Box>
 

--- a/frontend/src/components/identification/IdentificationHistory.tsx
+++ b/frontend/src/components/identification/IdentificationHistory.tsx
@@ -1,25 +1,13 @@
-import { useState } from "react";
 import { Link as RouterLink } from "react-router-dom";
-import {
-  Box,
-  Typography,
-  Avatar,
-  Stack,
-  Chip,
-  IconButton,
-  Link as MuiLink,
-  Menu,
-  MenuItem,
-} from "@mui/material";
+import { Box, Typography, Avatar, Stack, Chip, Link as MuiLink } from "@mui/material";
 import HistoryIcon from "@mui/icons-material/History";
 import { countChipSx } from "../common/chipSx";
 import { accentListItemSx } from "../common/layoutSx";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import type { Identification } from "../../services/types";
 import { TaxonLink } from "../common/TaxonLink";
-import { getPdslsUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { Section, SectionHeader } from "../common/Section";
+import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
 
 export interface IdentificationHistoryProps {
   identifications: Identification[];
@@ -43,16 +31,6 @@ export function IdentificationHistory({
   currentUserDid,
   onDeleteIdentification,
 }: IdentificationHistoryProps) {
-  const [deletingUri, setDeletingUri] = useState<string | null>(null);
-  const [menuAnchorEl, setMenuAnchorEl] = useState<Record<string, HTMLElement | null>>({});
-
-  const handleMenuOpen = (uri: string, event: React.MouseEvent<HTMLElement>) => {
-    setMenuAnchorEl((prev) => ({ ...prev, [uri]: event.currentTarget }));
-  };
-
-  const handleMenuClose = (uri: string) => {
-    setMenuAnchorEl((prev) => ({ ...prev, [uri]: null }));
-  };
   // Sort oldest first
   const sortedIds = [...identifications].sort(
     (a, b) => new Date(a.date_identified).getTime() - new Date(b.date_identified).getTime(),
@@ -177,48 +155,13 @@ export function IdentificationHistory({
                     </Box>
                   </Box>
                   <Box sx={{ alignSelf: "flex-start", mt: 0.5 }}>
-                    <IconButton
-                      size="small"
-                      onClick={(e) => handleMenuOpen(id.uri, e)}
-                      aria-label="More options"
-                      sx={{ color: "text.disabled", p: 0.5 }}
-                    >
-                      <MoreVertIcon fontSize="small" />
-                    </IconButton>
-                    <Menu
-                      anchorEl={menuAnchorEl[id.uri]}
-                      open={Boolean(menuAnchorEl[id.uri])}
-                      onClose={() => handleMenuClose(id.uri)}
-                      anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-                      transformOrigin={{ vertical: "top", horizontal: "right" }}
-                    >
-                      <MenuItem
-                        component="a"
-                        href={getPdslsUrl(id.uri)}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        onClick={() => handleMenuClose(id.uri)}
-                      >
-                        View on AT Protocol
-                      </MenuItem>
-                      {currentUserDid && id.did === currentUserDid && onDeleteIdentification && (
-                        <MenuItem
-                          onClick={async () => {
-                            handleMenuClose(id.uri);
-                            setDeletingUri(id.uri);
-                            try {
-                              await onDeleteIdentification(id.uri);
-                            } finally {
-                              setDeletingUri(null);
-                            }
-                          }}
-                          disabled={deletingUri === id.uri}
-                          sx={{ color: "error.main" }}
-                        >
-                          Delete
-                        </MenuItem>
-                      )}
-                    </Menu>
+                    <RecordOverflowMenu
+                      atUri={id.uri}
+                      sx={{ p: 0.5 }}
+                      {...(currentUserDid && id.did === currentUserDid && onDeleteIdentification
+                        ? { onDelete: () => onDeleteIdentification(id.uri) }
+                        : {})}
+                    />
                   </Box>
                 </Stack>
               </Box>

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -9,8 +9,6 @@ import {
   Stack,
   IconButton,
   ButtonBase,
-  Menu,
-  MenuItem,
   List,
   ListItem,
   ListItemIcon,
@@ -18,7 +16,6 @@ import {
   Tooltip,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import MoreVertIcon from "@mui/icons-material/MoreVert";
 import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
 import FavoriteIcon from "@mui/icons-material/Favorite";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
@@ -42,12 +39,8 @@ import { PhotoLightbox } from "./PhotoLightbox";
 import { DataQualitySection } from "./DataQualitySection";
 import { UserCard } from "../common/UserCard";
 import { Section, SectionHeader } from "../common/Section";
-import {
-  formatEventDate,
-  getPdslsUrl,
-  buildOccurrenceAtUri,
-  getErrorMessage,
-} from "../../lib/utils";
+import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
+import { formatEventDate, buildOccurrenceAtUri, getErrorMessage } from "../../lib/utils";
 import { getLicenseLabel } from "../../lib/licenses";
 
 // Lazy so maplibre-gl is split into its own chunk, loaded only when an
@@ -65,8 +58,6 @@ export function ObservationDetail() {
 
   const [activeImageIndex, setActiveImageIndex] = useState(0);
   const [lightboxOpen, setLightboxOpen] = useState(false);
-  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null);
-  const menuOpen = Boolean(anchorEl);
 
   // Reconstruct AT URI from route params
   const atUri = did && rkey ? buildOccurrenceAtUri(did, rkey) : null;
@@ -95,28 +86,6 @@ export function ObservationDetail() {
       navigate(-1);
     } else {
       navigate("/");
-    }
-  };
-
-  const handleMenuOpen = (event: React.MouseEvent<HTMLElement>) => {
-    setAnchorEl(event.currentTarget);
-  };
-
-  const handleMenuClose = () => {
-    setAnchorEl(null);
-  };
-
-  const handleEditClick = () => {
-    handleMenuClose();
-    if (observation) {
-      dispatch(openEditModal(observation));
-    }
-  };
-
-  const handleDeleteClick = () => {
-    handleMenuClose();
-    if (observation) {
-      dispatch(openDeleteConfirm(observation));
     }
   };
 
@@ -189,36 +158,19 @@ export function ObservationDetail() {
             Observation
           </Typography>
           <Box sx={{ ml: "auto" }}>
-            <IconButton
-              size="small"
-              onClick={handleMenuOpen}
-              aria-label="More options"
-              sx={{ color: "text.disabled" }}
-            >
-              <MoreVertIcon fontSize="small" />
-            </IconButton>
-            <Menu
-              anchorEl={anchorEl}
-              open={menuOpen}
-              onClose={handleMenuClose}
-              anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
-              transformOrigin={{ vertical: "top", horizontal: "right" }}
-            >
-              {isOwner && <MenuItem onClick={handleEditClick}>Edit</MenuItem>}
-              {isOwner && (
-                <MenuItem onClick={handleDeleteClick} sx={{ color: "error.main" }}>
-                  Delete
-                </MenuItem>
-              )}
-              <MenuItem
-                component="a"
-                href={getPdslsUrl(observation.uri)}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                View on AT Protocol
-              </MenuItem>
-            </Menu>
+            <RecordOverflowMenu
+              atUri={observation.uri}
+              {...(isOwner
+                ? {
+                    onEdit: () => {
+                      dispatch(openEditModal(observation));
+                    },
+                    onDelete: () => {
+                      dispatch(openDeleteConfirm(observation));
+                    },
+                  }
+                : {})}
+            />
           </Box>
         </Box>
 


### PR DESCRIPTION
## Summary
- `ObservationDetail`, `FeedItem`, `IdentificationHistory`, and `CommentSection` each hand-rolled the same kebab icon button → anchored `Menu` → "View on AT Protocol" link (+ optional Edit/Delete) pattern — ~90 duplicated JSX lines plus ~40 duplicated state/handler lines across 4 files.
- `IdentificationHistory` and `CommentSection` each kept a per-row `Record<string, HTMLElement | null>` anchor-state map just to give every list row an independent menu; a self-contained component eliminates that entirely (each instance owns its own `anchorEl`).
- Extracted the shared pattern into `frontend/src/components/common/RecordOverflowMenu.tsx`, following the extraction precedent set by `common/CollapsibleSection.tsx`. It also owns its own "is deleting" state internally, so `IdentificationHistory` no longer needs to track `deletingUri` itself.
- `FeedItem`'s menu button sits inside a `CardActionArea` (so a click must not bubble into card navigation); this is handled via an opt-in `stopPropagation` prop rather than every caller re-implementing `preventDefault`/`stopPropagation`.
- Added `RecordOverflowMenu.stories.tsx` (ViewOnly / WithEdit / WithEditAndDelete variants).
- Not touching the grid-card duplication already covered by the open PR #730.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings
- [x] `npm run fmt:check` — passes
- [x] `npm run check:stories` — all 80 components have stories
- [x] `npm run build-storybook` — builds successfully
- [x] `npm run test:unit` — 161 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01FQwrdoHDf7iVxAwMNiQNGm)_