### PR TITLE
design-audit: extract shared imageSkeletonOverlaySx from ImageWithSkeleton/ObservationGridCardSkeleton

### DIFF
--- a/frontend/src/components/common/ImageWithSkeleton.tsx
+++ b/frontend/src/components/common/ImageWithSkeleton.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { Box, CardMedia, Skeleton, Typography } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material";
+import { imageSkeletonOverlaySx } from "./layoutSx";
 
 interface ImageWithSkeletonProps {
   src?: string | undefined;
@@ -41,13 +42,7 @@ export function ImageWithSkeleton({
 
   return (
     <Box sx={{ position: "relative", overflow: "hidden", ...sx }}>
-      {!loaded && (
-        <Skeleton
-          variant="rectangular"
-          animation="wave"
-          sx={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
-        />
-      )}
+      {!loaded && <Skeleton variant="rectangular" animation="wave" sx={imageSkeletonOverlaySx} />}
       <CardMedia
         component="img"
         image={src}

--- a/frontend/src/components/common/ObservationGridCardSkeleton.tsx
+++ b/frontend/src/components/common/ObservationGridCardSkeleton.tsx
@@ -1,5 +1,6 @@
 import { Box, Card, CardContent, Skeleton, Typography } from "@mui/material";
 import { observationGridCardContentSx } from "./ObservationGridCard";
+import { imageSkeletonOverlaySx } from "./layoutSx";
 
 /**
  * Loading placeholder for ObservationGridCard.
@@ -8,10 +9,7 @@ export function ObservationGridCardSkeleton() {
   return (
     <Card sx={{ display: "flex", flexDirection: "column" }}>
       <Box sx={{ position: "relative", aspectRatio: "1", width: "100%" }}>
-        <Skeleton
-          variant="rectangular"
-          sx={{ position: "absolute", inset: 0, width: "100%", height: "100%" }}
-        />
+        <Skeleton variant="rectangular" sx={imageSkeletonOverlaySx} />
       </Box>
       <CardContent sx={observationGridCardContentSx}>
         <Typography variant="body2">

--- a/frontend/src/components/common/layoutSx.ts
+++ b/frontend/src/components/common/layoutSx.ts
@@ -39,3 +39,15 @@ export const accentListItemSx = {
   borderRadius: "0 4px 4px 0",
   py: 1,
 } as const;
+
+/**
+ * Full-bleed absolute overlay for a `Skeleton` layered over an image's
+ * `position: relative` container, shared by `ImageWithSkeleton` and its
+ * static loading-state counterpart so the two can't drift apart.
+ */
+export const imageSkeletonOverlaySx = {
+  position: "absolute",
+  inset: 0,
+  width: "100%",
+  height: "100%",
+} as const;


### PR DESCRIPTION
## Summary
- `ImageWithSkeleton.tsx` and `ObservationGridCardSkeleton.tsx` each hardcoded an identical `sx` block for the absolute-inset `Skeleton` overlay layered over an image's `position: relative` container.
- `ObservationGridCardSkeleton` already imports `observationGridCardContentSx` from the real component specifically to keep the loading placeholder from drifting from the real layout — the overlay sx duplication undermined that same intent.
- Extracted the shared block as `imageSkeletonOverlaySx` in `common/layoutSx.ts` (alongside the file's other shared sx constants: `detailHeaderSx`, `stickyHeaderSx`, `accentListItemSx`) and pointed both components at it.

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx oxlint` on changed files — clean
- [x] `npx oxfmt --check` on changed files — clean (auto-fixed one formatting nit)
- [x] `npx vitest run --config frontend/vitest.config.ts` — 161/161 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEmxM5p8f7Y174TqVrrTFV)_