### PR TITLE
design-audit: remove hardcoded font stack duplicate in Wordmark

### DIFF
--- a/frontend/src/components/common/Wordmark.tsx
+++ b/frontend/src/components/common/Wordmark.tsx
@@ -13,7 +13,7 @@ export function Wordmark({ sx }: WordmarkProps) {
     <Typography
       component="span"
       sx={{
-        fontFamily: '"DM Sans", sans-serif',
+        // fontFamily inherits the theme's brand sans stack (DM Sans + fallbacks).
         fontWeight: 600,
         fontSize: "1.125rem",
         lineHeight: 1,


### PR DESCRIPTION
## What

`Wordmark.tsx` hardcoded `fontFamily: '"DM Sans", sans-serif'` on its `Typography` — a narrower, one-off copy of the brand sans stack that the theme already defines as `typography.fontFamily` (`frontend/src/theme/index.ts`), which every `Typography` inherits by default.

## Why

Same category as the existing `placeholder`/`monoStack` token pattern: a hardcoded literal that duplicates (and drifts from) a value the theme already centralizes. This one was missing the theme's full fallback chain (`-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu`), so removing it both deletes the duplication and gets the correct fallbacks for free.

## Verification

- Visually a no-op: DM Sans is self-hosted and loaded globally in `main.tsx`, and the theme's default `typography.fontFamily` is the same DM Sans stack, so the rendered font is unchanged.
- `npx tsc --noEmit` — clean.
- `npm run lint` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings).
- `npm run test:unit` — 161/161 passing.
- `npm run check:stories` — all 85 components have stories (Wordmark's story is unaffected).


---
_Generated by [Claude Code](https://claude.ai/code/session_01VAPndnHVwhmTQJ9qjb7P19)_