### PR TITLE
design-audit: extract shared BrandLockup from TopBar/Sidebar

### DIFF
--- a/frontend/src/components/common/BrandLockup.stories.tsx
+++ b/frontend/src/components/common/BrandLockup.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { BrandLockup } from "./BrandLockup";
+
+const meta = {
+  title: "Common/BrandLockup",
+  component: BrandLockup,
+  parameters: {
+    layout: "centered",
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof BrandLockup>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "The home link used in TopBar and Sidebar: leaf-eye mark (tinted primary) + wordmark.",
+      },
+    },
+  },
+};
+
+export const CompactLogo: Story = {
+  args: {
+    logoSize: 28,
+  },
+  parameters: {
+    docs: {
+      description: {
+        story: "Sidebar sizing — a smaller logo mark than the top bar's.",
+      },
+    },
+  },
+};

--- a/frontend/src/components/common/BrandLockup.tsx
+++ b/frontend/src/components/common/BrandLockup.tsx
@@ -1,0 +1,39 @@
+import { Box, type SxProps, type Theme } from "@mui/material";
+import { Link } from "react-router-dom";
+import { Logo } from "./Logo";
+import { Wordmark } from "./Wordmark";
+
+interface BrandLockupProps {
+  /** Logo mark diameter in pixels (default 32). */
+  logoSize?: number;
+  onClick?: (() => void) | undefined;
+  sx?: SxProps<Theme> | undefined;
+  wordmarkSx?: SxProps<Theme> | undefined;
+}
+
+/**
+ * The app's home link: leaf-eye mark (tinted primary) + wordmark. Shared by
+ * `TopBar` and `Sidebar`, which only differ in logo size, link click handler,
+ * and outer spacing/hover.
+ */
+export function BrandLockup({ logoSize = 32, onClick, sx, wordmarkSx }: BrandLockupProps) {
+  return (
+    <Box
+      component={Link}
+      to="/"
+      onClick={onClick}
+      sx={{
+        display: "flex",
+        alignItems: "center",
+        gap: 1.5,
+        textDecoration: "none",
+        ...sx,
+      }}
+    >
+      <Box sx={{ color: "primary.main", display: "inline-flex" }}>
+        <Logo size={logoSize} />
+      </Box>
+      <Wordmark sx={wordmarkSx} />
+    </Box>
+  );
+}

--- a/frontend/src/components/common/Wordmark.stories.tsx
+++ b/frontend/src/components/common/Wordmark.stories.tsx
@@ -1,7 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-import { Box } from "@mui/material";
 import { Wordmark } from "./Wordmark";
-import { Logo } from "./Logo";
 
 const meta = {
   title: "Common/Wordmark",
@@ -26,20 +24,5 @@ export const Default: Story = {
   },
 };
 
-export const Lockup: Story = {
-  render: () => (
-    <Box sx={{ display: "flex", alignItems: "center", gap: 1.5 }}>
-      <Box sx={{ color: "primary.main", display: "inline-flex" }}>
-        <Logo size={32} />
-      </Box>
-      <Wordmark />
-    </Box>
-  ),
-  parameters: {
-    docs: {
-      description: {
-        story: "The full brand lockup as used in the top bar: leaf-eye mark + wordmark.",
-      },
-    },
-  },
-};
+// The full brand lockup (leaf-eye mark + wordmark) now lives in
+// `BrandLockup`, shared by TopBar and Sidebar — see Common/BrandLockup.

--- a/frontend/src/components/common/Wordmark.tsx
+++ b/frontend/src/components/common/Wordmark.tsx
@@ -2,7 +2,7 @@ import { Box, Typography, type SxProps, type Theme } from "@mui/material";
 
 interface WordmarkProps {
   /** Hide the wordmark text below this breakpoint (icon-only). */
-  sx?: SxProps<Theme>;
+  sx?: SxProps<Theme> | undefined;
 }
 
 // The "Observ.ing" wordmark. Set in DM Sans, weight 600. The dot is the brand

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -10,8 +10,7 @@ import {
   Divider,
 } from "@mui/material";
 import { Login, Logout, MenuBook } from "@mui/icons-material";
