### PR TITLE
design-audit: use shared EmptyState in IdentificationHistory/CommentSection/TransparencyPage

### DIFF
--- a/frontend/src/components/comment/CommentSection.tsx
+++ b/frontend/src/components/comment/CommentSection.tsx
@@ -12,6 +12,7 @@ import { RelativeTime } from "../common/RelativeTime";
 import { UserCard } from "../common/UserCard";
 import { Section, SectionHeader } from "../common/Section";
 import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
+import { EmptyState } from "../common/EmptyState";
 
 interface CommentSectionProps {
   observationUri: string;
@@ -79,15 +80,11 @@ export function CommentSection({ observationUri, observationCid, comments }: Com
         }
       />
       {comments.length === 0 && !showForm && (
-        <Typography
-          variant="body2"
-          sx={{
-            color: "text.secondary",
-            mb: 2,
-          }}
-        >
-          No comments yet. Start a discussion!
-        </Typography>
+        <EmptyState
+          message="No comments yet. Start a discussion!"
+          p={0}
+          sx={{ mb: 2, textAlign: "left" }}
+        />
       )}
       {comments.length > 0 && (
         <Stack spacing={2} sx={{ mb: 2 }}>

--- a/frontend/src/components/identification/IdentificationHistory.tsx
+++ b/frontend/src/components/identification/IdentificationHistory.tsx
@@ -8,6 +8,7 @@ import { RelativeTime } from "../common/RelativeTime";
 import { Section, SectionHeader } from "../common/Section";
 import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
 import { UserCard } from "../common/UserCard";
+import { EmptyState } from "../common/EmptyState";
 
 export interface IdentificationHistoryProps {
   identifications: Identification[];
@@ -70,14 +71,11 @@ export function IdentificationHistory({
           : {})}
       />
       {sortedIds.length === 0 ? (
-        <Typography
-          variant="body2"
-          sx={{
-            color: "text.secondary",
-          }}
-        >
-          No identifications yet. Be the first to suggest an ID!
-        </Typography>
+        <EmptyState
+          message="No identifications yet. Be the first to suggest an ID!"
+          p={0}
+          sx={{ textAlign: "left" }}
+        />
       ) : (
         <Stack spacing={2}>
           {sortedIds.map((id) => {

--- a/frontend/src/components/transparency/TransparencyPage.tsx
+++ b/frontend/src/components/transparency/TransparencyPage.tsx
@@ -1,5 +1,4 @@
 import {
-  Box,
   Paper,
   Table,
   TableBody,
@@ -13,6 +12,7 @@ import {
 import { usePageTitle } from "../../hooks/usePageTitle";
 import transparencyData from "../../data/transparency.json";
 import { PageContainer } from "../common/PageContainer";
+import { EmptyState } from "../common/EmptyState";
 
 interface ServiceCost {
   name: string;
@@ -93,11 +93,7 @@ export function TransparencyPage() {
 
       <Paper variant="outlined" sx={{ borderRadius: 2 }}>
         {sortedMonths.length === 0 ? (
-          <Box sx={{ p: 3 }}>
-            <Typography variant="body2" sx={{ color: "text.secondary" }}>
-              No cost data has been recorded yet.
-            </Typography>
-          </Box>
+          <EmptyState message="No cost data has been recorded yet." p={3} />
         ) : (
           <TableContainer>
             <Table size="small">


### PR DESCRIPTION
## What

Three components each hand-rolled the same "no X yet" empty-state markup (a `Typography` with `color: text.secondary`, one wrapped in an extra `Box`) instead of using the already-established `common/EmptyState` component:

- `frontend/src/components/identification/IdentificationHistory.tsx` — "No identifications yet. Be the first to suggest an ID!"
- `frontend/src/components/comment/CommentSection.tsx` — "No comments yet. Start a discussion!"
- `frontend/src/components/transparency/TransparencyPage.tsx` — "No cost data has been recorded yet." (also drops the now-unused wrapping `Box`)

## Why

`common/EmptyState` already exists for exactly this shape and is used consistently in `FeedView.tsx`, `NotificationsPage.tsx`, `ProfileView.tsx`, and `TaxonObservations.tsx`. These three call sites were duplicating the same pattern by hand instead of using the shared primitive — the same category of fix as prior "extract shared X" passes in this audit series. Both `IdentificationHistory.stories.tsx` and `CommentSection.stories.tsx` already have dedicated `Empty*` story variants, confirming the empty state is a first-class case that just never migrated to the shared component.

Each empty message keeps its original left-aligned placement (`p={0}`, `textAlign: "left"` override where the original wasn't centered) or padding (`p={3}` for TransparencyPage, matching the original `Box p:3` wrapper) so there's no unintended layout change — just centralizing the decision into one component.

## Verification

- `npx tsc --noEmit` — clean.
- `npm run lint` — no new warnings (3 pre-existing, unrelated `react-hooks/exhaustive-deps` warnings).
- `npm run test:unit` — 161/161 passing.
- `npm run check:stories` — all 85 components have stories.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HGYjpMbvCeMyV93jxdXTbb)_