### PR TITLE
design-audit: centralize taxon URL building into buildTaxonUrl

### DIFF
--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -5,16 +5,10 @@ import type { TaxaResult } from "../../services/types";
 import { ConservationStatus } from "./ConservationStatus";
 import { renderAutocompleteInput } from "./autocompleteInput";
 import { shouldItalicizeTaxonName } from "./TaxonLink";
-import { nameToSlug } from "../../lib/taxonSlug";
+import { buildTaxonUrl } from "../../lib/taxonSlug";
 
 export function taxonUrlFor(option: TaxaResult): string | null {
-  if (option.rank?.toLowerCase() === "kingdom") {
-    return `/taxon/${nameToSlug(option.scientificName)}`;
-  }
-  if (option.kingdom) {
-    return `/taxon/${nameToSlug(option.kingdom)}/${nameToSlug(option.scientificName)}`;
-  }
-  return null;
+  return buildTaxonUrl(option.scientificName, option.kingdom, option.rank);
 }
 
 interface TaxaAutocompleteViewProps {

--- a/frontend/src/components/common/TaxonLink.tsx
+++ b/frontend/src/components/common/TaxonLink.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom";
 import { Chip, Typography } from "@mui/material";
-import { nameToSlug } from "../../lib/taxonSlug";
+import { buildTaxonUrl } from "../../lib/taxonSlug";
 
 const ITALICIZED_RANKS = new Set(["species", "genus", "subspecies", "variety"]);
 
@@ -46,17 +46,7 @@ export function TaxonLink({
   // Default italic behavior: italicize species/genus/subspecies/variety ranks
   const shouldItalicize = italic !== undefined ? italic : shouldItalicizeTaxonName(name, rank);
 
-  // Build the URL using kingdom/name pattern with hyphenated slugs
-  // All non-kingdom taxa require a kingdom prefix
-  let taxonUrl: string | null;
-  if (rank === "kingdom") {
-    taxonUrl = `/taxon/${nameToSlug(name)}`;
-  } else if (kingdom) {
-    taxonUrl = `/taxon/${nameToSlug(kingdom)}/${nameToSlug(name)}`;
-  } else {
-    // No valid URL without kingdom - render as plain text
-    taxonUrl = null;
-  }
+  const taxonUrl = buildTaxonUrl(name, kingdom, rank);
 
   const handleClick = (e: React.MouseEvent) => {
     // Stop propagation if handler provided (e.g., to prevent parent link activation)

--- a/frontend/src/components/identification/VisualIdCards.tsx
+++ b/frontend/src/components/identification/VisualIdCards.tsx
@@ -3,7 +3,7 @@ import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import PlaceIcon from "@mui/icons-material/Place";
 import type { SpeciesSuggestion } from "../../services/api";
-import { nameToSlug } from "../../lib/taxonSlug";
+import { buildTaxonUrl } from "../../lib/taxonSlug";
 
 /**
  * Ranks we'll roll up to, ordered from most specific to most general.
@@ -61,16 +61,6 @@ function determineMode(sortedByConfidence: SpeciesSuggestion[]): Mode {
   return top.confidence >= DOMINANT_FLOOR && top.confidence >= DOMINANT_GAP * runnerUp.confidence
     ? "dominant"
     : "ambiguous";
-}
-
-function buildTaxonUrl(
-  name: string,
-  kingdom: string | undefined,
-  rank?: AncestorRank,
-): string | null {
-  if (rank === "kingdom") return `/taxon/${nameToSlug(name)}`;
-  if (kingdom) return `/taxon/${nameToSlug(kingdom)}/${nameToSlug(name)}`;
-  return null;
 }
 
 function TaxonLinkButton({ url, taxonName }: { url: string; taxonName: string }) {

--- a/frontend/src/components/taxon/TaxonBreadcrumb.tsx
+++ b/frontend/src/components/taxon/TaxonBreadcrumb.tsx
@@ -1,5 +1,5 @@
 import type { TaxonAncestor } from "../../bindings/TaxonAncestor";
-import { nameToSlug } from "../../lib/taxonSlug";
+import { buildTaxonUrl } from "../../lib/taxonSlug";
 import { Breadcrumbs, type BreadcrumbItem } from "../common/Breadcrumbs";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 
@@ -17,12 +17,7 @@ interface TaxonBreadcrumbProps {
  */
 export function TaxonBreadcrumb({ ancestors, kingdom }: TaxonBreadcrumbProps) {
   const items: BreadcrumbItem[] = ancestors.map((a) => {
-    const url =
-      a.rank === "kingdom"
-        ? `/taxon/${nameToSlug(a.name)}`
-        : kingdom
-          ? `/taxon/${nameToSlug(kingdom)}/${nameToSlug(a.name)}`
-          : undefined;
+    const url = buildTaxonUrl(a.name, kingdom, a.rank) ?? undefined;
     return {
       label: a.name,
       italic: shouldItalicizeTaxonName(a.name, a.rank),

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -4,7 +4,7 @@ import { Box, Container, Typography, Button, Drawer } from "@mui/material";
 import type { TreeViewDefaultItemModelProperties } from "@mui/x-tree-view";
 import { fetchTaxonChildren } from "../../services/api";
 import type { TaxonDetail, TaxaResult } from "../../services/types";
-import { slugToName, nameToSlug } from "../../lib/taxonSlug";
+import { slugToName, buildTaxonUrl } from "../../lib/taxonSlug";
 import { useTaxon, useTaxonOccurrences } from "../../lib/query/hooks";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { useWikidataThumbnails } from "../../hooks/useWikidataThumbnails";
@@ -358,11 +358,8 @@ export function TaxonExplorer() {
     const node = nodesRef.current.get(id);
     if (!node) return;
     setMobileTreeOpen(false);
-    if (node.rank === "kingdom") {
-      navigate(`/taxon/${nameToSlug(node.name)}`);
-    } else {
-      navigate(`/taxon/${nameToSlug(node.kingdom)}/${nameToSlug(node.name)}`);
-    }
+    const url = buildTaxonUrl(node.name, node.kingdom, node.rank);
+    if (url) navigate(url);
   };
 
   const handleTreeExpansionToggle = async (id: string, isExpanded: boolean) => {

--- a/frontend/src/lib/taxonSlug.ts
+++ b/frontend/src/lib/taxonSlug.ts
@@ -15,3 +15,19 @@ export function nameToSlug(name: string): string {
 export function slugToName(slug: string): string {
   return slug.replace(/-/g, " ");
 }
+
+/**
+ * Build the URL for a taxon's detail page. Kingdom-rank taxa link directly;
+ * every other rank needs a kingdom prefix, and with no kingdom there's no
+ * link. Rank is compared case-insensitively since it can arrive from
+ * different upstream sources with inconsistent casing.
+ */
+export function buildTaxonUrl(
+  name: string,
+  kingdom?: string | undefined,
+  rank?: string | undefined,
+): string | null {
+  if (rank?.toLowerCase() === "kingdom") return `/taxon/${nameToSlug(name)}`;
+  if (kingdom) return `/taxon/${nameToSlug(kingdom)}/${nameToSlug(name)}`;
+  return null;
+}


### PR DESCRIPTION
## What

The rule "kingdom-rank taxa link to `/taxon/{slug(name)}`; other taxa need a kingdom prefix, `/taxon/{slug(kingdom)}/{slug(name)}`; with no kingdom, there's no link" was independently reimplemented in five places:

- `common/TaxonLink.tsx`
- `common/TaxaAutocompleteView.tsx` (`taxonUrlFor`)
- `identification/VisualIdCards.tsx` (`buildTaxonUrl`)
- `taxon/TaxonBreadcrumb.tsx`
- `taxon/TaxonExplorer.tsx` (`handleTreeSelect`)

The copies had already drifted: only `TaxaAutocompleteView`'s lowercased `rank` before comparing to `"kingdom"`; the other four did a strict `===` check, so a differently-cased rank (e.g. `"Kingdom"`) would silently fall through to the non-kingdom branch and build a wrong nested URL (`/taxon/Animalia/Animalia` instead of `/taxon/Animalia`) everywhere except the autocomplete dropdown. `TaxonExplorer`'s copy also lacked the no-kingdom guard the other four had, so it could navigate to a URL with a literal `undefined` segment.

Adds one `buildTaxonUrl(name, kingdom?, rank?)` helper to `lib/taxonSlug.ts` — standardizing on the more defensive case-insensitive rank comparison — and points all five call sites at it.

No visual change; behavior only changes for the previously-inconsistent edge cases described above (all converging on the correct/safer behavior).

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` — no new warnings (pre-existing exhaustive-deps warnings in unrelated files)
- [x] `npm run fmt:check` — passes
- [x] `npm run check:stories` — all 83 components have stories
- [x] `npm run test:unit` — 161 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_011dMRbz9r9Zf5uwzhsWwsBC)_