### PR TITLE
design-audit: rename ModalOverlay's isOpen prop to open

### DIFF
--- a/frontend/src/components/modals/ModalOverlay.stories.tsx
+++ b/frontend/src/components/modals/ModalOverlay.stories.tsx
@@ -31,21 +31,21 @@ const sampleContent = (
 
 export const Closed: Story = {
   args: {
-    isOpen: false,
+    open: false,
     children: sampleContent,
   },
 };
 
 export const Open: Story = {
   args: {
-    isOpen: true,
+    open: true,
     children: sampleContent,
   },
 };
 
 export const WideModal: Story = {
   args: {
-    isOpen: true,
+    open: true,
     maxWidth: "md",
     children: sampleContent,
   },

--- a/frontend/src/components/modals/ModalOverlay.tsx
+++ b/frontend/src/components/modals/ModalOverlay.tsx
@@ -3,19 +3,19 @@ import { Dialog, DialogContent, IconButton, useMediaQuery, useTheme } from "@mui
 import CloseIcon from "@mui/icons-material/Close";
 
 interface ModalOverlayProps {
-  isOpen: boolean;
+  open: boolean;
   onClose: () => void;
   children: ReactNode;
   maxWidth?: "xs" | "sm" | "md" | "lg" | "xl" | false;
 }
 
-export function ModalOverlay({ isOpen, onClose, children, maxWidth = "sm" }: ModalOverlayProps) {
+export function ModalOverlay({ open, onClose, children, maxWidth = "sm" }: ModalOverlayProps) {
   const theme = useTheme();
   const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
 
   return (
     <Dialog
-      open={isOpen}
+      open={open}
       onClose={onClose}
       maxWidth={maxWidth}
       fullWidth

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -529,7 +529,7 @@ export function UploadModal() {
 
   return (
     <>
-      <ModalOverlay isOpen={isOpen} onClose={handleRequestClose}>
+      <ModalOverlay open={isOpen} onClose={handleRequestClose}>
         <Typography variant="h5" sx={{ fontWeight: 600, mb: 2 }}>
           {isEditMode ? "Edit Observation" : "New Observation"}
         </Typography>


### PR DESCRIPTION
## Summary
- `ModalOverlay` was the one dialog-family component naming its visibility prop `isOpen`; every other dialog (`ConfirmDialog`, `LoginModal`, `DeleteConfirmDialog`) uses MUI's own `open`, with `isOpen` reserved for local variable names at call sites.
- Renamed the prop to `open` in `ModalOverlay.tsx`, updated its stories, and updated the one real caller (`UploadModal.tsx`).

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] `npm run lint` (oxlint) passes with only pre-existing, unrelated warnings
- [x] Verified no other callers of `ModalOverlay` reference `isOpen`

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01ANEuoj7jMfEAvyhFVhBEfx

---
_Generated by [Claude Code](https://claude.ai/code/session_01ANEuoj7jMfEAvyhFVhBEfx)_