### PR TITLE
design-audit: reuse shared KingdomSelect in ExploreFilterPanel

### DIFF
--- a/frontend/src/components/common/KingdomSelect.stories.tsx
+++ b/frontend/src/components/common/KingdomSelect.stories.tsx
@@ -47,3 +47,14 @@ export const Small: Story = {
     size: "small",
   },
 };
+
+export const OptionalFilter: Story = {
+  args: {
+    value: "",
+    onChange: () => undefined,
+    size: "small",
+    required: false,
+    emptyOption: { value: "", label: "All Kingdoms" },
+    emptyOptionItalic: false,
+  },
+};

--- a/frontend/src/components/common/KingdomSelect.tsx
+++ b/frontend/src/components/common/KingdomSelect.tsx
@@ -7,16 +7,33 @@ export interface KingdomSelectProps {
   size?: SelectProps["size"];
   /** Distinguishes this select's `labelId` when more than one instance mounts at once. */
   idPrefix?: string;
+  /** Placeholder option's value/label. Defaults to the required-field "None" placeholder. */
+  emptyOption?: { value: string; label: string };
+  /** Italicize the empty option, as for a true placeholder rather than a selectable "all" option. Defaults to true. */
+  emptyOptionItalic?: boolean;
+  /** Whether the field itself is required. Defaults to true, matching the upload/ID-panel usage. */
+  required?: boolean;
+  margin?: "none" | "dense" | "normal";
 }
 
 /**
- * Required "Kingdom" dropdown shown alongside a free-typed taxon name that
- * didn't match a known taxon (upload form, visual-ID suggestion panel).
+ * "Kingdom" dropdown shared by the upload form, visual-ID suggestion panel
+ * (both required, with a "None" placeholder), and the explore feed filter
+ * (optional, with an "All Kingdoms" placeholder).
  */
-export function KingdomSelect({ value, onChange, size, idPrefix = "kingdom" }: KingdomSelectProps) {
+export function KingdomSelect({
+  value,
+  onChange,
+  size,
+  idPrefix = "kingdom",
+  emptyOption = { value: "", label: "None" },
+  emptyOptionItalic = true,
+  required = true,
+  margin = "normal",
+}: KingdomSelectProps) {
   const labelId = `${idPrefix}-label`;
   return (
-    <FormControl fullWidth margin="normal" required size={size}>
+    <FormControl fullWidth margin={margin} required={required} size={size}>
       <InputLabel id={labelId}>Kingdom</InputLabel>
       <Select
         labelId={labelId}
@@ -24,8 +41,8 @@ export function KingdomSelect({ value, onChange, size, idPrefix = "kingdom" }: K
         label="Kingdom"
         onChange={(e) => onChange(e.target.value)}
       >
-        <MenuItem value="">
-          <em>None</em>
+        <MenuItem value={emptyOption.value}>
+          {emptyOptionItalic ? <em>{emptyOption.label}</em> : emptyOption.label}
         </MenuItem>
         {KINGDOMS.map((k) => (
           <MenuItem key={k.value} value={k.value}>

--- a/frontend/src/components/feed/ExploreFilterPanel.tsx
+++ b/frontend/src/components/feed/ExploreFilterPanel.tsx
@@ -1,23 +1,12 @@
 import { useState } from "react";
-import {
-  Box,
-  Typography,
-  TextField,
-  Autocomplete,
-  FormControl,
-  InputLabel,
-  Select,
-  MenuItem,
-  Button,
-  Stack,
-  Chip,
-} from "@mui/material";
+import { Box, Typography, TextField, Autocomplete, Button, Stack, Chip } from "@mui/material";
 import FilterListIcon from "@mui/icons-material/FilterList";
 import ClearIcon from "@mui/icons-material/Clear";
 import VerifiedOutlinedIcon from "@mui/icons-material/VerifiedOutlined";
 import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { countChipSx } from "../common/chipSx";
 import { CollapsibleSection } from "../common/CollapsibleSection";
+import { KingdomSelect } from "../common/KingdomSelect";
 import { TaxonThumbnail } from "../common/TaxonThumbnail";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
 import { AdapterDateFns } from "@mui/x-date-pickers/AdapterDateFns";
@@ -25,10 +14,7 @@ import { useAppDispatch, useAppSelector } from "../../store";
 import { setFilters } from "../../store/feedSlice";
 import type { FeedFilters } from "../../services/types";
 import { useDebouncedTaxaSearch } from "../../hooks/useDebouncedTaxaSearch";
-import { KINGDOMS as KINGDOM_OPTIONS } from "../../lib/kingdoms";
 import { QUALITY_CRITERIA, type QualityCriterion } from "../../lib/qualityCriteria";
-
-const KINGDOMS = [{ value: "", label: "All Kingdoms" }, ...KINGDOM_OPTIONS];
 
 export function ExploreFilterPanel() {
   const dispatch = useAppDispatch();
@@ -159,16 +145,18 @@ export function ExploreFilterPanel() {
       />
 
       {/* Kingdom Dropdown */}
-      <FormControl fullWidth size="small" sx={{ mb: 2 }}>
-        <InputLabel>Kingdom</InputLabel>
-        <Select value={kingdom} label="Kingdom" onChange={(e) => setKingdom(e.target.value)}>
-          {KINGDOMS.map((k) => (
-            <MenuItem key={k.value} value={k.value}>
-              {k.label}
-            </MenuItem>
-          ))}
-        </Select>
-      </FormControl>
+      <Box sx={{ mb: 2 }}>
+        <KingdomSelect
+          idPrefix="explore-kingdom"
+          value={kingdom}
+          onChange={setKingdom}
+          size="small"
+          margin="none"
+          required={false}
+          emptyOption={{ value: "", label: "All Kingdoms" }}
+          emptyOptionItalic={false}
+        />
+      </Box>
 
       {/* Date Range */}
       <LocalizationProvider dateAdapter={AdapterDateFns}>


### PR DESCRIPTION
## Summary
- `ExploreFilterPanel` reimplemented the same `FormControl`/`Select`/`MenuItem` Kingdom dropdown that `common/KingdomSelect` was already extracted to share between `UploadModal` and `IdentificationPanel`, plus its own local `KINGDOMS` array built from `lib/kingdoms`.
- Extended `KingdomSelect` with optional `emptyOption`, `emptyOptionItalic`, `required`, and `margin` props (all defaulting to the existing "required field + italic 'None' placeholder" behavior), so the two existing call sites are unaffected.
- Switched `ExploreFilterPanel` to render `KingdomSelect` with an "All Kingdoms" placeholder (optional, non-italic), removing ~15 lines of duplicated JSX/state and the redundant local `KINGDOMS` const.
- Added a `KingdomSelect.stories.tsx` variant (`OptionalFilter`) covering the new optional/"All Kingdoms" mode.

## Test plan
- [x] `npx tsc -p . --noEmit` — clean
- [x] `npx oxlint` / `npx oxfmt --check` on changed files — clean
- [x] `npx vitest run --config frontend/vitest.config.ts` — 173/173 passing
- [x] `node scripts/check-stories.mjs` — all components have stories


---
_Generated by [Claude Code](https://claude.ai/code/session_014TCELUgb8cUxp5iRFWmqjC)_