### PR TITLE
design-audit: extract shared ExpandToggleButton chevron toggle

### DIFF
--- a/frontend/src/components/common/CollapsibleSection.tsx
+++ b/frontend/src/components/common/CollapsibleSection.tsx
@@ -1,8 +1,8 @@
 import { useState, type ReactNode } from "react";
-import { Collapse, IconButton } from "@mui/material";
+import { Collapse } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
 import { Section, SectionHeader } from "./Section";
+import { ExpandToggleButton } from "./ExpandToggleButton";
 
 interface CollapsibleSectionProps {
   title: ReactNode;
@@ -56,17 +56,7 @@ export function CollapsibleSection({
         trailing={
           <>
             {trailing}
-            <IconButton
-              size="small"
-              aria-label={expanded ? "Collapse section" : "Expand section"}
-              sx={{
-                p: 0.25,
-                transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
-                transition: (theme) => theme.transitions.create("transform"),
-              }}
-            >
-              <ExpandMoreIcon fontSize="small" />
-            </IconButton>
+            <ExpandToggleButton expanded={expanded} />
           </>
         }
       />

--- a/frontend/src/components/common/ExpandToggleButton.stories.tsx
+++ b/frontend/src/components/common/ExpandToggleButton.stories.tsx
@@ -1,0 +1,19 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { ExpandToggleButton } from "./ExpandToggleButton";
+
+const meta = {
+  title: "Common/ExpandToggleButton",
+  component: ExpandToggleButton,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ExpandToggleButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Collapsed: Story = {
+  args: { expanded: false },
+};
+
+export const Expanded: Story = {
+  args: { expanded: true },
+};

--- a/frontend/src/components/common/ExpandToggleButton.tsx
+++ b/frontend/src/components/common/ExpandToggleButton.tsx
@@ -1,0 +1,26 @@
+import { IconButton } from "@mui/material";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+
+interface ExpandToggleButtonProps {
+  expanded: boolean;
+}
+
+/**
+ * The site-wide rotating chevron used to hint an expand/collapse toggle.
+ * Purely visual — the click handler lives on the surrounding header.
+ */
+export function ExpandToggleButton({ expanded }: ExpandToggleButtonProps) {
+  return (
+    <IconButton
+      size="small"
+      aria-label={expanded ? "Collapse section" : "Expand section"}
+      sx={{
+        p: 0.25,
+        transform: expanded ? "rotate(180deg)" : "rotate(0deg)",
+        transition: (theme) => theme.transitions.create("transform"),
+      }}
+    >
+      <ExpandMoreIcon fontSize="small" />
+    </IconButton>
+  );
+}

--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -3,7 +3,6 @@ import {
   Box,
   Paper,
   Collapse,
-  IconButton,
   Typography,
   TextField,
   Autocomplete,
@@ -17,12 +16,11 @@ import {
   Divider,
 } from "@mui/material";
 import FilterListIcon from "@mui/icons-material/FilterList";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-import ExpandLessIcon from "@mui/icons-material/ExpandLess";
 import ClearIcon from "@mui/icons-material/Clear";
 import VerifiedOutlinedIcon from "@mui/icons-material/VerifiedOutlined";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { countChipSx } from "../common/chipSx";
+import { ExpandToggleButton } from "../common/ExpandToggleButton";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
 import { useAppDispatch, useAppSelector } from "../../store";
@@ -121,9 +119,7 @@ export function ExploreFilterPanel() {
             <Chip size="small" label={activeFilterCount} color="primary" sx={countChipSx} />
           )}
         </Stack>
-        <IconButton size="small" aria-label={isExpanded ? "Collapse section" : "Expand section"}>
-          {isExpanded ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-        </IconButton>
+        <ExpandToggleButton expanded={isExpanded} />
       </Box>
       {/* Collapsible filter content */}
       <Collapse in={isExpanded}>

--- a/frontend/src/components/lexicon/LexiconView.tsx
+++ b/frontend/src/components/lexicon/LexiconView.tsx
@@ -13,12 +13,11 @@ import {
   TableHead,
   TableRow,
   Collapse,
-  IconButton,
   Link as MuiLink,
 } from "@mui/material";
-import { ExpandMore, ExpandLess } from "@mui/icons-material";
 import { labelChipSx, valueChipSx } from "../common/chipSx";
 import { monoStack } from "../../theme";
+import { ExpandToggleButton } from "../common/ExpandToggleButton";
 
 // Eagerly import all lexicons at build time via the @lexicons alias.
 // This avoids duplicating the schema files — the source of truth remains in /lexicons/.
@@ -225,9 +224,7 @@ function DefSection({ name, def }: { name: string; def: LexiconDef }) {
         sx={{ display: "flex", alignItems: "center", cursor: "pointer" }}
         onClick={() => setOpen(!open)}
       >
-        <IconButton size="small" aria-label={open ? "Collapse section" : "Expand section"}>
-          {open ? <ExpandLess /> : <ExpandMore />}
-        </IconButton>
+        <ExpandToggleButton expanded={open} />
         <Typography variant="subtitle2" component="code" sx={{ fontFamily: monoStack }}>
           #{name}
         </Typography>


### PR DESCRIPTION
## Summary
- `ExploreFilterPanel.tsx` and `LexiconView.tsx` each reimplemented the expand/collapse chevron `IconButton` from scratch (icon-swap style), duplicating a pattern that `CollapsibleSection.tsx` already implements as a rotating chevron for its 4 other consumers.
- Extracted the rotating-chevron pattern into a new shared `common/ExpandToggleButton.tsx` and switched all three call sites to use it, centralizing the visual decision and removing the duplicated `sx`/icon-swap logic.
- Added `ExpandToggleButton.stories.tsx` with collapsed/expanded variants, following the existing `common/` story conventions.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `npm run lint` — no new warnings (pre-existing unrelated warnings only)
- [x] `npm run check:stories` — all components have stories
- [x] `npm run test:unit` — 161 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_012Wtf9w27FVADX1p1zj7Wj2

---
_Generated by [Claude Code](https://claude.ai/code/session_012Wtf9w27FVADX1p1zj7Wj2)_