### PR TITLE
design-audit: use theme.palette.common.white token in Logo instead of raw #ffffff

### DIFF
--- a/frontend/src/components/common/Logo.tsx
+++ b/frontend/src/components/common/Logo.tsx
@@ -1,3 +1,5 @@
+import { useTheme } from "@mui/material";
+
 interface LogoProps {
   size?: number;
 }
@@ -8,6 +10,8 @@ interface LogoProps {
 // pupil use `currentColor`, so the mark inherits the accent green from its
 // parent — forest green in light mode, the brighter accent in dark mode.
 export function Logo({ size = 32 }: LogoProps) {
+  const theme = useTheme();
+  const white = theme.palette.common.white;
   return (
     <svg
       width={size}
@@ -18,9 +22,9 @@ export function Logo({ size = 32 }: LogoProps) {
     >
       <g transform="translate(100,100) rotate(-45)">
         <path d="M-60,0 Q0,-70 60,0 Q0,70 -60,0Z" fill="currentColor" />
-        <circle cx="0" cy="0" r="18" fill="#ffffff" />
+        <circle cx="0" cy="0" r="18" fill={white} />
         <circle cx="0" cy="0" r="9" fill="currentColor" />
-        <circle cx="3.5" cy="-3.5" r="2.5" fill="#ffffff" opacity="0.65" />
+        <circle cx="3.5" cy="-3.5" r="2.5" fill={white} opacity="0.65" />
       </g>
     </svg>
   );


### PR DESCRIPTION
## Summary

- `Logo.tsx` (the brand mark, rendered via `currentColor` so it inherits the accent green from its parent) hardcoded the pupil highlight/glint circles to raw `#ffffff` instead of going through the theme.
- Replaces both literals with `theme.palette.common.white` via `useTheme()`, matching the established `sx="common.white"` pattern already used across the codebase (`UserCard`, `PendingBadge`, `LiveIdView`, `PhotoLightbox`, `UploadModal`, `ConservationStatus`) for the same color, and following the same "raw literal → theme palette token" motivation as the existing `placeholder` token pattern in `theme/index.ts`.
- `useTheme()` (rather than `sx`) is required here since the color is applied via a raw SVG `fill` attribute, not a `sx` prop — same approach already used in `LocationMap.tsx`/`LocationPicker.tsx` for theme-driven non-sx values.

No visual or behavioral change — `common.white` resolves to `#ffffff` in both light and dark theme.

## Test plan

- [x] `npx tsc --noEmit -p .` passes
- [x] `npx oxlint frontend/src/components/common/Logo.tsx` passes with no findings
- [x] `npm run check:stories` — all components still have stories (`Logo.stories.tsx` unaffected, no story changes needed)
- [x] Verified all call sites (`LandingPage`, `TopBar`, `Sidebar`, `Wordmark.stories.tsx`) render `<Logo>` under the app's `ThemeProvider`, so `useTheme()` is always available

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LJtwFEDTZ6mVcENmL4ibc6)_