### PR TITLE
design-audit: extract shared LikeButton from FeedItem/ObservationDetail

### DIFF
--- a/frontend/src/components/common/LikeButton.stories.tsx
+++ b/frontend/src/components/common/LikeButton.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { LikeButton } from "./LikeButton";
+
+const meta = {
+  title: "Common/LikeButton",
+  component: LikeButton,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    liked: false,
+    count: 0,
+    onToggle: () => {},
+  },
+} satisfies Meta<typeof LikeButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Unliked: Story = {};
+
+export const Liked: Story = {
+  args: { liked: true, count: 1 },
+};
+
+export const WithCount: Story = {
+  args: { liked: true, count: 42 },
+};
+
+export const LoggedOut: Story = {
+  args: { loggedOut: true, count: 5 },
+};
+
+export const Pending: Story = {
+  args: { disabled: true, count: 3 },
+};

--- a/frontend/src/components/common/LikeButton.tsx
+++ b/frontend/src/components/common/LikeButton.tsx
@@ -1,0 +1,39 @@
+import { IconButton, Stack, Tooltip, Typography, type SxProps, type Theme } from "@mui/material";
+import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
+import FavoriteIcon from "@mui/icons-material/Favorite";
+
+export interface LikeButtonProps {
+  liked: boolean;
+  count: number;
+  /** Disables the button, e.g. while an optimistic update is pending. */
+  disabled?: boolean;
+  /** Shows a "Log in to like" tooltip and disables the button. */
+  loggedOut?: boolean;
+  onToggle: () => void;
+  sx?: SxProps<Theme>;
+}
+
+export function LikeButton({ liked, count, disabled, loggedOut, onToggle, sx }: LikeButtonProps) {
+  return (
+    <Tooltip title={loggedOut ? "Log in to like" : ""}>
+      <span>
+        <Stack direction="row" sx={{ alignItems: "center", flexShrink: 0, ...sx }}>
+          <IconButton
+            size="small"
+            onClick={onToggle}
+            disabled={loggedOut || disabled}
+            aria-label={liked ? "Unlike" : "Like"}
+            sx={{ color: liked ? "error.main" : "text.disabled" }}
+          >
+            {liked ? <FavoriteIcon fontSize="small" /> : <FavoriteBorderIcon fontSize="small" />}
+          </IconButton>
+          {count > 0 && (
+            <Typography variant="body2" sx={{ color: "text.secondary", ml: -0.25 }}>
+              {count}
+            </Typography>
+          )}
+        </Stack>
+      </span>
+    </Tooltip>
+  );
+}

--- a/frontend/src/components/feed/FeedItem.tsx
+++ b/frontend/src/components/feed/FeedItem.tsx
@@ -1,16 +1,6 @@
 import { memo } from "react";
 import { useNavigate } from "react-router-dom";
-import {
-  Box,
-  Typography,
-  IconButton,
-  Card,
-  CardContent,
-  CardActionArea,
-  Tooltip,
-} from "@mui/material";
-import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
-import FavoriteIcon from "@mui/icons-material/Favorite";
+import { Box, Typography, Card, CardContent, CardActionArea } from "@mui/material";
 import type { Occurrence } from "../../services/types";
 import { useAppSelector } from "../../store";
 import { useIsPending } from "../../store/pendingSlice";
@@ -19,6 +9,7 @@ import { useLike } from "../../lib/query/mutations";
 import { TaxonLink } from "../common/TaxonLink";
 import { UserCard } from "../common/UserCard";
 import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
+import { LikeButton } from "../common/LikeButton";
 import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
@@ -136,34 +127,15 @@ export const FeedItem = memo(function FeedItem({ observation, onEdit, onDelete }
               </Typography>
             )}
           </Box>
-          <Box sx={{ display: "flex", alignItems: "center", flexShrink: 0 }}>
-            <Tooltip title={!currentUser ? "Log in to like" : ""}>
-              <span>
-                <IconButton
-                  size="small"
-                  onClick={() =>
-                    like.mutate({ uri: observation.uri, cid: observation.cid, liked: !liked })
-                  }
-                  disabled={!currentUser || isPending}
-                  aria-label={liked ? "Unlike" : "Like"}
-                  sx={{
-                    color: liked ? "error.main" : "text.disabled",
-                  }}
-                >
-                  {liked ? (
-                    <FavoriteIcon fontSize="small" />
-                  ) : (
-                    <FavoriteBorderIcon fontSize="small" />
-                  )}
-                </IconButton>
-              </span>
-            </Tooltip>
-            {likeCount > 0 && (
-              <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                {likeCount}
-              </Typography>
-            )}
-          </Box>
+          <LikeButton
+            liked={liked}
+            count={likeCount}
+            disabled={isPending}
+            loggedOut={!currentUser}
+            onToggle={() =>
+              like.mutate({ uri: observation.uri, cid: observation.cid, liked: !liked })
+            }
+          />
         </Box>
       </CardContent>
     </Card>

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -13,11 +13,8 @@ import {
   ListItem,
   ListItemIcon,
   ListItemText,
-  Tooltip,
 } from "@mui/material";
 import ArrowBackIcon from "@mui/icons-material/ArrowBack";
