### PR TITLE
design-audit: fix ProfileIdentificationCardSkeleton layout drift

### DIFF
--- a/frontend/src/components/profile/ProfileIdentificationCardSkeleton.tsx
+++ b/frontend/src/components/profile/ProfileIdentificationCardSkeleton.tsx
@@ -1,4 +1,5 @@
-import { Box, Card, Skeleton } from "@mui/material";
+import { Box, Card, CardContent, Skeleton } from "@mui/material";
+import { observationGridCardContentSx } from "../common/ObservationGridCard";
 
 /**
  * Skeleton for profile identification card grid items
@@ -18,11 +19,10 @@ export function ProfileIdentificationCardSkeleton() {
       >
         <Skeleton variant="circular" width={28} height={28} sx={{ mb: 1 }} />
         <Skeleton variant="text" width="60%" height={20} />
-        <Skeleton variant="text" width="40%" height={16} />
       </Box>
-      <Box sx={{ p: 1.5 }}>
+      <CardContent sx={observationGridCardContentSx}>
         <Skeleton variant="text" width="50%" height={16} />
-      </Box>
+      </CardContent>
     </Card>
   );
 }


### PR DESCRIPTION
## Summary
- `ProfileIdentificationCardSkeleton` (used as the loading placeholder for the identifications grid in `ProfileView.tsx`) had drifted out of sync with the real card it previews.
- The icon box in the real card (`ProfileView.tsx`) renders exactly one line of text (the scientific name), but the skeleton rendered an extra second text-skeleton line, causing a visible height jump when data loads.
- The bottom content area of the real card uses the shared `observationGridCardContentSx` token (from `common/ObservationGridCard.tsx`, also reused by `ObservationGridCardSkeleton`), but this skeleton hand-rolled its own `sx={{ p: 1.5 }}` `Box` instead — the same class of drift already fixed once for `TaxonDetailSkeleton` (#767).
- Fixed by dropping the extra skeleton line and switching to `CardContent sx={observationGridCardContentSx}`, matching `ObservationGridCardSkeleton`'s existing pattern.

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `npx oxlint` on the changed file — clean
- [x] `npx oxfmt --check` on the changed file — clean
- [x] `npx vitest run` — 173 tests pass
- [x] `node scripts/check-stories.mjs` — all 96 components still have stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013KiEhzVjXzMz1KhCLbJFR6

---
_Generated by [Claude Code](https://claude.ai/code/session_013KiEhzVjXzMz1KhCLbJFR6)_