### PR TITLE
design-audit: extract shared PROFILE_STAT_ROW_SX from ProfileStat/ProfileHeaderSkeleton

### DIFF
--- a/frontend/src/components/profile/ProfileHeaderSkeleton.tsx
+++ b/frontend/src/components/profile/ProfileHeaderSkeleton.tsx
@@ -1,6 +1,11 @@
 import { Box, Skeleton, Stack } from "@mui/material";
 import { UserCardSkeleton } from "../common/UserCardSkeleton";
-import { PROFILE_HEADER_SX, PROFILE_STAT_BOX_SX, PROFILE_AVATAR_SIZE } from "./profileLayout";
+import {
+  PROFILE_HEADER_SX,
+  PROFILE_STAT_BOX_SX,
+  PROFILE_STAT_ROW_SX,
+  PROFILE_AVATAR_SIZE,
+} from "./profileLayout";
 
 /**
  * Skeleton loader matching profile header layout
@@ -20,15 +25,7 @@ export function ProfileHeaderSkeleton() {
         {[1, 2, 3].map((i) => (
           <Box key={i} sx={PROFILE_STAT_BOX_SX}>
             <Skeleton variant="text" width="50%" height={28} sx={{ mx: "auto" }} />
-            <Stack
-              direction="row"
-              spacing={0.5}
-              sx={{
-                alignItems: "center",
-                justifyContent: "center",
-                mt: 0.5,
-              }}
-            >
+            <Stack direction="row" spacing={0.5} sx={PROFILE_STAT_ROW_SX}>
               <Skeleton variant="circular" width={14} height={14} />
               <Skeleton variant="text" width="50%" height={16} />
             </Stack>

--- a/frontend/src/components/profile/ProfileStat.tsx
+++ b/frontend/src/components/profile/ProfileStat.tsx
@@ -1,6 +1,6 @@
 import type SvgIcon from "@mui/material/SvgIcon";
 import { Box, Stack, Typography } from "@mui/material";
-import { PROFILE_STAT_BOX_SX, PROFILE_STAT_ICON_SX } from "./profileLayout";
+import { PROFILE_STAT_BOX_SX, PROFILE_STAT_ICON_SX, PROFILE_STAT_ROW_SX } from "./profileLayout";
 
 interface ProfileStatProps {
   count: number;
@@ -18,15 +18,7 @@ export function ProfileStat({ count, color, icon: Icon, label }: ProfileStatProp
       <Typography variant="h6" component="span" sx={{ fontWeight: 700, color }}>
         {count.toLocaleString()}
       </Typography>
-      <Stack
-        direction="row"
-        spacing={0.5}
-        sx={{
-          alignItems: "center",
-          justifyContent: "center",
-          mt: 0.5,
-        }}
-      >
+      <Stack direction="row" spacing={0.5} sx={PROFILE_STAT_ROW_SX}>
         <Icon sx={PROFILE_STAT_ICON_SX} />
         <Typography variant="caption" sx={{ color: "text.secondary" }}>
           {label}

--- a/frontend/src/components/profile/profileLayout.ts
+++ b/frontend/src/components/profile/profileLayout.ts
@@ -23,5 +23,12 @@ export const PROFILE_STAT_ICON_SX: SxProps<Theme> = {
   color: "text.secondary",
 };
 
+/** Icon + label row inside a stat box, shared between ProfileStat and ProfileHeaderSkeleton */
+export const PROFILE_STAT_ROW_SX: SxProps<Theme> = {
+  alignItems: "center",
+  justifyContent: "center",
+  mt: 0.5,
+};
+
 /** Profile avatar size */
 export const PROFILE_AVATAR_SIZE = 80;


### PR DESCRIPTION
## Summary
- `ProfileStat` and its skeleton loader (`ProfileHeaderSkeleton`) each defined the same `Stack` row `sx` (icon + label row: `alignItems: center, justifyContent: center, mt: 0.5`) inline, verbatim.
- `profileLayout.ts` already centralizes the sibling tokens for this exact stats row (`PROFILE_STAT_BOX_SX`, `PROFILE_STAT_ICON_SX`), so this duplication was just a gap in that existing pattern.
- Added `PROFILE_STAT_ROW_SX` to `profileLayout.ts` and pointed both components at it.

## Test plan
- [x] `npx tsc --noEmit -p .` — clean
- [x] `npx oxlint frontend/src/components/profile/` — clean
- [x] `npx oxfmt --check frontend/src/components/profile` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01F2RdmKnUG9J1buRJSCDuPx

---
_Generated by [Claude Code](https://claude.ai/code/session_01F2RdmKnUG9J1buRJSCDuPx)_