### PR TITLE
design-audit: extract shared UserCardSkeleton and glassBlurSx

### DIFF
--- a/frontend/src/components/common/UserCardSkeleton.stories.tsx
+++ b/frontend/src/components/common/UserCardSkeleton.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Skeleton } from "@mui/material";
+import { UserCardSkeleton } from "./UserCardSkeleton";
+
+const meta = {
+  title: "Common/UserCardSkeleton",
+  component: UserCardSkeleton,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    avatarSize: { control: { type: "number" } },
+    nameWidth: { control: { type: "text" } },
+    nameHeight: { control: { type: "number" } },
+    trailingWidth: { control: { type: "text" } },
+    subtitleWidth: { control: { type: "text" } },
+    subtitleHeight: { control: { type: "number" } },
+    spacing: { control: { type: "number" } },
+  },
+} satisfies Meta<typeof UserCardSkeleton>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    nameWidth: "30%",
+  },
+};
+
+export const WithTrailingAndSubtitle: Story = {
+  args: {
+    nameWidth: "30%",
+    trailingWidth: "20%",
+    subtitleWidth: "15%",
+  },
+};
+
+export const WithEndAdornment: Story = {
+  args: {
+    avatarSize: 44,
+    nameWidth: 120,
+    subtitleWidth: 140,
+    endAdornment: <Skeleton variant="circular" width={28} height={28} />,
+  },
+};
+
+export const ProfileHeaderSize: Story = {
+  args: {
+    avatarSize: 80,
+    spacing: 2,
+    nameWidth: 180,
+    nameHeight: 32,
+    subtitleWidth: 120,
+    subtitleHeight: 20,
+  },
+};

--- a/frontend/src/components/common/UserCardSkeleton.tsx
+++ b/frontend/src/components/common/UserCardSkeleton.tsx
@@ -1,0 +1,72 @@
+import type { ReactNode } from "react";
+import { Box, Skeleton, Stack } from "@mui/material";
+import type { SxProps, Theme } from "@mui/material";
+
+export interface UserCardSkeletonProps {
+  /** Avatar diameter in pixels (default 40, matches `UserCard`'s default). */
+  avatarSize?: number;
+  /** Width of the name placeholder line. */
+  nameWidth?: number | string;
+  /** Height of the name placeholder line (default 20). */
+  nameHeight?: number;
+  /**
+   * Width of a placeholder rendered beside the name on the same baseline row
+   * (e.g. a timestamp), matching `UserCard`'s `trailing` slot. Omit to skip.
+   */
+  trailingWidth?: number | string;
+  /** Height of the trailing placeholder (default matches `nameHeight`, capped smaller). */
+  trailingHeight?: number;
+  /**
+   * Width of a placeholder line below the name (e.g. an `@handle`), matching
+   * `UserCard`'s `showHandle`/`belowName` slot. Omit to skip.
+   */
+  subtitleWidth?: number | string;
+  /** Height of the subtitle placeholder line (default 16). */
+  subtitleHeight?: number;
+  /** Content rendered after the text column, e.g. a trailing action button skeleton. */
+  endAdornment?: ReactNode;
+  /** Horizontal spacing between avatar and text column (default 1.5, matches `UserCard`). */
+  spacing?: number;
+  /** `sx` for the outer row Stack. */
+  sx?: SxProps<Theme>;
+}
+
+/**
+ * Avatar + name (+ optional trailing/subtitle) placeholder row matching
+ * `UserCard`'s layout, shared by loading states across feed, observation, and
+ * profile skeletons.
+ */
+export function UserCardSkeleton({
+  avatarSize = 40,
+  nameWidth = "30%",
+  nameHeight = 20,
+  trailingWidth,
+  trailingHeight,
+  subtitleWidth,
+  subtitleHeight = 16,
+  endAdornment,
+  spacing = 1.5,
+  sx,
+}: UserCardSkeletonProps) {
+  return (
+    <Stack direction="row" spacing={spacing} sx={{ alignItems: "center", ...sx }}>
+      <Skeleton variant="circular" width={avatarSize} height={avatarSize} />
+      <Box sx={{ flex: 1, minWidth: 0 }}>
+        <Stack direction="row" spacing={1} sx={{ alignItems: "baseline", flexWrap: "wrap" }}>
+          <Skeleton variant="text" width={nameWidth} height={nameHeight} />
+          {trailingWidth != null && (
+            <Skeleton
+              variant="text"
+              width={trailingWidth}
+              height={trailingHeight ?? subtitleHeight}
+            />
+          )}
+        </Stack>
+        {subtitleWidth != null && (
+          <Skeleton variant="text" width={subtitleWidth} height={subtitleHeight} />
+        )}
+      </Box>
+      {endAdornment}
+    </Stack>
+  );
+}

