### PR TITLE
design-audit: reuse observationGridCardContentSx in ProfileView identifications tab

### DIFF
--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -21,7 +21,7 @@ import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
 import { UserCard } from "../common/UserCard";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
-import { ObservationGridCard } from "../common/ObservationGridCard";
+import { ObservationGridCard, observationGridCardContentSx } from "../common/ObservationGridCard";
 import { ObservationGridCardSkeleton } from "../common/ObservationGridCardSkeleton";
 import { CenteredSpinner } from "../common/CenteredSpinner";
 import { EmptyState } from "../common/EmptyState";
@@ -204,7 +204,7 @@ export function ProfileView() {
                     {id.scientific_name}
                   </Typography>
                 </Box>
-                <CardContent sx={{ p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 }}>
+                <CardContent sx={observationGridCardContentSx}>
                   <Typography
                     variant="caption"
                     noWrap


### PR DESCRIPTION
## What

`ObservationGridCard.tsx` exports `observationGridCardContentSx` specifically so the `CardContent` padding rule can't drift from the real layout (it's already shared with `ObservationGridCardSkeleton`):

```ts
// Shared with ObservationGridCardSkeleton so the loading placeholder can't drift from the real layout.
export const observationGridCardContentSx = { p: 1.5, "&:last-child": { pb: 1.5 }, flex: 1 };
```

`ProfileView.tsx`'s identifications-tab card hand-copied the exact same literal object instead of importing it. This swaps in the shared constant.

## Why

Pure dedup — the values were already byte-for-byte identical, so this is zero visual risk. `ProfileView.tsx` already imports from `../common/ObservationGridCard` for `ObservationGridCard` itself, so this is a small, tight, reversible change that closes the drift gap the original comment was meant to prevent.

## Test plan

- [x] `tsc --noEmit` passes clean
- [x] `oxlint` clean on changed files
- [x] `vitest run` — all 173 unit tests pass
- [x] `oxfmt` formatting applied

---
_Generated by [Claude Code](https://claude.ai/code/session_01RyA7tbvEnxDqB117SGgnrq)_