### PR TITLE
design-audit: extract shared KingdomSelect/RankSelect from UploadModal/IdentificationPanel

### DIFF
--- a/frontend/src/components/common/KingdomSelect.stories.tsx
+++ b/frontend/src/components/common/KingdomSelect.stories.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { KingdomSelect } from "./KingdomSelect";
+
+const meta = {
+  title: "Common/KingdomSelect",
+  component: KingdomSelect,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: 280 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <KingdomSelect {...args} value={value} onChange={setValue} />;
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof KingdomSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: "",
+    onChange: () => undefined,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    value: "Plantae",
+    onChange: () => undefined,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    value: "",
+    onChange: () => undefined,
+    size: "small",
+  },
+};

--- a/frontend/src/components/common/KingdomSelect.tsx
+++ b/frontend/src/components/common/KingdomSelect.tsx
@@ -1,0 +1,38 @@
+import { FormControl, InputLabel, MenuItem, Select, type SelectProps } from "@mui/material";
+import { KINGDOMS } from "../../lib/kingdoms";
+
+export interface KingdomSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  size?: SelectProps["size"];
+  /** Distinguishes this select's `labelId` when more than one instance mounts at once. */
+  idPrefix?: string;
+}
+
+/**
+ * Required "Kingdom" dropdown shown alongside a free-typed taxon name that
+ * didn't match a known taxon (upload form, visual-ID suggestion panel).
+ */
+export function KingdomSelect({ value, onChange, size, idPrefix = "kingdom" }: KingdomSelectProps) {
+  const labelId = `${idPrefix}-label`;
+  return (
+    <FormControl fullWidth margin="normal" required size={size}>
+      <InputLabel id={labelId}>Kingdom</InputLabel>
+      <Select
+        labelId={labelId}
+        value={value}
+        label="Kingdom"
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <MenuItem value="">
+          <em>None</em>
+        </MenuItem>
+        {KINGDOMS.map((k) => (
+          <MenuItem key={k.value} value={k.value}>
+            {k.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/frontend/src/components/common/RankSelect.stories.tsx
+++ b/frontend/src/components/common/RankSelect.stories.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { RankSelect } from "./RankSelect";
+
+const meta = {
+  title: "Common/RankSelect",
+  component: RankSelect,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: 280 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <RankSelect {...args} value={value} onChange={setValue} />;
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof RankSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: "",
+    onChange: () => undefined,
+  },
+};
+
+export const Selected: Story = {
+  args: {
+    value: "genus",
+    onChange: () => undefined,
+  },
+};
+
+export const Small: Story = {
+  args: {
+    value: "",
+    onChange: () => undefined,
+    size: "small",
+  },
+};

--- a/frontend/src/components/common/RankSelect.tsx
+++ b/frontend/src/components/common/RankSelect.tsx
@@ -1,0 +1,38 @@
+import { FormControl, InputLabel, MenuItem, Select, type SelectProps } from "@mui/material";
+import { TAXON_RANKS } from "../../lib/taxonRanks";
+
+export interface RankSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  size?: SelectProps["size"];
+  /** Distinguishes this select's `labelId` when more than one instance mounts at once. */
+  idPrefix?: string;
+}
+
+/**
+ * Optional "Rank" dropdown shown alongside a free-typed taxon name that
+ * didn't match a known taxon (upload form, visual-ID suggestion panel).
+ */
+export function RankSelect({ value, onChange, size, idPrefix = "rank" }: RankSelectProps) {
+  const labelId = `${idPrefix}-label`;
+  return (
+    <FormControl fullWidth margin="normal" size={size}>
+      <InputLabel id={labelId}>Rank (optional)</InputLabel>
+      <Select
+        labelId={labelId}
+        value={value}
+        label="Rank (optional)"
+        onChange={(e) => onChange(e.target.value)}
+      >
+        <MenuItem value="">
+          <em>None</em>
+        </MenuItem>
+        {TAXON_RANKS.map((r) => (
+          <MenuItem key={r} value={r}>
+            {r}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -1,16 +1,5 @@
 import { useState, useCallback, type FormEvent } from "react";
-import {
-  Box,
-  Typography,
-  Button,
-  Stack,
-  Divider,
-  CircularProgress,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-} from "@mui/material";
+import { Box, Typography, Button, Stack, Divider, CircularProgress } from "@mui/material";
 import CheckIcon from "@mui/icons-material/Check";
 import EditIcon from "@mui/icons-material/Edit";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
@@ -18,13 +7,13 @@ import type { TaxaResult } from "../../services/types";
 import { useSubmitIdentification } from "../../lib/query/mutations";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { TaxonMatchChip } from "../common/TaxonMatchChip";
+import { KingdomSelect } from "../common/KingdomSelect";
+import { RankSelect } from "../common/RankSelect";
 import { VisualIdCards } from "./VisualIdCards";
 import { useVisualId } from "../../hooks/useVisualId";
 import { TaxonLink } from "../common/TaxonLink";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
 import { useToast } from "../../hooks/useToast";
-import { KINGDOMS } from "../../lib/kingdoms";
-import { TAXON_RANKS } from "../../lib/taxonRanks";
 
 interface IdentificationPanelProps {
   observation: {
@@ -260,45 +249,16 @@ export function IdentificationPanel({
           </Stack>
 
           {!!taxonName.trim() && !matchedTaxon && (
-            <FormControl fullWidth margin="normal" required size="small">
-              <InputLabel id="suggest-kingdom-label">Kingdom</InputLabel>
-              <Select
-                labelId="suggest-kingdom-label"
-                value={kingdom}
-                label="Kingdom"
-                onChange={(e) => setKingdom(e.target.value)}
-              >
-                <MenuItem value="">
-                  <em>None</em>
-                </MenuItem>
-                {KINGDOMS.map((k) => (
-                  <MenuItem key={k.value} value={k.value}>
-                    {k.label}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <KingdomSelect
+              idPrefix="suggest-kingdom"
+              value={kingdom}
+              onChange={setKingdom}
+              size="small"
+            />
           )}
 
           {!!taxonName.trim() && !matchedTaxon && (
-            <FormControl fullWidth margin="normal" size="small">
-              <InputLabel id="suggest-rank-label">Rank (optional)</InputLabel>
-              <Select
-                labelId="suggest-rank-label"
-                value={rank}
-                label="Rank (optional)"
-                onChange={(e) => setRank(e.target.value)}
-              >
-                <MenuItem value="">
-                  <em>None</em>
-                </MenuItem>
-                {TAXON_RANKS.map((r) => (
-                  <MenuItem key={r} value={r}>
-                    {r}
-                  </MenuItem>
-                ))}
-              </Select>
-            </FormControl>
+            <RankSelect idPrefix="suggest-rank" value={rank} onChange={setRank} size="small" />
           )}
 
           <Stack

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -39,11 +39,11 @@ import { ModalOverlay } from "./ModalOverlay";
 import { ConfirmDialog } from "../common/ConfirmDialog";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { TaxonMatchChip } from "../common/TaxonMatchChip";
+import { KingdomSelect } from "../common/KingdomSelect";
+import { RankSelect } from "../common/RankSelect";
 import { VisualId } from "../identification/VisualId";
 import { PhotoLightbox } from "../observation/PhotoLightbox";
 import { getErrorMessage, fileToBase64, formatCoordinate } from "../../lib/utils";
-import { KINGDOMS } from "../../lib/kingdoms";
-import { TAXON_RANKS } from "../../lib/taxonRanks";
 import { pickPhotos } from "../../lib/photoPicker";
 import { LICENSE_OPTIONS, DEFAULT_LICENSE } from "../../lib/licenses";
 
@@ -707,51 +707,25 @@ export function UploadModal() {
                 />
 
                 {!!species.trim() && !matchedTaxon && (
-                  <FormControl fullWidth margin="normal" required>
-                    <InputLabel id="kingdom-label">Kingdom</InputLabel>
-                    <Select
-                      labelId="kingdom-label"
-                      value={kingdom}
-                      label="Kingdom"
-                      onChange={(e) => {
-                        setKingdom(e.target.value);
-                        setIsDirty(true);
-                      }}
-                    >
-                      <MenuItem value="">
-                        <em>None</em>
-                      </MenuItem>
-                      {KINGDOMS.map((k) => (
-                        <MenuItem key={k.value} value={k.value}>
-                          {k.label}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
+                  <KingdomSelect
+                    idPrefix="kingdom"
+                    value={kingdom}
+                    onChange={(value) => {
+                      setKingdom(value);
+                      setIsDirty(true);
+                    }}
+                  />
                 )}
 
                 {!!species.trim() && !matchedTaxon && (
-                  <FormControl fullWidth margin="normal">
-                    <InputLabel id="rank-label">Rank (optional)</InputLabel>
-                    <Select
-                      labelId="rank-label"
-                      value={rank}
-                      label="Rank (optional)"
-                      onChange={(e) => {
-                        setRank(e.target.value);
-                        setIsDirty(true);
-                      }}
-                    >
-                      <MenuItem value="">
-                        <em>None</em>
-                      </MenuItem>
-                      {TAXON_RANKS.map((r) => (
-                        <MenuItem key={r} value={r}>
-                          {r}
-                        </MenuItem>
-                      ))}
-                    </Select>
-                  </FormControl>
+                  <RankSelect
+                    idPrefix="rank"
+                    value={rank}
+                    onChange={(value) => {
+                      setRank(value);
+                      setIsDirty(true);
+                    }}
+                  />
                 )}
 
                 <StepNav step={STEP_IDENTIFY} />


### PR DESCRIPTION
## Summary
- `UploadModal.tsx` and `IdentificationPanel.tsx` both rendered identical Kingdom/Rank `FormControl` + `Select` markup (mapping the same `KINGDOMS`/`TAXON_RANKS` lists) for the free-typed-taxon fallback form, shown when a user types a taxon name that doesn't match a known taxon.
- Extracted the duplicated markup into `common/KingdomSelect.tsx` and `common/RankSelect.tsx`, matching the existing `common/` component-extraction pattern used throughout the design-audit history on this repo (e.g. `TaxonMatchChip`, `ProfileStat`, `ExternalLinkIconButton`).
- Each new component takes `value`, `onChange`, optional `size`, and an `idPrefix` so callers can keep distinct `labelId`s when both selects mount more than once on a page. Call sites keep their own `onChange` wrappers (e.g. `UploadModal`'s `setIsDirty` side effect).
- Added Storybook stories for both new components (`Default`, `Selected`, `Small` variants).

## Test plan
- [x] `tsc --noEmit` — clean
- [x] `oxlint frontend/src` — no new warnings (pre-existing warnings unrelated to this change)
- [x] `node scripts/check-stories.mjs` — all components have stories
- [x] `vitest run` — 163 tests passed
- [x] `oxfmt` applied to changed files

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01NUQp94vLSAs9tiW2M77Aen

---
_Generated by [Claude Code](https://claude.ai/code/session_01NUQp94vLSAs9tiW2M77Aen)_