### PR TITLE
design-audit: centralize MuiToggleButton textTransform in theme

### DIFF
--- a/frontend/src/components/map/LocationPicker.tsx
+++ b/frontend/src/components/map/LocationPicker.tsx
@@ -364,7 +364,7 @@ export function LocationPicker({
         size="small"
         onClick={() => setShowCoordinates((v) => !v)}
         endIcon={showCoordinates ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-        sx={{ mt: 1, textTransform: "none", color: "text.secondary" }}
+        sx={{ mt: 1, color: "text.secondary" }}
       >
         {showCoordinates ? "Hide coordinates" : "Enter coordinates manually"}
       </Button>

--- a/frontend/src/components/settings/SettingsPage.tsx
+++ b/frontend/src/components/settings/SettingsPage.tsx
@@ -94,7 +94,6 @@ export function SettingsPage() {
               px: 3,
               py: 1,
               gap: 1,
-              textTransform: "none",
               fontWeight: 500,
             },
           }}

--- a/frontend/src/components/taxon/TaxonDescriptionSection.tsx
+++ b/frontend/src/components/taxon/TaxonDescriptionSection.tsx
@@ -63,11 +63,7 @@ export function TaxonDescriptionSection({ descriptions, sx }: TaxonDescriptionSe
           )}
         </Box>
       ))}
-      <Button
-        size="small"
-        onClick={() => setExpanded((v) => !v)}
-        sx={{ mt: 1, textTransform: "none" }}
-      >
+      <Button size="small" onClick={() => setExpanded((v) => !v)} sx={{ mt: 1 }}>
         {expanded ? "Show less" : "Read more"}
       </Button>
     </CollapsibleSection>

--- a/frontend/src/theme/index.ts
+++ b/frontend/src/theme/index.ts
@@ -202,6 +202,13 @@ const createAppTheme = (mode: PaletteMode): Theme => {
           },
         },
       },
+      MuiToggleButton: {
+        styleOverrides: {
+          root: {
+            textTransform: "none",
+          },
+        },
+      },
       // Every ListItemButton in the app (nav rows, notification rows) rounds
       // its corners the same way — centralized here instead of repeating
       // `borderRadius: 2` at each call site.


### PR DESCRIPTION
## Summary

- `MuiButton` and `MuiTab` already get `textTransform: "none"` centralized in the theme, but `ToggleButton` didn't — `SettingsPage.tsx`'s theme-mode `ToggleButtonGroup` had to set it manually via a `.MuiToggleButton-root` selector.
- Added a `MuiToggleButton` styleOverride to the theme, matching the existing `MuiButton`/`MuiTab` pattern, and removed the now-unnecessary override in `SettingsPage.tsx`.
- Also removed two `textTransform: "none"` sx props on plain `Button`s (`TaxonDescriptionSection.tsx`, `LocationPicker.tsx`) that were already redundant with the existing `MuiButton` theme override — dead code that happened to sit next to the real fix.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `oxlint` shows no new warnings
- [x] `oxfmt --check` passes
- [x] `vitest run` — 173/173 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRK7jFi6vpgJiHZx7V4eP6)_