### PR TITLE
design-audit: extract shared ProfileStat component from ProfileView

### DIFF
--- a/frontend/src/components/profile/ProfileStat.stories.tsx
+++ b/frontend/src/components/profile/ProfileStat.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Stack } from "@mui/material";
+import CameraAltIcon from "@mui/icons-material/CameraAlt";
+import FingerprintIcon from "@mui/icons-material/Fingerprint";
+import GrassIcon from "@mui/icons-material/Grass";
+import { ProfileStat } from "./ProfileStat";
+
+const meta = {
+  title: "Profile/ProfileStat",
+  component: ProfileStat,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ProfileStat>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Observations: Story = {
+  args: {
+    count: 24,
+    color: "primary.main",
+    icon: <CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />,
+    label: "Observations",
+  },
+};
+
+export const Identifications: Story = {
+  args: {
+    count: 51,
+    color: "secondary.main",
+    icon: <FingerprintIcon sx={{ fontSize: 14, color: "text.secondary" }} />,
+    label: "IDs",
+  },
+};
+
+export const Species: Story = {
+  args: {
+    count: 18,
+    color: "success.main",
+    icon: <GrassIcon sx={{ fontSize: 14, color: "text.secondary" }} />,
+    label: "Species",
+  },
+};
+
+export const Row: Story = {
+  args: {
+    count: 24,
+    color: "primary.main",
+    icon: <CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />,
+    label: "Observations",
+  },
+  render: () => (
+    <Stack direction="row" spacing={2}>
+      <ProfileStat
+        count={24}
+        color="primary.main"
+        icon={<CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+        label="Observations"
+      />
+      <ProfileStat
+        count={51}
+        color="secondary.main"
+        icon={<FingerprintIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+        label="IDs"
+      />
+      <ProfileStat
+        count={18}
+        color="success.main"
+        icon={<GrassIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+        label="Species"
+      />
+    </Stack>
+  ),
+};

--- a/frontend/src/components/profile/ProfileStat.tsx
+++ b/frontend/src/components/profile/ProfileStat.tsx
@@ -1,0 +1,37 @@
+import type { ReactElement } from "react";
+import { Box, Stack, Typography } from "@mui/material";
+import { PROFILE_STAT_BOX_SX } from "./profileLayout";
+
+interface ProfileStatProps {
+  count: number;
+  color: string;
+  icon: ReactElement;
+  label: string;
+}
+
+/**
+ * Single stat box (count + icon + label) used in the profile header stats row.
+ */
+export function ProfileStat({ count, color, icon, label }: ProfileStatProps) {
+  return (
+    <Box sx={PROFILE_STAT_BOX_SX}>
+      <Typography variant="h6" component="span" sx={{ fontWeight: 700, color }}>
+        {count.toLocaleString()}
+      </Typography>
+      <Stack
+        direction="row"
+        spacing={0.5}
+        sx={{
+          alignItems: "center",
+          justifyContent: "center",
+          mt: 0.5,
+        }}
+      >
+        {icon}
+        <Typography variant="caption" sx={{ color: "text.secondary" }}>
+          {label}
+        </Typography>
+      </Stack>
+    </Box>
+  );
+}

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -27,7 +27,8 @@ import { CenteredSpinner } from "../common/CenteredSpinner";
 import { EmptyState } from "../common/EmptyState";
 import { ProfileHeaderSkeleton } from "./ProfileHeaderSkeleton";
 import { ProfileIdentificationCardSkeleton } from "./ProfileIdentificationCardSkeleton";
-import { PROFILE_HEADER_SX, PROFILE_STAT_BOX_SX, PROFILE_AVATAR_SIZE } from "./profileLayout";
+import { ProfileStat } from "./ProfileStat";
+import { PROFILE_HEADER_SX, PROFILE_AVATAR_SIZE } from "./profileLayout";
 import { observationGridSx } from "../common/observationGridLayout";
 import { usePageTitle } from "../../hooks/usePageTitle";
 
@@ -102,99 +103,24 @@ export function ProfileView() {
           {/* Stats */}
           {counts && (
             <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
-              <Box sx={PROFILE_STAT_BOX_SX}>
-                <Typography
-                  variant="h6"
-                  component="span"
-                  sx={{
-                    fontWeight: 700,
-                    color: "primary.main",
-                  }}
-                >
-                  {counts.observations.toLocaleString()}
-                </Typography>
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  sx={{
-                    alignItems: "center",
-                    justifyContent: "center",
-                    mt: 0.5,
-                  }}
-                >
-                  <CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: "text.secondary",
-                    }}
-                  >
-                    Observations
-                  </Typography>
-                </Stack>
-              </Box>
-              <Box sx={PROFILE_STAT_BOX_SX}>
-                <Typography
-                  variant="h6"
-                  component="span"
-                  sx={{
-                    fontWeight: 700,
-                    color: "secondary.main",
-                  }}
-                >
-                  {counts.identifications.toLocaleString()}
-                </Typography>
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  sx={{
-                    alignItems: "center",
-                    justifyContent: "center",
-                    mt: 0.5,
-                  }}
-                >
-                  <FingerprintIcon sx={{ fontSize: 14, color: "text.secondary" }} />
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: "text.secondary",
-                    }}
-                  >
-                    IDs
-                  </Typography>
-                </Stack>
-              </Box>
-              <Box sx={PROFILE_STAT_BOX_SX}>
-                <Typography
-                  variant="h6"
-                  component="span"
-                  sx={{
-                    fontWeight: 700,
-                    color: "success.main",
-                  }}
-                >
-                  {counts.species.toLocaleString()}
-                </Typography>
-                <Stack
-                  direction="row"
-                  spacing={0.5}
-                  sx={{
-                    alignItems: "center",
-                    justifyContent: "center",
-                    mt: 0.5,
-                  }}
-                >
-                  <GrassIcon sx={{ fontSize: 14, color: "text.secondary" }} />
-                  <Typography
-                    variant="caption"
-                    sx={{
-                      color: "text.secondary",
-                    }}
-                  >
-                    Species
-                  </Typography>
-                </Stack>
-              </Box>
+              <ProfileStat
+                count={counts.observations}
+                color="primary.main"
+                icon={<CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+                label="Observations"
+              />
+              <ProfileStat
+                count={counts.identifications}
+                color="secondary.main"
+                icon={<FingerprintIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+                label="IDs"
+              />
+              <ProfileStat
+                count={counts.species}
+                color="success.main"
+                icon={<GrassIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+                label="Species"
+              />
             </Stack>
           )}
 


### PR DESCRIPTION
## What

`ProfileView.tsx` repeated the same ~27-line stat-box block three times (Observations/Identifications/Species) — each rendering a `Box` (using the already-shared `PROFILE_STAT_BOX_SX`) → a bold count `Typography` (differing only by `primary.main`/`secondary.main`/`success.main`) → a `Stack` with a small `fontSize: 14, color: "text.secondary"` icon and caption label.

Extracted a new `ProfileStat({ count, color, icon, label })` component (`frontend/src/components/profile/ProfileStat.tsx`) and replaced all three inline blocks with 4-prop call sites, collapsing ~95 lines to ~20.

## Why

Same category as prior "extract shared X" passes in this audit series — the layout `sx` (`PROFILE_STAT_BOX_SX`) had already been pulled into `profileLayout.ts` and shared with `ProfileHeaderSkeleton`, but the JSX structure itself was still triplicated in `ProfileView`. This was the clearest remaining duplication in the design system per this pass's audit.

Added `ProfileStat.stories.tsx` with per-stat variants plus a `Row` story mirroring the real header layout, keeping `check:stories` coverage intact.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings).
- `npm run test:unit` — 161/161 passing.
- `npm run check:stories` — all 86 components have stories.
- Visually a no-op: same DOM structure/styling, just componentized.


---
_Generated by [Claude Code](https://claude.ai/code/session_01RuAgXQFzirDyNwr22oEjT6)_