### PR TITLE
design-audit: extract shared LicenseSelect from UploadModal/SettingsPage

### DIFF
--- a/frontend/src/components/common/LicenseSelect.stories.tsx
+++ b/frontend/src/components/common/LicenseSelect.stories.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Box } from "@mui/material";
+import { LicenseSelect } from "./LicenseSelect";
+import { DEFAULT_LICENSE } from "../../lib/licenses";
+
+const meta = {
+  title: "Common/LicenseSelect",
+  component: LicenseSelect,
+  parameters: {
+    layout: "padded",
+  },
+  decorators: [
+    (Story) => (
+      <Box sx={{ width: 320 }}>
+        <Story />
+      </Box>
+    ),
+  ],
+  render: (args) => {
+    const [value, setValue] = useState(args.value);
+    return <LicenseSelect {...args} value={value} onChange={setValue} />;
+  },
+  tags: ["autodocs"],
+} satisfies Meta<typeof LicenseSelect>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    value: DEFAULT_LICENSE,
+    onChange: () => undefined,
+  },
+};
+
+export const WithNoneOption: Story = {
+  args: {
+    value: "__none__",
+    onChange: () => undefined,
+    label: "Default license",
+    noneOption: { value: "__none__", label: "No default (use CC BY)" },
+  },
+};
+
+export const Small: Story = {
+  args: {
+    value: DEFAULT_LICENSE,
+    onChange: () => undefined,
+    size: "small",
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    value: DEFAULT_LICENSE,
+    onChange: () => undefined,
+    disabled: true,
+  },
+};

--- a/frontend/src/components/common/LicenseSelect.tsx
+++ b/frontend/src/components/common/LicenseSelect.tsx
@@ -1,0 +1,50 @@
+import { FormControl, InputLabel, MenuItem, Select, type SelectChangeEvent } from "@mui/material";
+import { LICENSE_OPTIONS } from "../../lib/licenses";
+
+export interface LicenseSelectProps {
+  value: string;
+  onChange: (value: string) => void;
+  label?: string;
+  /** Distinguishes this select's `labelId` when more than one instance mounts at once. */
+  idPrefix?: string;
+  size?: "small" | "medium";
+  disabled?: boolean;
+  margin?: "none" | "dense" | "normal";
+  /** Optional leading sentinel option, e.g. "No default (use CC BY)". */
+  noneOption?: { value: string; label: string };
+}
+
+/**
+ * Creative Commons license dropdown shown wherever a license is picked or
+ * defaulted (upload form, settings preferences).
+ */
+export function LicenseSelect({
+  value,
+  onChange,
+  label = "License",
+  idPrefix = "license",
+  size,
+  disabled,
+  margin = "normal",
+  noneOption,
+}: LicenseSelectProps) {
+  const labelId = `${idPrefix}-label`;
+  return (
+    <FormControl fullWidth margin={margin} size={size} disabled={disabled}>
+      <InputLabel id={labelId}>{label}</InputLabel>
+      <Select
+        labelId={labelId}
+        value={value}
+        label={label}
+        onChange={(e: SelectChangeEvent<string>) => onChange(e.target.value)}
+      >
+        {noneOption && <MenuItem value={noneOption.value}>{noneOption.label}</MenuItem>}
+        {LICENSE_OPTIONS.map((opt) => (
+          <MenuItem key={opt.value} value={opt.value}>
+            {opt.label}
+          </MenuItem>
+        ))}
+      </Select>
+    </FormControl>
+  );
+}

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -42,12 +42,13 @@ import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
 import { TaxonMatchChip } from "../common/TaxonMatchChip";
 import { KingdomSelect } from "../common/KingdomSelect";
 import { RankSelect } from "../common/RankSelect";
+import { LicenseSelect } from "../common/LicenseSelect";
 import { VisualId } from "../identification/VisualId";
 import { PhotoLightbox } from "../observation/PhotoLightbox";
 import { getErrorMessage, fileToBase64, formatCoordinate } from "../../lib/utils";
 import { pickPhotos } from "../../lib/photoPicker";
 import { MAX_IMAGES, vetImageFiles } from "../../lib/imageSelection";
