### PR TITLE
design-audit: use shared CenteredSpinner in WikiCommonsGallery

### DIFF
--- a/frontend/src/components/common/WikiCommonsGallery.tsx
+++ b/frontend/src/components/common/WikiCommonsGallery.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
-import { Box, ImageList, ImageListItem, ImageListItemBar, Typography, Link as MuiLink } from "@mui/material";
+import {
+  Box,
+  ImageList,
+  ImageListItem,
+  ImageListItemBar,
+  Typography,
+  Link as MuiLink,
+} from "@mui/material";
 import { CenteredSpinner } from "./CenteredSpinner";
 
 interface CommonsImage {

--- a/frontend/src/components/common/WikiCommonsGallery.tsx
+++ b/frontend/src/components/common/WikiCommonsGallery.tsx
@@ -1,13 +1,6 @@
 import { useEffect, useState } from "react";
-import {
-  Box,
-  ImageList,
-  ImageListItem,
-  ImageListItemBar,
-  Typography,
-  Link as MuiLink,
-  CircularProgress,
-} from "@mui/material";
+import { Box, ImageList, ImageListItem, ImageListItemBar, Typography, Link as MuiLink } from "@mui/material";
+import { CenteredSpinner } from "./CenteredSpinner";
 
 interface CommonsImage {
   thumbUrl: string;
@@ -115,11 +108,7 @@ export function WikiCommonsGallery({ taxonName, limit = 12 }: WikiCommonsGallery
   }, [taxonName, limit]);
 
   if (loading) {
-    return (
-      <Box sx={{ display: "flex", justifyContent: "center", py: 2 }}>
-        <CircularProgress size={24} />
-      </Box>
-    );
+    return <CenteredSpinner p={0} sx={{ py: 2 }} />;
   }
 
   if (images.length === 0) {


### PR DESCRIPTION
## Summary
- `WikiCommonsGallery`'s loading state reimplemented the same `Box{display:flex, justifyContent:center}` + `CircularProgress size={24}` wrapper that `common/CenteredSpinner.tsx` already provides.
- `CenteredSpinner` is the established convention for this pattern, already used by `ProfileView`, `NotificationsPage`, and `FeedView`.
- Swapped the inline duplicate for `<CenteredSpinner p={0} sx={{ py: 2 }} />`, passing `p={0}` to preserve the original `py: 2`-only spacing (CenteredSpinner defaults to `p={4}`, which would have added unwanted horizontal padding).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint src/components/common/WikiCommonsGallery.tsx` — clean
- [x] `node scripts/check-stories.mjs` — all 92 components have stories
- [x] `npx vitest run` — 173 tests passed

---
_Generated by [Claude Code](https://claude.ai/code/session_016Jy8wU9zVADdz1jRGuX4Ko)_