### PR TITLE
design-audit: extract shared PageContainer from Notifications/Settings/Transparency/Docs pages

### DIFF
--- a/frontend/src/components/common/PageContainer.stories.tsx
+++ b/frontend/src/components/common/PageContainer.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Typography } from "@mui/material";
+import { PageContainer } from "./PageContainer";
+
+const meta = {
+  title: "Common/PageContainer",
+  component: PageContainer,
+  parameters: {
+    layout: "fullscreen",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof PageContainer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    maxWidth: "sm",
+    children: (
+      <>
+        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+          Page title
+        </Typography>
+        <Typography variant="body2" sx={{ color: "text.secondary" }}>
+          Page content goes here.
+        </Typography>
+      </>
+    ),
+  },
+};
+
+export const MediumWidth: Story = {
+  args: {
+    ...Default.args,
+    maxWidth: "md",
+  },
+};

--- a/frontend/src/components/common/PageContainer.tsx
+++ b/frontend/src/components/common/PageContainer.tsx
@@ -1,0 +1,33 @@
+import type { ReactNode, Ref, UIEventHandler } from "react";
+import { Box, Container } from "@mui/material";
+import type { ContainerProps } from "@mui/material";
+
+export interface PageContainerProps {
+  /** Passed through to the inner `Container`. */
+  maxWidth?: ContainerProps["maxWidth"];
+  /** Ref on the scrollable outer `Box`, for pages that track scroll position (e.g. infinite scroll). */
+  scrollRef?: Ref<HTMLDivElement>;
+  /** Scroll handler on the outer `Box`. */
+  onScroll?: UIEventHandler<HTMLDivElement>;
+  children: ReactNode;
+}
+
+/**
+ * Scrollable full-height page shell (Box + Container) shared by top-level
+ * pages (Notifications, Settings, Transparency, Docs) so the outer chrome
+ * isn't hand-copied per page.
+ */
+export function PageContainer({
+  maxWidth = "sm",
+  scrollRef,
+  onScroll,
+  children,
+}: PageContainerProps) {
+  return (
+    <Box ref={scrollRef} onScroll={onScroll} sx={{ flex: 1, overflow: "auto", height: "100%" }}>
+      <Container maxWidth={maxWidth} sx={{ py: 3 }}>
+        {children}
+      </Container>
+    </Box>
+  );
+}

--- a/frontend/src/components/docs/DocsPage.tsx
+++ b/frontend/src/components/docs/DocsPage.tsx
@@ -1,7 +1,8 @@
 import { Link as RouterLink } from "react-router-dom";
-import { Box, Container, Typography, Paper, Stack } from "@mui/material";
+import { Box, Typography, Paper, Stack } from "@mui/material";
 import { Schema, AutoStories, GitHub, AccountBalance, ChevronRight } from "@mui/icons-material";
 import { usePageTitle } from "../../hooks/usePageTitle";