--- a/frontend/src/components/common/layoutSx.ts
+++ b/frontend/src/components/common/layoutSx.ts
@@ -10,6 +10,19 @@ export const detailHeaderSx = {
 } as const;
 
 /**
+ * Frosted "glass" backdrop shared by sticky/translucent surfaces (the app's
+ * `TopBar` and detail-page `stickyHeaderSx`): a blurred pane with a
+ * bottom divider. Callers add their own `backgroundColor`/`bgcolor` (each
+ * surface derives its translucency from a different palette source) and
+ * positioning/`zIndex`.
+ */
+export const glassBlurSx = {
+  backdropFilter: "blur(8px)",
+  borderBottom: 1,
+  borderColor: "divider",
+} as const;
+
+/**
  * Sticky, blurred "glass" header for detail pages: pins to the top of a
  * scrolling pane with a translucent backdrop derived from the page background,
  * so content scrolls under it. Mode-aware via the theme palette.
@@ -20,12 +33,10 @@ export const stickyHeaderSx: SxProps<Theme> = {
   zIndex: 3,
   px: { xs: 2, sm: 4 },
   py: 1.25,
-  borderBottom: 1,
-  borderColor: "divider",
+  ...glassBlurSx,
   display: "flex",
   alignItems: "center",
   backgroundColor: (theme) => alpha(theme.palette.background.default, 0.86),
-  backdropFilter: "blur(8px)",
 };
 
 /**

--- a/frontend/src/components/feed/FeedItemSkeleton.tsx
+++ b/frontend/src/components/feed/FeedItemSkeleton.tsx
@@ -1,4 +1,5 @@
-import { Box, Card, Skeleton, Stack } from "@mui/material";
+import { Box, Card, Skeleton } from "@mui/material";
+import { UserCardSkeleton } from "../common/UserCardSkeleton";
 import { FEED_CARD_SX, FEED_IMAGE_MAX_HEIGHT } from "./feedLayout";
 
 /**
@@ -8,22 +9,14 @@ export function FeedItemSkeleton() {
   return (
     <Card sx={FEED_CARD_SX}>
       {/* CardHeader: avatar, name/handle, timestamp */}
-      <Box sx={{ display: "flex", gap: 1, p: 2 }}>
-        <Skeleton variant="circular" width={40} height={40} />
-        <Box sx={{ flex: 1, minWidth: 0 }}>
-          <Stack
-            direction="row"
-            spacing={1}
-            sx={{
-              alignItems: "baseline",
-              flexWrap: "wrap",
-            }}
-          >
-            <Skeleton variant="text" width="30%" height={20} />
-            <Skeleton variant="text" width="20%" height={16} />
-          </Stack>
-          <Skeleton variant="text" width="15%" height={16} />
-        </Box>
+      <Box sx={{ p: 2 }}>
+        <UserCardSkeleton
+          avatarSize={40}
+          spacing={1}
+          nameWidth="30%"
+          trailingWidth="20%"
+          subtitleWidth="15%"
+        />
       </Box>
       {/* Image */}
       <Skeleton variant="rectangular" height={FEED_IMAGE_MAX_HEIGHT} />

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -26,6 +26,7 @@ import { UserAvatar } from "../common/UserAvatar";
 import { useNavigation } from "../../hooks/useNavigation";
 import { getNavItems } from "./NavConfig";
 import { PendingIndicator } from "./PendingIndicator";
+import { glassBlurSx } from "../common/layoutSx";
 
 interface TopBarProps {
   onMobileMenuClick: () => void;
@@ -64,10 +65,8 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
       elevation={0}
       sx={{
         bgcolor: (theme) => alpha(theme.palette.background.paper, 0.8),
-        backdropFilter: "blur(8px)",
+        ...glassBlurSx,
         color: "text.primary",
-        borderBottom: 1,
-        borderColor: "divider",
         zIndex: theme.zIndex.drawer + 1,
       }}
     >

--- a/frontend/src/components/observation/ObservationDetailSkeleton.tsx
+++ b/frontend/src/components/observation/ObservationDetailSkeleton.tsx
@@ -1,5 +1,6 @@
 import { Box, Divider, Skeleton } from "@mui/material";
 import { DetailHeaderSkeleton } from "../common/DetailHeaderSkeleton";
+import { UserCardSkeleton } from "../common/UserCardSkeleton";
 
 /**
  * Skeleton loader matching observation detail page layout
@@ -18,13 +19,13 @@ export function ObservationDetailSkeleton() {
       <Divider sx={{ mx: 3 }} />
 
       {/* Observer + date with like control */}
