### PR TITLE
design-audit: fix TaxonDetailSkeleton loading-state header mismatch

### DIFF
--- a/frontend/src/components/common/DetailHeaderSkeleton.stories.tsx
+++ b/frontend/src/components/common/DetailHeaderSkeleton.stories.tsx
@@ -10,6 +10,7 @@ const meta = {
   tags: ["autodocs"],
   argTypes: {
     titleWidth: { control: { type: "number" } },
+    sticky: { control: { type: "boolean" } },
   },
 } satisfies Meta<typeof DetailHeaderSkeleton>;
 
@@ -25,5 +26,12 @@ export const Default: Story = {
 export const ShortTitle: Story = {
   args: {
     titleWidth: 60,
+  },
+};
+
+export const Sticky: Story = {
+  args: {
+    titleWidth: 60,
+    sticky: true,
   },
 };

--- a/frontend/src/components/common/DetailHeaderSkeleton.tsx
+++ b/frontend/src/components/common/DetailHeaderSkeleton.tsx
@@ -1,18 +1,25 @@
 import { Box, Skeleton } from "@mui/material";
-import { detailHeaderSx } from "./layoutSx";
+import { detailHeaderSx, stickyHeaderSx } from "./layoutSx";
 
 export interface DetailHeaderSkeletonProps {
   /** Width of the placeholder title text, in px. */
   titleWidth: number;
+  /**
+   * Match `stickyHeaderSx` (sticky, blurred) instead of the default
+   * `detailHeaderSx` bar — set this when the real page's header is sticky,
+   * e.g. the taxon detail panel, so the loading state doesn't visually jump.
+   */
+  sticky?: boolean;
 }
 
 /**
  * Avatar + title placeholder row shared by detail-page skeleton loaders
- * (taxon detail, observation detail), matching the real page's `detailHeaderSx` bar.
+ * (taxon detail, observation detail), matching the real page's header bar
+ * (`detailHeaderSx` by default, or `stickyHeaderSx` when `sticky` is set).
  */
-export function DetailHeaderSkeleton({ titleWidth }: DetailHeaderSkeletonProps) {
+export function DetailHeaderSkeleton({ titleWidth, sticky }: DetailHeaderSkeletonProps) {
   return (
-    <Box sx={detailHeaderSx}>
+    <Box sx={sticky ? stickyHeaderSx : detailHeaderSx}>
       <Skeleton variant="circular" width={40} height={40} sx={{ mr: 1 }} />
       <Skeleton variant="text" width={titleWidth} height={24} />
     </Box>

--- a/frontend/src/components/taxon/TaxonDetailSkeleton.tsx
+++ b/frontend/src/components/taxon/TaxonDetailSkeleton.tsx
@@ -8,7 +8,7 @@ import { DetailHeaderSkeleton } from "../common/DetailHeaderSkeleton";
 export function TaxonDetailSkeleton() {
   return (
     <Box>
-      <DetailHeaderSkeleton titleWidth={60} />
+      <DetailHeaderSkeleton titleWidth={60} sticky />
 
       {/* Main content */}
       <Box sx={{ p: 3 }}>


### PR DESCRIPTION
## Summary

- `DetailHeaderSkeleton` (`frontend/src/components/common/DetailHeaderSkeleton.tsx`) always rendered the flat `detailHeaderSx` bar, and its docstring claimed parity with both the taxon-detail and observation-detail real headers.
- But `TaxonDetailHeader` (`frontend/src/components/taxon/TaxonDetailHeader.tsx`) actually uses the sticky, blurred `stickyHeaderSx` bar — so `TaxonDetailSkeleton`'s loading state showed a non-sticky, opaque header that visually snapped to sticky/blurred once real data loaded.
- `ObservationDetailSkeleton` was already correct (its real header, `ObservationDetail`, does use `detailHeaderSx`).
- Added an optional `sticky` prop to `DetailHeaderSkeleton` so `TaxonDetailSkeleton` can opt into the same bar its real header uses, and added a `Sticky` Storybook story to cover the new variant.

## Test plan

- [x] `npx tsc --noEmit` — passes
- [x] `npx oxlint` on changed files — clean
- [x] `npx oxfmt --check` on changed files — clean
- [x] `node scripts/check-stories.mjs` — all components have stories
- [x] Manual read-through confirming `ObservationDetailSkeleton` (unchanged, still uses default non-sticky bar) matches `ObservationDetail`'s real header


---
_Generated by [Claude Code](https://claude.ai/code/session_018grapL9vc8F9Y1sLz9C7Fu)_