### PR TITLE
test(frontend): model-based property suite for the submit → visible lifecycle

### DIFF
--- a/frontend/src/store/submissionLifecycle.test.ts
+++ b/frontend/src/store/submissionLifecycle.test.ts
@@ -1,26 +1,17 @@
 /**
  * Model-based property tests for the submit → visible lifecycle.
  *
- * A freshly-created observation is durable on the PDS the moment
- * `createRecord` returns, but it is NOT readable from our API until the
- * commit has travelled PDS → relay → Tap → tap-ingester → `ingester.occurrences`.
- * The appview is read-only on that schema (see docs/architecture.md and
- * routes/occurrences/write.rs: "there is a single writer"), so there is no
- * read-your-writes path server-side. The gap is papered over client-side by a
- * "tombstone" row spliced into the query caches (occurrenceCache.ts) plus a
- * localStorage-backed poll (pendingSlice.ts).
+ * A new observation is durable on the PDS as soon as `createRecord` returns but
+ * unreadable from our API until the commit reaches `ingester.occurrences`, and
+ * the appview is read-only on that schema. The gap is bridged entirely client
+ * side by a tombstone row in the query caches (occurrenceCache.ts) plus a
+ * localStorage-backed poll (pendingSlice.ts) — together, the whole state
+ * machine between pressing submit and seeing the observation.
  *
- * Those two pieces are the entire state machine standing between a user
- * pressing submit and seeing their observation, and neither had a test. This
- * file drives the REAL reducers, thunks and cache patchers through randomly
- * interleaved lifecycle events — submit, ingester arrival, poll timeout, feed
- * refetch, reload, clock advance — and asserts invariants after every step.
- * Only the API boundary (`fetchObservation` / `pollObservation`) and `Date.now`
- * are controlled; everything else is production code.
- *
- * Invariants that DON'T hold today are pinned at the bottom with `it.fails`,
- * so CI stays green while the violation stays documented — and the moment
- * someone fixes one, its test goes red asking to be promoted to `it`.
+ * fast-check interleaves the commands below in random orders, running
+ * `checkInvariants` after every step. Only `fetchObservation`,
+ * `pollObservation` and `Date.now` are stubbed; everything else is production
+ * code. Properties that don't hold today are pinned with `it.fails` below.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
@@ -30,9 +21,8 @@ import type * as ApiModule from "../services/api";
 import type { Occurrence, OccurrenceDetailResponse, Profile } from "../services/types";
 
 // ── Controlled boundary ──────────────────────────────────────────────────────
-// The ingester's view of the world. `ingested` flips when a commit has made it
-// all the way to `ingester.occurrences`; until then the API returns null, which
-// is exactly what the appview does for a record it has just written to the PDS.
+// Stands in for `ingester.occurrences`. While `ingested` is false the API
+// returns null, exactly as it does for a record just written to the PDS.
 interface WorldRecord {
   uri: string;
   cid: string;
@@ -56,9 +46,7 @@ vi.mock("../services/api", async (importOriginal) => ({
     const rec = world.records.get(uri);
     return rec?.ingested ? { occurrence: canonical(rec), identifications: [], comments: [] } : null;
   },
-  // The real implementation loops for ~30s; the commands below decide when (and
-  // whether) it resolves, which is the only part of its behaviour the lifecycle
-  // depends on.
+  // The real one loops for ~30s; here the commands decide when it resolves.
   pollObservation: (uri: string): Promise<boolean> =>
     new Promise<boolean>((resolve) => {
       world.polls.set(uri, resolve);
@@ -82,11 +70,7 @@ const PROFILE_KEY = qk.profileFeed(AUTHOR.did, "observations");
 const uriOf = (n: number) => `at://did:plc:author/bio.lexicons.temp.v0-1.occurrence/obs${n}`;
 const cidOf = (n: number) => `bafycid${n}`;
 
-/**
- * The record as the API returns it once ingested. Deliberately distinguishable
- * from a tombstone: real blob URL, resolved taxonomy, a real identification
- * count — the fields `reconcileOccurrence` exists to swap in.
- */
+/** The record as the API returns it once ingested — never mistakable for a tombstone. */
 function canonical(rec: WorldRecord): Occurrence {
   return {
     uri: rec.uri,
@@ -136,9 +120,9 @@ function makeStore() {
 }
 type TestStore = ReturnType<typeof makeStore>;
 
-/** Let every already-resolved promise chain in the thunk run to completion. */
+/** Let the thunk's already-resolved promise chain run to completion. */
 async function settle() {
-  // Sequential by design: each tick lets one more `await` in the thunk chain run.
+  // Sequential by design: each tick advances one `await` in the chain.
   // eslint-disable-next-line no-await-in-loop
   for (let i = 0; i < 8; i++) await Promise.resolve();
   await new Promise((resolve) => setTimeout(resolve, 0));
@@ -154,11 +138,9 @@ function persistedUris(): string[] {
 // ── Model / real ─────────────────────────────────────────────────────────────
 interface Model {
   /**
-   * Submitted observations by index, and how far each has got.
-   * `polled` = the poll settled either way; `reconciled` = it settled
-   * *successfully*, so `reconcileOccurrence` ran. A timed-out poll is
-   * documented to leave the tombstone alone (occurrenceCache.ts), so the two
-   * must not be conflated.
+   * How far each submission has got. `polled` = the poll settled either way;
+   * `reconciled` = it settled successfully. A timed-out poll deliberately
+   * leaves the tombstone alone, so the two must not be conflated.
    */
   submitted: Map<number, { ingested: boolean; polled: boolean; reconciled: boolean }>;
   /** Uris the author has actually seen in one of their own lists. */
@@ -169,11 +151,7 @@ interface Real {
   store: TestStore;
 }
 
-/**
- * Properties that must hold after every single lifecycle event, whatever the
- * interleaving. Violations found here are real bugs in the shipped state
- * machine, not artefacts of the harness.
- */
+/** Must hold after every lifecycle event, whatever the interleaving. */
 function checkInvariants(model: Model, real: Real) {
   const feed = rowsIn(FEED_KEY);
   const profile = rowsIn(PROFILE_KEY);
@@ -187,19 +165,16 @@ function checkInvariants(model: Model, real: Real) {
     for (const uri of uris) expect(world.records.has(uri)).toBe(true);
   }
 
-  // Once a poll has reported success, any row still showing that record must
-  // be the canonical one — swapping the tombstone out is the whole job of
-  // `reconcileOccurrence`.
+  // Once a poll reports success, any row still showing that record must be the
+  // canonical one — swapping the tombstone out is `reconcileOccurrence`'s job.
   for (const [n, state] of model.submitted) {
     if (!state.reconciled) continue;
     const row = feed.find((r) => r.uri === uriOf(n));
     if (row) expect(isTombstone(row)).toBe(false);
   }
 
-  // NB: the redux-pending ↔ localStorage mirror is deliberately NOT asserted
-  // here — it is violated today, and the interleaving property would fail on
-  // every run before reaching anything else. See `checkStorageMirror` and the
-  // pinned test at the bottom of this file.
+  // The pending ↔ localStorage mirror is checked separately: it is violated
+  // today and would fail every run before reaching anything else.
 
   // A submission whose poll has settled is no longer in flight — no stale spinner.
   const inFlight = real.store.getState().pending.submissions.map((s) => s.uri);
@@ -208,11 +183,7 @@ function checkInvariants(model: Model, real: Real) {
   }
 }
 
-/**
- * The pending set drives the TopBar indicator; localStorage is its durable
- * mirror across reloads. They must agree, or a reload resurrects (or loses)
- * in-flight submissions.
- */
+/** The pending set drives the TopBar indicator; localStorage mirrors it across reloads. */
 function checkStorageMirror(real: Real) {
   const inFlight = real.store.getState().pending.submissions.map((s) => s.uri);
   expect([...persistedUris()].sort()).toEqual([...inFlight].sort());
@@ -322,9 +293,8 @@ class PollTimesOut implements Cmd {
 }
 
 /**
- * A background refetch of the lists — what `invalidateOccurrenceLists()` does
- * after any delete (mutations.ts:208), and what a pull-to-refresh would do.
- * Pages are replaced wholesale by the server's answer.
+ * What `invalidateOccurrenceLists()` does after any delete (mutations.ts:208):
+ * the cached pages are replaced wholesale by the server's answer.
  */
 class RefetchLists implements Cmd {
   check() {
@@ -341,10 +311,7 @@ class RefetchLists implements Cmd {
   }
 }
 
-/**
- * Browser reload: the in-memory query cache and the redux store are gone,
- * localStorage survives, and App.tsx re-arms the outstanding polls.
- */
+/** Reload: query cache and store gone, localStorage survives, App.tsx re-arms the polls. */
 class Reload implements Cmd {
   check() {
     return true;
@@ -363,7 +330,7 @@ class Reload implements Cmd {
   }
 }
 
-/** Wall-clock advance — exercises the 2-minute `MAX_AGE_MS` cutoff on resume. */
+/** Exercises the 2-minute `MAX_AGE_MS` cutoff on resume. */
 class AdvanceClock implements Cmd {
   constructor(readonly ms: number) {}
   check() {
@@ -428,14 +395,11 @@ describe("submission lifecycle (model-based)", () => {
 });
 
 // ── Pinned violations ────────────────────────────────────────────────────────
-// The session guarantees below are the ones a user actually feels, and none of
-// them hold today. Each is written as the property we WANT, marked `it.fails`
-// so CI stays green while the gap stays visible. When one is fixed its test
-// goes red — promote it to `it` and, where it applies, fold the invariant back
-// into `checkInvariants` above so the interleaving property enforces it too.
-//
-// The first two scenarios are the minimal counterexamples fast-check shrank to
-// before these invariants were lifted out of the property.
+// Session guarantees that don't hold today, written as the property we WANT and
+// marked `it.fails` so CI stays green while the gap stays visible. When one is
+// fixed its test goes red: promote it to `it` and, where it applies, fold the
+// invariant into `checkInvariants`. The first two scenarios are the minimal
+// counterexamples fast-check shrank to.
 
 describe("session guarantees (known violations)", () => {
   async function scenario(...cmds: Cmd[]): Promise<[Model, Real]> {
@@ -446,32 +410,26 @@ describe("session guarantees (known violations)", () => {
     return [model, real];
   }
 
-  // Read-your-writes. The PDS has acked the write, so the record is durable and
-  // the author's own uri/cid survive in localStorage — but the only thing that
-  // ever put it on screen was an in-memory tombstone, and a reload wipes the
-  // query cache (queryClient.ts: "in-memory only"). `resumePendingSubmissions`
-  // re-arms the poll but carries no content to rebuild the row from, and
-  // `reconcileOccurrence` only patches rows that already exist.
+  // Read-your-writes. The only thing that ever put the row on screen was an
+  // in-memory tombstone, and a reload wipes the query cache. The poll is
+  // re-armed, but carries no content to rebuild the row from.
   it.fails("shows the author their own submission after a reload", async () => {
     const [, real] = await scenario(new Submit(0), new Reload());
     expect(real.store.getState().pending.submissions).toHaveLength(1); // still tracked…
     expect(rowsIn(FEED_KEY).map((r) => r.uri)).toContain(uriOf(0)); // …but not shown
   });
 
-  // Monotonic reads. Deleting any *other* observation calls
-  // `invalidateOccurrenceLists()` (mutations.ts:208), refetching the feed from a
-  // server that does not have the new record yet — so a row the author was
-  // already looking at disappears from under them.
+  // Monotonic reads. Deleting any *other* observation refetches the feed from a
+  // server that doesn't have this record yet, so the row vanishes mid-read.
   it.fails("never removes a row the author has already seen", async () => {
     const [model] = await scenario(new Submit(0), new RefetchLists());
     expect(model.everSeen).toContain(uriOf(0));
     expect(rowsIn(FEED_KEY).map((r) => r.uri)).toContain(uriOf(0));
   });
 
-  // Storage mirror. `loadPersisted` filters entries past MAX_AGE_MS but never
-  // writes the filtered list back, and when *every* entry is stale no
-  // `trackSubmission` is dispatched — so nothing calls `persist()` and the dead
-  // key outlives the submissions it describes.
+  // `loadPersisted` filters entries past MAX_AGE_MS but never writes the
+  // filtered list back, and an all-stale key dispatches nothing — so nothing
+  // calls `persist()` and the dead key survives.
   it.fails("clears expired submissions out of localStorage on resume", async () => {
     const [, real] = await scenario(new Submit(0), new AdvanceClock(120_000), new Reload());
     expect(real.store.getState().pending.submissions).toHaveLength(0);

--- a/frontend/src/store/submissionLifecycle.test.ts
+++ b/frontend/src/store/submissionLifecycle.test.ts
@@ -16,7 +16,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { configureStore } from "@reduxjs/toolkit";
 import fc from "fast-check";
-import type { InfiniteData } from "@tanstack/react-query";
+import { InfiniteQueryObserver, type InfiniteData } from "@tanstack/react-query";
 import type * as ApiModule from "../services/api";
 import type { Occurrence, OccurrenceDetailResponse, Profile } from "../services/types";
 
@@ -58,12 +58,18 @@ import authReducer from "./authSlice";
 import feedReducer from "./feedSlice";
 import uiReducer from "./uiSlice";
 import pendingReducer, { trackSubmission, resumePendingSubmissions } from "./pendingSlice";
-import { makeTombstoneOccurrence, prependOccurrence } from "../lib/query/occurrenceCache";
+import {
+  invalidateOccurrenceLists,
+  makeTombstoneOccurrence,
+  prependOccurrence,
+} from "../lib/query/occurrenceCache";
 import { queryClient } from "../lib/query/queryClient";
 import { qk } from "../lib/query/keys";
 
 const AUTHOR: Profile = { did: "did:plc:author", handle: "author.example" };
 const STORAGE_KEY = "observing-pending-submissions";
+// Mirrors `MAX_AGE_MS` in pendingSlice.ts, which does not export it.
+const MAX_AGE_MS = 2 * 60 * 1000;
 const FEED_KEY = qk.feed("home", {}, true);
 const PROFILE_KEY = qk.profileFeed(AUTHOR.did, "observations");
 
@@ -101,11 +107,50 @@ function serverPage(): OccurrencePage {
   return { occurrences: rows };
 }
 
+const LIST_KEYS = [FEED_KEY, PROFILE_KEY] as const;
+
 function seedListCaches() {
-  const page = serverPage();
-  const data: InfiniteData<OccurrencePage> = { pages: [page], pageParams: [undefined] };
-  queryClient.setQueryData(FEED_KEY, data);
-  queryClient.setQueryData(PROFILE_KEY, { pages: [{ ...page }], pageParams: [undefined] });
+  for (const key of LIST_KEYS) {
+    const data: InfiniteData<OccurrencePage> = { pages: [serverPage()], pageParams: [undefined] };
+    queryClient.setQueryData(key, data);
+  }
+}
+
+/**
+ * Keep the author's two lists *observed*. `invalidateQueries` only refetches
+ * queries something is subscribed to, and no component is mounted here — without
+ * this, `invalidateOccurrenceLists()` would be a silent no-op and `RefetchLists`
+ * would have to reimplement it. `staleTime: Infinity` keeps the seeded data from
+ * triggering a fetch on subscribe, so only an explicit invalidate refetches.
+ */
+let listSubscriptions: (() => void)[] = [];
+
+function unmountListCaches() {
+  for (const unsubscribe of listSubscriptions) unsubscribe();
+  listSubscriptions = [];
+}
+
+function mountListCaches() {
+  unmountListCaches();
+  for (const queryKey of LIST_KEYS) {
+    const observer = new InfiniteQueryObserver<OccurrencePage>(queryClient, {
+      queryKey,
+      queryFn: () => serverPage(),
+      initialPageParam: undefined,
+      getNextPageParam: () => undefined,
+      staleTime: Infinity,
+      refetchOnMount: false,
+      refetchOnWindowFocus: false,
+      retry: false,
+    });
+    listSubscriptions.push(observer.subscribe(() => {}));
+  }
+}
+
+/** Seed the caches from the current world and start observing them. */
+function openLists() {
+  seedListCaches();
+  mountListCaches();
 }
 
 function rowsIn(key: readonly unknown[]): Occurrence[] {
@@ -120,20 +165,28 @@ function makeStore() {
 }
 type TestStore = ReturnType<typeof makeStore>;
 
-/** Let the thunk's already-resolved promise chain run to completion. */
+/**
+ * Let the thunk's already-resolved promise chain run to completion. Yielding to
+ * the macrotask queue drains every microtask queued behind it, so one turn is
+ * enough however deep the promise chain gets.
+ */
 async function settle() {
-  // Sequential by design: each tick advances one `await` in the chain.
-  // eslint-disable-next-line no-await-in-loop
-  for (let i = 0; i < 8; i++) await Promise.resolve();
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-function persistedUris(): string[] {
+interface PersistedEntry {
+  uri: string;
+  createdAt: number;
+}
+
+function persistedEntries(): PersistedEntry[] {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return [];
-  const parsed: { uri: string }[] = JSON.parse(raw);
-  return parsed.map((s) => s.uri);
+  const parsed: PersistedEntry[] = JSON.parse(raw);
+  return parsed;
 }
+
+const persistedUris = (): string[] => persistedEntries().map((s) => s.uri);
 
 // ── Model / real ─────────────────────────────────────────────────────────────
 interface Model {
@@ -173,13 +226,24 @@ function checkInvariants(model: Model, real: Real) {
     if (row) expect(isTombstone(row)).toBe(false);
   }
 
-  // The pending ↔ localStorage mirror is checked separately: it is violated
-  // today and would fail every run before reaching anything else.
-
   // A submission whose poll has settled is no longer in flight — no stale spinner.
   const inFlight = real.store.getState().pending.submissions.map((s) => s.uri);
   for (const [n, state] of model.submitted) {
     if (state.polled) expect(inFlight).not.toContain(uriOf(n));
+  }
+
+  // The pending set is mirrored into localStorage so a reload can re-arm the
+  // polls. Strict equality doesn't hold today — `loadPersisted` drops expired
+  // entries without writing the filtered list back (pinned below) — so state the
+  // two directions that do: nothing in flight is ever missing from storage, and
+  // anything left in storage that isn't in flight has aged past the cutoff.
+  // Without this, a `persist()` that stopped writing would go unnoticed.
+  const persisted = persistedEntries();
+  const persistedUriSet = new Set(persisted.map((s) => s.uri));
+  for (const uri of inFlight) expect(persistedUriSet).toContain(uri);
+  for (const entry of persisted) {
+    if (inFlight.includes(entry.uri)) continue;
+    expect(now - entry.createdAt).toBeGreaterThanOrEqual(MAX_AGE_MS);
   }
 }
 
@@ -189,12 +253,30 @@ function checkStorageMirror(real: Real) {
   expect([...persistedUris()].sort()).toEqual([...inFlight].sort());
 }
 
+/** Both of the author's own lists are on screen; either one counts as "seen". */
 function observe(model: Model) {
-  for (const row of rowsIn(FEED_KEY)) model.everSeen.add(row.uri);
+  for (const key of LIST_KEYS) {
+    for (const row of rowsIn(key)) model.everSeen.add(row.uri);
+  }
 }
 
 // ── Commands ─────────────────────────────────────────────────────────────────
 type Cmd = fc.AsyncCommand<Model, Real, false>;
+
+/** The exact row the UploadModal splices in on a successful PDS write. */
+function tombstoneFor(n: number): Occurrence {
+  return makeTombstoneOccurrence({
+    uri: uriOf(n),
+    cid: cidOf(n),
+    observer: AUTHOR,
+    latitude: 1,
+    longitude: 2,
+    scientificName: "Quercus",
+    kingdom: "Plantae",
+    imageUrls: [`data:image/jpeg;base64,preview${n}`],
+    createdAt: new Date(now).toISOString(),
+  });
+}
 
 /** The UploadModal `onSuccess` path: splice a tombstone, then start polling. */
 class Submit implements Cmd {
@@ -211,20 +293,7 @@ class Submit implements Cmd {
     };
     world.records.set(rec.uri, rec);
 
-    prependOccurrence(
-      makeTombstoneOccurrence({
-        uri: rec.uri,
-        cid: rec.cid,
-        observer: AUTHOR,
-        latitude: 1,
-        longitude: 2,
-        scientificName: "Quercus",
-        kingdom: "Plantae",
-        imageUrls: [`data:image/jpeg;base64,preview${this.n}`],
-        createdAt: new Date(now).toISOString(),
-      }),
-      AUTHOR.did,
-    );
+    prependOccurrence(tombstoneFor(this.n), AUTHOR.did);
     void r.store.dispatch(trackSubmission({ uri: rec.uri, cid: rec.cid, kind: "create" }));
 
     m.submitted.set(this.n, { ingested: false, polled: false, reconciled: false });
@@ -234,6 +303,31 @@ class Submit implements Cmd {
   }
   toString() {
     return `Submit(${this.n})`;
+  }
+}
+
+/**
+ * `onSuccess` running twice for one write — React strict-mode re-invocation, or
+ * a resumed poll racing the modal. `prependOccurrence` guards against it by uri;
+ * without that guard the row would appear twice, which is what the no-duplicates
+ * invariant is there to catch.
+ */
+class ResubmitSameRow implements Cmd {
+  constructor(readonly n: number) {}
+  check(m: Model) {
+    // Only while the submission is still in flight: both real causes of a
+    // double `onSuccess` happen before the poll settles.
+    const s = m.submitted.get(this.n);
+    return !!s && !s.polled;
+  }
+  async run(m: Model, r: Real) {
+    prependOccurrence(tombstoneFor(this.n), AUTHOR.did);
+    await settle();
+    observe(m);
+    checkInvariants(m, r);
+  }
+  toString() {
+    return `ResubmitSameRow(${this.n})`;
   }
 }
 
@@ -293,15 +387,16 @@ class PollTimesOut implements Cmd {
 }
 
 /**
- * What `invalidateOccurrenceLists()` does after any delete (mutations.ts:208):
- * the cached pages are replaced wholesale by the server's answer.
+ * Any delete calls `invalidateOccurrenceLists()` (mutations.ts:208). We call the
+ * real one — the lists are observed (see `mountListCaches`), so its tag predicate
+ * has to actually match them for the refetch to happen.
  */
 class RefetchLists implements Cmd {
   check() {
     return true;
   }
   async run(m: Model, r: Real) {
-    seedListCaches();
+    await invalidateOccurrenceLists();
     await settle();
     observe(m);
     checkInvariants(m, r);
@@ -317,9 +412,14 @@ class Reload implements Cmd {
     return true;
   }
   async run(m: Model, r: Real) {
+    unmountListCaches();
     queryClient.clear();
+    // The previous page's polls die with it; `resumePendingSubmissions` arms new
+    // ones. Without this the old resolvers linger and `PollTimesOut` can't tell
+    // a re-armed poll from a leaked one.
+    world.polls.clear();
     r.store = makeStore();
-    seedListCaches();
+    openLists();
     await r.store.dispatch(resumePendingSubmissions());
     await settle();
     observe(m);
@@ -357,6 +457,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  unmountListCaches();
   vi.restoreAllMocks();
   queryClient.clear();
   localStorage.clear();
@@ -368,6 +469,7 @@ const commandArbs = [
   fc.integer({ min: 0, max: OBS - 1 }).map((n) => new Submit(n)),
   fc.integer({ min: 0, max: OBS - 1 }).map((n) => new IngesterDelivers(n)),
   fc.integer({ min: 0, max: OBS - 1 }).map((n) => new PollTimesOut(n)),
+  fc.integer({ min: 0, max: OBS - 1 }).map((n) => new ResubmitSameRow(n)),
   fc.constant(new RefetchLists()),
   fc.constant(new Reload()),
   fc.integer({ min: 0, max: 200_000 }).map((ms) => new AdvanceClock(ms)),
@@ -377,6 +479,7 @@ describe("submission lifecycle (model-based)", () => {
   it("holds its cache/pending invariants under arbitrary interleavings", async () => {
     await fc.assert(
       fc.asyncProperty(fc.commands(commandArbs, { maxCommands: 20 }), async (cmds) => {
+        unmountListCaches();
         world = { records: new Map(), polls: new Map() };
         now = Date.UTC(2026, 0, 1);
         localStorage.clear();
@@ -385,7 +488,7 @@ describe("submission lifecycle (model-based)", () => {
         await fc.asyncModelRun(() => {
           const model: Model = { submitted: new Map(), everSeen: new Set() };
           const real: Real = { store: makeStore() };
-          seedListCaches();
+          openLists();
           return { model, real };
         }, cmds);
       }),
@@ -405,25 +508,46 @@ describe("session guarantees (known violations)", () => {
   async function scenario(...cmds: Cmd[]): Promise<[Model, Real]> {
     const model: Model = { submitted: new Map(), everSeen: new Set() };
     const real: Real = { store: makeStore() };
-    seedListCaches();
+    openLists();
     for (const cmd of cmds) if (cmd.check(model)) await cmd.run(model, real);
     return [model, real];
   }
 
+  // Each `it.fails` below carries exactly ONE assertion, because `it.fails`
+  // passes on *any* error: fold a precondition in and a regression that breaks
+  // the precondition instead keeps the test green while it silently stops
+  // testing what it names. The preconditions hold today, so they are asserted
+  // here as ordinary tests that go red on their own.
+  describe("preconditions", () => {
+    it("keeps polling a submission a reload interrupted", async () => {
+      const [, real] = await scenario(new Submit(0), new Reload());
+      expect(real.store.getState().pending.submissions).toHaveLength(1);
+    });
+
+    it("puts a just-submitted row in front of the author", async () => {
+      const [model] = await scenario(new Submit(0));
+      expect(model.everSeen).toContain(uriOf(0));
+    });
+
+    it("drops submissions past MAX_AGE_MS from the resumed set", async () => {
+      const [, real] = await scenario(new Submit(0), new AdvanceClock(MAX_AGE_MS), new Reload());
+      expect(real.store.getState().pending.submissions).toHaveLength(0);
+    });
+  });
+
   // Read-your-writes. The only thing that ever put the row on screen was an
   // in-memory tombstone, and a reload wipes the query cache. The poll is
-  // re-armed, but carries no content to rebuild the row from.
+  // re-armed (see the precondition above), but carries no content to rebuild
+  // the row from.
   it.fails("shows the author their own submission after a reload", async () => {
-    const [, real] = await scenario(new Submit(0), new Reload());
-    expect(real.store.getState().pending.submissions).toHaveLength(1); // still tracked…
-    expect(rowsIn(FEED_KEY).map((r) => r.uri)).toContain(uriOf(0)); // …but not shown
+    await scenario(new Submit(0), new Reload());
+    expect(rowsIn(FEED_KEY).map((r) => r.uri)).toContain(uriOf(0));
   });
 
   // Monotonic reads. Deleting any *other* observation refetches the feed from a
   // server that doesn't have this record yet, so the row vanishes mid-read.
   it.fails("never removes a row the author has already seen", async () => {
-    const [model] = await scenario(new Submit(0), new RefetchLists());
-    expect(model.everSeen).toContain(uriOf(0));
+    await scenario(new Submit(0), new RefetchLists());
     expect(rowsIn(FEED_KEY).map((r) => r.uri)).toContain(uriOf(0));
   });
 
@@ -431,8 +555,7 @@ describe("session guarantees (known violations)", () => {
   // filtered list back, and an all-stale key dispatches nothing — so nothing
   // calls `persist()` and the dead key survives.
   it.fails("clears expired submissions out of localStorage on resume", async () => {
-    const [, real] = await scenario(new Submit(0), new AdvanceClock(120_000), new Reload());
-    expect(real.store.getState().pending.submissions).toHaveLength(0);
+    const [, real] = await scenario(new Submit(0), new AdvanceClock(MAX_AGE_MS), new Reload());
     checkStorageMirror(real);
   });
 });

--- a/frontend/src/store/submissionLifecycle.test.ts
+++ b/frontend/src/store/submissionLifecycle.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Model-based property tests for the submit → visible lifecycle.
+ *
+ * A freshly-created observation is durable on the PDS the moment
+ * `createRecord` returns, but it is NOT readable from our API until the
+ * commit has travelled PDS → relay → Tap → tap-ingester → `ingester.occurrences`.
+ * The appview is read-only on that schema (see docs/architecture.md and
+ * routes/occurrences/write.rs: "there is a single writer"), so there is no
+ * read-your-writes path server-side. The gap is papered over client-side by a
+ * "tombstone" row spliced into the query caches (occurrenceCache.ts) plus a
+ * localStorage-backed poll (pendingSlice.ts).
+ *
+ * Those two pieces are the entire state machine standing between a user
+ * pressing submit and seeing their observation, and neither had a test. This
+ * file drives the REAL reducers, thunks and cache patchers through randomly
+ * interleaved lifecycle events — submit, ingester arrival, poll timeout, feed
+ * refetch, reload, clock advance — and asserts invariants after every step.
+ * Only the API boundary (`fetchObservation` / `pollObservation`) and `Date.now`
+ * are controlled; everything else is production code.
+ *
+ * Invariants that DON'T hold today are pinned at the bottom with `it.fails`,
+ * so CI stays green while the violation stays documented — and the moment
+ * someone fixes one, its test goes red asking to be promoted to `it`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { configureStore } from "@reduxjs/toolkit";
+import fc from "fast-check";
+import type { InfiniteData } from "@tanstack/react-query";
+import type * as ApiModule from "../services/api";
+import type { Occurrence, OccurrenceDetailResponse, Profile } from "../services/types";
+
+// ── Controlled boundary ──────────────────────────────────────────────────────
+// The ingester's view of the world. `ingested` flips when a commit has made it
+// all the way to `ingester.occurrences`; until then the API returns null, which
+// is exactly what the appview does for a record it has just written to the PDS.
+interface WorldRecord {
+  uri: string;
+  cid: string;
+  ingested: boolean;
+  /** Submission order, used to sort the server's newest-first response. */
+  seq: number;
+}
+
+interface World {
+  records: Map<string, WorldRecord>;
+  /** Resolvers for outstanding `pollObservation` calls, keyed by uri. */
+  polls: Map<string, (processed: boolean) => void>;
+}
+
+let world: World = { records: new Map(), polls: new Map() };
+let now = Date.UTC(2026, 0, 1);
+
+vi.mock("../services/api", async (importOriginal) => ({
+  ...(await importOriginal<typeof ApiModule>()),
+  fetchObservation: async (uri: string): Promise<OccurrenceDetailResponse | null> => {
+    const rec = world.records.get(uri);
+    return rec?.ingested ? { occurrence: canonical(rec), identifications: [], comments: [] } : null;
+  },
+  // The real implementation loops for ~30s; the commands below decide when (and
+  // whether) it resolves, which is the only part of its behaviour the lifecycle
+  // depends on.
+  pollObservation: (uri: string): Promise<boolean> =>
+    new Promise<boolean>((resolve) => {
+      world.polls.set(uri, resolve);
+    }),
+}));
+
+// Imported after the mock is registered so the thunks close over the stubs.
+import authReducer from "./authSlice";
+import feedReducer from "./feedSlice";
+import uiReducer from "./uiSlice";
+import pendingReducer, { trackSubmission, resumePendingSubmissions } from "./pendingSlice";
+import { makeTombstoneOccurrence, prependOccurrence } from "../lib/query/occurrenceCache";
+import { queryClient } from "../lib/query/queryClient";
+import { qk } from "../lib/query/keys";
+
+const AUTHOR: Profile = { did: "did:plc:author", handle: "author.example" };
+const STORAGE_KEY = "observing-pending-submissions";
+const FEED_KEY = qk.feed("home", {}, true);
+const PROFILE_KEY = qk.profileFeed(AUTHOR.did, "observations");
+
+const uriOf = (n: number) => `at://did:plc:author/bio.lexicons.temp.v0-1.occurrence/obs${n}`;
+const cidOf = (n: number) => `bafycid${n}`;
+
+/**
+ * The record as the API returns it once ingested. Deliberately distinguishable
+ * from a tombstone: real blob URL, resolved taxonomy, a real identification
+ * count — the fields `reconcileOccurrence` exists to swap in.
+ */
+function canonical(rec: WorldRecord): Occurrence {
+  return {
+    uri: rec.uri,
+    cid: rec.cid,
+    observer: AUTHOR,
+    effectiveTaxonomy: { scientificName: "Quercus alba", rank: "species", kingdom: "Plantae" },
+    identificationCount: 1,
+    location: { latitude: 1, longitude: 2 },
+    images: [{ url: `https://cdn.example/${rec.cid}.jpg` }],
+    createdAt: new Date(rec.seq).toISOString(),
+    likeCount: 0,
+    viewerHasLiked: false,
+    qualityIssues: [],
+  };
+}
+
+/** Tombstones carry the uploader's own inline preview; canonical rows never do. */
+const isTombstone = (o: Occurrence) => o.images.some((i) => i.url.startsWith("data:"));
+
+type OccurrencePage = { occurrences: Occurrence[]; cursor?: string };
+
+/** What `/feeds/home` would return right now: ingested records, newest first. */
+function serverPage(): OccurrencePage {
+  const rows = [...world.records.values()]
+    .filter((r) => r.ingested)
+    .sort((a, b) => b.seq - a.seq)
+    .map(canonical);
+  return { occurrences: rows };
+}
+
+function seedListCaches() {
+  const page = serverPage();
+  const data: InfiniteData<OccurrencePage> = { pages: [page], pageParams: [undefined] };
+  queryClient.setQueryData(FEED_KEY, data);
+  queryClient.setQueryData(PROFILE_KEY, { pages: [{ ...page }], pageParams: [undefined] });
+}
+
+function rowsIn(key: readonly unknown[]): Occurrence[] {
+  const data = queryClient.getQueryData<InfiniteData<OccurrencePage>>(key);
+  return data?.pages.flatMap((p) => p.occurrences) ?? [];
+}
+
+function makeStore() {
+  return configureStore({
+    reducer: { auth: authReducer, feed: feedReducer, ui: uiReducer, pending: pendingReducer },
+  });
+}
+type TestStore = ReturnType<typeof makeStore>;
+
+/** Let every already-resolved promise chain in the thunk run to completion. */
+async function settle() {
+  // Sequential by design: each tick lets one more `await` in the thunk chain run.
+  // eslint-disable-next-line no-await-in-loop
+  for (let i = 0; i < 8; i++) await Promise.resolve();
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
+function persistedUris(): string[] {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return [];
+  const parsed: { uri: string }[] = JSON.parse(raw);
+  return parsed.map((s) => s.uri);
+}
+
+// ── Model / real ─────────────────────────────────────────────────────────────
+interface Model {
+  /**
+   * Submitted observations by index, and how far each has got.
+   * `polled` = the poll settled either way; `reconciled` = it settled
+   * *successfully*, so `reconcileOccurrence` ran. A timed-out poll is
+   * documented to leave the tombstone alone (occurrenceCache.ts), so the two
+   * must not be conflated.
+   */
+  submitted: Map<number, { ingested: boolean; polled: boolean; reconciled: boolean }>;
+  /** Uris the author has actually seen in one of their own lists. */
+  everSeen: Set<string>;
+}
+
+interface Real {
+  store: TestStore;
+}
+
+/**
+ * Properties that must hold after every single lifecycle event, whatever the
+ * interleaving. Violations found here are real bugs in the shipped state
+ * machine, not artefacts of the harness.
+ */
+function checkInvariants(model: Model, real: Real) {
+  const feed = rowsIn(FEED_KEY);
+  const profile = rowsIn(PROFILE_KEY);
+
+  for (const rows of [feed, profile]) {
+    // No duplicates: a tombstone and its canonical twin must never coexist.
+    const uris = rows.map((r) => r.uri);
+    expect(new Set(uris).size).toBe(uris.length);
+
+    // No phantoms: every row traces back to something actually submitted.
+    for (const uri of uris) expect(world.records.has(uri)).toBe(true);
+  }
+
+  // Once a poll has reported success, any row still showing that record must
+  // be the canonical one — swapping the tombstone out is the whole job of
+  // `reconcileOccurrence`.
+  for (const [n, state] of model.submitted) {
+    if (!state.reconciled) continue;
+    const row = feed.find((r) => r.uri === uriOf(n));
+    if (row) expect(isTombstone(row)).toBe(false);
+  }
+
+  // NB: the redux-pending ↔ localStorage mirror is deliberately NOT asserted
+  // here — it is violated today, and the interleaving property would fail on
+  // every run before reaching anything else. See `checkStorageMirror` and the
+  // pinned test at the bottom of this file.
+
+  // A submission whose poll has settled is no longer in flight — no stale spinner.
+  const inFlight = real.store.getState().pending.submissions.map((s) => s.uri);
+  for (const [n, state] of model.submitted) {
+    if (state.polled) expect(inFlight).not.toContain(uriOf(n));
+  }
+}
+
+/**
+ * The pending set drives the TopBar indicator; localStorage is its durable
+ * mirror across reloads. They must agree, or a reload resurrects (or loses)
+ * in-flight submissions.
+ */
+function checkStorageMirror(real: Real) {
+  const inFlight = real.store.getState().pending.submissions.map((s) => s.uri);
+  expect([...persistedUris()].sort()).toEqual([...inFlight].sort());
+}
+
+function observe(model: Model) {
+  for (const row of rowsIn(FEED_KEY)) model.everSeen.add(row.uri);
+}
+
+// ── Commands ─────────────────────────────────────────────────────────────────
+type Cmd = fc.AsyncCommand<Model, Real, false>;
+
+/** The UploadModal `onSuccess` path: splice a tombstone, then start polling. */
+class Submit implements Cmd {
+  constructor(readonly n: number) {}
+  check(m: Model) {
+    return !m.submitted.has(this.n);
+  }
+  async run(m: Model, r: Real) {
+    const rec: WorldRecord = {
+      uri: uriOf(this.n),
+      cid: cidOf(this.n),
+      ingested: false,
+      seq: this.n,
+    };
+    world.records.set(rec.uri, rec);
+
+    prependOccurrence(
+      makeTombstoneOccurrence({
+        uri: rec.uri,
+        cid: rec.cid,
+        observer: AUTHOR,
+        latitude: 1,
+        longitude: 2,
+        scientificName: "Quercus",
+        kingdom: "Plantae",
+        imageUrls: [`data:image/jpeg;base64,preview${this.n}`],
+        createdAt: new Date(now).toISOString(),
+      }),
+      AUTHOR.did,
+    );
+    void r.store.dispatch(trackSubmission({ uri: rec.uri, cid: rec.cid, kind: "create" }));
+
+    m.submitted.set(this.n, { ingested: false, polled: false, reconciled: false });
+    await settle();
+    observe(m);
+    checkInvariants(m, r);
+  }
+  toString() {
+    return `Submit(${this.n})`;
+  }
+}
+
+/** The commit reaches `ingester.occurrences` and the in-flight poll sees it. */
+class IngesterDelivers implements Cmd {
+  constructor(readonly n: number) {}
+  check(m: Model) {
+    const s = m.submitted.get(this.n);
+    return !!s && !s.ingested;
+  }
+  async run(m: Model, r: Real) {
+    const rec = world.records.get(uriOf(this.n));
+    if (rec) rec.ingested = true;
+
+    const resolve = world.polls.get(uriOf(this.n));
+    const state = m.submitted.get(this.n);
+    if (state) state.ingested = true;
+    if (resolve) {
+      world.polls.delete(uriOf(this.n));
+      resolve(true);
+      if (state) {
+        state.polled = true;
+        state.reconciled = true;
+      }
+    }
+
+    await settle();
+    observe(m);
+    checkInvariants(m, r);
+  }
+  toString() {
+    return `IngesterDelivers(${this.n})`;
+  }
+}
+
+/** ~30s elapses without the ingester catching up; the poll gives up. */
+class PollTimesOut implements Cmd {
+  constructor(readonly n: number) {}
+  check(m: Model) {
+    const s = m.submitted.get(this.n);
+    return !!s && !s.polled && world.polls.has(uriOf(this.n));
+  }
+  async run(m: Model, r: Real) {
+    const resolve = world.polls.get(uriOf(this.n));
+    world.polls.delete(uriOf(this.n));
+    resolve?.(false);
+    const state = m.submitted.get(this.n);
+    if (state) state.polled = true;
+
+    await settle();
+    observe(m);
+    checkInvariants(m, r);
+  }
+  toString() {
+    return `PollTimesOut(${this.n})`;
+  }
+}
+
+/**
+ * A background refetch of the lists — what `invalidateOccurrenceLists()` does
+ * after any delete (mutations.ts:208), and what a pull-to-refresh would do.
+ * Pages are replaced wholesale by the server's answer.
+ */
+class RefetchLists implements Cmd {
+  check() {
+    return true;
+  }
+  async run(m: Model, r: Real) {
+    seedListCaches();
+    await settle();
+    observe(m);
+    checkInvariants(m, r);
+  }
+  toString() {
+    return "RefetchLists";
+  }
+}
+
+/**
+ * Browser reload: the in-memory query cache and the redux store are gone,
+ * localStorage survives, and App.tsx re-arms the outstanding polls.
+ */
+class Reload implements Cmd {
+  check() {
+    return true;
+  }
+  async run(m: Model, r: Real) {
+    queryClient.clear();
+    r.store = makeStore();
+    seedListCaches();
+    await r.store.dispatch(resumePendingSubmissions());
+    await settle();
+    observe(m);
+    checkInvariants(m, r);
+  }
+  toString() {
+    return "Reload";
+  }
+}
+
+/** Wall-clock advance — exercises the 2-minute `MAX_AGE_MS` cutoff on resume. */
+class AdvanceClock implements Cmd {
+  constructor(readonly ms: number) {}
+  check() {
+    return true;
+  }
+  async run(m: Model, r: Real) {
+    now += this.ms;
+    await settle();
+    observe(m);
+    checkInvariants(m, r);
+  }
+  toString() {
+    return `AdvanceClock(${this.ms}ms)`;
+  }
+}
+
+// ── Harness ──────────────────────────────────────────────────────────────────
+beforeEach(() => {
+  world = { records: new Map(), polls: new Map() };
+  now = Date.UTC(2026, 0, 1);
+  vi.spyOn(Date, "now").mockImplementation(() => now);
+  localStorage.clear();
+  queryClient.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  queryClient.clear();
+  localStorage.clear();
+});
+
+const OBS = 3;
+
+const commandArbs = [
+  fc.integer({ min: 0, max: OBS - 1 }).map((n) => new Submit(n)),
+  fc.integer({ min: 0, max: OBS - 1 }).map((n) => new IngesterDelivers(n)),
+  fc.integer({ min: 0, max: OBS - 1 }).map((n) => new PollTimesOut(n)),
+  fc.constant(new RefetchLists()),
+  fc.constant(new Reload()),
+  fc.integer({ min: 0, max: 200_000 }).map((ms) => new AdvanceClock(ms)),
+];
+
+describe("submission lifecycle (model-based)", () => {
+  it("holds its cache/pending invariants under arbitrary interleavings", async () => {
+    await fc.assert(
+      fc.asyncProperty(fc.commands(commandArbs, { maxCommands: 20 }), async (cmds) => {
+        world = { records: new Map(), polls: new Map() };
+        now = Date.UTC(2026, 0, 1);
+        localStorage.clear();
+        queryClient.clear();
+
+        await fc.asyncModelRun(() => {
+          const model: Model = { submitted: new Map(), everSeen: new Set() };
+          const real: Real = { store: makeStore() };
+          seedListCaches();
+          return { model, real };
+        }, cmds);
+      }),
+      { numRuns: 300 },
+    );
+  }, 60_000);
+});
+
+// ── Pinned violations ────────────────────────────────────────────────────────
+// The session guarantees below are the ones a user actually feels, and none of
+// them hold today. Each is written as the property we WANT, marked `it.fails`
+// so CI stays green while the gap stays visible. When one is fixed its test
+// goes red — promote it to `it` and, where it applies, fold the invariant back
+// into `checkInvariants` above so the interleaving property enforces it too.
+//
+// The first two scenarios are the minimal counterexamples fast-check shrank to
+// before these invariants were lifted out of the property.
+
+describe("session guarantees (known violations)", () => {
+  async function scenario(...cmds: Cmd[]): Promise<[Model, Real]> {
+    const model: Model = { submitted: new Map(), everSeen: new Set() };
+    const real: Real = { store: makeStore() };
+    seedListCaches();
+    for (const cmd of cmds) if (cmd.check(model)) await cmd.run(model, real);
+    return [model, real];
+  }
+
+  // Read-your-writes. The PDS has acked the write, so the record is durable and
+  // the author's own uri/cid survive in localStorage — but the only thing that
+  // ever put it on screen was an in-memory tombstone, and a reload wipes the
+  // query cache (queryClient.ts: "in-memory only"). `resumePendingSubmissions`
+  // re-arms the poll but carries no content to rebuild the row from, and
+  // `reconcileOccurrence` only patches rows that already exist.
+  it.fails("shows the author their own submission after a reload", async () => {
+    const [, real] = await scenario(new Submit(0), new Reload());
+    expect(real.store.getState().pending.submissions).toHaveLength(1); // still tracked…
+    expect(rowsIn(FEED_KEY).map((r) => r.uri)).toContain(uriOf(0)); // …but not shown
+  });
+
+  // Monotonic reads. Deleting any *other* observation calls
+  // `invalidateOccurrenceLists()` (mutations.ts:208), refetching the feed from a
+  // server that does not have the new record yet — so a row the author was
+  // already looking at disappears from under them.
+  it.fails("never removes a row the author has already seen", async () => {
+    const [model] = await scenario(new Submit(0), new RefetchLists());
+    expect(model.everSeen).toContain(uriOf(0));
+    expect(rowsIn(FEED_KEY).map((r) => r.uri)).toContain(uriOf(0));
+  });
+
+  // Storage mirror. `loadPersisted` filters entries past MAX_AGE_MS but never
+  // writes the filtered list back, and when *every* entry is stale no
+  // `trackSubmission` is dispatched — so nothing calls `persist()` and the dead
+  // key outlives the submissions it describes.
+  it.fails("clears expired submissions out of localStorage on resume", async () => {
+    const [, real] = await scenario(new Submit(0), new AdvanceClock(120_000), new Reload());
+    expect(real.store.getState().pending.submissions).toHaveLength(0);
+    checkStorageMirror(real);
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.1",
         "dotenv": "^17.4.2",
+        "fast-check": "^4.9.0",
         "jsdom": "^29.1.1",
         "msw": "^2.14.6",
         "msw-storybook-addon": "^2.0.7",
@@ -7950,6 +7951,29 @@
         "node": ">=12.0.0"
       }
     },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -10403,6 +10427,23 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/quickselect": {
       "version": "3.0.0",
@@ -13253,24 +13294,6 @@
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/yaml": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
-      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/yargs": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13296,6 +13296,24 @@
         "node": ">=18"
       }
     },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
     "node_modules/yargs": {
       "version": "17.7.3",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.1",
     "dotenv": "^17.4.2",
+    "fast-check": "^4.9.0",
     "jsdom": "^29.1.1",
     "msw": "^2.14.6",
     "msw-storybook-addon": "^2.0.7",


### PR DESCRIPTION
## Why

An observation is durable on the PDS as soon as `createRecord` returns, but
unreadable from our API until the commit reaches `ingester.occurrences` — and
the appview is read-only on that schema ("there is a single writer",
`routes/occurrences/write.rs`). There is no read-your-writes path server-side;
the gap is bridged entirely by `lib/query/occurrenceCache.ts` (tombstone rows)
and `store/pendingSlice.ts` (a localStorage-backed poll).

Those two files are the whole state machine between pressing submit and seeing
your observation, and neither had a test — every other slice in `store/` does.

## What

`frontend/src/store/submissionLifecycle.test.ts`, plus `fast-check` as a dev
dependency. Seven lifecycle events — `Submit`, `ResubmitSameRow`,
`IngesterDelivers`, `PollTimesOut`, `RefetchLists`, `Reload`, `AdvanceClock` —
interleaved in random orders, with invariants checked after every step rather
than only at the end. Only `fetchObservation` / `pollObservation` / `Date.now`
are stubbed; the reducers, thunks, cache patchers and `queryClient` are
production code, so there is no parallel reimplementation to drift out of sync.

300 runs × up to 20 commands (~1.5s). Stable at 8000 × 32.

**Holds today:** no duplicate uris, no phantom rows, reconcile swaps the
tombstone once a poll succeeds, no stale spinner after a poll settles, and
nothing in flight is ever missing from localStorage.

## Three violations found

Each is written as the property we want and marked `it.fails`, so CI stays green
while the gap stays visible — and each goes red when the underlying bug is fixed.
Each carries exactly one assertion: `it.fails` passes on *any* error, so folding
a precondition into the same test would let a regression keep it green. The
preconditions are asserted separately, as ordinary tests.

1. **Stale localStorage is never cleaned.** `loadPersisted` filters entries past
   `MAX_AGE_MS` but never writes the filtered list back, and an all-stale key
   dispatches nothing, so `persist()` never runs. Shrunk to
   `Submit(0), AdvanceClock(120s), Reload`.
2. **A list refetch drops an in-flight row.** Deleting any observation calls
   `invalidateOccurrenceLists()`, refetching from a server that lacks the new
   record — so deleting an unrelated observation makes a just-posted one vanish,
   no reload involved. Broader than the reload case this started from.
3. **A reload keeps polling but loses the row.** The poll is re-armed (asserted
   as a precondition), but carries no content to rebuild the row from.

## Notes

- Tests only; no production code touched.
- The model separates "poll settled" from "poll succeeded" — a timed-out poll is
  documented to leave the tombstone in place, so conflating them false-positives.
- `tsconfig.json` excludes `**/*.test.ts`, so this file is transpiled by vitest
  but never typechecked. Pre-existing.

## Follow-ups

Fix 1 is a one-liner. Fixes 2 and 3 need a design change — either a select-time
pending overlay merged in `useFeed`, or an appview-owned `pending_occurrences`
table UNIONed into the author's own feed. Neither is in this PR.
