### PR TITLE
fix(explore): make the entire collapsible section header clickable

### DIFF
--- a/frontend/src/components/common/CollapsibleSection.tsx
+++ b/frontend/src/components/common/CollapsibleSection.tsx
@@ -1,8 +1,27 @@
 import { useState, type ReactNode } from "react";
-import { Collapse } from "@mui/material";
+import { Box, Collapse } from "@mui/material";
 import type { SxProps, Theme } from "@mui/material/styles";
-import { Section, SectionHeader } from "./Section";
+import { Section, SectionHeader, SECTION_PADDING } from "./Section";
 import { ExpandToggleButton } from "./ExpandToggleButton";
+
+// The toggle target is the same box whether open or closed: the header row
+// bleeds out to fill the card's full width and padding (negative top/side
+// margins to the edges, matching padding to put the content back), giving a
+// click area and hover highlight the size of the collapsed card. `borderRadius`
+// matches the card so the highlight is a rounded rectangle in both states; the
+// card's `overflow: hidden` clips its top corners flush to the card edge. There
+// is deliberately no negative *bottom* margin: the row's own bottom padding is
+// the full click target down to the body, and nothing overlaps it. The card
+// drops its own bottom padding (`pb: 0` below) so the row still fills the card
+// when collapsed, and the body supplies that padding back when expanded.
+const headerSx: SxProps<Theme> = {
+  mt: -SECTION_PADDING,
+  mx: -SECTION_PADDING,
+  p: SECTION_PADDING,
+  borderRadius: 2,
+  transition: (theme) => theme.transitions.create("background-color"),
+  "&:hover": { bgcolor: "action.hover" },
+};
 
 interface CollapsibleSectionProps {
   title: ReactNode;
@@ -47,12 +66,12 @@ export function CollapsibleSection({
   };
 
   return (
-    <Section sx={sx}>
+    <Section sx={{ overflow: "hidden", pb: 0, ...sx }}>
       <SectionHeader
         onClick={toggle}
         {...(icon != null ? { icon } : {})}
         title={title}
-        sx={{ mb: expanded ? 1.5 : 0 }}
+        sx={headerSx}
         trailing={
           <>
             {trailing}
@@ -61,7 +80,15 @@ export function CollapsibleSection({
         }
       />
       <Collapse in={expanded} unmountOnExit>
-        {children}
+        {/*
+          All of the expanded-only spacing lives here, inside the one element
+          whose height MUI animates, so open/close is a single smooth height
+          transition with no margin step on the header. `pt` is the gap between
+          the header and the body; `pb` is the card's bottom padding, which the
+          card itself drops (`pb: 0` above) so the collapsed card stays tight
+          around the header.
+        */}
+        <Box sx={{ pt: 1.5, pb: SECTION_PADDING }}>{children}</Box>
       </Collapse>
     </Section>
   );

--- a/frontend/src/components/common/Section.tsx
+++ b/frontend/src/components/common/Section.tsx
@@ -9,6 +9,13 @@ export interface SectionProps {
 }
 
 /**
+ * Padding (in theme spacing units) applied inside every {@link Section} card.
+ * Exported so a collapsible header can bleed its click target out to the card
+ * edges with a matching negative margin.
+ */
+export const SECTION_PADDING = 2.5;
+
+/**
  * Bordered card wrapper shared by the observation detail sections (Details,
  * Data quality, Identification history, Discussion) so they read as peers
  * instead of each defining its own Paper styling.
@@ -18,7 +25,7 @@ export function Section({ children, sx }: SectionProps) {
     <Paper
       elevation={0}
       sx={{
-        p: 2.5,
+        p: SECTION_PADDING,
         bgcolor: "background.paper",
         borderRadius: 2,
         border: 1,
@@ -52,6 +59,10 @@ export function SectionHeader({ icon, title, trailing, onClick, sx }: SectionHea
     <Stack
       direction="row"
       spacing={1}
+      // Space children with `gap` rather than sibling margins so the trailing
+      // slot's `ml: "auto"` can push it to the right edge instead of being
+      // overridden by the spacing rule.
+      useFlexGap
       {...(onClick ? { onClick } : {})}
       sx={{
         alignItems: "center",


### PR DESCRIPTION
The Filters panel on Explore (and every other CollapsibleSection) only toggled when the click landed on the header row itself, leaving the card's 2.5-unit padding as a dead zone around it. Bleed the header out to the card edges with matching negative margins so the whole card toggles the section, and add an action.hover background so the hit area is visible.

Also switch SectionHeader's Stack to useFlexGap so the trailing slot's `ml: "auto"` actually right-aligns the count chip / chevron instead of being overridden by the sibling-margin spacing rule.