### PR TITLE
design-audit: reuse shared FullPageStatus in ObservationDetail/TaxonExplorer/ProfileView

### DIFF
--- a/frontend/src/components/observation/ObservationDetail.tsx
+++ b/frontend/src/components/observation/ObservationDetail.tsx
@@ -18,6 +18,7 @@ import ArrowBackIcon from "@mui/icons-material/ArrowBack";
 import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import MyLocationIcon from "@mui/icons-material/MyLocation";
 import NumbersIcon from "@mui/icons-material/Numbers";
+import SearchOffIcon from "@mui/icons-material/SearchOff";
 import { getImageUrl } from "../../services/api";
 import { useAppSelector, useAppDispatch } from "../../store";
 import { usePageTitle } from "../../hooks/usePageTitle";
@@ -39,6 +40,8 @@ import { UserCard } from "../common/UserCard";
 import { Section, SectionHeader } from "../common/Section";
 import { RecordOverflowMenu } from "../common/RecordOverflowMenu";
 import { CenteredSpinner } from "../common/CenteredSpinner";
+import { FullPageStatus } from "../common/FullPageStatus";
+import { fullPageStatusSecondaryActionSx } from "../common/layoutSx";
 import { formatEventDate, buildOccurrenceAtUri, getErrorMessage } from "../../lib/utils";
 import { getLicenseLabel } from "../../lib/licenses";
 
