### PR TITLE
design-audit: use shared ImageWithSkeleton in TaxonHeroCard

### DIFF
--- a/frontend/src/components/common/ImageWithSkeleton.stories.tsx
+++ b/frontend/src/components/common/ImageWithSkeleton.stories.tsx
@@ -20,6 +20,7 @@ const meta = {
     src: { control: { type: "text" } },
     alt: { control: { type: "text" } },
     emptyText: { control: { type: "text" } },
+    objectFit: { control: { type: "radio" }, options: ["cover", "contain"] },
   },
 } satisfies Meta<typeof ImageWithSkeleton>;
 
@@ -30,6 +31,22 @@ export const Loaded: Story = {
   args: {
     src: "https://commons.wikimedia.org/wiki/Special:FilePath/Quercus_robur.jpg?width=320",
     alt: "Quercus robur leaves",
+  },
+};
+
+export const ContainFit: Story = {
+  args: {
+    src: "https://commons.wikimedia.org/wiki/Special:FilePath/Quercus_robur.jpg?width=320",
+    alt: "Quercus robur leaves",
+    objectFit: "contain",
+  },
+  parameters: {
+    docs: {
+      description: {
+        story:
+          '`objectFit="contain"` letterboxes the image instead of cropping it — used by `TaxonHeroCard` so the full specimen photo stays visible.',
+      },
+    },
   },
 };
 

--- a/frontend/src/components/common/ImageWithSkeleton.tsx
+++ b/frontend/src/components/common/ImageWithSkeleton.tsx
@@ -9,6 +9,7 @@ interface ImageWithSkeletonProps {
   sx?: SxProps<Theme>;
   loading?: "lazy" | "eager";
   emptyText?: string;
+  objectFit?: "cover" | "contain";
 }
 
 export function ImageWithSkeleton({
@@ -17,6 +18,7 @@ export function ImageWithSkeleton({
   sx,
   loading = "lazy",
   emptyText = "No image",
+  objectFit = "cover",
 }: ImageWithSkeletonProps) {
   const [loaded, setLoaded] = useState(false);
 
@@ -52,7 +54,7 @@ export function ImageWithSkeleton({
         sx={{
           width: "100%",
           height: "100%",
-          objectFit: "cover",
+          objectFit,
           opacity: loaded ? 1 : 0,
           transition: "opacity 0.3s ease",
         }}

--- a/frontend/src/components/taxon/TaxonHeroCard.tsx
+++ b/frontend/src/components/taxon/TaxonHeroCard.tsx
@@ -2,6 +2,7 @@ import { Box, Typography, Chip, Stack } from "@mui/material";
 import type { TaxonDetail } from "../../services/types";
 import { ConservationStatus } from "../common/ConservationStatus";
 import { ExternalLinkChip } from "../common/ExternalLinkChip";
+import { ImageWithSkeleton } from "../common/ImageWithSkeleton";
 import { shouldItalicizeTaxonName } from "../common/TaxonLink";
 
 export interface TaxonHeroCardProps {
@@ -26,36 +27,23 @@ export function TaxonHeroCard({ taxon, heroUrl }: TaxonHeroCardProps) {
       sx={{ alignItems: { xs: "stretch", sm: "flex-start" } }}
     >
       {heroUrl && (
-        <Box
+        <ImageWithSkeleton
+          src={heroUrl}
+          alt={taxon.scientificName}
+          objectFit="contain"
           sx={{
             width: 248,
             height: 248,
             maxWidth: "100%",
             flexShrink: 0,
             borderRadius: 1.75,
-            overflow: "hidden",
             border: 1,
             borderColor: "divider",
             boxShadow: (theme) => theme.palette.cardShadow["hero"],
             backgroundColor: (theme) => theme.palette.overlay["backdrop"],
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
             mx: { xs: "auto", sm: 0 },
           }}
-        >
-          <Box
-            component="img"
-            src={heroUrl}
-            alt={taxon.scientificName}
-            sx={{
-              width: "100%",
-              height: "100%",
-              objectFit: "contain",
-              display: "block",
-            }}
-          />
-        </Box>
+        />
       )}
       <Box sx={{ flex: 1, minWidth: 0 }}>
         {/* Scientific Name */}


### PR DESCRIPTION
## Summary
- `TaxonHeroCard`'s hero image was a raw `Box component="img"` with no loading state, unlike every other photo-bearing card (`ObservationGridCard`, `FeedItem`) which uses `common/ImageWithSkeleton.tsx` for a skeleton placeholder, empty-state fallback, and fade-in.
- `ImageWithSkeleton` hardcoded `objectFit: "cover"`, which would have cropped the taxon hero photo, so added an `objectFit?: "cover" | "contain"` prop (default `"cover"`, matching prior behavior for its two existing callers) and switched `TaxonHeroCard` to use it with `objectFit="contain"`.
- Added a `ContainFit` story to `ImageWithSkeleton.stories.tsx` documenting the new prop.
- Same pattern as prior design-audit passes reusing shared image/skeleton primitives (e.g. `imageSkeletonOverlaySx`, `CenteredSpinner`).

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint` on changed files — clean
- [x] `npx oxfmt --check` on changed files — clean
- [x] `node scripts/check-stories.mjs` — all 96 components still have stories
- [x] Verified `ObservationGridCard` and `FeedItem` (the other two `ImageWithSkeleton` callers) are unaffected, since `objectFit` defaults to `"cover"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W4U3uxXT67LCu176DD7PWj

---
_Generated by [Claude Code](https://claude.ai/code/session_01W4U3uxXT67LCu176DD7PWj)_