### PR TITLE
design-audit: extract shared useMobileFullScreen hook

### DIFF
--- a/frontend/src/components/common/ConfirmDialog.tsx
+++ b/frontend/src/components/common/ConfirmDialog.tsx
@@ -6,10 +6,9 @@ import {
   DialogActions,
   Typography,
   Button,
-  useMediaQuery,
-  useTheme,
 } from "@mui/material";
 import { ButtonSpinner } from "./ButtonSpinner";
+import { useMobileFullScreen } from "../../hooks/useMobileFullScreen";
 
 type ConfirmColor = "primary" | "error" | "warning" | "info" | "success" | "inherit";
 
@@ -47,8 +46,7 @@ export function ConfirmDialog({
   pending = false,
   pendingLabel,
 }: ConfirmDialogProps) {
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const fullScreen = useMobileFullScreen();
 
   const resolvedConfirmColor: ConfirmColor = confirmColor ?? (destructive ? "error" : "primary");
 

--- a/frontend/src/components/modals/LoginModal.tsx
+++ b/frontend/src/components/modals/LoginModal.tsx
@@ -10,18 +10,16 @@ import {
   Box,
   Link,
   Alert,
-  useMediaQuery,
-  useTheme,
 } from "@mui/material";
 import { useAppDispatch, useAppSelector } from "../../store";
 import { closeLoginModal } from "../../store/uiSlice";
 import { initiateLogin } from "../../services/api";
 import { ButtonSpinner } from "../common/ButtonSpinner";
+import { useMobileFullScreen } from "../../hooks/useMobileFullScreen";
 
 export function LoginModal() {
   const dispatch = useAppDispatch();
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const fullScreen = useMobileFullScreen();
   const isOpen = useAppSelector((state) => state.ui.loginModalOpen);
   const [handle, setHandle] = useState("");
   const [error, setError] = useState<string | null>(null);

--- a/frontend/src/components/modals/ModalOverlay.tsx
+++ b/frontend/src/components/modals/ModalOverlay.tsx
@@ -1,6 +1,7 @@
 import type { ReactNode } from "react";
-import { Dialog, DialogContent, IconButton, useMediaQuery, useTheme } from "@mui/material";
+import { Dialog, DialogContent, IconButton } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
+import { useMobileFullScreen } from "../../hooks/useMobileFullScreen";
 
 interface ModalOverlayProps {
   open: boolean;
@@ -10,8 +11,7 @@ interface ModalOverlayProps {
 }
 
 export function ModalOverlay({ open, onClose, children, maxWidth = "sm" }: ModalOverlayProps) {
-  const theme = useTheme();
-  const fullScreen = useMediaQuery(theme.breakpoints.down("sm"));
+  const fullScreen = useMobileFullScreen();
 
   return (
     <Dialog

--- a/frontend/src/hooks/useMobileFullScreen.ts
+++ b/frontend/src/hooks/useMobileFullScreen.ts
@@ -1,0 +1,11 @@
+import { useMediaQuery, useTheme } from "@mui/material";
+
+/**
+ * Whether a Dialog should render fullscreen at the current viewport size —
+ * the `sm` breakpoint, shared by every modal so they switch to fullscreen
+ * together.
+ */
+export function useMobileFullScreen(): boolean {
+  const theme = useTheme();
+  return useMediaQuery(theme.breakpoints.down("sm"));
+}


### PR DESCRIPTION
## Summary
- `ModalOverlay`, `ConfirmDialog`, and `LoginModal` each independently derived whether their `Dialog` should go fullscreen via `useTheme()` + `useMediaQuery(theme.breakpoints.down("sm"))`.
- Extracted a shared `useMobileFullScreen()` hook (`frontend/src/hooks/useMobileFullScreen.ts`) and switched all three call sites to use it, so the breakpoint stays in sync across all modals instead of being copy-pasted.
- No behavior change — same breakpoint, same fullscreen logic.

## Test plan
- [x] `tsc --noEmit` passes
- [x] `oxlint` passes on changed files
- [x] `oxfmt --check` passes on changed files
- [x] `vitest run` — 173 tests pass

---
_Generated by [Claude Code](https://claude.ai/code/session_016MR1MTCazy5U38TBiYBGhe)_