### PR TITLE
design-audit: extract shared ButtonSpinner from 5 duplicated startIcon spinners

### DIFF
--- a/frontend/src/components/common/ButtonSpinner.stories.tsx
+++ b/frontend/src/components/common/ButtonSpinner.stories.tsx
@@ -1,0 +1,29 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "@mui/material";
+import { ButtonSpinner } from "./ButtonSpinner";
+
+const meta = {
+  title: "Common/ButtonSpinner",
+  component: ButtonSpinner,
+  tags: ["autodocs"],
+} satisfies Meta<typeof ButtonSpinner>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Larger: Story = {
+  args: { size: 24 },
+};
+
+export const InButton: Story = {
+  args: {},
+  render: (args) => (
+    <Button variant="contained" disabled startIcon={<ButtonSpinner {...args} />}>
+      Saving...
+    </Button>
+  ),
+};

--- a/frontend/src/components/common/ButtonSpinner.tsx
+++ b/frontend/src/components/common/ButtonSpinner.tsx
@@ -1,0 +1,10 @@
+import { CircularProgress } from "@mui/material";
+
+/**
+ * Small inline spinner for a `Button`'s `startIcon` while an action is
+ * pending — inherits the button's text color so it reads correctly on both
+ * contained and outlined/text variants.
+ */
+export function ButtonSpinner({ size = 16 }: { size?: number }) {
+  return <CircularProgress size={size} color="inherit" />;
+}

--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -6,10 +6,10 @@ import {
   DialogActions,
   Typography,
   Button,
-  CircularProgress,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
+import { ButtonSpinner } from "./ButtonSpinner";
 
 type ConfirmColor = "primary" | "error" | "warning" | "info" | "success" | "inherit";
 
@@ -71,7 +71,7 @@ export function ConfirmDialog({
           color={resolvedConfirmColor}
           variant="contained"
           disabled={pending}
-          startIcon={pending ? <CircularProgress size={16} color="inherit" /> : undefined}
+          startIcon={pending ? <ButtonSpinner /> : undefined}
         >
           {pending ? (pendingLabel ?? confirmLabel) : confirmLabel}
         </Button>

--- a/frontend/src/components/identification/IdentificationPanel.tsx
+++ b/frontend/src/components/identification/IdentificationPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, type FormEvent } from "react";
-import { Box, Typography, Button, Stack, Divider, CircularProgress } from "@mui/material";
+import { Box, Typography, Button, Stack, Divider } from "@mui/material";
 import CheckIcon from "@mui/icons-material/Check";
 import EditIcon from "@mui/icons-material/Edit";
 import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
@@ -14,6 +14,7 @@ import { useVisualId } from "../../hooks/useVisualId";
 import { TaxonLink } from "../common/TaxonLink";
 import { useFormSubmit } from "../../hooks/useFormSubmit";
 import { useToast } from "../../hooks/useToast";
+import { ButtonSpinner } from "../common/ButtonSpinner";
 
 interface IdentificationPanelProps {
   observation: {
@@ -235,11 +236,7 @@ export function IdentificationPanel({
                 onClick={visualId.handleFetch}
                 disabled={isSubmitting || visualId.isLoading}
                 startIcon={
-                  visualId.isLoading ? (
-                    <CircularProgress size={16} color="inherit" />
-                  ) : (
-                    <AutoFixHighIcon fontSize="small" />
-                  )
+                  visualId.isLoading ? <ButtonSpinner /> : <AutoFixHighIcon fontSize="small" />
                 }
                 sx={{ whiteSpace: "nowrap", height: 40 }}
               >

--- a/frontend/src/components/identification/VisualId.tsx
+++ b/frontend/src/components/identification/VisualId.tsx
@@ -3,6 +3,7 @@ import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 import type { SpeciesSuggestion } from "../../services/api";
 import { useVisualId } from "../../hooks/useVisualId";
 import { VisualIdCards, type AncestorSelection } from "./VisualIdCards";
+import { ButtonSpinner } from "../common/ButtonSpinner";
 
 interface VisualIdProps {
   imageUrl: string;
@@ -42,9 +43,7 @@ export function VisualId({
           variant="outlined"
           color="secondary"
           size="small"
-          startIcon={
-            isLoading ? <CircularProgress size={16} color="inherit" /> : <AutoFixHighIcon />
-          }
+          startIcon={isLoading ? <ButtonSpinner /> : <AutoFixHighIcon />}
           onClick={handleFetch}
           disabled={disabled || isLoading}
           fullWidth

--- a/frontend/src/components/modals/LoginModal.tsx
+++ b/frontend/src/components/modals/LoginModal.tsx
@@ -10,13 +10,13 @@ import {
   Box,
   Link,
   Alert,
-  CircularProgress,
   useMediaQuery,
   useTheme,
 } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeLoginModal } from "../../store/uiSlice";
 import { initiateLogin } from "../../services/api";
+import { ButtonSpinner } from "../common/ButtonSpinner";
 
 export function LoginModal() {
   const dispatch = useAppDispatch();
@@ -106,7 +106,7 @@ export function LoginModal() {
             variant="contained"
             color="primary"
             disabled={!handle.trim() || isLoading}
-            startIcon={isLoading ? <CircularProgress size={16} color="inherit" /> : null}
+            startIcon={isLoading ? <ButtonSpinner /> : null}
           >
             {isLoading ? "Connecting..." : "Continue"}
           </Button>

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -37,6 +37,7 @@ import { validateTaxon } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
 import { ConfirmDialog } from "../common/ConfirmDialog";
+import { ButtonSpinner } from "../common/ButtonSpinner";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { TaxonMatchChip } from "../common/TaxonMatchChip";
 import { KingdomSelect } from "../common/KingdomSelect";
@@ -835,9 +836,7 @@ export function UploadModal() {
                     variant="contained"
                     color="primary"
                     disabled={isSubmitting}
-                    startIcon={
-                      isSubmitting ? <CircularProgress size={16} color="inherit" /> : undefined
-                    }
+                    startIcon={isSubmitting ? <ButtonSpinner /> : undefined}
                   >
                     {isSubmitting
                       ? isEditMode


### PR DESCRIPTION
## Summary
- `<CircularProgress size={16} color="inherit" />` was copy-pasted byte-for-byte as a `Button`'s `startIcon` in 5 places: `ConfirmDialog`, `LoginModal`, `UploadModal`, `IdentificationPanel`, and `VisualId`.
- Extracted a new `common/ButtonSpinner` component and swapped all 5 call sites to use it, dropping now-unused `CircularProgress` imports where applicable.
- Left the two unrelated `CircularProgress` usages alone (a `size={24}` `Suspense` fallback overlay in `UploadModal`, and a bare `size={16}` inline status-row spinner in `VisualId`) since they aren't the button-startIcon pattern.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint frontend/src` — no new warnings (pre-existing unrelated `exhaustive-deps` warnings only)
- [x] `npx oxfmt --check frontend/src` — all files correctly formatted
- [x] `node scripts/check-stories.mjs` — all 94 components have stories (added `ButtonSpinner.stories.tsx` with Default/Larger/InButton variants)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RP58P1mpuj4ugitQV7E55N)_