### PR TITLE
design-audit: standardize lazy Suspense fallbacks on shared CenteredSpinner

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,7 +1,7 @@
 import { lazy, Suspense, useEffect, useMemo, useState } from "react";
 import { BrowserRouter, Routes, Route, useLocation } from "react-router-dom";
 import { Provider } from "react-redux";
-import { ThemeProvider, CssBaseline, Box, Alert, CircularProgress } from "@mui/material";
+import { ThemeProvider, CssBaseline, Box, Alert } from "@mui/material";
 import { getTheme } from "./theme";
 import { store, useAppDispatch, useAppSelector } from "./store";
 import { checkAuth } from "./store/authSlice";
@@ -18,6 +18,7 @@ import { DeleteConfirmDialog } from "./components/modals/DeleteConfirmDialog";
 import { FAB } from "./components/common/FAB";
 import { ToastContainer } from "./components/common/Toast";
 import { ErrorBoundary } from "./components/common/ErrorBoundary";
+import { CenteredSpinner } from "./components/common/CenteredSpinner";
 import { OfflineBanner } from "./components/common/OfflineBanner";
 import { UpdatePrompt } from "./components/common/UpdatePrompt";
 import { QueryProvider } from "./lib/query/QueryProvider";
@@ -141,15 +142,7 @@ function AppContent() {
         }}
       >
         <ErrorBoundary resetKey={location.pathname}>
-          <Suspense
-            fallback={
-              <Box
-                sx={{ flex: 1, display: "flex", alignItems: "center", justifyContent: "center" }}
-              >
-                <CircularProgress />
-              </Box>
-            }
-          >
+          <Suspense fallback={<CenteredSpinner sx={{ flex: 1, alignItems: "center" }} />}>
             <Routes>
               <Route path="/" element={showLanding ? <LandingPage /> : <FeedView tab="home" />} />
               <Route path="/explore" element={<FeedView tab="explore" />} />

--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -12,7 +12,6 @@ import {
   Button,
   Stack,
   IconButton,
-  CircularProgress,
   FormControl,
   InputLabel,
   Select,
@@ -36,6 +35,7 @@ import { useSubmitObservation, useUpdateObservation } from "../../lib/query/muta
 import { validateTaxon } from "../../services/api";
 import type { TaxaResult } from "../../services/types";
 import { ModalOverlay } from "./ModalOverlay";
+import { CenteredSpinner } from "../common/CenteredSpinner";
 import { ConfirmDialog } from "../common/ConfirmDialog";
 import { ButtonSpinner } from "../common/ButtonSpinner";
 import { TaxaAutocomplete } from "../common/TaxaAutocomplete";
@@ -613,16 +613,7 @@ export function UploadModal() {
               <StepContent>
                 <Suspense
                   fallback={
-                    <Box
-                      sx={{
-                        height: 260,
-                        display: "flex",
-                        alignItems: "center",
-                        justifyContent: "center",
-                      }}
-                    >
-                      <CircularProgress size={24} />
-                    </Box>
+                    <CenteredSpinner size={24} sx={{ height: 260, alignItems: "center" }} />
                   }
                 >
                   <LocationPicker

--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -38,6 +38,7 @@ import { DataQualitySection } from "./DataQualitySection";
 import { UserCard } from "../common/UserCard";
 import { Section, SectionHeader } from "../common/Section";
 import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
+import { CenteredSpinner } from "../common/CenteredSpinner";
 import { formatEventDate, buildOccurrenceAtUri, getErrorMessage } from "../../lib/utils";
 import { getLicenseLabel } from "../../lib/licenses";
 
@@ -380,7 +381,11 @@ export function ObservationDetail() {
                 </ListItem>
                 {observation.location && (
                   <Box sx={{ mt: 1 }}>
-                    <Suspense fallback={<Box sx={{ height: 180 }} />}>
+                    <Suspense
+                      fallback={
+                        <CenteredSpinner size={24} sx={{ height: 180, alignItems: "center" }} />
+                      }
+                    >
                       <LocationMap
                         latitude={observation.location.latitude}
                         longitude={observation.location.longitude}


### PR DESCRIPTION
## Summary

- `App.tsx`, `UploadModal.tsx`, and `ObservationDetail.tsx` each hand-rolled their own flex-centered `CircularProgress` box for lazy-loaded route/component `Suspense` fallbacks, instead of reusing the existing `common/CenteredSpinner.tsx`.
- `ObservationDetail`'s `LocationMap` fallback had no spinner at all — just a blank 180px box while the map chunk loads, a genuine loading-state gap.
- Replaced all three with `<CenteredSpinner sx={{...}} />`, matching the pattern already used in `ProfileView.tsx`, `WikiCommonsGallery.tsx`, `NotificationsPage.tsx`, and `FeedView.tsx`.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `oxlint` shows no new warnings
- [x] `oxfmt --check` passes
- [x] `vitest run` — 173/173 tests pass


---
_Generated by [Claude Code](https://claude.ai/code/session_014zQszQosvj8VJGzFhZwKxB)_