### PR TITLE
fix(upload): enforce the MAX_IMAGES cap across a whole picked batch

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -45,6 +45,7 @@ import { VisualId } from "../identification/VisualId";
 import { PhotoLightbox } from "../observation/PhotoLightbox";
 import { getErrorMessage, fileToBase64, formatCoordinate } from "../../lib/utils";
 import { pickPhotos } from "../../lib/photoPicker";
+import { MAX_IMAGES, vetImageFiles } from "../../lib/imageSelection";
 import { LICENSE_OPTIONS, DEFAULT_LICENSE } from "../../lib/licenses";
 
 const LocationPicker = lazy(() =>
@@ -166,10 +167,6 @@ export function UploadModal() {
   const [discardConfirmOpen, setDiscardConfirmOpen] = useState(false);
   const [lightbox, setLightbox] = useState<{ src: string; alt: string } | null>(null);
 
-  const MAX_IMAGES = 10;
-  const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
-  const VALID_TYPES = ["image/jpeg", "image/png", "image/webp"];
-
   const hasLocation = !!lat && !!lng;
 
   useEffect(() => {
@@ -272,42 +269,41 @@ export function UploadModal() {
   };
 
   const addFiles = (files: File[]) => {
-    for (const file of files) {
-      if (!VALID_TYPES.includes(file.type)) {
-        toast.error(`Invalid file type: ${file.name}. Use JPG, PNG, or WebP.`);
-        continue;
-      }
+    const { accepted, invalidType, tooLarge, exceededCap } = vetImageFiles(files, images.length);
 
-      if (file.size > MAX_FILE_SIZE) {
-        toast.error(`File too large: ${file.name}. Max size is 10MB.`);
-        continue;
-      }
+    for (const file of invalidType) {
+      toast.error(`Invalid file type: ${file.name}. Use JPG, PNG, or WebP.`);
+    }
+    for (const file of tooLarge) {
+      toast.error(`File too large: ${file.name}. Max size is 10MB.`);
+    }
+    if (exceededCap) {
+      toast.error(`Maximum ${MAX_IMAGES} images allowed.`);
+    }
+    if (accepted.length === 0) return;
 
-      if (images.length >= MAX_IMAGES) {
-        toast.error(`Maximum ${MAX_IMAGES} images allowed.`);
-        break;
-      }
+    const isFirstPhoto = images.length === 0;
+    const additions = accepted.map((file) => ({ file, preview: URL.createObjectURL(file) }));
+    setImages((prev) => [...prev, ...additions]);
+    setIsDirty(true);
 
-      const preview = URL.createObjectURL(file);
-      setImages((prev) => [...prev, { file, preview }]);
-      setIsDirty(true);
-
-      if (images.length === 0) {
-        extractExifData(file);
-        if (!species && !isEditMode) {
-          setVisualIdImageUrl(preview);
-        }
+    // Only the observation's very first photo seeds the date/location and the
+    // visual ID; the rest of the batch is just attached.
+    const first = additions[0];
+    if (isFirstPhoto && first) {
+      extractExifData(first.file);
+      if (!species && !isEditMode) {
+        setVisualIdImageUrl(first.preview);
       }
     }
   };
 
   const handlePickImages = async () => {
-    const remaining = MAX_IMAGES - images.length;
-    if (remaining <= 0) {
+    if (images.length >= MAX_IMAGES) {
       toast.error(`Maximum ${MAX_IMAGES} images allowed.`);
       return;
     }
-    const files = await pickPhotos({ multiple: true, maxCount: remaining });
+    const files = await pickPhotos({ multiple: true });
     if (files.length > 0) addFiles(files);
   };
 

--- a/frontend/src/lib/imageSelection.test.ts
+++ b/frontend/src/lib/imageSelection.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { MAX_IMAGES, MAX_FILE_SIZE, vetImageFiles } from "./imageSelection";
+
+function imageFile(name: string, { type = "image/jpeg", size = 1024 } = {}): File {
+  const file = new File([""], name, { type });
+  // Files built in jsdom are empty; fake the size rather than allocating bytes.
+  Object.defineProperty(file, "size", { value: size });
+  return file;
+}
+
+const batchOf = (count: number) =>
+  Array.from({ length: count }, (_, i) => imageFile(`photo-${i}.jpg`));
+
+describe("vetImageFiles", () => {
+  it("accepts a batch that fits under the cap", () => {
+    const result = vetImageFiles(batchOf(3), 0);
+
+    expect(result.accepted).toHaveLength(3);
+    expect(result.exceededCap).toBe(false);
+  });
+
+  it("caps a single oversized batch instead of accepting all of it", () => {
+    // Regression: the cap used to be checked against a render-time
+    // `images.length` that never advanced within one call, so all 15 landed.
+    const result = vetImageFiles(batchOf(15), 0);
+
+    expect(result.accepted).toHaveLength(MAX_IMAGES);
+    expect(result.exceededCap).toBe(true);
+  });
+
+  it("counts photos already attached when computing headroom", () => {
+    const result = vetImageFiles(batchOf(5), MAX_IMAGES - 2);
+
+    expect(result.accepted).toHaveLength(2);
+    expect(result.exceededCap).toBe(true);
+  });
+
+  it("accepts nothing once the observation is already full", () => {
+    const result = vetImageFiles(batchOf(3), MAX_IMAGES);
+
+    expect(result.accepted).toEqual([]);
+    expect(result.exceededCap).toBe(true);
+  });
+
+  it("treats an over-full count as no headroom rather than negative", () => {
+    const result = vetImageFiles(batchOf(3), MAX_IMAGES + 5);
+
+    expect(result.accepted).toEqual([]);
+    expect(result.exceededCap).toBe(true);
+  });
+
+  it("separates out unsupported types without consuming headroom", () => {
+    const files = [imageFile("doc.pdf", { type: "application/pdf" }), ...batchOf(2)];
+
+    const result = vetImageFiles(files, 0);
+
+    expect(result.invalidType.map((f) => f.name)).toEqual(["doc.pdf"]);
+    expect(result.accepted).toHaveLength(2);
+    expect(result.exceededCap).toBe(false);
+  });
+
+  it("separates out files above the size limit", () => {
+    const files = [imageFile("huge.jpg", { size: MAX_FILE_SIZE + 1 }), ...batchOf(1)];
+
+    const result = vetImageFiles(files, 0);
+
+    expect(result.tooLarge.map((f) => f.name)).toEqual(["huge.jpg"]);
+    expect(result.accepted).toHaveLength(1);
+  });
+
+  it("accepts a file sitting exactly on the size limit", () => {
+    const result = vetImageFiles([imageFile("exact.jpg", { size: MAX_FILE_SIZE })], 0);
+
+    expect(result.accepted).toHaveLength(1);
+    expect(result.tooLarge).toEqual([]);
+  });
+
+  it("preserves the picked order among accepted files", () => {
+    const result = vetImageFiles(batchOf(4), 0);
+
+    expect(result.accepted.map((f) => f.name)).toEqual([
+      "photo-0.jpg",
+      "photo-1.jpg",
+      "photo-2.jpg",
+      "photo-3.jpg",
+    ]);
+  });
+
+  it("reports nothing for an empty batch", () => {
+    const result = vetImageFiles([], 0);
+
+    expect(result).toEqual({
+      accepted: [],
+      invalidType: [],
+      tooLarge: [],
+      exceededCap: false,
+    });
+  });
+});

--- a/frontend/src/lib/imageSelection.ts
+++ b/frontend/src/lib/imageSelection.ts
@@ -1,0 +1,59 @@
+// Vetting for photos picked into an observation. Lives here rather than in
+// UploadModal so the cap is enforced against a running count instead of a
+// render-time `images.length`, and so it can be tested without mounting the
+// modal.
+
+/** Most photos one observation can carry. */
+export const MAX_IMAGES = 10;
+
+/** Largest accepted size for a single photo. Mirrors the uploader's own check. */
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+export const VALID_IMAGE_TYPES = ["image/jpeg", "image/png", "image/webp"];
+
+export interface VettedImages {
+  /** Files that passed every check, already trimmed to fit under MAX_IMAGES. */
+  accepted: File[];
+  invalidType: File[];
+  tooLarge: File[];
+  /** True when an otherwise-valid file was dropped to stay within MAX_IMAGES. */
+  exceededCap: boolean;
+}
+
+/**
+ * Split a picked batch into the files that can be added and the ones that
+ * can't, given how many photos the observation already holds.
+ *
+ * Callers pass the whole batch at once: the cap is tracked across the batch,
+ * so selecting 15 files into an empty observation yields 10 accepted rather
+ * than all 15.
+ */
+export function vetImageFiles(files: File[], currentCount: number): VettedImages {
+  const result: VettedImages = {
+    accepted: [],
+    invalidType: [],
+    tooLarge: [],
+    exceededCap: false,
+  };
+  let remaining = Math.max(0, MAX_IMAGES - currentCount);
+
+  for (const file of files) {
+    if (!VALID_IMAGE_TYPES.includes(file.type)) {
+      result.invalidType.push(file);
+      continue;
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      result.tooLarge.push(file);
+      continue;
+    }
+    if (remaining === 0) {
+      // Everything left over is surplus; one "at the limit" message covers it.
+      result.exceededCap = true;
+      break;
+    }
+    result.accepted.push(file);
+    remaining -= 1;
+  }
+
+  return result;
+}

--- a/frontend/src/lib/photoPicker.ts
+++ b/frontend/src/lib/photoPicker.ts
@@ -3,7 +3,6 @@ import { OriginalPhotoPicker } from "capacitor-original-photo-picker";
 
 interface PickPhotosOptions {
   multiple?: boolean;
-  maxCount?: number;
 }
 
 export async function pickPhotos(options: PickPhotosOptions = {}): Promise<File[]> {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9713,9 +9713,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
Closes #685.

## The bug

`addFiles` checked the cap inside its loop:

```ts
if (images.length >= MAX_IMAGES) { ... break; }
```

`images` is the state captured at render and `setImages` is async, so the count never advanced within a single call. Selecting 15 photos into an empty observation read `0` on every iteration, never hit the `break`, and added all 15.

`PickPhotosOptions.maxCount` was meant to be the other half of the guard, but nothing read it — `pickWeb` destructures only `{ multiple }`.

**Third bug, same root cause, one line down:** `if (images.length === 0)` was also true for *every* file in a batch, so `extractExifData` ran once per photo and `visualIdImageUrl` was seeded from the **last** photo rather than the first. Not mentioned in the issue; fixed here since it's the same stale read.

## The design call

The issue asked whether `maxCount` should be applied in `pickWeb` or dropped. **Dropped**, because:

- The hidden `<input multiple>` calls `addFiles` directly and never goes through `pickPhotos`, so the picker can't be the enforcement point regardless.
- Slicing in `pickWeb` would silently discard files; `addFiles` can say why.

That leaves one enforcement point instead of two, covering all three entry paths (picker, file input, pending shared files).

## The change

Vetting moves out of the component into a pure `vetImageFiles(files, currentCount)` in `frontend/src/lib/imageSelection.ts`, which tracks remaining headroom as it walks the batch. `MAX_IMAGES` / `MAX_FILE_SIZE` / `VALID_IMAGE_TYPES` move there with it. Toast wording and ordering-by-reason are unchanged; `addFiles` now also does one batched `setImages` instead of one per file.

Extracting it is what makes the cap testable at all — the logic was previously reachable only by mounting `UploadModal` with Redux + react-query + router.

## Verification

- 10 new tests in `imageSelection.test.ts`; full unit suite passes (173).
- Reintroduced the stale-count bug locally to confirm the tests catch it — 2 failed as expected, then reverted.
- `tsc --noEmit` clean, `fmt:check` clean, `vite build` succeeds.
- `lint` reports 3 `exhaustive-deps` warnings; verified identical on `origin/main` (pre-existing, including the `addFiles` one in this file).

## Reviewer note

Toasts are now grouped by reason (all invalid-type, then all too-large, then one cap message) rather than interleaved in file order. Cosmetic, and arguably better for a mixed batch, but it is a behavior change.