-      <Box sx={{ display: "flex", alignItems: "center", gap: 1.5, px: 3, pt: 1.5, pb: 1.5 }}>
-        <Skeleton variant="circular" width={44} height={44} />
-        <Box sx={{ flex: 1 }}>
-          <Skeleton variant="text" width={120} height={20} />
-          <Skeleton variant="text" width={140} height={16} />
-        </Box>
-        <Skeleton variant="circular" width={28} height={28} />
+      <Box sx={{ px: 3, pt: 1.5, pb: 1.5 }}>
+        <UserCardSkeleton
+          avatarSize={44}
+          nameWidth={120}
+          subtitleWidth={140}
+          endAdornment={<Skeleton variant="circular" width={28} height={28} />}
+        />
       </Box>
 
       {/* Image */}

--- a/frontend/src/components/profile/ProfileHeaderSkeleton.tsx
+++ b/frontend/src/components/profile/ProfileHeaderSkeleton.tsx
@@ -1,4 +1,5 @@
 import { Box, Skeleton, Stack } from "@mui/material";
+import { UserCardSkeleton } from "../common/UserCardSkeleton";
 import { PROFILE_HEADER_SX, PROFILE_STAT_BOX_SX, PROFILE_AVATAR_SIZE } from "./profileLayout";
 
 /**
@@ -7,19 +8,14 @@ import { PROFILE_HEADER_SX, PROFILE_STAT_BOX_SX, PROFILE_AVATAR_SIZE } from "./p
 export function ProfileHeaderSkeleton() {
   return (
     <Box sx={PROFILE_HEADER_SX}>
-      <Stack
-        direction="row"
+      <UserCardSkeleton
+        avatarSize={PROFILE_AVATAR_SIZE}
         spacing={2}
-        sx={{
-          alignItems: "center",
-        }}
-      >
-        <Skeleton variant="circular" width={PROFILE_AVATAR_SIZE} height={PROFILE_AVATAR_SIZE} />
-        <Box>
-          <Skeleton variant="text" width={180} height={32} />
-          <Skeleton variant="text" width={120} height={20} />
-        </Box>
-      </Stack>
+        nameWidth={180}
+        nameHeight={32}
+        subtitleWidth={120}
+        subtitleHeight={20}
+      />
       <Stack direction="row" spacing={2} sx={{ mt: 2 }}>
         {[1, 2, 3].map((i) => (
           <Box key={i} sx={PROFILE_STAT_BOX_SX}>


### PR DESCRIPTION
## Summary

**1. `common/UserCardSkeleton`** — `FeedItemSkeleton`, `ObservationDetailSkeleton`, and `ProfileHeaderSkeleton` each hand-rolled the same "avatar + name (+ trailing/subtitle)" placeholder row that `common/UserCard.tsx` already defines as the canonical shape used across real (non-loading) feed/observation/profile/comment/notification views.
- Extracted `common/UserCardSkeleton`, mirroring `UserCard`'s DOM shape and prop conventions (`avatarSize`, `spacing`, a baseline-row `trailingWidth` slot matching `UserCard`'s `trailing`, and a below-name `subtitleWidth` slot matching `showHandle`/`belowName`), plus an `endAdornment` slot for a trailing action control rendered outside the text column (used by `ObservationDetailSkeleton`'s like-button placeholder).
- Switched all three call sites to use it — this follows the same pattern as the existing `DetailHeaderSkeleton` extraction (#738), which solved the analogous "avatar + title" duplication between `ObservationDetailSkeleton` and `TaxonDetailSkeleton`.
- Added `UserCardSkeleton.stories.tsx` with variants covering the default shape, trailing + subtitle, an end adornment, and the larger profile-header sizing.

**2. `common/glassBlurSx`** — `TopBar`'s `AppBar` and `common/layoutSx`'s `stickyHeaderSx` each hand-wrote the same `backdropFilter: "blur(8px)"` + bottom-divider pair for their translucent "glass" surfaces, independently.
- Centralized that shared subset into a new `glassBlurSx` mixin; each caller keeps its own background-alpha source (`background.paper` vs `background.default`) and positioning/`zIndex`, since those genuinely differ per surface.

No visual or behavioral change at any call site in either change — same widths/heights/spacing/colors as before, just centralized.

## Test plan
- [x] `npx tsc -p tsconfig.json --noEmit` — clean
- [x] `npx oxlint frontend/src` — no new warnings
- [x] `npx oxfmt --check frontend/src frontend/tests scripts` — clean
- [x] `node scripts/check-stories.mjs` — all 96 components have stories
- [x] `npx vitest run --config frontend/vitest.config.ts` — 173/173 passing