### PR TITLE
design-audit: extract shared ValueChipList in LexiconView

### DIFF
--- a/frontend/src/components/common/chipSx.ts
+++ b/frontend/src/components/common/chipSx.ts
@@ -3,3 +3,6 @@ export const countChipSx = { height: 20, fontSize: "0.75rem" };
 
 /** Compact label badge — type/category text labels at xs size (e.g. in data tables). */
 export const labelChipSx = { height: 20, fontSize: "0.65rem" };
+
+/** Tiny value badge — enumerated values listed inline, smaller than labelChipSx. */
+export const valueChipSx = { height: 18, fontSize: "0.6rem" };

--- a/frontend/src/components/lexicon/LexiconView.tsx
+++ b/frontend/src/components/lexicon/LexiconView.tsx
@@ -17,7 +17,7 @@ import {
   Link as MuiLink,
 } from "@mui/material";
 import { ExpandMore, ExpandLess } from "@mui/icons-material";
-import { labelChipSx } from "../common/chipSx";
+import { labelChipSx, valueChipSx } from "../common/chipSx";
 import { monoStack } from "../../theme";
 
 // Eagerly import all lexicons at build time via the @lexicons alias.
@@ -102,6 +102,16 @@ function formatType(prop: LexiconProperty): string {
   return t;
 }
 
+function ValueChipList({ values }: { values: string[] }) {
+  return (
+    <Box sx={{ mt: 0.5, display: "flex", flexWrap: "wrap", gap: 0.5 }}>
+      {values.map((v) => (
+        <Chip key={v} label={v} size="small" variant="outlined" sx={valueChipSx} />
+      ))}
+    </Box>
+  );
+}
+
 function PropertyTable({
   properties,
   required,
@@ -158,32 +168,8 @@ function PropertyTable({
                 >
                   {formatType(prop)}
                 </Typography>
-                {prop.enum && (
-                  <Box sx={{ mt: 0.5, display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                    {prop.enum.map((v) => (
-                      <Chip
-                        key={v}
-                        label={v}
-                        size="small"
-                        variant="outlined"
-                        sx={{ height: 18, fontSize: "0.6rem" }}
-                      />
-                    ))}
-                  </Box>
-                )}
-                {prop.knownValues && (
-                  <Box sx={{ mt: 0.5, display: "flex", flexWrap: "wrap", gap: 0.5 }}>
-                    {prop.knownValues.map((v) => (
-                      <Chip
-                        key={v}
-                        label={v}
-                        size="small"
-                        variant="outlined"
-                        sx={{ height: 18, fontSize: "0.6rem" }}
-                      />
-                    ))}
-                  </Box>
-                )}
+                {prop.enum && <ValueChipList values={prop.enum} />}
+                {prop.knownValues && <ValueChipList values={prop.knownValues} />}
               </TableCell>
               <TableCell>
                 <Typography

--- a/package-lock.json
+++ b/package-lock.json
@@ -7989,9 +7989,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.3.tgz",
-      "integrity": "sha512-i70LwGWUduXqzicKXWshooq+sWL1K3WUU5rKZNG/0i3a1OSoX3HqhH5WbWwTmqWfor4urUakGPiRQcleRZTwOg==",
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
       "dev": true,
       "funding": [
         {
@@ -13296,24 +13296,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {


### PR DESCRIPTION
## What

`PropertyTable` in `LexiconView.tsx` rendered `prop.enum` and `prop.knownValues` with two byte-for-byte identical blocks: same wrapping `Box` (`mt: 0.5, display: "flex", flexWrap: "wrap", gap: 0.5`) and the same inline `sx={{ height: 18, fontSize: "0.6rem" }}` on each `Chip`, differing only in which array was mapped.

Extracted a local `ValueChipList({ values })` component and hoisted the inline `sx` to a new `valueChipSx` token in `common/chipSx.ts`, following the existing `countChipSx`/`labelChipSx` pattern already used elsewhere in the codebase.

No visual or behavioral change.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings (pre-existing exhaustive-deps warnings in unrelated files)
- [x] `npm run fmt:check` — passes
- [x] `npm run check:stories` — all 83 components have stories
- [x] `npm run test:unit` — 161 tests pass
- [x] `npm run build-storybook` — succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01HuicZHT3wx2mAnWq7okyd3)_