### PR TITLE
design-audit: extract shared UserAvatar, fix TopBar's flat-grey fallback

### DIFF
--- a/frontend/src/components/common/UserAvatar.stories.tsx
+++ b/frontend/src/components/common/UserAvatar.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Stack } from "@mui/material";
+import { UserAvatar } from "./UserAvatar";
+
+const meta = {
+  title: "Common/UserAvatar",
+  component: UserAvatar,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+  args: {
+    did: "did:plc:abc123xyz",
+    handle: "alice.bsky.social",
+    displayName: "Alice Naturalist",
+    src: "https://i.pravatar.cc/150?img=5",
+    size: 40,
+  },
+  argTypes: {
+    size: { control: { type: "number" } },
+  },
+} satisfies Meta<typeof UserAvatar>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const FallbackGradient: Story = {
+  args: {
+    src: undefined,
+  },
+};
+
+export const LargerSize: Story = {
+  args: {
+    src: undefined,
+    size: 80,
+  },
+};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <Stack direction="row" spacing={2} alignItems="center">
+      <UserAvatar {...args} src={undefined} size={32} />
+      <UserAvatar {...args} src={undefined} size={40} />
+      <UserAvatar {...args} src={undefined} size={80} />
+    </Stack>
+  ),
+};

--- a/frontend/src/components/common/UserAvatar.stories.tsx
+++ b/frontend/src/components/common/UserAvatar.stories.tsx
@@ -41,7 +41,7 @@ export const LargerSize: Story = {
 
 export const Sizes: Story = {
   render: (args) => (
-    <Stack direction="row" spacing={2} alignItems="center">
+    <Stack direction="row" spacing={2} sx={{ alignItems: "center" }}>
       <UserAvatar {...args} src={undefined} size={32} />
       <UserAvatar {...args} src={undefined} size={40} />
       <UserAvatar {...args} src={undefined} size={80} />

--- a/frontend/src/components/common/UserAvatar.tsx
+++ b/frontend/src/components/common/UserAvatar.tsx
@@ -1,0 +1,45 @@
+import { Avatar } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material";
+import { gradientFromString } from "../../lib/gradientFromString";
+
+export interface UserAvatarProps {
+  /** did/handle seed for the deterministic gradient shown when there's no image. */
+  did?: string | undefined;
+  handle?: string | null | undefined;
+  /** Resolved display name: `alt` text, and (image-less) the fallback initial. */
+  displayName: string;
+  /** Avatar image URL. Falls back to the gradient-initial avatar when omitted. */
+  src?: string | undefined;
+  /** Avatar diameter in pixels (default 40). */
+  size?: number;
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Avatar + image-less fallback shared by `UserCard` and any other place a
+ * user's own avatar is rendered outside that row layout (e.g. `TopBar`'s
+ * account menu). The fallback is a deterministic gradient (stable per user)
+ * with the display-name initial, instead of MUI's flat grey default.
+ */
+export function UserAvatar({ did, handle, displayName, src, size = 40, sx }: UserAvatarProps) {
+  if (src) {
+    return <Avatar src={src} alt={displayName} sx={{ width: size, height: size, ...sx }} />;
+  }
+
+  return (
+    <Avatar
+      alt={displayName}
+      sx={{
+        width: size,
+        height: size,
+        background: gradientFromString(did ?? handle ?? displayName),
+        color: "common.white",
+        fontWeight: 600,
+        fontSize: size * 0.45,
+        ...sx,
+      }}
+    >
+      {displayName[0]}
+    </Avatar>
+  );
+}

--- a/frontend/src/components/common/UserCard.tsx
+++ b/frontend/src/components/common/UserCard.tsx
@@ -1,9 +1,9 @@
 import type { ReactNode } from "react";
 import { Link } from "react-router-dom";
-import { Avatar, Box, Stack, Typography } from "@mui/material";
+import { Box, Stack, Typography } from "@mui/material";
 import type { SxProps, Theme, TypographyProps } from "@mui/material";
 import { getDisplayName } from "../../lib/utils";
-import { gradientFromString } from "../../lib/gradientFromString";
+import { UserAvatar } from "./UserAvatar";
 
 /** The minimal actor shape rendered by UserCard (matches Profile / NotificationActor). */
 export interface UserCardActor {
@@ -88,26 +88,14 @@ export function UserCard({
 
   const stop = stopPropagation ? (e: React.MouseEvent) => e.stopPropagation() : undefined;
 
-  const avatar = src ? (
-    <Avatar src={src} alt={displayName} sx={{ width: avatarSize, height: avatarSize }} />
-  ) : (
-    // Image-less fallback: a deterministic gradient (stable per user) with the
-    // display-name initial, instead of MUI's flat grey default. Still a real
-    // MUI Avatar so it stays a `.MuiAvatar-root` (consistent shape + asserted
-    // by avatar tests).
-    <Avatar
-      alt={displayName}
-      sx={{
-        width: avatarSize,
-        height: avatarSize,
-        background: gradientFromString(did ?? actor.handle ?? displayName),
-        color: "common.white",
-        fontWeight: 600,
-        fontSize: avatarSize * 0.45,
-      }}
-    >
-      {displayName[0]}
-    </Avatar>
+  const avatar = (
+    <UserAvatar
+      did={did}
+      handle={actor.handle}
+      displayName={displayName}
+      src={src}
+      size={avatarSize}
+    />
   );
 
   const name = (

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -8,7 +8,6 @@ import {
   Button,
   IconButton,
   Tooltip,
-  Avatar,
   Typography,
   Skeleton,
   useTheme,
@@ -24,6 +23,7 @@ import { Person, Login, Logout, MenuBook, Settings, Menu as MenuIcon } from "@mu
 import { getDisplayName } from "../../lib/utils";
 import { Logo } from "../common/Logo";
 import { Wordmark } from "../common/Wordmark";
+import { UserAvatar } from "../common/UserAvatar";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
 import { PendingIndicator } from "./PendingIndicator";
@@ -173,9 +173,13 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
                   sx={{ p: 0.5 }}
                   aria-label="Account menu"
                 >
-                  <Avatar
-                    {...(user.avatar ? { src: user.avatar } : {})}
-                    sx={{ width: 40, height: 40, border: 2, borderColor: "divider" }}
+                  <UserAvatar
+                    did={user.did}
+                    handle={user.handle}
+                    displayName={getDisplayName(user, "User")}
+                    src={user.avatar}
+                    size={40}
+                    sx={{ border: 2, borderColor: "divider" }}
                   />
                 </IconButton>
                 <Menu


### PR DESCRIPTION
## Summary

- `TopBar`'s account-menu avatar rendered a bare MUI `Avatar`, so a signed-in user without a profile picture saw a plain grey circle in the header — while every other avatar of them in the app (via `UserCard`) shows the branded deterministic-gradient + initial fallback that `UserCard` was built to provide.
- Extracted that avatar-with-fallback rendering out of `UserCard` into a new shared `frontend/src/components/common/UserAvatar.tsx`, and updated both `UserCard` and `TopBar` to use it.
- No behavior change for any existing `UserCard` caller (avatar fallback, gradient seed, and sizing are unchanged); `TopBar`'s account avatar now matches the rest of the app.

## Test plan

- [x] `npx tsc --noEmit` — clean
- [x] `npm run lint` (oxlint) — no new warnings
- [x] `npx oxfmt --check` on changed files — formatted correctly
- [x] `npx vitest run` — 163/163 tests passing

---
_Generated by [Claude Code](https://claude.ai/code/session_01JvxZcY2gbVtMbF1bRkDUNv)_