+import { PageContainer } from "../common/PageContainer";
 
 interface DocLink {
   label: string;
@@ -42,56 +43,54 @@ export function DocsPage() {
   usePageTitle("Docs");
 
   return (
-    <Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
-      <Container maxWidth="sm" sx={{ py: 3 }}>
-        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
-          Docs
-        </Typography>
-        <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>
-          Reference material and resources for Observ.ing.
-        </Typography>
+    <PageContainer maxWidth="sm">
+      <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+        Docs
+      </Typography>
+      <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>
+        Reference material and resources for Observ.ing.
+      </Typography>
 
-        <Stack spacing={1.5}>
-          {links.map((link) => {
-            const linkProps = link.to
-              ? { component: RouterLink, to: link.to }
-              : {
-                  component: "a" as const,
-                  href: link.href,
-                  target: "_blank",
-                  rel: "noopener noreferrer",
-                };
-            return (
-              <Paper
-                key={link.label}
-                variant="outlined"
-                {...linkProps}
-                sx={{
-                  p: 2,
-                  borderRadius: 2,
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 2,
-                  textDecoration: "none",
-                  color: "text.primary",
-                  "&:hover": { bgcolor: "action.hover", borderColor: "primary.main" },
-                }}
-              >
-                <Box sx={{ color: "primary.main", display: "flex" }}>{link.icon}</Box>
-                <Box sx={{ flex: 1, minWidth: 0 }}>
-                  <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
-                    {link.label}
-                  </Typography>
-                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                    {link.description}
-                  </Typography>
-                </Box>
-                <ChevronRight sx={{ color: "text.secondary" }} />
-              </Paper>
-            );
-          })}
-        </Stack>
-      </Container>
-    </Box>
+      <Stack spacing={1.5}>
+        {links.map((link) => {
+          const linkProps = link.to
+            ? { component: RouterLink, to: link.to }
+            : {
+                component: "a" as const,
+                href: link.href,
+                target: "_blank",
+                rel: "noopener noreferrer",
+              };
+          return (
+            <Paper
+              key={link.label}
+              variant="outlined"
+              {...linkProps}
+              sx={{
+                p: 2,
+                borderRadius: 2,
+                display: "flex",
+                alignItems: "center",
+                gap: 2,
+                textDecoration: "none",
+                color: "text.primary",
+                "&:hover": { bgcolor: "action.hover", borderColor: "primary.main" },
+              }}
+            >
+              <Box sx={{ color: "primary.main", display: "flex" }}>{link.icon}</Box>
+              <Box sx={{ flex: 1, minWidth: 0 }}>
+                <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
+                  {link.label}
+                </Typography>
+                <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                  {link.description}
+                </Typography>
+              </Box>
+              <ChevronRight sx={{ color: "text.secondary" }} />
+            </Paper>
+          );
+        })}
+      </Stack>
+    </PageContainer>
   );
 }

--- a/frontend/src/components/notifications/NotificationsPage.tsx
+++ b/frontend/src/components/notifications/NotificationsPage.tsx
@@ -1,6 +1,6 @@
 import { useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { Box, Container, Typography, Button, List, ListItem, ListItemButton } from "@mui/material";
+import { Box, Typography, Button, List, ListItem, ListItemButton } from "@mui/material";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import { getImageUrl } from "../../services/api";
 import type { Notification } from "../../services/types";
@@ -9,6 +9,7 @@ import { RelativeTime } from "../common/RelativeTime";
 import { UserCard } from "../common/UserCard";
 import { CenteredSpinner } from "../common/CenteredSpinner";
 import { EmptyState } from "../common/EmptyState";
+import { PageContainer } from "../common/PageContainer";
 import { useNotifications } from "../../lib/query/hooks";
 import { useMarkNotificationRead } from "../../lib/query/mutations";
 
@@ -56,76 +57,70 @@ export function NotificationsPage() {
   const hasUnread = notifications.some((n) => !n.read);
 
   return (
-    <Box
-      ref={contentRef}
-      onScroll={handleScroll}
-      sx={{ flex: 1, overflow: "auto", height: "100%" }}
-    >
-      <Container maxWidth="sm" sx={{ py: 3 }}>
-        <Box
+    <PageContainer scrollRef={contentRef} onScroll={handleScroll} maxWidth="sm">
+      <Box
+        sx={{
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          mb: 2,
+        }}
+      >
+        <Typography
+          variant="h5"
           sx={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            mb: 2,
+            fontWeight: 700,
           }}
         >
-          <Typography
-            variant="h5"
+          Notifications
+        </Typography>
+        {hasUnread && (
+          <Button size="small" onClick={handleMarkAllRead}>
+            Mark all read
+          </Button>
+        )}
+      </Box>
+
+      {!isLoading && notifications.length === 0 && (
+        <EmptyState message="No notifications yet" p={0} sx={{ mt: 4 }} />
+      )}
+
+      <List disablePadding>
+        {notifications.map((n) => (
+          <ListItem
+            key={n.id}
+            disablePadding
             sx={{
-              fontWeight: 700,
+              bgcolor: n.read ? "transparent" : "action.hover",
+              borderRadius: 2,
+              mb: 0.5,
             }}
           >
-            Notifications
-          </Typography>
-          {hasUnread && (
-            <Button size="small" onClick={handleMarkAllRead}>
-              Mark all read
-            </Button>
-          )}
-        </Box>
+            <ListItemButton onClick={() => handleClick(n)} sx={{ borderRadius: 2, py: 1.5 }}>
+              <UserCard
+                actor={n.actor ?? {}}
+                linkDid={n.actorDid}
+                avatarSize={40}
+                {...(n.actor?.avatar ? { avatarSrc: getImageUrl(n.actor.avatar) } : {})}
+                nameVariant="body2"
+                showHandle
+                trailing={
+                  <Typography component="span" variant="body2">
+                    {getKindText(n.kind)}
+                  </Typography>
+                }
+                belowName={
+                  <Typography variant="body2" sx={{ color: "text.secondary" }}>
+                    <RelativeTime date={new Date(n.createdAt)} />
+                  </Typography>
+                }
+              />
+            </ListItemButton>
+          </ListItem>
+        ))}
+      </List>
 
-        {!isLoading && notifications.length === 0 && (
-          <EmptyState message="No notifications yet" p={0} sx={{ mt: 4 }} />
-        )}
-
-        <List disablePadding>
-          {notifications.map((n) => (
-            <ListItem
-              key={n.id}
-              disablePadding
-              sx={{
-                bgcolor: n.read ? "transparent" : "action.hover",
-                borderRadius: 2,
-                mb: 0.5,
-              }}
-            >
-              <ListItemButton onClick={() => handleClick(n)} sx={{ borderRadius: 2, py: 1.5 }}>
-                <UserCard
-                  actor={n.actor ?? {}}
-                  linkDid={n.actorDid}
-                  avatarSize={40}
-                  {...(n.actor?.avatar ? { avatarSrc: getImageUrl(n.actor.avatar) } : {})}
-                  nameVariant="body2"
-                  showHandle
-                  trailing={
-                    <Typography component="span" variant="body2">
-                      {getKindText(n.kind)}
-                    </Typography>
-                  }
-                  belowName={
-                    <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                      <RelativeTime date={new Date(n.createdAt)} />
-                    </Typography>
-                  }
-                />
-              </ListItemButton>
-            </ListItem>
-          ))}
-        </List>
-
-        {(isLoading || isFetchingNextPage) && <CenteredSpinner p={0} sx={{ py: 3 }} />}
-      </Container>
-    </Box>
+      {(isLoading || isFetchingNextPage) && <CenteredSpinner p={0} sx={{ py: 3 }} />}
+    </PageContainer>
   );
 }

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -1,6 +1,4 @@
 import {
-  Box,
-  Container,
   Typography,
   ToggleButtonGroup,
   ToggleButton,
@@ -19,6 +17,7 @@ import { setThemeMode, type ThemeMode } from "../../store/uiSlice";
 import { useUserPreferences } from "../../lib/query/hooks";
 import { useUpdatePreferences } from "../../lib/query/mutations";
 import { LICENSE_OPTIONS } from "../../lib/licenses";
+import { PageContainer } from "../common/PageContainer";
 
 const NO_DEFAULT = "__none__";
 
@@ -50,96 +49,93 @@ export function SettingsPage() {
   };
 
   return (
-    <Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
-      <Container maxWidth="sm" sx={{ py: 3 }}>
+    <PageContainer maxWidth="sm">
+      <Typography
+        variant="h5"
+        sx={{
+          fontWeight: 700,
+          mb: 3,
+        }}
+      >
+        Settings
+      </Typography>
+
+      <Paper variant="outlined" sx={{ p: 3, borderRadius: 2, mb: 3 }}>
         <Typography
-          variant="h5"
+          variant="subtitle1"
           sx={{
-            fontWeight: 700,
-            mb: 3,
+            fontWeight: 600,
+            mb: 0.5,
           }}
         >
-          Settings
+          Appearance
         </Typography>
+        <Typography
+          variant="body2"
+          sx={{
+            color: "text.secondary",
+            mb: 2,
+          }}
+        >
+          Choose how Observ.ing looks to you. Select a single theme, or sync with your system
+          settings.
+        </Typography>
+        <ToggleButtonGroup
+          value={themeMode}
+          exclusive
+          onChange={handleThemeChange}
+          aria-label="Theme mode"
+          sx={{
+            "& .MuiToggleButton-root": {
+              px: 3,
+              py: 1,
+              gap: 1,
+              textTransform: "none",
+              fontWeight: 500,
+            },
+          }}
+        >
+          <ToggleButton value="light" aria-label="Light mode">
+            <LightMode fontSize="small" />
+            Light
+          </ToggleButton>
+          <ToggleButton value="dark" aria-label="Dark mode">
+            <DarkMode fontSize="small" />
+            Dark
+          </ToggleButton>
+          <ToggleButton value="system" aria-label="System theme">
+            <SettingsBrightness fontSize="small" />
+            System
+          </ToggleButton>
+        </ToggleButtonGroup>
+      </Paper>
 
-        <Paper variant="outlined" sx={{ p: 3, borderRadius: 2, mb: 3 }}>
-          <Typography
-            variant="subtitle1"
-            sx={{
-              fontWeight: 600,
-              mb: 0.5,
-            }}
-          >
-            Appearance
+      {user && (
+        <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
+          <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
+            Upload defaults
           </Typography>
-          <Typography
-            variant="body2"
-            sx={{
-              color: "text.secondary",
-              mb: 2,
-            }}
-          >
-            Choose how Observ.ing looks to you. Select a single theme, or sync with your system
-            settings.
+          <Typography variant="body2" sx={{ color: "text.secondary", mb: 2 }}>
+            Pre-fill the license for new observation photos. You can still change it on each upload.
           </Typography>
-          <ToggleButtonGroup
-            value={themeMode}
-            exclusive
-            onChange={handleThemeChange}
-            aria-label="Theme mode"
-            sx={{
-              "& .MuiToggleButton-root": {
-                px: 3,
-                py: 1,
-                gap: 1,
-                textTransform: "none",
-                fontWeight: 500,
-              },
-            }}
-          >
-            <ToggleButton value="light" aria-label="Light mode">
-              <LightMode fontSize="small" />
-              Light
-            </ToggleButton>
-            <ToggleButton value="dark" aria-label="Dark mode">
-              <DarkMode fontSize="small" />
-              Dark
-            </ToggleButton>
-            <ToggleButton value="system" aria-label="System theme">
-              <SettingsBrightness fontSize="small" />
-              System
-            </ToggleButton>
-          </ToggleButtonGroup>
+          <FormControl fullWidth size="small" disabled={updatePrefs.isPending}>
+            <InputLabel id="default-license-label">Default license</InputLabel>
+            <Select
+              labelId="default-license-label"
+              value={defaultLicense ?? NO_DEFAULT}
+              label="Default license"
+              onChange={handleLicenseChange}
+            >
+              <MenuItem value={NO_DEFAULT}>No default (use CC BY)</MenuItem>
+              {LICENSE_OPTIONS.map((opt) => (
+                <MenuItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         </Paper>
-
-        {user && (
-          <Paper variant="outlined" sx={{ p: 3, borderRadius: 2 }}>
-            <Typography variant="subtitle1" sx={{ fontWeight: 600, mb: 0.5 }}>
-              Upload defaults
-            </Typography>
-            <Typography variant="body2" sx={{ color: "text.secondary", mb: 2 }}>
-              Pre-fill the license for new observation photos. You can still change it on each
-              upload.
-            </Typography>
-            <FormControl fullWidth size="small" disabled={updatePrefs.isPending}>
-              <InputLabel id="default-license-label">Default license</InputLabel>
-              <Select
-                labelId="default-license-label"
-                value={defaultLicense ?? NO_DEFAULT}
-                label="Default license"
-                onChange={handleLicenseChange}
-              >
-                <MenuItem value={NO_DEFAULT}>No default (use CC BY)</MenuItem>
-                {LICENSE_OPTIONS.map((opt) => (
-                  <MenuItem key={opt.value} value={opt.value}>
-                    {opt.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
-          </Paper>
-        )}
-      </Container>
-    </Box>
+      )}
+    </PageContainer>
   );
 }

--- a/frontend/src/components/transparency/TransparencyPage.tsx
+++ b/frontend/src/components/transparency/TransparencyPage.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  Container,
   Paper,
   Table,
   TableBody,
@@ -13,6 +12,7 @@ import {
 } from "@mui/material";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import transparencyData from "../../data/transparency.json";
+import { PageContainer } from "../common/PageContainer";
 
 interface ServiceCost {
   name: string;
@@ -83,69 +83,67 @@ export function TransparencyPage() {
   const grandTotal = sortedMonths.reduce((sum, m) => sum + monthTotal(m), 0);
 
   return (
-    <Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
-      <Container maxWidth="md" sx={{ py: 3 }}>
-        <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
-          Transparency
-        </Typography>
-        <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>
-          {data.notes}
-        </Typography>
+    <PageContainer maxWidth="md">
+      <Typography variant="h5" sx={{ fontWeight: 700, mb: 1 }}>
+        Transparency
+      </Typography>
+      <Typography variant="body2" sx={{ color: "text.secondary", mb: 3 }}>
+        {data.notes}
+      </Typography>
 
-        <Paper variant="outlined" sx={{ borderRadius: 2 }}>
-          {sortedMonths.length === 0 ? (
-            <Box sx={{ p: 3 }}>
-              <Typography variant="body2" sx={{ color: "text.secondary" }}>
-                No cost data has been recorded yet.
-              </Typography>
-            </Box>
-          ) : (
-            <TableContainer>
-              <Table size="small">
-                <TableHead>
-                  <TableRow>
-                    <TableCell>Month</TableCell>
+      <Paper variant="outlined" sx={{ borderRadius: 2 }}>
+        {sortedMonths.length === 0 ? (
+          <Box sx={{ p: 3 }}>
+            <Typography variant="body2" sx={{ color: "text.secondary" }}>
+              No cost data has been recorded yet.
+            </Typography>
+          </Box>
+        ) : (
+          <TableContainer>
+            <Table size="small">
+              <TableHead>
+                <TableRow>
+                  <TableCell>Month</TableCell>
+                  {services.map((s) => (
+                    <TableCell key={s} align="right">
+                      {s}
+                    </TableCell>
+                  ))}
+                  <TableCell align="right">Total</TableCell>
+                </TableRow>
+              </TableHead>
+              <TableBody>
+                {sortedMonths.map((m) => (
+                  <TableRow key={m.month}>
+                    <TableCell>{formatMonth(m.month)}</TableCell>
                     {services.map((s) => (
                       <TableCell key={s} align="right">
-                        {s}
-                      </TableCell>
-                    ))}
-                    <TableCell align="right">Total</TableCell>
-                  </TableRow>
-                </TableHead>
-                <TableBody>
-                  {sortedMonths.map((m) => (
-                    <TableRow key={m.month}>
-                      <TableCell>{formatMonth(m.month)}</TableCell>
-                      {services.map((s) => (
-                        <TableCell key={s} align="right">
-                          {formatCurrency(costFor(m, s))}
-                        </TableCell>
-                      ))}
-                      <TableCell align="right" sx={{ fontWeight: 600 }}>
-                        {formatCurrency(monthTotal(m))}
-                      </TableCell>
-                    </TableRow>
-                  ))}
-                </TableBody>
-                <TableFooter>
-                  <TableRow>
-                    <TableCell sx={{ fontWeight: 600 }}>Total</TableCell>
-                    {services.map((s) => (
-                      <TableCell key={s} align="right" sx={{ fontWeight: 600 }}>
-                        {formatCurrency(serviceTotals.get(s) ?? 0)}
+                        {formatCurrency(costFor(m, s))}
                       </TableCell>
                     ))}
                     <TableCell align="right" sx={{ fontWeight: 600 }}>
-                      {formatCurrency(grandTotal)}
+                      {formatCurrency(monthTotal(m))}
                     </TableCell>
                   </TableRow>
-                </TableFooter>
-              </Table>
-            </TableContainer>
-          )}
-        </Paper>
-      </Container>
-    </Box>
+                ))}
+              </TableBody>
+              <TableFooter>
+                <TableRow>
+                  <TableCell sx={{ fontWeight: 600 }}>Total</TableCell>
+                  {services.map((s) => (
+                    <TableCell key={s} align="right" sx={{ fontWeight: 600 }}>
+                      {formatCurrency(serviceTotals.get(s) ?? 0)}
+                    </TableCell>
+                  ))}
+                  <TableCell align="right" sx={{ fontWeight: 600 }}>
+                    {formatCurrency(grandTotal)}
+                  </TableCell>
+                </TableRow>
+              </TableFooter>
+            </Table>
+          </TableContainer>
+        )}
+      </Paper>
+    </PageContainer>
   );
 }


### PR DESCRIPTION
## What

Four top-level pages — `NotificationsPage`, `SettingsPage`, `TransparencyPage`, `DocsPage` — each hand-copied the identical outer page shell:

```tsx
<Box sx={{ flex: 1, overflow: "auto", height: "100%" }}>
  <Container maxWidth="..." sx={{ py: 3 }}>
    ...
  </Container>
</Box>
```

This extracts that shell into a new `frontend/src/components/common/PageContainer.tsx`, matching the existing house style for shared page-level primitives (e.g. `FullPageStatus`, `Section`). `NotificationsPage` uses infinite scroll, so `PageContainer` exposes optional `scrollRef`/`onScroll` passthrough for that case.

## Why

Pure duplication removal — no behavior or visual change. One of the recurring `design-audit:` passes that centralize repeated layout/styling into shared components (see `git log --grep "design-audit:"` for prior passes).

## Testing

- `npx tsc --noEmit -p tsconfig.json` — clean
- `npm run lint` — clean (pre-existing warnings unrelated to this change)
- `npm run fmt:check` — clean
- `npm run check:stories` — all components have stories (added `PageContainer.stories.tsx`)
- `npm run test:unit` — 161 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lgxz6nym6M8o6dcK3od8Nn)_