### PR TITLE
design-audit: make LoginModal fullscreen on mobile, matching ConfirmDialog/ModalOverlay

### DIFF
--- a/frontend/src/components/modals/LoginModal.tsx
+++ b/frontend/src/components/modals/LoginModal.tsx
@@ -11,6 +11,8 @@ import {
   Link,
   Alert,
   CircularProgress,
+  useMediaQuery,
+  useTheme,
 } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeLoginModal } from "../../store/uiSlice";
@@ -18,6 +20,8 @@ import { initiateLogin } from "../../services/api";
 
 export function LoginModal() {
   const dispatch = useAppDispatch();
+  const theme = useTheme();
+  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
   const isOpen = useAppSelector((state) => state.ui.loginModalOpen);
   const [handle, setHandle] = useState("");
   const [error, setError] = useState<string | null>(null);
@@ -47,7 +51,7 @@ export function LoginModal() {
   };
 
   return (
-    <Dialog open={isOpen} onClose={handleClose} maxWidth="xs" fullWidth>
+    <Dialog open={isOpen} onClose={handleClose} maxWidth="xs" fullWidth fullScreen={fullScreen}>
       <form onSubmit={handleSubmit}>
         <DialogTitle>Log in</DialogTitle>
         <DialogContent>


### PR DESCRIPTION
## Summary
- `LoginModal` was the only `Dialog` in the app that didn't compute `fullScreen` via `useMediaQuery(theme.breakpoints.down("sm"))`, so on mobile it stayed a small, centered `xs`-width dialog instead of going fullscreen like every other modal (`ConfirmDialog`, `ModalOverlay`/`UploadModal`).
- Since `LoginModal` is the app's login gate — a high-traffic surface — this is a real mobile UX inconsistency, not just a stylistic nit.
- Added the same `useTheme()` + `useMediaQuery(theme.breakpoints.down("sm"))` pattern already used by `ConfirmDialog.tsx` and `ModalOverlay.tsx`, and passed `fullScreen` to the `Dialog`.
- Considered routing `LoginModal` through the shared `ModalOverlay` component instead, but `ModalOverlay` hardcodes an IconButton + `DialogContent`-only shape with no slot for `DialogTitle`/`DialogActions`, so reusing it here would require a larger restructure. The minimal, house-style-consistent fix was preferred for this one-line-of-behavior change.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` — passes clean (no new errors)
- [x] `npm run lint` — no new warnings introduced (pre-existing warnings in unrelated files only)
- [x] `npm run fmt:check` — passes
- [ ] Manual check: open LoginModal on a narrow viewport and confirm it goes fullscreen

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01FCkWTSqvm4hRYVRxJVc8Ei


---
_Generated by [Claude Code](https://claude.ai/code/session_01FCkWTSqvm4hRYVRxJVc8Ei)_