### PR TITLE
design-audit: make UploadModal step headers keyboard-accessible

### DIFF
--- a/frontend/src/components/modals/UploadModal.tsx
+++ b/frontend/src/components/modals/UploadModal.tsx
@@ -18,7 +18,7 @@ import {
   MenuItem,
   Stepper,
   Step,
-  StepLabel,
+  StepButton,
   StepContent,
   useTheme,
 } from "@mui/material";
@@ -540,13 +540,12 @@ export function UploadModal() {
           <Stepper activeStep={activeStep} orientation="vertical" nonLinear>
             {/* Step 1 — Photos (optional) */}
             <Step completed={photoCount > 0}>
-              <StepLabel
+              <StepButton
                 optional={<Typography variant="caption">{stepSummaries[STEP_PHOTOS]}</Typography>}
                 onClick={() => setActiveStep(STEP_PHOTOS)}
-                sx={{ cursor: "pointer" }}
               >
                 Photos
-              </StepLabel>
+              </StepButton>
               <StepContent>
                 {photoCount > 0 && (
                   <Stack direction="row" spacing={1} sx={{ mb: 1, flexWrap: "wrap", gap: 1 }}>
@@ -602,14 +601,20 @@ export function UploadModal() {
 
             {/* Step 2 — Location (required) */}
             <Step completed={hasLocation}>
-              <StepLabel
-                error={activeStep > STEP_LOCATION && !hasLocation}
+              <StepButton
                 optional={<Typography variant="caption">{stepSummaries[STEP_LOCATION]}</Typography>}
                 onClick={() => setActiveStep(STEP_LOCATION)}
-                sx={{ cursor: "pointer" }}
+                sx={
+                  activeStep > STEP_LOCATION && !hasLocation
+                    ? {
+                        "& .MuiStepLabel-label": { color: "error.main" },
+                        "& .MuiStepIcon-root": { color: "error.main" },
+                      }
+                    : undefined
+                }
               >
                 Location
-              </StepLabel>
+              </StepButton>
               <StepContent>
                 <Suspense
                   fallback={
@@ -633,13 +638,12 @@ export function UploadModal() {
 
             {/* Step 3 — Identify (optional) */}
             <Step completed={!!species.trim()}>
-              <StepLabel
+              <StepButton
                 optional={<Typography variant="caption">{stepSummaries[STEP_IDENTIFY]}</Typography>}
                 onClick={() => setActiveStep(STEP_IDENTIFY)}
-                sx={{ cursor: "pointer" }}
               >
                 Identify
-              </StepLabel>
+              </StepButton>
               <StepContent>
                 <TaxaAutocomplete
                   value={species}
@@ -723,13 +727,12 @@ export function UploadModal() {
 
             {/* Step 4 — Details + submit */}
             <Step completed={false}>
-              <StepLabel
+              <StepButton
                 optional={<Typography variant="caption">{stepSummaries[STEP_DETAILS]}</Typography>}
                 onClick={() => setActiveStep(STEP_DETAILS)}
-                sx={{ cursor: "pointer" }}
               >
                 Date &amp; details
-              </StepLabel>
+              </StepButton>
               <StepContent>
                 <LicenseSelect
                   value={license}


### PR DESCRIPTION
## Summary
- `UploadModal`'s vertical `Stepper` (Photos → Location → Identify → Date & details) let users jump between steps by attaching `onClick` to each `StepLabel`, but `StepLabel` renders a plain `div` — no `tabIndex`, keyboard handling, or focus ring, so step-jumping only worked for mouse users.
- Swapped all four steps from `StepLabel` to MUI's `StepButton`, the documented primitive for non-linear steppers (it wraps the label in a real `ButtonBase`/`<button>`), restoring keyboard and screen-reader operability with no custom key-handling code needed.
- `StepButton` doesn't forward `StepLabel`'s `error` prop (verified against the MUI 9.0.1 source), so the Location step's "you skipped a required step" red styling now applies via an `sx` override on the same `.MuiStepLabel-label` / `.MuiStepIcon-root` classes instead, preserving the original visual behavior.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `oxlint` / `oxfmt --check` on the changed file — no new warnings, correctly formatted
- [x] `vite build` — succeeds
- [x] Loaded the `Modals/UploadModal` Storybook story in headless Chromium: all 4 steps render as native `<button>` elements; focusing the "Location" step and pressing <kbd>Enter</kbd> switches the active step (previously impossible via keyboard)

🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01PZCirZFBULKDBnnoTnTXb1

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZCirZFBULKDBnnoTnTXb1)_