### PR TITLE
design-audit: extract shared ExternalLinkIconButton from TaxaAutocompleteView/VisualIdCards

### DIFF
--- a/frontend/src/components/common/ExternalLinkIconButton.stories.tsx
+++ b/frontend/src/components/common/ExternalLinkIconButton.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Stack } from "@mui/material";
+import { ExternalLinkIconButton } from "./ExternalLinkIconButton";
+
+const meta = {
+  title: "Common/ExternalLinkIconButton",
+  component: ExternalLinkIconButton,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  args: {
+    href: "https://www.gbif.org/species/1",
+    label: "Panthera leo",
+  },
+} satisfies Meta<typeof ExternalLinkIconButton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const LargerIcon: Story = {
+  args: { fontSize: 16 },
+};
+
+export const Row: Story = {
+  render: () => (
+    <Stack direction="row" spacing={1}>
+      <ExternalLinkIconButton href="https://www.gbif.org/species/1" label="Panthera leo" />
+      <ExternalLinkIconButton
+        href="https://www.gbif.org/species/2"
+        label="Ursus arctos"
+        fontSize={16}
+      />
+    </Stack>
+  ),
+};

--- a/frontend/src/components/common/ExternalLinkIconButton.tsx
+++ b/frontend/src/components/common/ExternalLinkIconButton.tsx
@@ -1,0 +1,46 @@
+import { IconButton } from "@mui/material";
+import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import type { SxProps, Theme } from "@mui/material/styles";
+
+export interface ExternalLinkIconButtonProps {
+  /** Destination URL; opens in a new tab. */
+  href: string;
+  /** Name used to build the title/aria-label, e.g. "Open {label} in new tab". */
+  label: string;
+  /** Icon font size in px. Defaults to 14. */
+  fontSize?: number;
+  /** Extra sx merged onto the button (e.g. spacing overrides). */
+  sx?: SxProps<Theme>;
+  /** Mousedown handler override — used by Autocomplete rows to stop the popper from closing before the click fires. */
+  onMouseDown?: (e: React.MouseEvent) => void;
+}
+
+/**
+ * A small "open in new tab" icon button for linking out to a taxon or other
+ * external resource. Used inline in cards/rows where a full ExternalLinkChip
+ * would be too heavy.
+ */
+export function ExternalLinkIconButton({
+  href,
+  label,
+  fontSize = 14,
+  sx,
+  onMouseDown,
+}: ExternalLinkIconButtonProps) {
+  return (
+    <IconButton
+      size="small"
+      component="a"
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      onMouseDown={onMouseDown}
+      onClick={(e: React.MouseEvent) => e.stopPropagation()}
+      title={`Open ${label} in new tab`}
+      aria-label={`Open ${label} in new tab`}
+      sx={{ p: 0.5, flexShrink: 0, ...sx }}
+    >
+      <OpenInNewIcon sx={{ fontSize }} />
+    </IconButton>
+  );
+}

--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -1,11 +1,11 @@
 import type { ReactNode } from "react";
-import { Autocomplete, Box, IconButton, Stack, Typography } from "@mui/material";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
+import { Autocomplete, Box, Stack, Typography } from "@mui/material";
 import type { TaxaResult } from "../../services/types";
 import { ConservationStatus } from "./ConservationStatus";
 import { renderAutocompleteInput } from "./autocompleteInput";
 import { shouldItalicizeTaxonName } from "./TaxonLink";
 import { buildTaxonUrl } from "../../lib/taxonSlug";
+import { ExternalLinkIconButton } from "./ExternalLinkIconButton";
 
 export function taxonUrlFor(option: TaxaResult): string | null {
   return buildTaxonUrl(option.scientificName, option.kingdom, option.rank);
@@ -185,12 +185,10 @@ export function TaxaAutocompleteView({
                 )}
               </Box>
               {taxonUrl && (
-                <IconButton
-                  size="small"
-                  component="a"
+                <ExternalLinkIconButton
                   href={taxonUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
+                  label={option.scientificName}
+                  fontSize={16}
                   // MUI Autocomplete picks the row on mousedown, not click —
                   // stop propagation so the row doesn't select. Also
                   // preventDefault: without it the input loses focus on
@@ -200,13 +198,7 @@ export function TaxaAutocompleteView({
                     e.preventDefault();
                     e.stopPropagation();
                   }}
-                  onClick={(e: React.MouseEvent) => e.stopPropagation()}
-                  title="Open taxon in new tab"
-                  aria-label={`Open ${option.scientificName} in new tab`}
-                  sx={{ p: 0.5, flexShrink: 0 }}
-                >
-                  <OpenInNewIcon sx={{ fontSize: 16 }} />
-                </IconButton>
+                />
               )}
             </Box>
           );

--- a/frontend/src/components/identification/VisualIdCards.tsx
+++ b/frontend/src/components/identification/VisualIdCards.tsx
@@ -1,9 +1,9 @@
-import { Box, ButtonBase, IconButton, Stack, Typography } from "@mui/material";
+import { Box, ButtonBase, Stack, Typography } from "@mui/material";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
-import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import PlaceIcon from "@mui/icons-material/Place";
 import type { SpeciesSuggestion } from "../../services/api";
 import { buildTaxonUrl } from "../../lib/taxonSlug";
+import { ExternalLinkIconButton } from "../common/ExternalLinkIconButton";
 
 /**
  * Ranks we'll roll up to, ordered from most specific to most general.
@@ -64,21 +64,7 @@ function determineMode(sortedByConfidence: SpeciesSuggestion[]): Mode {
 }
 
 function TaxonLinkButton({ url, taxonName }: { url: string; taxonName: string }) {
-  return (
-    <IconButton
-      size="small"
-      component="a"
-      href={url}
-      target="_blank"
-      rel="noopener noreferrer"
-      onClick={(e: React.MouseEvent) => e.stopPropagation()}
-      sx={{ p: 0.5, ml: 0.5, flexShrink: 0 }}
-      title="Open taxon in new tab"
-      aria-label={`Open ${taxonName} in new tab`}
-    >
-      <OpenInNewIcon sx={{ fontSize: 14 }} />
-    </IconButton>
-  );
+  return <ExternalLinkIconButton href={url} label={taxonName} sx={{ ml: 0.5 }} />;
 }
 
 function findCommonAncestor(suggestions: SpeciesSuggestion[]): AncestorMatch | null {


### PR DESCRIPTION
## Summary
- `TaxaAutocompleteView.tsx` and `VisualIdCards.tsx` each hand-rolled the same "open taxon in new tab" `IconButton` — same `href`/`target`/`rel`, same `title`/`aria-label` phrasing (`Open {name} in new tab`), same `sx` shape (`p: 0.5, flexShrink: 0`), same `OpenInNewIcon` — differing only in icon `fontSize` (16 vs 14) and an Autocomplete-specific `onMouseDown` guard.
- There was already a chip-style equivalent (`common/ExternalLinkChip.tsx`) but no icon-button variant, so this fills that gap with `common/ExternalLinkIconButton.tsx` and replaces both call sites.
- Added Storybook stories (`Default`, `LargerIcon`, `Row`) for the new component.

## Test plan
- [x] `npx tsc --noEmit` — passes
- [x] `oxlint` on touched files — clean
- [x] `oxfmt --check` on touched files — clean
- [x] `node scripts/check-stories.mjs` — all components have stories


---
_Generated by [Claude Code](https://claude.ai/code/session_01NNSP6cEug3E7b7bChG4B1X)_