### PR TITLE
design-audit: extract shared DetailHeaderSkeleton from Taxon/ObservationDetailSkeleton

### DIFF
--- a/frontend/src/components/common/DetailHeaderSkeleton.stories.tsx
+++ b/frontend/src/components/common/DetailHeaderSkeleton.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { DetailHeaderSkeleton } from "./DetailHeaderSkeleton";
+
+const meta = {
+  title: "Common/DetailHeaderSkeleton",
+  component: DetailHeaderSkeleton,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    titleWidth: { control: { type: "number" } },
+  },
+} satisfies Meta<typeof DetailHeaderSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    titleWidth: 100,
+  },
+};
+
+export const ShortTitle: Story = {
+  args: {
+    titleWidth: 60,
+  },
+};

--- a/frontend/src/components/common/DetailHeaderSkeleton.tsx
+++ b/frontend/src/components/common/DetailHeaderSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Box, Skeleton } from "@mui/material";
+import { detailHeaderSx } from "./layoutSx";
+
+export interface DetailHeaderSkeletonProps {
+  /** Width of the placeholder title text, in px. */
+  titleWidth: number;
+}
+
+/**
+ * Avatar + title placeholder row shared by detail-page skeleton loaders
+ * (taxon detail, observation detail), matching the real page's `detailHeaderSx` bar.
+ */
+export function DetailHeaderSkeleton({ titleWidth }: DetailHeaderSkeletonProps) {
+  return (
+    <Box sx={detailHeaderSx}>
+      <Skeleton variant="circular" width={40} height={40} sx={{ mr: 1 }} />
+      <Skeleton variant="text" width={titleWidth} height={24} />
+    </Box>
+  );
+}

--- a/frontend/src/components/observation/ObservationDetailSkeleton.tsx
+++ b/frontend/src/components/observation/ObservationDetailSkeleton.tsx
@@ -1,5 +1,5 @@
 import { Box, Divider, Skeleton } from "@mui/material";
-import { detailHeaderSx } from "../common/layoutSx";
+import { DetailHeaderSkeleton } from "../common/DetailHeaderSkeleton";
 
 /**
  * Skeleton loader matching observation detail page layout
@@ -7,11 +7,7 @@ import { detailHeaderSx } from "../common/layoutSx";
 export function ObservationDetailSkeleton() {
   return (
     <Box>
-      {/* Header */}
-      <Box sx={detailHeaderSx}>
-        <Skeleton variant="circular" width={40} height={40} sx={{ mr: 1 }} />
-        <Skeleton variant="text" width={100} height={24} />
-      </Box>
+      <DetailHeaderSkeleton titleWidth={100} />
 
       {/* Species header */}
       <Box sx={{ px: 3, pt: 2, pb: 1.5 }}>

--- a/frontend/src/components/taxon/TaxonDetailSkeleton.tsx
+++ b/frontend/src/components/taxon/TaxonDetailSkeleton.tsx
@@ -1,6 +1,6 @@
 import { Box, Divider, Skeleton, Stack } from "@mui/material";
 import { FeedItemSkeleton } from "../feed/FeedItemSkeleton";
-import { detailHeaderSx } from "../common/layoutSx";
+import { DetailHeaderSkeleton } from "../common/DetailHeaderSkeleton";
 
 /**
  * Skeleton loader matching taxon detail page layout
@@ -8,11 +8,7 @@ import { detailHeaderSx } from "../common/layoutSx";
 export function TaxonDetailSkeleton() {
   return (
     <Box>
-      {/* Header */}
-      <Box sx={detailHeaderSx}>
-        <Skeleton variant="circular" width={40} height={40} sx={{ mr: 1 }} />
-        <Skeleton variant="text" width={60} height={24} />
-      </Box>
+      <DetailHeaderSkeleton titleWidth={60} />
 
       {/* Main content */}
       <Box sx={{ p: 3 }}>


### PR DESCRIPTION
## Summary
- `TaxonDetailSkeleton` and `ObservationDetailSkeleton` each repeated the same avatar + title placeholder row wrapped in `detailHeaderSx` (circular skeleton + text skeleton), differing only in the title width.
- Extracted a new `common/DetailHeaderSkeleton` primitive parameterized by `titleWidth`, and updated both consumers to use it.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — no new warnings
- [x] `npm run fmt:check` — passes
- [x] `npm run check:stories` — all components have stories
- [x] `npx vitest run` — 161 tests pass
- [x] `storybook build` — succeeds, new `DetailHeaderSkeleton` story included

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_014U2ef9cnmKtW9v4P91orFs)_