### PR TITLE
design-audit: extract shared TaxonMatchChip from UploadModal/IdentificationPanel

### DIFF
--- a/frontend/src/components/common/TaxonMatchChip.stories.tsx
+++ b/frontend/src/components/common/TaxonMatchChip.stories.tsx
@@ -1,0 +1,62 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Stack } from "@mui/material";
+import { TaxonMatchChip } from "./TaxonMatchChip";
+import type { TaxaResult } from "../../services/types";
+
+const MATCHED_WITH_PHOTO: TaxaResult = {
+  id: "Plantae/Quercus robur",
+  scientificName: "Quercus robur",
+  commonName: "English Oak",
+  rank: "species",
+  kingdom: "Plantae",
+  family: "Fagaceae",
+  genus: "Quercus",
+  source: "gbif",
+  photoUrl: "https://placehold.co/40x40",
+};
+
+const MATCHED_NO_PHOTO: TaxaResult = {
+  id: "Plantae/Quercus robur",
+  scientificName: "Quercus robur",
+  commonName: "English Oak",
+  rank: "species",
+  kingdom: "Plantae",
+  family: "Fagaceae",
+  genus: "Quercus",
+  source: "gbif",
+};
+
+const meta = {
+  title: "Common/TaxonMatchChip",
+  component: TaxonMatchChip,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof TaxonMatchChip>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const ExistingWithPhoto: Story = {
+  args: { matchedTaxon: MATCHED_WITH_PHOTO },
+};
+
+export const ExistingNoPhoto: Story = {
+  args: { matchedTaxon: MATCHED_NO_PHOTO },
+};
+
+export const NewTaxon: Story = {
+  args: { matchedTaxon: null },
+};
+
+export const AllStates: Story = {
+  args: { matchedTaxon: null },
+  render: () => (
+    <Stack spacing={1} sx={{ alignItems: "flex-start" }}>
+      <TaxonMatchChip matchedTaxon={MATCHED_WITH_PHOTO} />
+      <TaxonMatchChip matchedTaxon={MATCHED_NO_PHOTO} />
+      <TaxonMatchChip matchedTaxon={null} />
+    </Stack>
+  ),
+};

--- a/frontend/src/components/common/TaxonMatchChip.tsx
+++ b/frontend/src/components/common/TaxonMatchChip.tsx
@@ -1,0 +1,43 @@
+import { Avatar, Chip } from "@mui/material";
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
+import type { TaxaResult } from "../../services/types";
+
+export interface TaxonMatchChipProps {
+  /** The matched taxon, or `null` if the typed name has no match yet. */
+  matchedTaxon: TaxaResult | null;
+}
+
+/**
+ * Shows whether a typed taxon name resolved to an existing taxon or would
+ * create a new one. Used as `bottomContent` under a `TaxaAutocomplete`.
+ */
+export function TaxonMatchChip({ matchedTaxon }: TaxonMatchChipProps) {
+  if (!matchedTaxon) {
+    return (
+      <Chip
+        icon={<AddCircleOutlinedIcon />}
+        label="New taxon"
+        color="info"
+        size="small"
+        variant="outlined"
+        sx={{ mt: 0.5 }}
+      />
+    );
+  }
+
+  return (
+    <Chip
+      {...(matchedTaxon.photoUrl
+        ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
+        : { icon: <CheckCircleOutlinedIcon /> })}
+      label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
+        .filter((p): p is string => Boolean(p))
+        .join(" · ")}
+      color="success"
+      size="small"
+      variant="outlined"
+      sx={{ mt: 0.5 }}
+    />
+  );
+}

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -1,10 +1,8 @@
 import { useState, useCallback, type FormEvent } from "react";
 import {
-  Avatar,
   Box,
   Typography,
   Button,
-  Chip,
   Stack,
   Divider,
   CircularProgress,
@@ -16,11 +14,10 @@ import {
 import CheckIcon from "@mui/icons-material/Check";
 import EditIcon from "@mui/icons-material/Edit";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
-import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
-import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
 import type { TaxaResult } from "../../services/types";
 import { useSubmitIdentification } from "../../lib/query/mutations";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
+import { TaxonMatchChip } from "../common/TaxonMatchChip";
 import { VisualIdCards } from "./VisualIdCards";
 import { useVisualId } from "../../hooks/useVisualId";
 import { TaxonLink } from "../common/TaxonLink";
@@ -216,29 +213,7 @@ export function IdentificationPanel({
                 margin="none"
                 bottomContent={
                   taxonName.trim() ? (
-                    matchedTaxon ? (
-                      <Chip
-                        {...(matchedTaxon.photoUrl
-                          ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
-                          : { icon: <CheckCircleOutlinedIcon /> })}
-                        label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
-                          .filter((p): p is string => Boolean(p))
-                          .join(" · ")}
-                        color="success"
-                        size="small"
-                        variant="outlined"
-                        sx={{ mt: 0.5 }}
-                      />
-                    ) : (
-                      <Chip
-                        icon={<AddCircleOutlinedIcon />}
-                        label="New taxon"
-                        color="info"
-                        size="small"
-                        variant="outlined"
-                        sx={{ mt: 0.5 }}
-                      />
-                    )
+                    <TaxonMatchChip matchedTaxon={matchedTaxon} />
                   ) : (
                     <VisualIdCards
                       suggestions={visualId.suggestions}

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -5,13 +5,11 @@
 // `uploadModalOpen` flag.
 import { lazy, Suspense, useState, useEffect, type FormEvent, type ChangeEvent } from "react";
 import {
-  Avatar,
   Box,
   ButtonBase,
   Typography,
   TextField,
   Button,
-  Chip,
   Stack,
   IconButton,
   CircularProgress,
@@ -27,8 +25,6 @@ import {
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import AddPhotoAlternateIcon from "@mui/icons-material/AddPhotoAlternate";
-import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
-import AddCircleOutlinedIcon from "@mui/icons-material/AddCircleOutlined";
 import ExifReader from "exifreader";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeUploadModal, consumePendingUploadFiles } from "../../store/uiSlice";
@@ -42,6 +38,7 @@ import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
 import { ConfirmDialog } from "../common/ConfirmDialog";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
+import { TaxonMatchChip } from "../common/TaxonMatchChip";
 import { VisualId } from "../identification/VisualId";
 import { PhotoLightbox } from "../observation/PhotoLightbox";
 import { getErrorMessage, fileToBase64, formatCoordinate } from "../../lib/utils";
@@ -679,29 +676,7 @@ export function UploadModal() {
                   placeholder="e.g. Eschscholzia californica - leave blank if unknown"
                   bottomContent={
                     species.trim() ? (
-                      matchedTaxon ? (
-                        <Chip
-                          {...(matchedTaxon.photoUrl
-                            ? { avatar: <Avatar src={matchedTaxon.photoUrl} alt="" /> }
-                            : { icon: <CheckCircleOutlinedIcon /> })}
-                          label={["Existing taxon", matchedTaxon.commonName, matchedTaxon.rank]
-                            .filter((p): p is string => Boolean(p))
-                            .join(" · ")}
-                          color="success"
-                          size="small"
-                          variant="outlined"
-                          sx={{ mt: 0.5 }}
-                        />
-                      ) : (
-                        <Chip
-                          icon={<AddCircleOutlinedIcon />}
-                          label="New taxon"
-                          color="info"
-                          size="small"
-                          variant="outlined"
-                          sx={{ mt: 0.5 }}
-                        />
-                      )
+                      <TaxonMatchChip matchedTaxon={matchedTaxon} />
                     ) : visualIdImageUrl ? (
                       <VisualId
                         imageUrl={visualIdImageUrl}


### PR DESCRIPTION
## Summary
- `UploadModal.tsx` and `IdentificationPanel.tsx` each hand-rolled an identical `bottomContent` block under their `TaxaAutocomplete`: a success-colored "Existing taxon" `Chip` (with the matched taxon's photo as an `Avatar`, or a checkmark icon when there's no photo), or an info-colored "New taxon" `Chip` when the typed name has no match yet — byte-for-byte the same ternary and props in both files.
- Extracted the shared logic into `common/TaxonMatchChip.tsx` (`{ matchedTaxon: TaxaResult | null }`), imported at both call sites. No visual or behavioral change — all literal values (colors, icons, label composition) are preserved exactly.
- Added `TaxonMatchChip.stories.tsx` covering the three states: existing taxon with photo, existing taxon without photo, and new taxon.
- Removed now-unused `Avatar`/`Chip`/`CheckCircleOutlinedIcon`/`AddCircleOutlinedIcon` imports from both files (verified each has no other usage).

## Test plan
- [x] `npx tsc --noEmit` — clean, no new errors
- [x] `npx oxlint` on changed files — no new warnings (one pre-existing, unrelated `exhaustive-deps` warning in `UploadModal.tsx` confirmed present before this change too)
- [x] `npx oxfmt --check` on changed files — passes
- [x] `node scripts/check-stories.mjs` — all components have stories
- [x] `npx vitest run` — 163 tests passed
- [x] `npx vite build` — production build succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bt7chT7463wsKGuvGUvuf6)_