@@ -110,14 +113,16 @@ export function ObservationDetail() {
   if (!observation) {
     return (
       <Box sx={{ flex: 1, overflow: "auto" }}>
-        <Container maxWidth="md" sx={{ p: 4, textAlign: "center" }}>
-          <Typography color="error" sx={{ mb: 2 }}>
-            {!atUri ? "No observation URI provided" : "Observation not found"}
-          </Typography>
-          <Button variant="outlined" onClick={handleBack}>
-            Go Back
-          </Button>
-        </Container>
+        <FullPageStatus
+          icon={<SearchOffIcon />}
+          title={atUri ? "Observation not found" : "No observation URI provided"}
+          description="It may have been deleted, or the link you followed is incorrect."
+          actions={
+            <Button variant="outlined" onClick={handleBack} sx={fullPageStatusSecondaryActionSx}>
+              Go Back
+            </Button>
+          }
+        />
       </Box>
     );
   }

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -16,6 +16,7 @@ import OpenInNewIcon from "@mui/icons-material/OpenInNew";
 import CameraAltIcon from "@mui/icons-material/CameraAlt";
 import FingerprintIcon from "@mui/icons-material/Fingerprint";
 import GrassIcon from "@mui/icons-material/Grass";
+import SearchOffIcon from "@mui/icons-material/SearchOff";
 import { useProfileFeed } from "../../lib/query/hooks";
 import { getObservationUrl } from "../../lib/utils";
 import { RelativeTime } from "../common/RelativeTime";
@@ -25,6 +26,8 @@ import { ObservationGridCard, observationGridCardContentSx } from "../common/Obs
 import { ObservationGridCardSkeleton } from "../common/ObservationGridCardSkeleton";
 import { CenteredSpinner } from "../common/CenteredSpinner";
 import { EmptyState } from "../common/EmptyState";
+import { FullPageStatus } from "../common/FullPageStatus";
+import { fullPageStatusSecondaryActionSx } from "../common/layoutSx";
 import { ProfileHeaderSkeleton } from "./ProfileHeaderSkeleton";
 import { ProfileIdentificationCardSkeleton } from "./ProfileIdentificationCardSkeleton";
 import { ProfileStat } from "./ProfileStat";
@@ -53,25 +56,39 @@ export function ProfileView() {
 
   if (!did) {
     return (
-      <Container maxWidth="md" sx={{ p: 4 }}>
-        <Typography
-          sx={{
-            color: "text.secondary",
-          }}
-        >
-          Profile not found
-        </Typography>
-      </Container>
+      <FullPageStatus
+        icon={<SearchOffIcon />}
+        title="Profile not found"
+        description="No profile identifier was provided."
+        actions={
+          <Button
+            variant="outlined"
+            onClick={() => window.history.back()}
+            sx={fullPageStatusSecondaryActionSx}
+          >
+            Go Back
+          </Button>
+        }
+      />
     );
   }
 
   if (error) {
     return (
-      <Container maxWidth="md" sx={{ p: 4 }}>
-        <Typography color="error">
-          {error instanceof Error ? error.message : "Failed to load profile"}
-        </Typography>
-      </Container>
+      <FullPageStatus
+        icon={<SearchOffIcon />}
+        title="Unable to load profile"
+        description={error instanceof Error ? error.message : "Failed to load profile."}
+        actions={
+          <Button
+            variant="outlined"
+            onClick={() => window.history.back()}
+            sx={fullPageStatusSecondaryActionSx}
+          >
+            Go Back
+          </Button>
+        }
+      />
     );
   }
 

--- a/frontend/src/components/taxon/TaxonExplorer.tsx
+++ b/frontend/src/components/taxon/TaxonExplorer.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useParams, useNavigate } from "react-router-dom";
-import { Box, Container, Typography, Button, Drawer } from "@mui/material";
+import { Box, Button, Drawer } from "@mui/material";
+import SearchOffIcon from "@mui/icons-material/SearchOff";
 import type { TreeViewDefaultItemModelProperties } from "@mui/x-tree-view";
 import { fetchTaxonChildren } from "../../services/api";
 import type { TaxonDetail, TaxaResult } from "../../services/types";
@@ -11,6 +12,8 @@ import { useWikidataThumbnails } from "../../hooks/useWikidataThumbnails";
 import { TaxonDetailPanel } from "./TaxonDetailPanel";
 import { TaxonTreePanel } from "./TaxonTreePanel";
 import { TaxonDetailSkeleton } from "./TaxonDetailSkeleton";
+import { FullPageStatus } from "../common/FullPageStatus";
+import { fullPageStatusSecondaryActionSx } from "../common/layoutSx";
 
 const TREE_WIDTH = 312;
 
@@ -416,14 +419,16 @@ export function TaxonExplorer() {
 
   if (error || !taxon) {
     return (
-      <Container maxWidth="md" sx={{ p: 4, textAlign: "center" }}>
-        <Typography color="error" sx={{ mb: 2 }}>
-          {error || "Taxon not found"}
-        </Typography>
-        <Button variant="outlined" onClick={handleBack}>
-          Go Back
-        </Button>
-      </Container>
+      <FullPageStatus
+        icon={<SearchOffIcon />}
+        title="Taxon not found"
+        description={error || "It may have been removed, or the link you followed is incorrect."}
+        actions={
+          <Button variant="outlined" onClick={handleBack} sx={fullPageStatusSecondaryActionSx}>
+            Go Back
+          </Button>
+        }
+      />
     );
   }
 


### PR DESCRIPTION
## Summary

- `common/FullPageStatus.tsx` was extracted for the icon + heading + copy + action-row "not found / error" layout, but it was only wired into `NotFound.tsx` and `ErrorBoundary.tsx`. Three detail views kept hand-rolling their own near-identical `Container`/`Typography`/`Button` version instead of reusing it.
- `ObservationDetail.tsx` and `TaxonExplorer.tsx` had byte-for-byte identical `Container` blocks (`p: 4, textAlign: "center"`) for their not-found states.
- `ProfileView.tsx`'s two error states had no icon and, more notably, no action button at all — a real UX gap compared to the other detail pages, which the shared component's required `actions` prop now fixes.
- Replaced all four call sites with `FullPageStatus`, reusing the same `SearchOffIcon` and `fullPageStatusSecondaryActionSx` styling already established by `NotFound`/`ErrorBoundary`.
- Dropped now-unused `Container`/`Typography` imports from `TaxonExplorer.tsx`.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `oxlint` shows no new warnings
- [x] `oxfmt --check` passes
- [x] `vitest run` — 173/173 tests pass
- [x] `vite build` succeeds

---
_Generated by [Claude Code](https://claude.ai/code/session_01LK1MmHqhsUZJg5rkrdBbpy)_