### PR TITLE
design-audit: dedupe suggestion-row ButtonBase sx in VisualIdCards

### DIFF
--- a/frontend/src/components/identification/VisualIdCards.tsx
+++ b/frontend/src/components/identification/VisualIdCards.tsx
@@ -63,6 +63,18 @@ function determineMode(sortedByConfidence: SpeciesSuggestion[]): Mode {
     : "ambiguous";
 }
 
+// Shared shape for the suggestion-row ButtonBase in AncestorCard and
+// SpeciesCard — layout stays identical; only sizing/color varies by row.
+const SUGGESTION_ROW_BASE_SX = {
+  width: "100%",
+  textAlign: "left" as const,
+  borderRadius: 1,
+  border: "1px solid",
+  display: "flex",
+  alignItems: "center",
+  gap: 1.25,
+};
+
 function TaxonLinkButton({ url, taxonName }: { url: string; taxonName: string }) {
   return (
     <IconButton
@@ -251,16 +263,10 @@ function AncestorCard({ ancestor, onSelect }: { ancestor: AncestorMatch; onSelec
     <ButtonBase
       onClick={onSelect}
       sx={{
-        width: "100%",
-        textAlign: "left",
-        borderRadius: 1,
-        border: "1px solid",
+        ...SUGGESTION_ROW_BASE_SX,
         borderColor: "primary.main",
         bgcolor: "action.hover",
         p: 1.25,
-        display: "flex",
-        alignItems: "center",
-        gap: 1.25,
         minHeight: 64,
         "&:hover": { bgcolor: "action.selected" },
       }}
@@ -326,16 +332,10 @@ function SpeciesCard({
     <ButtonBase
       onClick={onSelect}
       sx={{
-        width: "100%",
-        textAlign: "left",
-        borderRadius: 1,
-        border: "1px solid",
+        ...SUGGESTION_ROW_BASE_SX,
         borderColor: primary ? "primary.main" : "divider",
         bgcolor: primary ? "action.hover" : "transparent",
         p: primary ? 1.25 : 1,
-        display: "flex",
-        alignItems: "center",
-        gap: 1.25,
         minHeight: primary ? 56 : 48,
         "&:hover": { bgcolor: "action.hover" },
       }}


### PR DESCRIPTION
## Summary
- `AncestorCard` and `SpeciesCard` in `VisualIdCards.tsx` each defined a near-identical 7-property `sx` block (`width`/`textAlign`/`borderRadius`/`border`/`display`/`alignItems`/`gap`) on their row `ButtonBase`.
- Extracted the shared shape into a `SUGGESTION_ROW_BASE_SX` constant, spread into both call sites. Each row keeps its own emphasis-dependent styling (`borderColor`/`bgcolor`/`p`/`minHeight`/hover) local, since those values legitimately differ between the two components.
- No visual or behavioral change — every literal value (including the existing minor hover-color inconsistency between the two rows) is preserved exactly; only the duplicated property declarations were consolidated.

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npx oxlint frontend/src` — no new warnings (pre-existing warnings elsewhere unrelated to this file)
- [x] `npx oxfmt --check` on the changed file — passes
- [ ] Visual check in Storybook (`VisualIdCards.stories.tsx`) — not run in this environment; the diff is a pure sx-object refactor with identical resolved values, so no visual difference is expected


---
_Generated by [Claude Code](https://claude.ai/code/session_01VGPCKFkSfT4FckS1EsUcb1)_