### PR TITLE
design-audit: add aria-label to location search field in LocationPicker

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -334,6 +334,10 @@ export function LocationPicker({
                   ...params.slotProps.input,
                   startAdornment: <SearchAdornment />,
                 },
+                htmlInput: {
+                  ...params.slotProps.htmlInput,
+                  "aria-label": "Search for a place",
+                },
               }}
               sx={[searchFieldSx, { mb: 1 }]}
             />


### PR DESCRIPTION
## Summary
- The location search `Autocomplete` in `LocationPicker` (used inside the create-observation upload flow) had no visible label and only a `placeholder`, which disappears once the user types and isn't a reliable accessible name — a gap flagged by Storybook's `addon-a11y`.
- Added `aria-label="Search for a place"` via `slotProps.htmlInput`, matching the existing pattern already established in `common/autocompleteInput.tsx`'s `renderAutocompleteInput({ search: true, ... })` helper (used by `TaxaAutocompleteView`) and documented on `common/SearchField.tsx`.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — no new warnings
- [x] `npm run fmt:check` — passes
- [x] `npm run check:stories` — all 82 components have stories
- [x] `npx vitest run` — 161 tests pass
- [x] `storybook build` — succeeds

Co-Authored-By: Claude Sonnet 5

---
_Generated by [Claude Code](https://claude.ai/code/session_01HqMxM2fhJ6vP2vXf2WqWE3)_