### PR TITLE
design-audit: centralize FullPageStatus icon styling + CTA button sx

### DIFF
--- a/frontend/src/components/common/ErrorBoundary.tsx
+++ b/frontend/src/components/common/ErrorBoundary.tsx
@@ -2,6 +2,7 @@ import { Component, type ErrorInfo, type ReactNode } from "react";
 import { Button } from "@mui/material";
 import ErrorOutlineIcon from "@mui/icons-material/ErrorOutlined";
 import { FullPageStatus } from "./FullPageStatus";
+import { fullPageStatusPrimaryActionSx, fullPageStatusSecondaryActionSx } from "./layoutSx";
 
 interface Props {
   children: ReactNode;
@@ -55,7 +56,7 @@ export class ErrorBoundary extends Component<Props, State> {
 
     return (
       <FullPageStatus
-        icon={<ErrorOutlineIcon sx={{ fontSize: 60, color: "text.disabled" }} />}
+        icon={<ErrorOutlineIcon />}
         title={isChunkError ? "Update available" : "Something went wrong"}
         description={
           isChunkError
@@ -68,7 +69,7 @@ export class ErrorBoundary extends Component<Props, State> {
               onClick={() => window.location.reload()}
               variant="contained"
               color="primary"
-              sx={{ px: 4, py: 1, fontWeight: 600 }}
+              sx={fullPageStatusPrimaryActionSx}
             >
               Reload
             </Button>
@@ -76,7 +77,7 @@ export class ErrorBoundary extends Component<Props, State> {
               onClick={() => window.location.assign("/")}
               variant="outlined"
               color="inherit"
-              sx={{ px: 3 }}
+              sx={fullPageStatusSecondaryActionSx}
             >
               Go home
             </Button>

--- a/frontend/src/components/common/FullPageStatus.stories.tsx
+++ b/frontend/src/components/common/FullPageStatus.stories.tsx
@@ -17,7 +17,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    icon: <ErrorOutlineIcon sx={{ fontSize: 60, color: "text.disabled" }} />,
+    icon: <ErrorOutlineIcon />,
     title: "Something went wrong",
     description: "An unexpected error occurred while loading this page.",
     actions: (
@@ -30,7 +30,7 @@ export const Default: Story = {
 
 export const WithEyebrow: Story = {
   args: {
-    icon: <ErrorOutlineIcon sx={{ fontSize: 60, color: "text.disabled" }} />,
+    icon: <ErrorOutlineIcon />,
     eyebrow: <div style={{ fontSize: "4rem", fontWeight: 700, marginBottom: 8 }}>404</div>,
     title: "Page not found",
     description: "The page you're looking for doesn't exist or has been moved.",

--- a/frontend/src/components/common/FullPageStatus.tsx
+++ b/frontend/src/components/common/FullPageStatus.tsx
@@ -1,5 +1,6 @@
 import { Box, Typography, Stack } from "@mui/material";
-import type { ReactNode } from "react";
+import type { SxProps, Theme } from "@mui/material/styles";
+import { cloneElement, isValidElement, type ReactNode } from "react";
 
 export interface FullPageStatusProps {
   /** Icon rendered inside the circular badge, e.g. an MUI icon element. */
@@ -53,7 +54,11 @@ export function FullPageStatus({
           mb: 3,
         }}
       >
-        {icon}
+        {isValidElement<{ sx?: SxProps<Theme> }>(icon)
+          ? cloneElement(icon, {
+              sx: { fontSize: 60, color: "text.disabled", ...icon.props.sx },
+            })
+          : icon}
       </Box>
       {eyebrow}
       <Typography variant="h6" component="h2" sx={{ color: "text.secondary", mb: 1 }}>

--- a/frontend/src/components/common/NotFound.tsx
+++ b/frontend/src/components/common/NotFound.tsx
@@ -2,11 +2,12 @@ import { Link } from "react-router-dom";
 import { Typography, Button } from "@mui/material";
 import SearchOffIcon from "@mui/icons-material/SearchOff";
 import { FullPageStatus } from "./FullPageStatus";
+import { fullPageStatusPrimaryActionSx, fullPageStatusSecondaryActionSx } from "./layoutSx";
 
 export function NotFound() {
   return (
     <FullPageStatus
-      icon={<SearchOffIcon sx={{ fontSize: 60, color: "text.disabled" }} />}
+      icon={<SearchOffIcon />}
       eyebrow={
         <Typography
           variant="h1"
@@ -34,11 +35,7 @@ export function NotFound() {
             to="/"
             variant="contained"
             color="primary"
-            sx={{
-              px: 4,
-              py: 1,
-              fontWeight: 600,
-            }}
+            sx={fullPageStatusPrimaryActionSx}
           >
             Go home
           </Button>
@@ -46,7 +43,7 @@ export function NotFound() {
             onClick={() => window.history.back()}
             variant="outlined"
             color="inherit"
-            sx={{ px: 3 }}
+            sx={fullPageStatusSecondaryActionSx}
           >
             Go back
           </Button>

--- a/frontend/src/components/common/layoutSx.ts
+++ b/frontend/src/components/common/layoutSx.ts
@@ -51,3 +51,15 @@ export const imageSkeletonOverlaySx = {
   width: "100%",
   height: "100%",
 } as const;
+
+/** Primary CTA button in a `FullPageStatus` action row (NotFound, ErrorBoundary). */
+export const fullPageStatusPrimaryActionSx = {
+  px: 4,
+  py: 1,
+  fontWeight: 600,
+} as const;
+
+/** Secondary CTA button in a `FullPageStatus` action row (NotFound, ErrorBoundary). */
+export const fullPageStatusSecondaryActionSx = {
+  px: 3,
+} as const;


### PR DESCRIPTION
## Summary
- `NotFound` and `ErrorBoundary` (both consumers of the shared `FullPageStatus` layout) each repeated the exact same `sx={{ fontSize: 60, color: "text.disabled" }}` on their status icon, and the exact same primary (`px: 4, py: 1, fontWeight: 600`) / secondary (`px: 3`) CTA button `sx` — four byte-for-byte duplicated literals across two real components plus their Storybook fixtures.
- `FullPageStatus` now applies the icon styling itself (via `cloneElement`, letting a caller's own `sx` still win/merge), so callers just pass a bare icon element.
- The CTA button `sx` moves into `layoutSx.ts` as `fullPageStatusPrimaryActionSx` / `fullPageStatusSecondaryActionSx`, following the existing `imageSkeletonOverlaySx` / `accentListItemSx` precedent in that file.
- Updated `FullPageStatus.stories.tsx` fixtures to match.

## Test plan
- [x] `npx tsc --noEmit` — no errors
- [x] `npx oxlint frontend/src` — no new warnings (pre-existing unrelated warnings only)
- [x] `npx oxfmt --check` on touched files — all formatted
- [x] `node scripts/check-stories.mjs` — all 90 components still have stories

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01CEJFSC7MtQC2mrjvJ3E513

---
_Generated by [Claude Code](https://claude.ai/code/session_01CEJFSC7MtQC2mrjvJ3E513)_