### PR TITLE
design-audit: centralize ProfileStat icon styling as statIconSx

### DIFF
--- a/frontend/src/components/profile/ProfileStat.stories.tsx
+++ b/frontend/src/components/profile/ProfileStat.stories.tsx
@@ -18,7 +18,7 @@ export const Observations: Story = {
   args: {
     count: 24,
     color: "primary.main",
-    icon: <CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />,
+    icon: CameraAltIcon,
     label: "Observations",
   },
 };
@@ -27,7 +27,7 @@ export const Identifications: Story = {
   args: {
     count: 51,
     color: "secondary.main",
-    icon: <FingerprintIcon sx={{ fontSize: 14, color: "text.secondary" }} />,
+    icon: FingerprintIcon,
     label: "IDs",
   },
 };
@@ -36,7 +36,7 @@ export const Species: Story = {
   args: {
     count: 18,
     color: "success.main",
-    icon: <GrassIcon sx={{ fontSize: 14, color: "text.secondary" }} />,
+    icon: GrassIcon,
     label: "Species",
   },
 };
@@ -45,29 +45,14 @@ export const Row: Story = {
   args: {
     count: 24,
     color: "primary.main",
-    icon: <CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />,
+    icon: CameraAltIcon,
     label: "Observations",
   },
   render: () => (
     <Stack direction="row" spacing={2}>
-      <ProfileStat
-        count={24}
-        color="primary.main"
-        icon={<CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
-        label="Observations"
-      />
-      <ProfileStat
-        count={51}
-        color="secondary.main"
-        icon={<FingerprintIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
-        label="IDs"
-      />
-      <ProfileStat
-        count={18}
-        color="success.main"
-        icon={<GrassIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
-        label="Species"
-      />
+      <ProfileStat count={24} color="primary.main" icon={CameraAltIcon} label="Observations" />
+      <ProfileStat count={51} color="secondary.main" icon={FingerprintIcon} label="IDs" />
+      <ProfileStat count={18} color="success.main" icon={GrassIcon} label="Species" />
     </Stack>
   ),
 };

--- a/frontend/src/components/profile/ProfileStat.tsx
+++ b/frontend/src/components/profile/ProfileStat.tsx
@@ -1,18 +1,18 @@
-import type { ReactElement } from "react";
+import type SvgIcon from "@mui/material/SvgIcon";
 import { Box, Stack, Typography } from "@mui/material";
-import { PROFILE_STAT_BOX_SX } from "./profileLayout";
+import { PROFILE_STAT_BOX_SX, PROFILE_STAT_ICON_SX } from "./profileLayout";
 
 interface ProfileStatProps {
   count: number;
   color: string;
-  icon: ReactElement;
+  icon: typeof SvgIcon;
   label: string;
 }
 
 /**
  * Single stat box (count + icon + label) used in the profile header stats row.
  */
-export function ProfileStat({ count, color, icon, label }: ProfileStatProps) {
+export function ProfileStat({ count, color, icon: Icon, label }: ProfileStatProps) {
   return (
     <Box sx={PROFILE_STAT_BOX_SX}>
       <Typography variant="h6" component="span" sx={{ fontWeight: 700, color }}>
@@ -27,7 +27,7 @@ export function ProfileStat({ count, color, icon, label }: ProfileStatProps) {
           mt: 0.5,
         }}
       >
-        {icon}
+        <Icon sx={PROFILE_STAT_ICON_SX} />
         <Typography variant="caption" sx={{ color: "text.secondary" }}>
           {label}
         </Typography>

--- a/frontend/src/components/profile/ProfileView.tsx
+++ b/frontend/src/components/profile/ProfileView.tsx
@@ -123,19 +123,19 @@ export function ProfileView() {
               <ProfileStat
                 count={counts.observations}
                 color="primary.main"
-                icon={<CameraAltIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+                icon={CameraAltIcon}
                 label="Observations"
               />
               <ProfileStat
                 count={counts.identifications}
                 color="secondary.main"
-                icon={<FingerprintIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+                icon={FingerprintIcon}
                 label="IDs"
               />
               <ProfileStat
                 count={counts.species}
                 color="success.main"
-                icon={<GrassIcon sx={{ fontSize: 14, color: "text.secondary" }} />}
+                icon={GrassIcon}
                 label="Species"
               />
             </Stack>

--- a/frontend/src/components/profile/profileLayout.ts
+++ b/frontend/src/components/profile/profileLayout.ts
@@ -17,5 +17,11 @@ export const PROFILE_STAT_BOX_SX: SxProps<Theme> = {
   px: 1,
 };
 
+/** Small secondary-colored icon styling used by ProfileStat */
+export const PROFILE_STAT_ICON_SX: SxProps<Theme> = {
+  fontSize: 14,
+  color: "text.secondary",
+};
+
 /** Profile avatar size */
 export const PROFILE_AVATAR_SIZE = 80;


### PR DESCRIPTION
## Summary
- `ProfileStat`'s `icon` prop took a caller-styled `ReactElement`, so every call site repeated the same `sx={{ fontSize: 14, color: "text.secondary" }}` literal: 3 times in `ProfileView.tsx` and 4 times across `ProfileStat.stories.tsx`.
- `ProfileStat` now accepts an icon component (`icon: typeof SvgIcon`) and applies a shared `PROFILE_STAT_ICON_SX` token (in `profileLayout.ts`, alongside the existing `PROFILE_STAT_BOX_SX`) internally, so callers just pass the icon component (e.g. `icon={CameraAltIcon}`).
- Same pattern as prior design-audit passes that extracted shared sx (`pendingCardSx`, `glassBlurSx`).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint frontend/src/components/profile` — clean
- [x] `npx oxfmt --check` on changed files — clean
- [x] `node scripts/check-stories.mjs` — all 96 components still have stories
- [x] Manually verified `ProfileView`'s three stat icons (camera/fingerprint/grass) and all `ProfileStat.stories.tsx` variants render with the same icon sizing/color as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CJZQQvuv9hm4dAh6NqgnoP

---
_Generated by [Claude Code](https://claude.ai/code/session_01CJZQQvuv9hm4dAh6NqgnoP)_