### PR TITLE
design-audit: add aria-label to taxon link button in VisualIdCards

### DIFF
--- a/frontend/src/components/identification/VisualIdCards.tsx
+++ b/frontend/src/components/identification/VisualIdCards.tsx
@@ -73,7 +73,7 @@ function buildTaxonUrl(
   return null;
 }
 
-function TaxonLinkButton({ url }: { url: string }) {
+function TaxonLinkButton({ url, taxonName }: { url: string; taxonName: string }) {
   return (
     <IconButton
       size="small"
@@ -84,6 +84,7 @@ function TaxonLinkButton({ url }: { url: string }) {
       onClick={(e: React.MouseEvent) => e.stopPropagation()}
       sx={{ p: 0.5, ml: 0.5, flexShrink: 0 }}
       title="Open taxon in new tab"
+      aria-label={`Open ${taxonName} in new tab`}
     >
       <OpenInNewIcon sx={{ fontSize: 14 }} />
     </IconButton>
@@ -283,7 +284,7 @@ function AncestorCard({ ancestor, onSelect }: { ancestor: AncestorMatch; onSelec
           {RANK_LABEL[ancestor.rank]} · {Math.round(ancestor.confidence * 100)}% match
         </Typography>
       </Box>
-      {url && <TaxonLinkButton url={url} />}
+      {url && <TaxonLinkButton url={url} taxonName={ancestor.name} />}
     </ButtonBase>
   );
 }
@@ -399,7 +400,7 @@ function SpeciesCard({
       <Typography variant="caption" sx={{ color: "text.secondary", flexShrink: 0 }}>
         {Math.round(suggestion.confidence * 100)}%
       </Typography>
-      {url && <TaxonLinkButton url={url} />}
+      {url && <TaxonLinkButton url={url} taxonName={suggestion.scientificName} />}
     </ButtonBase>
   );
 }


### PR DESCRIPTION
## Summary

- `TaxonLinkButton` (the icon-only "open taxon in new tab" button used in `AncestorCard` and `SpeciesCard` within `VisualIdCards.tsx`) only had a `title` attribute. Many screen readers/assistive technologies don't reliably expose `title` as the accessible name for a button, leaving it effectively unlabeled.
- Adds `aria-label={`Open ${taxonName} in new tab`}`, mirroring the existing pattern in `frontend/src/components/common/TaxaAutocompleteView.tsx` which implements the identical affordance and already does this correctly.

## Test plan

- [x] `npx tsc --noEmit -p .` passes
- [x] `npx oxlint frontend/src/components/identification/VisualIdCards.tsx` passes with no findings
- [x] Verified the diff is a minimal, additive `aria-label` change with no behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0149fc7pBdSFfe6uq521GWx5)_