### PR TITLE
design-audit: align ConservationStatus size prop with house style

### DIFF
--- a/frontend/src/components/common/ConservationStatus.stories.tsx
+++ b/frontend/src/components/common/ConservationStatus.stories.tsx
@@ -19,7 +19,7 @@ const meta = {
     },
     size: {
       control: { type: "radio" },
-      options: ["sm", "md"],
+      options: ["small", "medium"],
     },
   },
 } satisfies Meta<typeof ConservationStatus>;
@@ -52,7 +52,7 @@ export const SmallSize: Story = {
   args: {
     status: { category: "VU", source: "IUCN" },
     showLabel: true,
-    size: "sm",
+    size: "small",
   },
 };
 

--- a/frontend/src/components/common/ConservationStatus.tsx
+++ b/frontend/src/components/common/ConservationStatus.tsx
@@ -10,7 +10,7 @@ interface ConservationStatusProps {
   /** Show full label instead of abbreviation */
   showLabel?: boolean;
   /** Size variant */
-  size?: "sm" | "md";
+  size?: "small" | "medium";
 }
 
 const CATEGORY_INFO: Record<string, { label: string }> = {
@@ -40,7 +40,7 @@ const SOURCE_INFO: Record<string, { name: string; fullName: string }> = {
 export function ConservationStatus({
   status,
   showLabel = false,
-  size = "md",
+  size = "medium",
 }: ConservationStatusProps) {
   const theme = useTheme();
   const info = CATEGORY_INFO[status.category];
@@ -70,7 +70,7 @@ export function ConservationStatus({
     <Tooltip title={tooltipContent} arrow enterTouchDelay={0} leaveTouchDelay={4000}>
       <Chip
         label={showLabel ? info.label : status.category}
-        size={size === "sm" ? "small" : "medium"}
+        size={size}
         sx={{
           backgroundColor: iucnColor,
           color: needsDarkText ? "common.black" : "common.white",
@@ -78,7 +78,7 @@ export function ConservationStatus({
           fontWeight: 600,
           textTransform: "uppercase",
           letterSpacing: "0.025em",
-          fontSize: size === "sm" ? "0.625rem" : "0.75rem",
+          fontSize: size === "small" ? "0.625rem" : "0.75rem",
           cursor: "help",
         }}
       />

--- a/frontend/src/components/common/TaxaAutocompleteView.tsx
+++ b/frontend/src/components/common/TaxaAutocompleteView.tsx
@@ -137,7 +137,7 @@ export function TaxaAutocompleteView({
                     <Chip label="synonym" size="small" variant="outlined" sx={labelChipSx} />
                   )}
                   {option.conservationStatus && (
-                    <ConservationStatus status={option.conservationStatus} size="sm" />
+                    <ConservationStatus status={option.conservationStatus} size="small" />
                   )}
                 </Stack>
                 {option.isSynonym && option.acceptedName && (


### PR DESCRIPTION
## Summary
- `ConservationStatus` accepted a custom `size?: "sm" | "md"` shorthand, mapped internally to MUI's `Chip` size prop.
- Its sibling `common/` components (`TaxaAutocomplete`, `TaxaAutocompleteView`) already use MUI's standard `"small" | "medium"` values directly.
- Renamed `ConservationStatus`'s `size` prop values to `"small" | "medium"` to match the house style, updated the one call site (`TaxaAutocompleteView`), and updated the Storybook controls/story accordingly.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint` on changed files — clean
- [x] `node scripts/check-stories.mjs` — all 92 components have stories
- [x] `npx vitest run` — 163 tests passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01TxKHKQ4dub8anVEakRirze)_