### PR TITLE
feat(setup): add db-up.sh to script local Postgres setup

### DIFF
--- a/.github/workflows/setup-smoke-mac.yml
+++ b/.github/workflows/setup-smoke-mac.yml
@@ -12,6 +12,7 @@ on:
     paths:
       - 'scripts/setup.sh'
       - 'scripts/doctor.sh'
+      - 'scripts/db-up.sh'
       - 'scripts/install-tap.sh'
       - 'scripts/download-models.sh'
       - 'Brewfile'
@@ -26,6 +27,7 @@ on:
     paths:
       - 'scripts/setup.sh'
       - 'scripts/doctor.sh'
+      - 'scripts/db-up.sh'
       - 'scripts/install-tap.sh'
       - 'scripts/download-models.sh'
       - 'Brewfile'
@@ -108,6 +110,12 @@ jobs:
 
       - name: Run npm run setup
         run: npm run setup
+
+      # Postgres is already running via brew above, so this exercises
+      # db-up.sh's adopt path: it must detect the existing server and exit
+      # 0 without starting a container or fighting over port 5432.
+      - name: Run npm run db:up (adopts the existing Postgres)
+        run: npm run db:up
 
       - name: Run npm run doctor
         run: npm run doctor

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ git clone <repo>
 cd core
 cp .env.example .env                  # tweak DATABASE_URL etc. as needed
 npm run setup                         # one-time: prereqs, deps, tap, models
-# ensure Postgres is running (see docs/development.md#database-setup)
+npm run db:up                         # start Postgres + PostGIS (or adopt a running one)
 process-compose up -D                 # runs migrations, then starts services
 open http://localhost:3000
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ for building the `tap` binary. Details in
 ```bash
 cp .env.example .env                  # tweak DATABASE_URL etc. as needed
 npm run setup                         # one-time: prereqs, deps, tap, models
-# ensure Postgres is running (see docs/development.md#database-setup)
+npm run db:up                         # start Postgres + PostGIS (or adopt a running one)
 process-compose up -D                 # runs migrations, then starts services
 open http://localhost:3000
 ```

--- a/docs/development.md
+++ b/docs/development.md
@@ -25,7 +25,7 @@ the project's `Brewfile`. asdf/mise users get Node and Go from
 ```bash
 cp .env.example .env       # tweak DATABASE_URL / DB_PASSWORD to match your Postgres
 npm run setup              # bootstraps everything below in one shot
-# ensure Postgres is running (see Database Setup below)
+npm run db:up              # start Postgres + PostGIS (or adopt a running one)
 process-compose up -D      # runs migrations, then starts services
 ```
 
@@ -37,8 +37,9 @@ that's already done. It runs:
 3. `./scripts/install-tap.sh` — pinned `tap` Go binary, if not on PATH
 4. `./scripts/download-models.sh` — BioCLIP models, if not present
 
