### PR TITLE
design-audit: make CollapsibleSection headers keyboard-accessible

### DIFF
--- a/frontend/src/components/common/CollapsibleSection.tsx
+++ b/frontend/src/components/common/CollapsibleSection.tsx
@@ -51,7 +51,7 @@ export function CollapsibleSection({
       <SectionHeader
         onClick={toggle}
         expanded={expanded}
-        aria-label={typeof title === "string" ? title : undefined}
+        {...(typeof title === "string" ? { "aria-label": title } : {})}
         {...(icon != null ? { icon } : {})}
         title={title}
         sx={{ mb: expanded ? 1.5 : 0 }}

--- a/frontend/src/components/common/CollapsibleSection.tsx
+++ b/frontend/src/components/common/CollapsibleSection.tsx
@@ -50,6 +50,7 @@ export function CollapsibleSection({
     <Section sx={sx}>
       <SectionHeader
         onClick={toggle}
+        expanded={expanded}
         {...(icon != null ? { icon } : {})}
         title={title}
         sx={{ mb: expanded ? 1.5 : 0 }}

--- a/frontend/src/components/common/CollapsibleSection.tsx
+++ b/frontend/src/components/common/CollapsibleSection.tsx
@@ -51,6 +51,7 @@ export function CollapsibleSection({
       <SectionHeader
         onClick={toggle}
         expanded={expanded}
+        aria-label={typeof title === "string" ? title : undefined}
         {...(icon != null ? { icon } : {})}
         title={title}
         sx={{ mb: expanded ? 1.5 : 0 }}

--- a/frontend/src/components/common/Section.tsx
+++ b/frontend/src/components/common/Section.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { KeyboardEvent, ReactNode } from "react";
 import { Box, Paper, Stack, Typography } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material";
 
@@ -39,6 +39,8 @@ export interface SectionHeaderProps {
   trailing?: ReactNode;
   /** When set the whole header row becomes clickable (used by collapsibles). */
   onClick?: () => void;
+  /** Whether the section this header controls is currently expanded (for `aria-expanded`). */
+  expanded?: boolean;
   /** Extra `sx` merged onto the header row (e.g. bottom spacing). */
   sx?: SxProps<Theme>;
 }
@@ -47,12 +49,34 @@ export interface SectionHeaderProps {
  * Icon + title (+ optional right-aligned trailing slot) row used as the header
  * of each {@link Section}.
  */
-export function SectionHeader({ icon, title, trailing, onClick, sx }: SectionHeaderProps) {
+export function SectionHeader({
+  icon,
+  title,
+  trailing,
+  onClick,
+  expanded,
+  sx,
+}: SectionHeaderProps) {
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      onClick?.();
+    }
+  };
+
   return (
     <Stack
       direction="row"
       spacing={1}
-      {...(onClick ? { onClick } : {})}
+      {...(onClick
+        ? {
+            onClick,
+            role: "button",
+            tabIndex: 0,
+            "aria-expanded": expanded,
+            onKeyDown: handleKeyDown,
+          }
+        : {})}
       sx={{
         alignItems: "center",
         ...(onClick ? { cursor: "pointer", userSelect: "none" } : {}),

--- a/frontend/src/components/common/Section.tsx
+++ b/frontend/src/components/common/Section.tsx
@@ -41,6 +41,12 @@ export interface SectionHeaderProps {
   onClick?: () => void;
   /** Whether the section this header controls is currently expanded (for `aria-expanded`). */
   expanded?: boolean;
+  /**
+   * Explicit accessible name for the header button. When provided it overrides
+   * the name that would otherwise be computed from the button's content
+   * (including any nested `aria-label` on the expand-toggle chevron).
+   */
+  "aria-label"?: string;
   /** Extra `sx` merged onto the header row (e.g. bottom spacing). */
   sx?: SxProps<Theme>;
 }
@@ -55,6 +61,7 @@ export function SectionHeader({
   trailing,
   onClick,
   expanded,
+  "aria-label": ariaLabel,
   sx,
 }: SectionHeaderProps) {
   const handleKeyDown = (event: KeyboardEvent) => {
@@ -74,6 +81,7 @@ export function SectionHeader({
             role: "button",
             tabIndex: 0,
             "aria-expanded": expanded,
+            ...(ariaLabel != null ? { "aria-label": ariaLabel } : {}),
             onKeyDown: handleKeyDown,
           }
         : {})}


### PR DESCRIPTION
## Summary

- `SectionHeader`'s clickable variant (used as the toggle header for every `CollapsibleSection`) rendered as a plain `Stack` with `onClick` + `cursor: pointer` — no `role`, `tabIndex`, keyboard handler, or `aria-expanded`. Mouse-only, despite a visible chevron implying interactivity.
- This one component backs `CollapsibleSection`, used by ~7 consumers app-wide: `DataQualitySection`, `ExploreFilterPanel`, `TaxonReferencesSection`, `TaxonMediaSection`, `TaxonDescriptionSection`, plus others — so the gap affected keyboard/screen-reader users across the whole expand/collapse pattern.
- Added `role="button"`, `tabIndex={0}`, an `onKeyDown` handler for Enter/Space, and threaded an `expanded` prop through from `CollapsibleSection`'s toggle state to set `aria-expanded`.

## Test plan

- [x] `tsc --noEmit` passes
- [x] `oxlint` shows no new warnings
- [x] `oxfmt --check` passes
- [x] `vitest run` — 173/173 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_01LJ1mzwGAQzRANVeE5zmy6c)_