### PR TITLE
design-audit: wire aria-haspopup/controls/expanded on all menu triggers

### DIFF
--- a/frontend/src/components/common/RecordOverflowMenu.tsx
+++ b/frontend/src/components/common/RecordOverflowMenu.tsx
@@ -57,20 +57,26 @@ export function RecordOverflowMenu({
   return (
     <>
       <IconButton
+        id="record-overflow-menu-button"
         size="small"
         onClick={handleOpen}
         aria-label="More options"
+        aria-haspopup="true"
+        aria-controls={open ? "record-overflow-menu" : undefined}
+        aria-expanded={open ? "true" : undefined}
         sx={{ color: "text.disabled", ...sx }}
       >
         <MoreVertIcon fontSize="small" />
       </IconButton>
       <Menu
+        id="record-overflow-menu"
         anchorEl={anchorEl}
         open={open}
         onClose={handleClose}
         onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
         anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
         transformOrigin={{ vertical: "top", horizontal: "right" }}
+        slotProps={{ list: { "aria-labelledby": "record-overflow-menu-button" } }}
       >
         {onEdit && (
           <MenuItem

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -153,9 +153,13 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
             ) : user ? (
               <>
                 <IconButton
+                  id="account-menu-button"
                   onClick={handleProfileMenuOpen}
                   sx={{ p: 0.5 }}
                   aria-label="Account menu"
+                  aria-haspopup="true"
+                  aria-controls={anchorEl ? "account-menu" : undefined}
+                  aria-expanded={anchorEl ? "true" : undefined}
                 >
                   <UserAvatar
                     did={user.did}
@@ -167,11 +171,13 @@ export function TopBar({ onMobileMenuClick, unreadCount }: TopBarProps) {
                   />
                 </IconButton>
                 <Menu
+                  id="account-menu"
                   anchorEl={anchorEl}
                   open={Boolean(anchorEl)}
                   onClose={handleProfileMenuClose}
                   onClick={handleProfileMenuClose}
                   slotProps={{
+                    list: { "aria-labelledby": "account-menu-button" },
                     paper: {
                       elevation: 4,
                       sx: {

--- a/frontend/src/components/map/BasemapSelector.tsx
+++ b/frontend/src/components/map/BasemapSelector.tsx
@@ -12,13 +12,18 @@ import { useBasemap } from "./useBasemap";
 export function BasemapSelector() {
   const [basemap, setBasemap] = useBasemap();
   const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
+  const open = Boolean(anchorEl);
 
   return (
     <>
       <Tooltip title="Basemap">
         <IconButton
+          id="basemap-selector-button"
           size="small"
           aria-label="Choose basemap"
+          aria-haspopup="true"
+          aria-controls={open ? "basemap-selector-menu" : undefined}
+          aria-expanded={open ? "true" : undefined}
           onClick={(e) => setAnchorEl(e.currentTarget)}
           sx={{
             position: "absolute",
@@ -34,7 +39,13 @@ export function BasemapSelector() {
           <LayersIcon fontSize="small" />
         </IconButton>
       </Tooltip>
-      <Menu anchorEl={anchorEl} open={Boolean(anchorEl)} onClose={() => setAnchorEl(null)}>
+      <Menu
+        id="basemap-selector-menu"
+        anchorEl={anchorEl}
+        open={open}
+        onClose={() => setAnchorEl(null)}
+        slotProps={{ list: { "aria-labelledby": "basemap-selector-button" } }}
+      >
         {BASEMAPS.map((b) => (
           <MenuItem
             key={b.id}


### PR DESCRIPTION
## Summary
- The three `IconButton`s in the app that open a `Menu` — the account menu (`TopBar`), the record overflow menu (`RecordOverflowMenu`), and the basemap selector (`BasemapSelector`) — each had an `aria-label` but were missing the `aria-haspopup`/`aria-controls`/`aria-expanded` wiring that MUI's own [Menu docs](https://mui.com/material-ui/react-menu/#basics) prescribe for accessible menu triggers.
- Without this, screen readers don't announce these buttons as menu triggers or reflect the menu's open/closed state.
- Added matching `id`/`aria-controls`/`aria-haspopup`/`aria-expanded` on each trigger button and `id`/`slotProps.list["aria-labelledby"]` on each corresponding `Menu`, consistently across all three.

## Test plan
- [x] `npx tsc --noEmit` — no new errors in touched files
- [x] `npx oxlint` on touched files — clean
- [x] `npx oxfmt --check` on touched files — clean
- [x] `npx vitest run` — 173/173 tests pass
- [x] `npx storybook build` — builds successfully, including `TopBar.stories.tsx`, `RecordOverflowMenu.stories.tsx`, and `BasemapSelector.stories.tsx`


---
_Generated by [Claude Code](https://claude.ai/code/session_01S5Wuq21bMPPad3qtiwY1Nw)_