-import FavoriteBorderIcon from "@mui/icons-material/FavoriteBorder";
-import FavoriteIcon from "@mui/icons-material/Favorite";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
 import NumbersIcon from "@mui/icons-material/Numbers";
@@ -30,6 +27,7 @@ import { useObservation } from "../../lib/query/hooks";
 import { useLike, useDeleteIdentification } from "../../lib/query/mutations";
 import { openDeleteConfirm, openEditModal } from "../../store/uiSlice";
 import { checkAuth } from "../../store/authSlice";
+import { LikeButton } from "../common/LikeButton";
 import { IdentificationPanel } from "../identification/IdentificationPanel";
 import { IdentificationHistory } from "../identification/IdentificationHistory";
 import { CommentSection } from "../comment/CommentSection";
@@ -218,34 +216,14 @@ export function ObservationDetail() {
               </Typography>
             }
           />
-          <Tooltip title={!user ? "Log in to like" : ""}>
-            <span>
-              <Stack direction="row" sx={{ alignItems: "center" }}>
-                <IconButton
-                  size="small"
-                  onClick={() =>
-                    like.mutate({ uri: observation.uri, cid: observation.cid, liked: !liked })
-                  }
-                  disabled={!user}
-                  aria-label={liked ? "Unlike" : "Like"}
-                  sx={{
-                    color: liked ? "error.main" : "text.disabled",
-                  }}
-                >
-                  {liked ? (
-                    <FavoriteIcon fontSize="small" />
-                  ) : (
-                    <FavoriteBorderIcon fontSize="small" />
-                  )}
-                </IconButton>
-                {likeCount > 0 && (
-                  <Typography variant="body2" sx={{ color: "text.secondary", ml: -0.25 }}>
-                    {likeCount}
-                  </Typography>
-                )}
-              </Stack>
-            </span>
-          </Tooltip>
+          <LikeButton
+            liked={liked}
+            count={likeCount}
+            loggedOut={!user}
+            onToggle={() =>
+              like.mutate({ uri: observation.uri, cid: observation.cid, liked: !liked })
+            }
+          />
         </Stack>
 
         {/* Images */}


### PR DESCRIPTION
## Summary

- `FeedItem.tsx` and `ObservationDetail.tsx` each hand-rolled the same like/unlike control: a `Tooltip` with "Log in to like" copy, an `IconButton` swapping `FavoriteIcon`/`FavoriteBorderIcon` with `aria-label={liked ? "Unlike" : "Like"}` and `color: liked ? "error.main" : "text.disabled"`, plus a conditional like-count `Typography`. The two copies had drifted slightly (different disabled conditions, different tooltip/count wrapper structure, one had a `ml: -0.25` count offset the other lacked).
- Extracts a new `frontend/src/components/common/LikeButton.tsx` with props `liked`, `count`, `disabled`, `loggedOut`, `onToggle`, and `sx`, following the same "extract duplicated presentational block into `common/`" pattern used by prior design-audit passes for `UserCard`, `RecordOverflowMenu`, and `ObservationGridCard`.
- Both call sites now render `<LikeButton>`, removing ~70 lines of duplicated JSX and now-unused imports (`IconButton`/`Tooltip`/`FavoriteIcon`/`FavoriteBorderIcon` in `FeedItem.tsx`; `Tooltip`/`FavoriteIcon`/`FavoriteBorderIcon` in `ObservationDetail.tsx`).
- Added `LikeButton.stories.tsx` covering unliked, liked, with-count, logged-out, and pending (disabled) states.
- No behavior or visual change intended; the minor `ml: -0.25` count-spacing tweak is now applied consistently in both places instead of only one.

## Test plan

- [x] `npx tsc --noEmit -p .` passes
- [x] `npx oxlint` passes on all touched files with no findings
- [x] `npx oxfmt --check` passes on all touched files
- [x] `npm run test:unit` — 161 tests pass
- [x] `npm run check:stories` — all 82 components have stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01VdSWkX1e4KWK4HKyyzJ2MS)_