-import { Logo } from "../common/Logo";
-import { Wordmark } from "../common/Wordmark";
+import { BrandLockup } from "../common/BrandLockup";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
 
@@ -40,24 +39,7 @@ export function Sidebar({ mobileOpen, onMobileClose, unreadCount }: SidebarProps
 
   const drawerContent = (
     <Box sx={{ display: "flex", flexDirection: "column", height: "100%" }}>
-      {/* Logo */}
-      <Box
-        component={Link}
-        to="/"
-        onClick={onMobileClose}
-        sx={{
-          p: 2.5,
-          display: "flex",
-          alignItems: "center",
-          gap: 1.5,
-          textDecoration: "none",
-        }}
-      >
-        <Box sx={{ color: "primary.main", display: "inline-flex" }}>
-          <Logo size={28} />
-        </Box>
-        <Wordmark />
-      </Box>
+      <BrandLockup logoSize={28} onClick={onMobileClose} sx={{ p: 2.5 }} />
 
       <Divider />
 

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -21,8 +21,7 @@ import {
 } from "@mui/material";
 import { Person, Login, Logout, MenuBook, Settings, Menu as MenuIcon } from "@mui/icons-material";
 import { getDisplayName } from "../../lib/utils";
-import { Logo } from "../common/Logo";
-import { Wordmark } from "../common/Wordmark";
+import { BrandLockup } from "../common/BrandLockup";
 import { UserAvatar } from "../common/UserAvatar";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
@@ -87,24 +86,10 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
               </IconButton>
             )}
 
-            {/* Logo */}
-            <Box
-              component={Link}
-              to="/"
-              sx={{
-                display: "flex",
-                alignItems: "center",
-                gap: 1.5,
-                textDecoration: "none",
-                mr: 2,
-                "&:hover": { opacity: 0.8 },
-              }}
-            >
-              <Box sx={{ color: "primary.main", display: "inline-flex" }}>
-                <Logo size={32} />
-              </Box>
-              <Wordmark sx={{ display: { xs: "none", sm: "block" } }} />
-            </Box>
+            <BrandLockup
+              sx={{ mr: 2, "&:hover": { opacity: 0.8 } }}
+              wordmarkSx={{ display: { xs: "none", sm: "block" } }}
+            />
 
             {/* Desktop Nav */}
             {!isMobile && (


### PR DESCRIPTION
## Summary

- `TopBar` and `Sidebar` each hand-rolled an identical "Link → tinted `Logo` → `Wordmark`" home-link block (same `{ color: "primary.main", display: "inline-flex" }` icon wrapper, same flex-row shape), differing only in logo size, click handler, and outer spacing/hover.
- Extracts a shared `common/BrandLockup` component (logo size, `onClick`, `sx`, `wordmarkSx` all parameterized) and switches both call sites to use it.
- `Wordmark.stories.tsx` already had a `Lockup` story documenting this exact composition without it being a real component — removed that duplicate example now that `BrandLockup` is the real thing, and added `BrandLockup.stories.tsx` in its place.
- Widened `Wordmark`'s `sx` prop type to `SxProps<Theme> | undefined` (matching the existing `CollapsibleSection` convention) so it can be passed through under `exactOptionalPropertyTypes`.

Net effect: centralizes the "what does the app's home link look like" decision in one place and removes ~14 duplicated lines.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — 0 errors
- [x] `npx oxlint frontend/src` — no new warnings (pre-existing warnings unrelated to this change)
- [x] `npx oxfmt --check frontend/src frontend/tests scripts` — passes
- [x] `node scripts/check-stories.mjs` — all components have stories
- [x] `npx vitest run --config frontend/vitest.config.ts` — 173/173 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01KCXAY8p7pXxetC95az2pvX)_