### PR TITLE
design-audit: extract shared FullPageStatus from ErrorBoundary/NotFound

### DIFF
--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { Component, type ErrorInfo, type ReactNode } from "react";
-import { Box, Typography, Button, Stack } from "@mui/material";
+import { Button } from "@mui/material";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
+import { FullPageStatus } from "./FullPageStatus";
 
 interface Props {
   children: ReactNode;
@@ -53,58 +54,35 @@ export class ErrorBoundary extends Component<Props, State> {
     );
 
     return (
-      <Box
-        sx={{
-          display: "flex",
-          flexDirection: "column",
-          alignItems: "center",
-          justifyContent: "center",
-          flex: 1,
-          p: 4,
-          textAlign: "center",
-        }}
-      >
-        <Box
-          sx={{
-            width: 120,
-            height: 120,
-            borderRadius: "50%",
-            bgcolor: "action.hover",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            mb: 3,
-          }}
-        >
-          <ErrorOutlineIcon sx={{ fontSize: 60, color: "text.disabled" }} />
-        </Box>
-        <Typography variant="h6" component="h2" sx={{ color: "text.secondary", mb: 1 }}>
-          {isChunkError ? "Update available" : "Something went wrong"}
-        </Typography>
-        <Typography variant="body2" sx={{ color: "text.disabled", mb: 4, maxWidth: 360 }}>
-          {isChunkError
+      <FullPageStatus
+        icon={<ErrorOutlineIcon sx={{ fontSize: 60, color: "text.disabled" }} />}
+        title={isChunkError ? "Update available" : "Something went wrong"}
+        description={
+          isChunkError
             ? "This page couldn't load, likely because a new version was just released. Reload to get the latest."
-            : "An unexpected error occurred while loading this page."}
-        </Typography>
-        <Stack direction="row" spacing={2}>
-          <Button
-            onClick={() => window.location.reload()}
-            variant="contained"
-            color="primary"
-            sx={{ px: 4, py: 1, fontWeight: 600 }}
-          >
-            Reload
-          </Button>
-          <Button
-            onClick={() => window.location.assign("/")}
-            variant="outlined"
-            color="inherit"
-            sx={{ px: 3 }}
-          >
-            Go home
-          </Button>
-        </Stack>
-      </Box>
+            : "An unexpected error occurred while loading this page."
+        }
+        actions={
+          <>
+            <Button
+              onClick={() => window.location.reload()}
+              variant="contained"
+              color="primary"
+              sx={{ px: 4, py: 1, fontWeight: 600 }}
+            >
+              Reload
+            </Button>
+            <Button
+              onClick={() => window.location.assign("/")}
+              variant="outlined"
+              color="inherit"
+              sx={{ px: 3 }}
+            >
+              Go home
+            </Button>
+          </>
+        }
+      />
     );
   }
 }

--- a/frontend/src/components/common/FullPageStatus.stories.tsx
+++ b/frontend/src/components/common/FullPageStatus.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "@mui/material";
+import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
+import { FullPageStatus } from "./FullPageStatus";
+
+const meta = {
+  title: "Common/FullPageStatus",
+  component: FullPageStatus,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof FullPageStatus>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    icon: <ErrorOutlineIcon sx={{ fontSize: 60, color: "text.disabled" }} />,
+    title: "Something went wrong",
+    description: "An unexpected error occurred while loading this page.",
+    actions: (
+      <Button variant="contained" color="primary">
+        Reload
+      </Button>
+    ),
+  },
+};
+
+export const WithEyebrow: Story = {
+  args: {
+    icon: <ErrorOutlineIcon sx={{ fontSize: 60, color: "text.disabled" }} />,
+    eyebrow: <div style={{ fontSize: "4rem", fontWeight: 700, marginBottom: 8 }}>404</div>,
+    title: "Page not found",
+    description: "The page you're looking for doesn't exist or has been moved.",
+    descriptionMaxWidth: 300,
+    actions: (
+      <Button variant="contained" color="primary">
+        Go home
+      </Button>
+    ),
+  },
+};

--- a/frontend/src/components/common/FullPageStatus.tsx
+++ b/frontend/src/components/common/FullPageStatus.tsx
@@ -1,0 +1,73 @@
+import { Box, Typography, Stack } from "@mui/material";
+import type { ReactNode } from "react";
+
+export interface FullPageStatusProps {
+  /** Icon rendered inside the circular badge, e.g. an MUI icon element. */
+  icon: ReactNode;
+  /** Optional content rendered between the icon badge and the title, e.g. a "404" mark. */
+  eyebrow?: ReactNode;
+  /** Heading text. */
+  title: ReactNode;
+  /** Supporting copy shown below the title. */
+  description: ReactNode;
+  /** Max width applied to the description so long copy doesn't stretch full-bleed. */
+  descriptionMaxWidth?: number;
+  /** Action buttons rendered in a row below the description. */
+  actions: ReactNode;
+}
+
+/**
+ * Full-page centered status layout (icon badge, heading, copy, action row) used
+ * for error/not-found style pages. For inline empty states within a list or
+ * feed, use `EmptyState` instead.
+ */
+export function FullPageStatus({
+  icon,
+  eyebrow,
+  title,
+  description,
+  descriptionMaxWidth = 360,
+  actions,
+}: FullPageStatusProps) {
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: "column",
+        alignItems: "center",
+        justifyContent: "center",
+        flex: 1,
+        p: 4,
+        textAlign: "center",
+      }}
+    >
+      <Box
+        sx={{
+          width: 120,
+          height: 120,
+          borderRadius: "50%",
+          bgcolor: "action.hover",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          mb: 3,
+        }}
+      >
+        {icon}
+      </Box>
+      {eyebrow}
+      <Typography variant="h6" component="h2" sx={{ color: "text.secondary", mb: 1 }}>
+        {title}
+      </Typography>
+      <Typography
+        variant="body2"
+        sx={{ color: "text.disabled", mb: 4, maxWidth: descriptionMaxWidth }}
+      >
+        {description}
+      </Typography>
+      <Stack direction="row" spacing={2}>
+        {actions}
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/components/common/NotFound.tsx
+++ b/frontend/src/components/common/NotFound.tsx
@@ -1,92 +1,57 @@
 import { Link } from "react-router-dom";
