### PR TITLE
design-audit: centralize ListItemButton corner radius into theme override

### DIFF
--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -94,11 +94,7 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
         <Divider sx={{ mb: 1 }} />
         <List dense>
           <ListItem disablePadding>
-            <ListItemButton
-              component={Link}
-              to="/docs"
-              onClick={onMobileClose}
-            >
+            <ListItemButton component={Link} to="/docs" onClick={onMobileClose}>
               <ListItemIcon sx={{ minWidth: 40 }}>
                 <MenuBook fontSize="small" />
               </ListItemIcon>

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -71,7 +71,6 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
               selected={isActive(item.path)}
               onClick={onMobileClose}
               sx={{
-                borderRadius: 2,
                 "&.Mui-selected": {
                   bgcolor: "primary.main",
                   color: "primary.contrastText",
@@ -99,7 +98,6 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
               component={Link}
               to="/docs"
               onClick={onMobileClose}
-              sx={{ borderRadius: 2 }}
             >
               <ListItemIcon sx={{ minWidth: 40 }}>
                 <MenuBook fontSize="small" />
@@ -112,7 +110,7 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
         <Divider sx={{ my: 1 }} />
 
         {user ? (
-          <ListItemButton onClick={onLogout} sx={{ borderRadius: 2 }}>
+          <ListItemButton onClick={onLogout}>
             <ListItemIcon sx={{ minWidth: 40 }}>
               <Logout fontSize="small" />
             </ListItemIcon>
@@ -122,7 +120,6 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
           <ListItemButton
             onClick={onLogin}
             sx={{
-              borderRadius: 2,
               bgcolor: "primary.main",
               color: "primary.contrastText",
               "&:hover": { bgcolor: "primary.dark" },

--- a/frontend/src/components/notifications/NotificationsPage.tsx
+++ b/frontend/src/components/notifications/NotificationsPage.tsx
@@ -96,7 +96,7 @@ export function NotificationsPage() {
               mb: 0.5,
             }}
           >
-            <ListItemButton onClick={() => handleClick(n)} sx={{ borderRadius: 2, py: 1.5 }}>
+            <ListItemButton onClick={() => handleClick(n)} sx={{ py: 1.5 }}>
               <UserCard
                 actor={n.actor ?? {}}
                 linkDid={n.actorDid}

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -202,6 +202,16 @@ const createAppTheme = (mode: PaletteMode): Theme => {
           },
         },
       },
+      // Every ListItemButton in the app (nav rows, notification rows) rounds
+      // its corners the same way — centralized here instead of repeating
+      // `borderRadius: 2` at each call site.
+      MuiListItemButton: {
+        styleOverrides: {
+          root: ({ theme }) => ({
+            borderRadius: theme.shape.borderRadius * 2,
+          }),
+        },
+      },
     },
   });
 };

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -208,7 +208,7 @@ const createAppTheme = (mode: PaletteMode): Theme => {
       MuiListItemButton: {
         styleOverrides: {
           root: ({ theme }) => ({
-            borderRadius: (theme.shape.borderRadius as number) * 2,
+            borderRadius: Number(theme.shape.borderRadius) * 2,
           }),
         },
       },

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -208,7 +208,7 @@ const createAppTheme = (mode: PaletteMode): Theme => {
       MuiListItemButton: {
         styleOverrides: {
           root: ({ theme }) => ({
-            borderRadius: theme.shape.borderRadius * 2,
+            borderRadius: (theme.shape.borderRadius as number) * 2,
           }),
         },
       },


### PR DESCRIPTION
## Summary
- Every `ListItemButton` in the app (Sidebar nav rows and Docs/Logout/Login rows, NotificationsPage rows) independently repeated `sx={{ borderRadius: 2 }}` — 5 occurrences across 2 files, all using the exact same value.
- Moved the radius into a `MuiListItemButton` `styleOverrides.root` entry in `theme/index.ts`, following the same pattern already used for the `MuiButton`/`MuiTab`/`MuiSkeleton` overrides in the same file.
- Removed the now-redundant `borderRadius: 2` at each call site.

This is a pure DRY refactor with no visual change: 100% of existing `ListItemButton` usages already applied the same radius, so centralizing it changes nothing at render time — it just removes the duplication and gives future call sites the right default for free.

## Test plan
- [x] `npm run build` — succeeds
- [x] `npx vitest run --config frontend/vitest.config.ts` — 163 tests pass
- [x] `npx storybook build -c frontend/.storybook` — succeeds
- [x] `npx oxlint` on changed files — clean

---
_Generated by [Claude Code](https://claude.ai/code/session_01GECu1JBUZKaJ49sr8yhHap)_