### PR TITLE
design-audit: rename ObservationGridCard's isPending prop to pending

### DIFF
--- a/frontend/src/components/common/ObservationGridCard.stories.tsx
+++ b/frontend/src/components/common/ObservationGridCard.stories.tsx
@@ -38,7 +38,7 @@ export const Fern: Story = {
 export const Pending: Story = {
   args: {
     observation: OAK_OBSERVATION,
-    isPending: true,
+    pending: true,
     badge: <PendingBadge />,
   },
   parameters: {

--- a/frontend/src/components/common/ObservationGridCard.tsx
+++ b/frontend/src/components/common/ObservationGridCard.tsx
@@ -14,7 +14,7 @@ export const observationGridCardContentSx = { p: 1.5, "&:last-child": { pb: 1.5 
 
 interface ObservationGridCardProps {
   observation: Occurrence;
-  isPending?: boolean;
+  pending?: boolean;
   // Overlay rendered inside the Card, above the CardActionArea (e.g. a
   // PendingBadge) — needs the Card's `position: relative` to anchor to.
   badge?: ReactNode;
@@ -22,7 +22,7 @@ interface ObservationGridCardProps {
 
 export const ObservationGridCard = memo(function ObservationGridCard({
   observation,
-  isPending = false,
+  pending = false,
   badge,
 }: ObservationGridCardProps) {
   const species = observation.communityId || observation.effectiveTaxonomy?.scientificName;
@@ -33,13 +33,13 @@ export const ObservationGridCard = memo(function ObservationGridCard({
       <CardActionArea
         component={Link}
         to={getObservationUrl(observation.uri)}
-        onClick={isPending ? (e) => e.preventDefault() : undefined}
+        onClick={pending ? (e) => e.preventDefault() : undefined}
         sx={{
           flex: 1,
           display: "flex",
           flexDirection: "column",
           alignItems: "stretch",
-          ...(isPending && { opacity: 0.7, pointerEvents: "none" }),
+          ...(pending && { opacity: 0.7, pointerEvents: "none" }),
         }}
       >
         <ImageWithSkeleton

--- a/frontend/src/components/feed/ExploreGridCard.tsx
+++ b/frontend/src/components/feed/ExploreGridCard.tsx
@@ -18,7 +18,7 @@ export const ExploreGridCard = memo(function ExploreGridCard({
   return (
     <ObservationGridCard
       observation={observation}
-      isPending={isPending}
+      pending={isPending}
       badge={isPending ? <PendingBadge /> : undefined}
     />
   );


### PR DESCRIPTION
## Summary
- Renames `ObservationGridCard`'s `isPending` prop to `pending`, matching the `common/` house style used elsewhere (e.g. `ConfirmDialog`'s `pending`/`pendingLabel`) and the precedent set by the prior `ModalOverlay isOpen→open` rename (#756). No other boolean prop in `common/` uses an `is`-prefix.
- Updates the sole call site (`ExploreGridCard.tsx`) and the Storybook `Pending` story args to match.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `npm run lint` — no new warnings
- [x] `npm run check:stories` — all 88 components have stories
- [x] `vitest run` — 161 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_014kP5Nb6y72WHzhw7ScuiTG)_