-Postgres lifecycle is left to you (it's stateful and often shared
-with other projects). Migrations are run automatically by
+Postgres stays a separate step (it's stateful and often shared with
+other projects), but `npm run db:up` handles it — see
+[Database Setup](#database-setup). Migrations are run automatically by
 `process-compose up` as the first process — see
 [Running services](#running-services).
 
@@ -64,7 +65,37 @@ Run PostgreSQL with PostGIS locally. All app services connect over
 production Cloud SQL is a separate concern handled by CI (see
 `docs/deployment.md`).
 
-Docker is the path of least resistance:
+### Scripted (recommended)
+
+```bash
+npm run db:up
+```
+
+Idempotent, and safe whatever your setup already looks like. It:
+
+1. Reads `DATABASE_URL` from `.env` for the user, password, database,
+   and port — so it can't drift from what the services connect to.
+2. Exits early if something already answers on that port, so an existing
+   native or containerized Postgres is adopted, never clobbered.
+3. Starts a `postgis` container otherwise, choosing a native image for
+   your architecture (see the Apple Silicon note below).
+4. Blocks until Postgres actually accepts connections — `docker run -d`
+   returns well before that, and starting `process-compose` too early
+   makes the `migrate` process fail.
+
+Data lives in a named Docker volume (`observing-pgdata`), so the
+container can be recreated without losing the database.
+
+```bash
+npm run db:up -- --stop       # stop the container, keep the data
+npm run db:up -- --destroy    # remove the container AND wipe the volume
+```
+
+It does not create the PostGIS extension: the first migration already
+runs `CREATE EXTENSION IF NOT EXISTS postgis`, and `process-compose`
+applies migrations before anything reads the database.
+
+### By hand
 
 ```bash
 # One-time: create the container
@@ -72,6 +103,7 @@ docker run --name observing-postgres \
   -e POSTGRES_PASSWORD=mysecretpassword \
   -e POSTGRES_DB=observing \
   -p 5432:5432 \
+  -v observing-pgdata:/var/lib/postgresql/data \
   -d postgis/postgis
 
 # After reboot / on subsequent sessions
@@ -82,19 +114,13 @@ docker start observing-postgres
 (no arm64 manifest), so it runs under slow QEMU emulation. Either pass
 `--platform linux/amd64` explicitly to silence the warning and force emulation,
 or use a native multi-arch image like `imresamu/postgis` (drop-in replacement,
-same env vars) for better performance:
-
-```bash
-docker run --name observing-postgres \
-  -e POSTGRES_PASSWORD=mysecretpassword \
-  -e POSTGRES_DB=observing \
-  -p 5432:5432 \
-  -d imresamu/postgis        # native arm64 + amd64; or add --platform linux/amd64 to postgis/postgis
-```
+same env vars) for better performance. `npm run db:up` picks this automatically
+on arm64; override it for either path with `POSTGIS_IMAGE=…`.
 
 Native installs (Postgres.app, Homebrew `postgresql@N` + `postgis`,
 etc.) work too — anything that exposes PostgreSQL with PostGIS on
-`localhost:5432` is fine.
+`localhost:5432` is fine. `npm run db:up` detects these and leaves them
+alone.
 
 ## Configuration
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "vite build -c frontend/vite.config.ts",
     "build-storybook": "storybook build -c frontend/.storybook",
     "check:stories": "node scripts/check-stories.mjs",
+    "db:up": "./scripts/db-up.sh",
     "doctor": "./scripts/doctor.sh",
     "generate-rust-types": "./scripts/generate-rust-types.sh",
     "setup": "./scripts/setup.sh",

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -25,7 +25,9 @@ processes:
     environment:
       - PORT=${SPECIES_ID_PORT:-3005}
       - MODEL_DIR=./models/bioclip
-      - ORT_DYLIB_PATH=/opt/homebrew/lib/libonnxruntime.dylib
+      # Overridable so Linux and Intel-macOS checkouts can point at their own
+      # ONNX Runtime; the default is the Apple Silicon Homebrew location.
+      - ORT_DYLIB_PATH=${ORT_DYLIB_PATH:-/opt/homebrew/lib/libonnxruntime.dylib}
     readiness_probe:
       http_get:
         host: localhost

--- a/scripts/db-up.sh
+++ b/scripts/db-up.sh
@@ -1,0 +1,263 @@
+#!/usr/bin/env bash
+# Start a local PostgreSQL + PostGIS for development. Idempotent — safe to
+# re-run.
+#
+# Steps (each skipped if already done):
+#   1. Read connection settings from .env (DATABASE_URL, else DB_* defaults)
+#   2. If something already answers on the port, use it and exit
+#   3. Otherwise start a postgis container, picking a native image per arch
+#   4. Block until Postgres actually accepts connections
+#
+# The PostGIS extension is intentionally NOT created here — the first
+# migration (crates/observing-db/migrations/20240101000000_initial.sql)
+# does `CREATE EXTENSION IF NOT EXISTS postgis`, and process-compose runs
+# migrations before any service reads the database.
+#
+# Usage:
+#   ./scripts/db-up.sh              # start (or adopt) Postgres
+#   ./scripts/db-up.sh --stop       # stop the container, keep the data
+#   ./scripts/db-up.sh --destroy    # remove the container AND its data volume
+#   ./scripts/db-up.sh --destroy -y # ...without the confirmation prompt
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [ -t 1 ]; then
+  GREEN=$'\033[0;32m'; YELLOW=$'\033[0;33m'; RED=$'\033[0;31m'
+  BOLD=$'\033[1m'; RESET=$'\033[0m'
+else
+  GREEN=''; YELLOW=''; RED=''; BOLD=''; RESET=''
+fi
+
+step() { printf "\n%s==> %s%s\n" "$BOLD" "$1" "$RESET"; }
+ok()   { printf "  %s✓%s %s\n" "$GREEN" "$RESET" "$1"; }
+warn() { printf "  %s!%s %s\n" "$YELLOW" "$RESET" "$1"; }
+err()  { printf "  %s✗%s %s\n" "$RED" "$RESET" "$1" >&2; }
+
+CONTAINER="${PG_CONTAINER_NAME:-observing-postgres}"
+VOLUME="${PG_VOLUME_NAME:-observing-pgdata}"
+
+# ---- Args -----------------------------------------------------------------
+
+action="up"
+assume_yes=0
+for arg in "$@"; do
+  case "$arg" in
+    --stop)        action="stop" ;;
+    --destroy)     action="destroy" ;;
+    -y|--yes)      assume_yes=1 ;;
+    -h|--help)     sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+    *) err "Unknown argument: $arg (try --help)"; exit 2 ;;
+  esac
+done
+
+# ---- 1. Connection settings ----------------------------------------------
+
+# Load .env the same way setup.sh and doctor.sh do, so this script and the
+# rest of the stack can never disagree about where the database lives.
+# `set -a; source .env` would overwrite an explicitly exported DATABASE_URL,
+# so stash and restore it — an env var passed on the command line should win
+# over the file, not the other way around.
+_explicit_database_url="${DATABASE_URL:-}"
+if [ -f .env ]; then
+  set -a
+  # shellcheck disable=SC1091
+  source .env 2>/dev/null || true
+  set +a
+fi
+[ -n "$_explicit_database_url" ] && DATABASE_URL="$_explicit_database_url"
+
+PG_USER="postgres"
+PG_PASSWORD="${DB_PASSWORD:-mysecretpassword}"
+PG_DB="observing"
+PG_HOST="localhost"
+PG_PORT="5432"
+
+# Parse DATABASE_URL when present; it is the source of truth everywhere else
+# in the stack (process-compose.yaml, migrate, appview, tap-ingester).
+if [ -n "${DATABASE_URL:-}" ]; then
+  rest="${DATABASE_URL#*://}"
+  if [[ "$rest" == *"@"* ]]; then
+    # Split on the LAST '@' so passwords containing '@' survive.
+    userinfo="${rest%@*}"
+    rest="${rest##*@}"
+    [ -n "${userinfo%%:*}" ] && PG_USER="${userinfo%%:*}"
+    if [[ "$userinfo" == *":"* ]]; then
+      PG_PASSWORD="${userinfo#*:}"
+    fi
+  fi
+
+  hostport="${rest%%/*}"
+  if [ "$hostport" != "$rest" ]; then
+    dbname="${rest#*/}"
+    dbname="${dbname%%\?*}"
+    [ -n "$dbname" ] && PG_DB="$dbname"
+  fi
+
+  if [ -n "$hostport" ]; then
+    if [[ "$hostport" == *":"* ]]; then
+      PG_HOST="${hostport%%:*}"
+      PG_PORT="${hostport##*:}"
+    else
+      PG_HOST="$hostport"
+    fi
+  fi
+fi
+
+# Starting a local container for a remote DATABASE_URL would quietly shadow
+# the database the rest of the stack talks to. Refuse instead.
+case "$PG_HOST" in
+  localhost|127.0.0.1|0.0.0.0|"") ;;
+  *)
+    err "DATABASE_URL points at a non-local host ($PG_HOST)."
+    err "This script only manages a local Postgres. Nothing to do."
+    exit 1
+    ;;
+esac
+
+# ---- Stop / destroy -------------------------------------------------------
+
+if [ "$action" = "stop" ]; then
+  step "Stopping $CONTAINER"
+  if docker stop "$CONTAINER" >/dev/null 2>&1; then
+    ok "Stopped (data preserved in volume $VOLUME)"
+  else
+    warn "Container $CONTAINER is not running"
+  fi
+  exit 0
+fi
+
+if [ "$action" = "destroy" ]; then
+  step "Destroying $CONTAINER and volume $VOLUME"
+  if [ "$assume_yes" -ne 1 ]; then
+    if [ -t 0 ]; then
+      printf "  This permanently deletes all local database data. Continue? [y/N] "
+      read -r reply
+      case "$reply" in
+        y|Y|yes|YES) ;;
+        *) echo "  Aborted."; exit 0 ;;
+      esac
+    else
+      err "Refusing to destroy data non-interactively without --yes"
+      exit 1
+    fi
+  fi
+  docker rm -f "$CONTAINER" >/dev/null 2>&1 && ok "Container removed" || warn "No container to remove"
+  docker volume rm "$VOLUME" >/dev/null 2>&1 && ok "Volume removed" || warn "No volume to remove"
+  exit 0
+fi
+
+# ---- 2. Adopt an existing Postgres ---------------------------------------
+
+step "Checking for an existing Postgres on $PG_HOST:$PG_PORT"
+
+port_answers() {
+  if command -v pg_isready >/dev/null 2>&1; then
+    pg_isready -q -h "$PG_HOST" -p "$PG_PORT" 2>/dev/null
+  elif command -v nc >/dev/null 2>&1; then
+    nc -z "$PG_HOST" "$PG_PORT" 2>/dev/null
+  else
+    return 1
+  fi
+}
+
+if port_answers; then
+  ok "Postgres already reachable on $PG_HOST:$PG_PORT — using it"
+  echo
+  echo "  Nothing to start. If this is a native install (Postgres.app,"
+  echo "  Homebrew), make sure database '$PG_DB' exists and DATABASE_URL"
+  echo "  in .env matches it. Run 'npm run doctor' to verify."
+  exit 0
+fi
+
+ok "Port $PG_PORT is free"
+
+# ---- 3. Docker preflight --------------------------------------------------
+
+step "Checking Docker"
+
+if ! command -v docker >/dev/null 2>&1; then
+  err "Docker is not installed."
+  err "Install Docker Desktop (https://docs.docker.com/get-docker/), or set up"
+  err "Postgres natively — see docs/development.md#database-setup."
+  exit 1
+fi
+
+if ! docker info >/dev/null 2>&1; then
+  err "Docker is installed but the daemon isn't running."
+  err "Start Docker Desktop (or your daemon) and re-run this script."
+  exit 1
+fi
+
+ok "Docker daemon is running"
+
+# The official postgis/postgis image publishes no arm64 manifest, so on Apple
+# Silicon it runs under QEMU emulation and is markedly slower. imresamu/postgis
+# is a drop-in multi-arch replacement with the same env vars.
+# Untagged to match docs/development.md; pin via POSTGIS_IMAGE if you want a
+# fixed major version.
+case "$(uname -m)" in
+  arm64|aarch64) IMAGE="${POSTGIS_IMAGE:-imresamu/postgis}" ;;
+  *)             IMAGE="${POSTGIS_IMAGE:-postgis/postgis}" ;;
+esac
+ok "Image for $(uname -m): $IMAGE"
+
+# ---- 4. Container lifecycle ----------------------------------------------
+
+step "Starting Postgres"
+
+state="$(docker inspect -f '{{.State.Status}}' "$CONTAINER" 2>/dev/null || echo "absent")"
+
+case "$state" in
+  running)
+    # Port probe failed but the container is up: it is bound elsewhere.
+    warn "Container $CONTAINER is running but nothing answers on $PG_PORT"
+    warn "Check its port mapping: docker port $CONTAINER"
+    ;;
+  exited|created|paused)
+    docker start "$CONTAINER" >/dev/null
+    ok "Started existing container $CONTAINER"
+    ;;
+  *)
+    docker run -d \
+      --name "$CONTAINER" \
+      -e POSTGRES_USER="$PG_USER" \
+      -e POSTGRES_PASSWORD="$PG_PASSWORD" \
+      -e POSTGRES_DB="$PG_DB" \
+      -p "$PG_PORT:5432" \
+      -v "$VOLUME:/var/lib/postgresql/data" \
+      "$IMAGE" >/dev/null
+    ok "Created container $CONTAINER (data volume: $VOLUME)"
+    ;;
+esac
+
+# ---- 5. Wait for readiness -----------------------------------------------
+
+# `docker run -d` returns long before Postgres accepts connections. Without
+# this wait, a following `process-compose up -D` races the database and the
+# one-shot migrate process fails.
+step "Waiting for Postgres to accept connections"
+
+for _ in $(seq 1 60); do
+  if docker exec "$CONTAINER" pg_isready -q -U "$PG_USER" -d "$PG_DB" 2>/dev/null; then
+    ok "Postgres is ready on $PG_HOST:$PG_PORT (database: $PG_DB)"
+    cat <<EOF
+
+Next steps:
+  - process-compose up -D       # runs migrations, then starts services
+  - open http://localhost:3000
+
+  ./scripts/db-up.sh --stop     # stop, keeping data
+  ./scripts/db-up.sh --destroy  # remove container and wipe data
+EOF
+    exit 0
+  fi
+  sleep 1
+done
+
+err "Postgres did not become ready within 60s."
+err "Inspect the logs: docker logs $CONTAINER"
+exit 1

--- a/scripts/doctor.sh
+++ b/scripts/doctor.sh
@@ -137,14 +137,14 @@ if command -v pg_isready >/dev/null 2>&1; then
     pass "Postgres reachable on localhost:5432"
     pg_running=1
   else
-    fail "Postgres not reachable on localhost:5432 — start it (see docs/development.md)"
+    fail "Postgres not reachable on localhost:5432 — run: npm run db:up"
   fi
 elif command -v nc >/dev/null 2>&1; then
   if nc -z localhost 5432 2>/dev/null; then
     pass "Something is listening on localhost:5432 (install postgresql-client for a deeper check)"
     pg_running=1
   else
-    fail "Nothing listening on localhost:5432 — start Postgres (see docs/development.md)"
+    fail "Nothing listening on localhost:5432 — run: npm run db:up"
   fi
 else
   warn "Can't probe Postgres (neither pg_isready nor nc available)"

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -8,9 +8,10 @@
 #   4. Install the upstream `tap` Go binary (./scripts/install-tap.sh)
 #   5. Download BioCLIP models (./scripts/download-models.sh)
 #
-# Postgres and migrations are intentionally out of scope: `process-compose
-# up -D` brings up a managed postgis container and runs migrations
-# automatically before the app services start.
+# Postgres is intentionally out of scope: it is stateful and usually shared
+# across checkouts, so starting it stays an explicit step
+# (`./scripts/db-up.sh`). Migrations are handled for you — `process-compose
+# up -D` runs them as a one-shot process before the app services start.
 
 set -euo pipefail
 
@@ -109,8 +110,7 @@ step "Setup complete"
 cat <<EOF
 
 Next steps:
-  - Make sure Postgres is running on localhost:5432
-    (see docs/development.md#database-setup)
+  - npm run db:up               # start Postgres + PostGIS (skips if already running)
   - process-compose up -D       # runs migrations, then starts services
   - open http://localhost:3000
   - Run ./scripts/doctor.sh anytime to diagnose problems


### PR DESCRIPTION
Postgres was the only prerequisite in the local setup still left to
prose. Contributors had to pick a Docker recipe by hand, work around the
arm64/QEMU footgun in the `postgis` image, and guess when the server was
actually accepting connections.

The quick start is now three commands with no branching narrative:

```bash
npm run setup
npm run db:up
process-compose up -D
```

## `scripts/db-up.sh`

- Parses `DATABASE_URL` from `.env` for user/password/db/port, so it
  cannot drift from what the services connect to. Refuses to run against
  a non-local host rather than starting a container that shadows it.
- Exits early when something already answers on the port — native
  Postgres.app and Homebrew installs are adopted, never clobbered, and
  never fought for 5432.
- Distinguishes "Docker not installed" from "daemon not running", which
  are different fixes.
- Picks `imresamu/postgis` on arm64 (native) and `postgis/postgis`
  elsewhere; override with `POSTGIS_IMAGE`.
- Blocks on `pg_isready`. `docker run -d` returns well before Postgres
  accepts connections, and starting `process-compose` too early makes
  the one-shot `migrate` process fail.
- Data lives in a named volume (`observing-pgdata`), so recreating the
  container does not wipe the database. `--stop` and `--destroy` manage
  the lifecycle; `--destroy` is confirmation-gated and requires `--yes`
  non-interactively.

It deliberately does not create the PostGIS extension — the first
migration already runs `CREATE EXTENSION IF NOT EXISTS postgis`.

It stays out of `setup.sh`: Postgres is stateful and shared across
checkouts (note `dev.sh` randomizes every port *except* 5432), so
starting it remains an explicit step.

## Two adjacent fixes

- **`ORT_DYLIB_PATH`** was the one hardcoded value in
  `process-compose.yaml`, making the `.env` setting and `doctor.sh`'s
  check both dead letters. Linux and Intel-macOS checkouts would pass
  `doctor` and then watch `species-id` die on an Apple Silicon Homebrew
  path. Now a `${VAR:-default}` override like every other line.
- **`setup.sh`'s header comment** claimed `process-compose` brings up a
  managed postgis container. It does not — and that is exactly what
  makes someone skip starting Postgres.

## Testing

- URL parser verified against 7 shapes, including a password containing
  `@` and the `postgresql:///observing` peer-auth form the macOS smoke
  test uses.
- Exercised locally: `--help`, non-local-host refusal, `--destroy`
  non-interactive guard, unknown-arg handling, and the "daemon not
  running" preflight.
- `setup-smoke-mac` gains `db-up.sh` in its path filters plus a step
  running `npm run db:up` against the brew Postgres it already starts,
  covering the adopt path in CI.

**Not yet verified:** container creation and the readiness loop — the
Docker daemon was down on the machine this was written on. Worth one
`npm run db:up` with Docker running before merge.

## Follow-ups (not in this PR)

- A lite profile skipping `species-id` to cut the 20–40 min cold start
- A Linux smoke test (would have caught the `ORT_DYLIB_PATH` bug)
- `doctor.sh` port checks ignore `DEV_PORT_OFFSET`