-import { LICENSE_OPTIONS, DEFAULT_LICENSE } from "../../lib/licenses";
+import { DEFAULT_LICENSE } from "../../lib/licenses";
 
 const LocationPicker = lazy(() =>
   import("../map/LocationPicker").then((m) => ({ default: m.LocationPicker })),
@@ -739,24 +740,13 @@ export function UploadModal() {
                 Date &amp; details
               </StepLabel>
               <StepContent>
-                <FormControl fullWidth margin="normal">
-                  <InputLabel id="license-label">License</InputLabel>
-                  <Select
-                    labelId="license-label"
-                    value={license}
-                    label="License"
-                    onChange={(e) => {
-                      setLicense(e.target.value);
-                      setIsDirty(true);
-                    }}
-                  >
-                    {LICENSE_OPTIONS.map((opt) => (
-                      <MenuItem key={opt.value} value={opt.value}>
-                        {opt.label}
-                      </MenuItem>
-                    ))}
-                  </Select>
-                </FormControl>
+                <LicenseSelect
+                  value={license}
+                  onChange={(value) => {
+                    setLicense(value);
+                    setIsDirty(true);
+                  }}
+                />
 
                 <TextField
                   fullWidth

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -4,11 +4,6 @@ import {
   ToggleButtonGroup,
   ToggleButton,
   Paper,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  type SelectChangeEvent,
   type SxProps,
   type Theme,
 } from "@mui/material";
@@ -19,8 +14,8 @@ import { useAppDispatch, useAppSelector } from "../../store";
 import { setThemeMode, type ThemeMode } from "../../store/uiSlice";
 import { useUserPreferences } from "../../lib/query/hooks";
 import { useUpdatePreferences } from "../../lib/query/mutations";
-import { LICENSE_OPTIONS } from "../../lib/licenses";
 import { PageContainer } from "../common/PageContainer";
+import { LicenseSelect } from "../common/LicenseSelect";
 
 const NO_DEFAULT = "__none__";
 
@@ -60,8 +55,7 @@ export function SettingsPage() {
     if (value) dispatch(setThemeMode(value));
   };
 
-  const handleLicenseChange = (e: SelectChangeEvent<string>) => {
-    const raw = e.target.value;
+  const handleLicenseChange = (raw: string) => {
     const next = raw === NO_DEFAULT ? null : raw;
     // The hook applies the change optimistically and rolls back on error.
     updatePrefs.mutate(
@@ -125,22 +119,16 @@ export function SettingsPage() {
           title="Upload defaults"
           description="Pre-fill the license for new observation photos. You can still change it on each upload."
         >
-          <FormControl fullWidth size="small" disabled={updatePrefs.isPending}>
-            <InputLabel id="default-license-label">Default license</InputLabel>
-            <Select
-              labelId="default-license-label"
-              value={defaultLicense ?? NO_DEFAULT}
-              label="Default license"
-              onChange={handleLicenseChange}
-            >
-              <MenuItem value={NO_DEFAULT}>No default (use CC BY)</MenuItem>
-              {LICENSE_OPTIONS.map((opt) => (
-                <MenuItem key={opt.value} value={opt.value}>
-                  {opt.label}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
+          <LicenseSelect
+            value={defaultLicense ?? NO_DEFAULT}
+            onChange={handleLicenseChange}
+            label="Default license"
+            idPrefix="default-license"
+            size="small"
+            margin="none"
+            disabled={updatePrefs.isPending}
+            noneOption={{ value: NO_DEFAULT, label: "No default (use CC BY)" }}
+          />
         </SettingsSection>
       )}
     </PageContainer>


### PR DESCRIPTION
## Summary

- The CC license `FormControl`/`InputLabel`/`Select`/`MenuItem` markup around `LICENSE_OPTIONS` was duplicated identically between `UploadModal`'s details step and `SettingsPage`'s default-license preference.
- Extracted `common/LicenseSelect`, following the same pattern as the existing `KingdomSelect`/`RankSelect` extraction (#772): a `noneOption` prop covers `SettingsPage`'s extra "No default (use CC BY)" sentinel `MenuItem`, and a `margin` prop preserves each call site's original spacing (`UploadModal` used `margin="normal"`, `SettingsPage` had none).
- Added `LicenseSelect.stories.tsx` with Default, WithNoneOption, Small, and Disabled variants.

No behavior or visual change at either call site.

## Test plan

- [x] `npx tsc --noEmit -p tsconfig.json` — clean
- [x] `npm run lint` — no new warnings
- [x] `npm run fmt:check` — clean
- [x] `npm run check:stories` — all components have stories
- [x] `npm run test:unit` — 173 passed

---
_Generated by [Claude Code](https://claude.ai/code/session_01KNJxdgEXuFYjczmUAops1V)_