### PR TITLE
fix(species-id): bump ONNX Runtime to 1.27.1 to match ort rc.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,12 +187,20 @@ ENTRYPOINT ["/app/observing-task-runner"]
 # ---------------------------------------------------------------------------
 FROM runtime-base AS runtime-observing-species-id
 
-# Install ONNX Runtime shared library
+# Install ONNX Runtime shared library.
+#
+# Keep the minor version in lockstep with the C API version the `ort` crate
+# asks for (`ort::MINOR_VERSION`, set by its default `api-NN` feature): API
+# version NN requires onnxruntime >= 1.NN. A too-old library here makes `ort`
+# panic on load (`BadVersion`) before the server binds its port, which surfaces
+# as a Cloud Run "container failed to start and listen on PORT" deploy failure.
+# The const assertion in crates/observing-species-id/src/model.rs fails the
+# build if the two drift apart.
 RUN apt-get update && apt-get install -y curl && \
     curl -fsSL --retry 5 --retry-all-errors --retry-delay 10 -o /tmp/ort.tgz \
-      https://github.com/microsoft/onnxruntime/releases/download/v1.24.4/onnxruntime-linux-x64-1.24.4.tgz && \
+      https://github.com/microsoft/onnxruntime/releases/download/v1.27.1/onnxruntime-linux-x64-1.27.1.tgz && \
     tar xzf /tmp/ort.tgz && \
-    cp onnxruntime-linux-x64-1.24.4/lib/libonnxruntime*.so* /usr/lib/ && \
+    cp onnxruntime-linux-x64-1.27.1/lib/libonnxruntime*.so* /usr/lib/ && \
     rm -rf onnxruntime-* /tmp/ort.tgz
 
 # Model bundle to bake in. Defaults to the full-accuracy ViT-H build used by

--- a/crates/observing-species-id/src/model.rs
+++ b/crates/observing-species-id/src/model.rs
@@ -15,6 +15,19 @@ use std::path::Path;
 use std::sync::Mutex;
 use tracing::{info, warn};
 
+/// ONNX Runtime C API version the linked `ort` crate requires, which must not
+/// exceed the minor version of the shared library baked into the runtime image
+/// (`onnxruntime-linux-x64-1.27.1` in the Dockerfile's species-id stage).
+///
+/// `ort` picks this up from its default `api-NN` feature, so a routine
+/// dependency bump can raise it without any source change here. When that
+/// happens `ort` panics on dylib load (`BadVersion`) before the server binds
+/// its port, and the only symptom is a Cloud Run "container failed to start and
+/// listen on PORT" deploy failure. This assertion turns that into a build
+/// error: bump the Dockerfile's onnxruntime download to a matching 1.NN.x
+/// release and update this constant together.
+const _: () = assert!(ort::MINOR_VERSION == 27);
+
 /// Default additive boost applied to in-range species when lat/lon is
 /// provided. Chosen so a +λ bump is meaningful against typical BioCLIP
 /// cosine similarities (~0.1–0.3 for matches) without overwhelming visual

--- a/docs/development.md
+++ b/docs/development.md
@@ -6,7 +6,9 @@
 - Rust (pinned to the channel in `rust-toolchain.toml`; `rustup` will pick it up automatically)
 - PostgreSQL (14+) with the PostGIS extension — production runs 16, but any modern version works locally
 - [`process-compose`](https://github.com/F1bonacc1/process-compose) to orchestrate the dev stack
-- ONNX Runtime, for the `species-id` service:
+- ONNX Runtime 1.27+, for the `species-id` service (older builds make it panic
+  on startup with `BadVersion`; the required minor version is asserted in
+  `crates/observing-species-id/src/model.rs`):
   - macOS: `brew install onnxruntime`
   - Linux: install via your distro (`libonnxruntime` / `onnxruntime-dev`)
 - Go 1.26+, only if you plan to build the upstream `tap` binary locally (see [Tap binary](#tap-binary) below)


### PR DESCRIPTION
## Problem

Every `main` CI run since 87c7def9 fails at **deploy → Deploy species-id**:

```
ERROR: (gcloud.run.deploy) The user-provided container failed to start and listen
on the port defined provided by the PORT=8080 environment variable within the
allocated timeout.
```

It is not a timeout despite the message — the revision died ~24s in, well under the 300s startup probe budget. The process was crashing.

## Cause

The trigger was `chore(deps): update Cargo dependencies (2026-07-31)` (#754), which touched only `Cargo.lock`:

```
 name = "ort"
-version = "2.0.0-rc.12"
+version = "2.0.0-rc.13"
```

`ort` is declared without pinning, so default features stay on — and its default set includes an `api-NN` feature that sets the ONNX Runtime C API version it requires:

- rc.12: `default = [..., "api-24"]`
- rc.13: `default = [..., "api-27"]`

The Dockerfile still installed onnxruntime **1.24.4**, unchanged since the crate was added. API version 27 needs onnxruntime >= 1.27, so `ort` panicked on dylib load, before `start_server` ever bound the port.

Nothing caught it: `rust-clippy` / `rust-test` never load the ORT dylib, and `build-images` / `deploy` only run on push to main.

## Changes

- **Dockerfile** — install `onnxruntime-linux-x64-1.27.1`, with a comment on the lockstep requirement.
- **model.rs** — `const _: () = assert!(ort::MINOR_VERSION == 27);`. Adding `api-27` to the feature list would not have helped: Cargo features are additive, so the `default` set would still pull in a future rc default. The assertion caps it — the next bump that raises the API floor fails `cargo build` pointing at the Dockerfile.
- **docs/development.md** — note the 1.27+ minimum for local dev.

## Verification

Since `build-images` / `deploy` are gated on `github.event_name == 'push'`, this PR will not exercise the image build. Verified natively instead.

A scratch binary against the exact `ort` 2.0.0-rc.13 from the lockfile:

- **1.24.4** → `panicked: Failed to load ONNX Runtime dylib: BadVersion { version_str: "1.24.4" }` — reproduces the deploy failure
- **1.27.1** → `OK: ORT API initialized`

Then the real service against the 2 GB BioCLIP bundle on onnxruntime 1.27.1: model loaded (200k species, ViT-H), `/health` ok, live `/identify` returned suggestions with geo-prior reranking in 1.9s. So 1.24 → 1.27 does not break the existing ONNX graph.

Also confirmed the 1.27.1 Linux tarball ships `lib/libonnxruntime.so`, matching the copy glob and `ORT_DYLIB_PATH`.

`cargo fmt --check`, `clippy --all-targets` (clean), and the 7 crate tests pass.