-import { Box, Typography, Button, Stack } from "@mui/material";
+import { Typography, Button } from "@mui/material";
 import SearchOffIcon from "@mui/icons-material/SearchOff";
+import { FullPageStatus } from "./FullPageStatus";
 
 export function NotFound() {
   return (
-    <Box
-      sx={{
-        display: "flex",
-        flexDirection: "column",
-        alignItems: "center",
-        justifyContent: "center",
-        flex: 1,
-        p: 4,
-        textAlign: "center",
-      }}
-    >
-      <Box
-        sx={{
-          width: 120,
-          height: 120,
-          borderRadius: "50%",
-          bgcolor: "action.hover",
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "center",
-          mb: 3,
-        }}
-      >
-        <SearchOffIcon sx={{ fontSize: 60, color: "text.disabled" }} />
-      </Box>
-      <Typography
-        variant="h1"
-        sx={{
-          fontSize: "4rem",
-          fontWeight: 700,
-          background: (theme) =>
-            `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
-          backgroundClip: "text",
-          WebkitBackgroundClip: "text",
-          WebkitTextFillColor: "transparent",
-          mb: 1,
-        }}
-      >
-        404
-      </Typography>
-      <Typography
-        variant="h6"
-        component="h2"
-        sx={{
-          color: "text.secondary",
-          mb: 1,
-        }}
-      >
-        Page not found
-      </Typography>
-      <Typography
-        variant="body2"
-        sx={{
-          color: "text.disabled",
-          mb: 4,
-          maxWidth: 300,
-        }}
-      >
-        The page you're looking for doesn't exist or has been moved.
-      </Typography>
-      <Stack direction="row" spacing={2}>
-        <Button
-          component={Link}
-          to="/"
-          variant="contained"
-          color="primary"
+    <FullPageStatus
+      icon={<SearchOffIcon sx={{ fontSize: 60, color: "text.disabled" }} />}
+      eyebrow={
+        <Typography
+          variant="h1"
           sx={{
-            px: 4,
-            py: 1,
-            fontWeight: 600,
+            fontSize: "4rem",
+            fontWeight: 700,
+            background: (theme) =>
+              `linear-gradient(135deg, ${theme.palette.primary.main}, ${theme.palette.primary.dark})`,
+            backgroundClip: "text",
+            WebkitBackgroundClip: "text",
+            WebkitTextFillColor: "transparent",
+            mb: 1,
           }}
         >
-          Go home
-        </Button>
-        <Button
-          onClick={() => window.history.back()}
-          variant="outlined"
-          color="inherit"
-          sx={{ px: 3 }}
-        >
-          Go back
-        </Button>
-      </Stack>
-    </Box>
+          404
+        </Typography>
+      }
+      title="Page not found"
+      description="The page you're looking for doesn't exist or has been moved."
+      descriptionMaxWidth={300}
+      actions={
+        <>
+          <Button
+            component={Link}
+            to="/"
+            variant="contained"
+            color="primary"
+            sx={{
+              px: 4,
+              py: 1,
+              fontWeight: 600,
+            }}
+          >
+            Go home
+          </Button>
+          <Button
+            onClick={() => window.history.back()}
+            variant="outlined"
+            color="inherit"
+            sx={{ px: 3 }}
+          >
+            Go back
+          </Button>
+        </>
+      }
+    />
   );
 }


### PR DESCRIPTION
## What

`ErrorBoundary.tsx` and `NotFound.tsx` each hand-rolled the same full-page status layout: a centered `Box`, a 120×120 circular icon badge, a title/description pair, and a row of action buttons. Extracts this into `common/FullPageStatus.tsx` — a small presentational component with `icon`, optional `eyebrow` (used by `NotFound`'s gradient "404" mark), `title`, `description`, `descriptionMaxWidth`, and `actions` props — so the layout decision lives in one place instead of two copy-pasted blocks.

`ErrorBoundary` and `NotFound` now just supply their icon/copy/buttons; no visual or behavioral change. Distinct from the existing lighter-weight `common/EmptyState.tsx`, which is for inline list/feed empty states rather than full-page ones.

Added `FullPageStatus.stories.tsx` per house style for newly-extracted `common/` components (see `RecordOverflowMenu`, `ObservationGridCard`, etc.).

## Test plan

- [x] `tsc --noEmit` — clean
- [x] `oxlint` / `oxfmt --check` — clean
- [x] `node scripts/check-stories.mjs` — all components still have stories
- [x] `vitest run` — 161 tests pass
- [x] `storybook build` — succeeds, new stories render


---
_Generated by [Claude Code](https://claude.ai/code/session_01EBhzh2b5BDdo1Cqh2pqAxe)_