### PR TITLE
fix(frontend): clear expired submissions out of localStorage on resume

### DIFF
--- a/frontend/src/store/pendingSlice.ts
+++ b/frontend/src/store/pendingSlice.ts
@@ -109,7 +109,13 @@ export const resumePendingSubmissions = createAsyncThunk<
   void,
   { state: RootState; dispatch: AppDispatch }
 >("pending/resume", async (_, { dispatch }) => {
-  for (const entry of loadPersisted()) {
+  const entries = loadPersisted();
+  // `loadPersisted` drops entries past MAX_AGE_MS but returns a filtered copy;
+  // write it back so the expired ones actually leave storage. An all-stale key
+  // dispatches nothing, so without this nothing would ever call `persist()` and
+  // the dead key would outlive every reload.
+  persist(entries);
+  for (const entry of entries) {
     void dispatch(trackSubmission(entry));
   }
 });

--- a/frontend/src/store/submissionLifecycle.test.ts
+++ b/frontend/src/store/submissionLifecycle.test.ts
@@ -174,19 +174,12 @@ async function settle() {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
-interface PersistedEntry {
-  uri: string;
-  createdAt: number;
-}
-
-function persistedEntries(): PersistedEntry[] {
+function persistedUris(): string[] {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return [];
-  const parsed: PersistedEntry[] = JSON.parse(raw);
-  return parsed;
+  const parsed: { uri: string }[] = JSON.parse(raw);
+  return parsed.map((s) => s.uri);
 }
-
-const persistedUris = (): string[] => persistedEntries().map((s) => s.uri);
 
 // ── Model / real ─────────────────────────────────────────────────────────────
 interface Model {
@@ -233,18 +226,9 @@ function checkInvariants(model: Model, real: Real) {
   }
 
   // The pending set is mirrored into localStorage so a reload can re-arm the
-  // polls. Strict equality doesn't hold today — `loadPersisted` drops expired
-  // entries without writing the filtered list back (pinned below) — so state the
-  // two directions that do: nothing in flight is ever missing from storage, and
-  // anything left in storage that isn't in flight has aged past the cutoff.
-  // Without this, a `persist()` that stopped writing would go unnoticed.
-  const persisted = persistedEntries();
-  const persistedUriSet = new Set(persisted.map((s) => s.uri));
-  for (const uri of inFlight) expect(persistedUriSet).toContain(uri);
-  for (const entry of persisted) {
-    if (inFlight.includes(entry.uri)) continue;
-    expect(now - entry.createdAt).toBeGreaterThanOrEqual(MAX_AGE_MS);
-  }
+  // polls, exactly — `resumePendingSubmissions` writes the aged-out entries back
+  // out on resume, so no stale key survives to weaken this.
+  checkStorageMirror(real);
 }
 
 /** The pending set drives the TopBar indicator; localStorage mirrors it across reloads. */
@@ -504,7 +488,7 @@ describe("submission lifecycle (model-based)", () => {
 // invariant into `checkInvariants`. The first two scenarios are the minimal
 // counterexamples fast-check shrank to.
 
-describe("session guarantees (known violations)", () => {
+describe("session guarantees", () => {
   async function scenario(...cmds: Cmd[]): Promise<[Model, Real]> {
     const model: Model = { submitted: new Map(), everSeen: new Set() };
     const real: Real = { store: makeStore() };
@@ -513,12 +497,12 @@ describe("session guarantees (known violations)", () => {
     return [model, real];
   }
 
-  // Each `it.fails` below carries exactly ONE assertion, because `it.fails`
-  // passes on *any* error: fold a precondition in and a regression that breaks
-  // the precondition instead keeps the test green while it silently stops
-  // testing what it names. The preconditions hold today, so they are asserted
-  // here as ordinary tests that go red on their own.
-  describe("preconditions", () => {
+  // The `it.fails` cases further down each carry exactly ONE assertion, because
+  // `it.fails` passes on *any* error: fold a precondition in and a regression
+  // that breaks the precondition instead keeps the test green while it silently
+  // stops testing what it names. Everything those two depend on is asserted here
+  // as an ordinary test that goes red on its own.
+  describe("hold today", () => {
     it("keeps polling a submission a reload interrupted", async () => {
       const [, real] = await scenario(new Submit(0), new Reload());
       expect(real.store.getState().pending.submissions).toHaveLength(1);
@@ -532,6 +516,11 @@ describe("session guarantees (known violations)", () => {
     it("drops submissions past MAX_AGE_MS from the resumed set", async () => {
       const [, real] = await scenario(new Submit(0), new AdvanceClock(MAX_AGE_MS), new Reload());
       expect(real.store.getState().pending.submissions).toHaveLength(0);
+    });
+
+    it("clears expired submissions out of localStorage on resume", async () => {
+      const [, real] = await scenario(new Submit(0), new AdvanceClock(MAX_AGE_MS), new Reload());
+      checkStorageMirror(real);
     });
   });
 
@@ -549,13 +538,5 @@ describe("session guarantees (known violations)", () => {
   it.fails("never removes a row the author has already seen", async () => {
     await scenario(new Submit(0), new RefetchLists());
     expect(rowsIn(FEED_KEY).map((r) => r.uri)).toContain(uriOf(0));
-  });
-
-  // `loadPersisted` filters entries past MAX_AGE_MS but never writes the
-  // filtered list back, and an all-stale key dispatches nothing — so nothing
-  // calls `persist()` and the dead key survives.
-  it.fails("clears expired submissions out of localStorage on resume", async () => {
-    const [, real] = await scenario(new Submit(0), new AdvanceClock(MAX_AGE_MS), new Reload());
-    checkStorageMirror(real);
   });
 });


### PR DESCRIPTION
## Why

Violation 1 from #811, which pinned it as `it.fails`. `loadPersisted` filters
entries past `MAX_AGE_MS` but returns a *filtered copy* without writing it back,
and an all-stale key dispatches nothing — so nothing ever calls `persist()` and
the dead key outlives every reload.

## What

One line in `resumePendingSubmissions`: write the filtered list back before
re-arming the polls. `persist([])` removes the key, so an all-stale key now
clears itself. It also self-heals a corrupt key, since `loadPersisted` returns
`[]` from its `catch`.

The suite tightens to match:

- `it.fails("clears expired submissions out of localStorage on resume")` becomes
  an ordinary test.
- The storage clause in `checkInvariants` goes back to the exact mirror
  (`checkStorageMirror`). It had been stated as the two weaker directions that
  held *around* the bug — nothing in flight missing from storage, anything left
  in storage that isn't in flight has aged out. Strict equality now holds across
  every interleaving.

Two violations remain pinned; both need the design change described in #811.

## Verification

Reverting the one-line fix turns three tests red — the property itself plus both
promoted cases — so the suite genuinely guards it:

```
Tests  3 failed | 2 passed | 2 expected fail (7)
```

With the fix:

- Property stable at 8000 runs × 32 commands.
- Full unit suite: 178 passed + 2 expected fail (was 177 + 3).
- `lint`, `fmt:check`, `tsc -p tsconfig.json` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014QkHaMXcaceHVFR7o18Cv2

---
_Generated by [Claude Code](https://claude.ai/code/session_014QkHaMXcaceHVFR7o18Cv2)_