### PR TITLE
design-audit: make LexiconView def headers keyboard-accessible

### DIFF
--- a/frontend/src/components/lexicon/LexiconView.tsx
+++ b/frontend/src/components/lexicon/LexiconView.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, type KeyboardEvent } from "react";
 import { usePageTitle } from "../../hooks/usePageTitle";
 import {
   Box,
@@ -216,13 +216,26 @@ function DefSection({ name, def }: { name: string; def: LexiconDef }) {
   const properties = def.record?.properties ?? def.properties;
   const required = def.record?.required ?? def.required;
 
+  const toggle = () => setOpen((prev) => !prev);
+  const handleKeyDown = (event: KeyboardEvent) => {
+    if (event.key === "Enter" || event.key === " ") {
+      event.preventDefault();
+      toggle();
+    }
+  };
+
   if (!properties) return null;
 
   return (
     <Box sx={{ mt: 2 }}>
       <Box
-        sx={{ display: "flex", alignItems: "center", cursor: "pointer" }}
-        onClick={() => setOpen(!open)}
+        sx={{ display: "flex", alignItems: "center", cursor: "pointer", userSelect: "none" }}
+        onClick={toggle}
+        role="button"
+        tabIndex={0}
+        aria-expanded={open}
+        aria-label={`#${name}`}
+        onKeyDown={handleKeyDown}
       >
         <ExpandToggleButton expanded={open} />
         <Typography variant="subtitle2" component="code" sx={{ fontFamily: monoStack }}>


### PR DESCRIPTION
## Summary
- `DefSection`'s clickable header (in `LexiconView.tsx`, the Lexicon/docs page) toggled its expand/collapse `Collapse` via a plain `<Box onClick>`, with no `role`, `tabIndex`, `aria-expanded`, or keyboard handler — so it couldn't be reached or activated via keyboard, and the nested `ExpandToggleButton` (a real, focusable `<button>` with no `onClick` of its own) was a dead stop for keyboard/screen-reader users.
- Brings it in line with the `role="button"` / `tabIndex={0}` / `aria-expanded` / Enter-Space `onKeyDown` pattern already established one commit ago in `common/Section.tsx`'s `SectionHeader` (used by `CollapsibleSection` sitewide), which `DefSection` had missed since it hand-rolls its header instead of reusing that shared component (its multi-chip layout — type/key chips inline with the code name — doesn't fit `SectionHeader`'s single-title slot cleanly).
- This affects every definition rendered per lexicon schema on the Lexicons page (dozens across project + external schemas).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint frontend/src` — no new warnings (pre-existing warnings only, none in the touched file)
- [x] `npx oxfmt --check` on the changed file — correctly formatted
- [ ] Manual keyboard check in Storybook/browser (not run in this session)


---
_Generated by [Claude Code](https://claude.ai/code/session_01DZxS6GLFEVS6ULEn8XsUR3)_