### PR TITLE
design-audit: make ExploreTable rows keyboard-accessible

### DIFF
--- a/frontend/src/components/feed/ExploreTable.tsx
+++ b/frontend/src/components/feed/ExploreTable.tsx
@@ -1,4 +1,4 @@
-import { memo } from "react";
+import { memo, type KeyboardEvent } from "react";
 import { useNavigate } from "react-router-dom";
 import {
   Paper,
@@ -110,10 +110,25 @@ const ExploreTableRow = memo(function ExploreTableRow({
       ? [obs.organismQuantity, obs.organismQuantityType].filter(Boolean).join(" ")
       : "—";
 
+  const url = getObservationUrl(obs.uri);
+  const open = () => navigate(url);
+  const handleKeyDown = (e: KeyboardEvent<HTMLTableRowElement>) => {
+    // Rows are <tr>s, not native links/buttons, so Enter/Space activation
+    // has to be wired up by hand to match the `role="link"` below.
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      open();
+    }
+  };
+
   return (
     <TableRow
       hover
-      onClick={() => navigate(getObservationUrl(obs.uri))}
+      onClick={open}
+      onKeyDown={handleKeyDown}
+      tabIndex={0}
+      role="link"
+      aria-label={`View observation of ${sciName}`}
       sx={{ cursor: "pointer", "& td": { whiteSpace: "nowrap" } }}
     >
       <TableCell sx={{ p: 0.5 }}>


### PR DESCRIPTION
## Summary
- `ExploreTable` rows are the only way to open an observation from the Explore feed's table view, but they were rendered as a plain `<TableRow onClick>` — a `<tr>` with no `tabIndex`, ARIA role, or keyboard handler, so keyboard-only users couldn't activate them.
- This is the one place in the app that deviates from the established "clickable card" convention used elsewhere (e.g. `ObservationGridCard`'s `CardActionArea` + `Link`, which gets keyboard support for free from a real `<a>`). A `<tr>` can't be swapped for an anchor without breaking table semantics, so the row now gets `role="link"`, `tabIndex={0}`, an `aria-label`, and an `onKeyDown` handler that activates on Enter/Space, matching the semantics a native link would provide.

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npm run lint` — no new warnings (pre-existing warnings in unrelated files only)
- [x] `npx oxfmt --check frontend/src/components/feed/ExploreTable.tsx` — formatted
- [x] `npm run test:unit` — 173/173 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FDtqss4RQAFiZxVKgTuFcF

---
_Generated by [Claude Code](https://claude.ai/code/session_01FDtqss4RQAFiZxVKgTuFcF)_